### PR TITLE
chore: Update .gitignore for data files and zen-mcp temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ dmypy.json
 # Data
 data/raw/*
 data/processed/*
+data/adjusted/*
+data/quarantine/*
 !data/.gitkeep
 
 # Artifacts
@@ -82,3 +84,6 @@ mlruns.db
 
 # OS
 Thumbs.db
+
+# Zen-MCP temporary files
+zen_precommit.changeset


### PR DESCRIPTION
## Summary

Adds ignore patterns to `.gitignore` to prevent untracked data files and temporary zen-mcp files from cluttering `git status`.

## Changes

Added the following patterns to `.gitignore`:
- `data/adjusted/*` - Adjusted price data files (generated/downloaded)
- `data/quarantine/*` - Quarantined bad data files (generated)
- `zen_precommit.changeset` - Temporary zen-mcp code review files

## Why

These files were showing up as untracked after working on the test coverage improvement:
```
Untracked files:
  data/adjusted/2025-10-19/
  data/adjusted/2025-10-20/
  data/quarantine/2025-10-19/
  data/quarantine/2025-10-20/
  zen_precommit.changeset
```

## Impact

- Cleaner `git status` output
- Prevents accidental commits of large data files
- Aligns with existing `data/raw/*` and `data/processed/*` ignore patterns
- Standard practice for generated/downloaded files

## Testing

- ✅ Verified files no longer show in `git status` after adding to `.gitignore`
- ✅ No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)