### PR TITLE
fix: Align make lint with pre-commit hook mypy --strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ fmt: ## Format code with black and ruff
 	poetry run black .
 	poetry run ruff check --fix .
 
-lint: ## Run linters (black, ruff, mypy)
+lint: ## Run linters (black, ruff, mypy --strict)
 	poetry run black --check .
 	poetry run ruff check .
-	poetry run mypy libs/ apps/ strategies/
+	poetry run mypy libs/ apps/ strategies/ --strict
 
 test: ## Run tests
 	PYTHONPATH=. poetry run pytest


### PR DESCRIPTION
## Summary

Fixes configuration mismatch between `make lint` and pre-commit quality gates that was causing confusion about "unused" type:ignore comments.

**Problem:**
- Pre-commit hook runs: `mypy --strict` (scripts/pre-commit-hook.sh:33)
- `make ci-local` runs: `mypy --strict` (Makefile:69)
- `make lint` was running: `mypy` (WITHOUT --strict) ← **INCONSISTENT**

This caused confusion where type:ignore comments appeared "unused" when running `make lint` but were actually required for `--strict` mode enforced by the pre-commit gate.

## Changes

- Makefile:34 - Add `--strict` flag to mypy command in lint target
- Update help text to reflect `--strict` usage

## Codex Review

**Approval:** "No issues found; the `make lint` target now matches the strict mypy posture used elsewhere. Consistency fix looks good—ships a clearer lint flow with no regressions."
**Continuation ID:** 633a9d54-cb6a-4ba2-8d7b-6d0890d96a32

## Verification

- [x] `make lint` passes (Success: no issues found in 109 source files)
- [x] Matches pre-commit hook behavior
- [x] Matches `make ci-local` behavior
- [x] All three enforcement points now consistent

## Impact

- ✅ Eliminates confusion about "unused" type:ignore warnings
- ✅ Developers get same results locally as in pre-commit gates
- ✅ Improved consistency across all quality gates

## Related

- Fixes root cause identified while investigating CI test failures
- No code changes needed - only build tool configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)