### PR TITLE
refactor(workflow): Split review skill into review-code and review-plan

### DIFF
--- a/.claude/commands/review-code.md
+++ b/.claude/commands/review-code.md
@@ -1,0 +1,148 @@
+---
+description: Review code changes with Gemini + Codex. Use /review-code for source code (.py, .sql, .yaml, etc). For plan/docs review use /review-plan.
+---
+
+# Code Review
+
+Review source code changes with Gemini + Codex via direct CLI.
+
+## Usage
+
+- `/review-code` — Review staged/unstaged code changes (both reviewers)
+- `/review-code branch` — Review all branch changes vs origin/master
+- `/review-code path/to/file.py` — Review a single file
+- `/review-code --reviewer gemini` — Gemini only
+- `/review-code --reviewer codex` — Codex only
+
+## Step 1: Determine Scope
+
+**Parse `$ARGUMENTS`:**
+- `branch` → branch mode
+- File path → single-file mode
+- `--reviewer <name>` → specified reviewer(s). Default: gemini + codex
+
+**Get changed files:**
+
+| Mode | Command |
+|------|---------|
+| Branch | `git diff origin/master...HEAD --name-only --diff-filter=ACM` |
+| Staged | `git diff --cached --name-only --diff-filter=ACM` |
+| Unstaged | `git diff --name-only` |
+
+**Guards:** On master → STOP. No changes → STOP. No staged files (not branch mode) → ask user to stage or switch to branch mode.
+
+Display file list before proceeding.
+
+## Step 2: Build & Send Prompt
+
+Write prompt to temp file with single-quoted heredoc (`<<'ENDPROMPT'`). Substitute `<GIT_SCOPE_CMD>` and `<GIT_FILES_CMD>` based on mode (branch: `git diff origin/master...HEAD`, staged: `git diff --cached`, unstaged: `git diff`).
+
+For single-file mode, replace the git discovery block with: `Review the file at: <path>. Read it with: cat <path>`
+
+**Prompt template:**
+
+```
+You are reviewing code changes in a git repository. Do NOT expect the diff on stdin.
+
+To discover what changed, run these git commands yourself:
+- List changed files: <GIT_FILES_CMD>
+- View the full diff: <GIT_SCOPE_CMD>
+- View diff for a specific file: <GIT_SCOPE_CMD> -- <file>
+- Read a file directly: cat <file>
+
+Review all changes with comprehensive analysis:
+
+**Architecture & Design (HIGH):**
+- Design patterns and maintainability standards followed?
+- Integration impact on other components considered?
+
+**Trading Safety (CRITICAL):**
+- Circuit breaker checks before critical operations?
+- Client_order_id values deterministic and collision-free?
+- Per-symbol and total position limits enforced?
+- Order state transitions valid and checked?
+
+**Concurrency & Data Safety (HIGH):**
+- Redis WATCH/MULTI/EXEC for concurrent updates?
+- DB operations wrapped in proper transactions?
+- Read-modify-write sequences atomic?
+
+**Error Handling (HIGH):**
+- Exceptions caught, logged with context, re-raised?
+- Logs include strategy_id, client_order_id, symbol?
+
+**Security (HIGH):**
+- Credentials, API keys never hardcoded or logged?
+- SQL queries parameterized?
+- Input validation for external data?
+
+**Code Quality (MEDIUM):**
+- All function signatures properly typed?
+- Input data validated (Pydantic, assertions)?
+- Docstrings complete and accurate?
+- ADRs created for architectural changes?
+
+**Testing & Edge Cases (MEDIUM):**
+- All code paths and boundary conditions tested?
+- Failure modes handled correctly?
+
+**Domain-Specific (HIGH):**
+- Research and production share feature calculation code?
+- All timestamps UTC and timezone-aware?
+
+Provide comprehensive analysis with issues categorized by severity (CRITICAL/HIGH/MEDIUM/LOW).
+```
+
+**Dispatch to reviewers (both get the same prompt file):**
+
+| Reviewer | Command |
+|----------|---------|
+| Gemini | `cat "$PROMPT_FILE" \| gemini` |
+| Codex | `cat "$PROMPT_FILE" \| codex exec -` |
+
+**NEVER use `codex review --uncommitted` or `codex review --base`** — these prevent custom prompts.
+
+## Step 3: Summarize & Fix Loop
+
+```
+Review Results:
+━━━━━━━━━━━━━━
+Files reviewed: X | Total issues: Y
+CRITICAL: N  HIGH: N  MEDIUM: N  LOW: N
+
+1. [SEVERITY] file:line — Description (Reviewer: name)
+```
+
+**Zero issues → Step 4 (APPROVED).**
+
+Otherwise: fix ALL issues (zero tolerance, including LOW) → re-stage → re-send same prompt to all reviewers → repeat until all approve.
+
+## Step 4: Report
+
+```
+Review APPROVED
+━━━━━━━━━━━━━━
+Reviewers: [list]
+
+zen-mcp-review: approved
+continuation-id: <uuidgen>
+```
+
+If fixes were made: "Run /review-code again for a fresh iteration."
+If zero issues on first try: fully approved.
+
+Clean up: `rm -f "$PROMPT_FILE"`
+
+## Error Handling
+
+Reviewer CLI unavailable → tell user, offer wait/retry or override (requires explicit user approval per CLAUDE.md policy). Document overrides in commit message: `ZEN_REVIEW_OVERRIDE: [reason] / User approved by: [name]`
+
+## Rules
+
+1. Same prompt every time — never bias with fix context
+2. Fresh start per `/review-code` invocation
+3. ALL reviewers must approve before reporting APPROVED
+4. Fix ALL issues including LOW
+5. Single-quoted heredocs to prevent shell injection
+6. Never pass diff content inline — reviewers use git commands
+7. Both reviewers get identical custom prompt via stdin

--- a/.claude/commands/review-plan.md
+++ b/.claude/commands/review-plan.md
@@ -1,0 +1,136 @@
+---
+description: Review plan/task documents by verifying all claims against the actual codebase. Use /review-plan for .md docs. For source code review use /review-code.
+---
+
+# Plan Review
+
+Review plan/task documents by verifying every factual claim (file paths, function signatures, permissions, DB schema) against the actual codebase. Uses Gemini + Codex via direct CLI.
+
+## Usage
+
+- `/review-plan` — Review changed plan/doc files (both reviewers)
+- `/review-plan docs/TASKS/P6T16_TASK.md` — Review a specific plan file
+- `/review-plan --reviewer gemini` — Gemini only
+- `/review-plan --reviewer codex` — Codex only
+
+## Step 1: Determine Scope
+
+**Parse `$ARGUMENTS`:**
+- File path → single-file mode
+- `--reviewer <name>` → specified reviewer(s). Default: gemini + codex
+
+**Get changed files:**
+
+| Mode | Command |
+|------|---------|
+| Staged | `git diff --cached --name-only --diff-filter=ACM` |
+| Unstaged | `git diff --name-only` |
+
+Filter to docs/plan files only (`.md`, `.txt`, files in `docs/`). If no plan files changed → STOP.
+
+Display file list before proceeding.
+
+## Step 2: Build & Send Prompt
+
+Write prompt to temp file with single-quoted heredoc (`<<'ENDPROMPT'`). Substitute `<GIT_FILES_CMD>` and `<FILE_LIST>` with actual values.
+
+For single-file mode, set `<FILE_LIST>` to the specified file path.
+
+**Prompt template:**
+
+```
+You are reviewing a task/plan document in a git repository. Do NOT expect the diff on stdin.
+
+To discover what changed, run these git commands yourself:
+- List changed files: <GIT_FILES_CMD>
+- Read a file directly: cat <file>
+
+Changed files: <FILE_LIST>
+
+Review the plan/task document(s) by verifying claims against the actual codebase:
+
+**Accuracy (CRITICAL):**
+- Do all referenced file paths actually exist? Verify with: ls <path>
+- Do function/method signatures match the actual source? Read the source files to confirm.
+- Are class names, dataclass fields, and return types correct?
+- Are database table and column names accurate? Check the migration files.
+
+**Permission & Security Mappings (HIGH):**
+- Do all referenced Permission enum values exist in the permissions module?
+- Are role-to-permission mappings accurate? Check ROLE_PERMISSIONS dict.
+- Are RBAC guards correctly specified for each page and action?
+- Are audit logging calls using the correct AuditLogger method signatures?
+
+**Architecture & Patterns (HIGH):**
+- Does the plan follow established patterns in the codebase? Read existing similar pages.
+- Are the navigation, page registration, and DB pool patterns consistent with existing pages?
+- Is the implementation order logical?
+
+**Code Examples (MEDIUM):**
+- Are code examples syntactically valid?
+- Do they use correct import paths, parameter names, and keyword arguments?
+- Are async/await patterns used correctly?
+
+**Completeness (MEDIUM):**
+- Are acceptance criteria testable and complete?
+- Are edge cases covered?
+- Are there important codebase details the plan missed?
+
+For EVERY claim about file paths, function signatures, or permissions, verify by reading the actual source file. Do not trust the plan — verify independently.
+
+Provide comprehensive analysis with issues categorized by severity (CRITICAL/HIGH/MEDIUM/LOW).
+```
+
+**Dispatch to reviewers (both get the same prompt file):**
+
+| Reviewer | Command |
+|----------|---------|
+| Gemini | `cat "$PROMPT_FILE" \| gemini` |
+| Codex | `cat "$PROMPT_FILE" \| codex exec -` |
+
+**NEVER use `codex review --uncommitted` or `codex review --base`** — these prevent custom prompts.
+
+## Step 3: Summarize & Fix Loop
+
+```
+Review Results:
+━━━━━━━━━━━━━━
+Files reviewed: X | Total issues: Y
+CRITICAL: N  HIGH: N  MEDIUM: N  LOW: N
+
+1. [SEVERITY] file:line — Description (Reviewer: name)
+```
+
+**Zero issues → Step 4 (APPROVED).**
+
+Otherwise: fix ALL issues (zero tolerance, including LOW) → re-send same prompt to all reviewers → repeat until all approve.
+
+## Step 4: Report
+
+```
+Review APPROVED
+━━━━━━━━━━━━━━
+Reviewers: [list]
+
+zen-mcp-review: approved
+continuation-id: <uuidgen>
+```
+
+If fixes were made: "Run /review-plan again for a fresh iteration."
+If zero issues on first try: fully approved.
+
+Clean up: `rm -f "$PROMPT_FILE"`
+
+## Error Handling
+
+Reviewer CLI unavailable → tell user, offer wait/retry or override (requires explicit user approval per CLAUDE.md policy). Document overrides in commit message: `ZEN_REVIEW_OVERRIDE: [reason] / User approved by: [name]`
+
+## Rules
+
+1. Same prompt every time — never bias with fix context
+2. Fresh start per `/review-plan` invocation
+3. ALL reviewers must approve before reporting APPROVED
+4. Fix ALL issues including LOW
+5. Single-quoted heredocs to prevent shell injection
+6. Both reviewers get identical custom prompt via stdin
+7. Reviewers must READ actual source files to verify — never trust the plan at face value

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -2,293 +2,57 @@
 description: Run one complete review iteration (review + fix + re-review) with Gemini + Codex via direct CLI. Each invocation is a fresh iteration.
 ---
 
-# Review Command
+# Review Command (Dispatcher)
 
-Run one complete shared-context review iteration. Each `/review` invocation handles: send to reviewers → fix issues → re-review (same continuation_id) → repeat until all approve.
+Routes to the appropriate specialized review skill based on changed file types.
 
 ## Usage
 
-- `/review` — Review staged changes (default reviewers: gemini + codex)
+- `/review` — Auto-detect review type from changed files
 - `/review branch` — Review all branch changes vs origin/master
-- `/review path/to/file.py` — Review a single file only
+- `/review path/to/file` — Review a single file
 - `/review --reviewer gemini` — Single reviewer only
 - `/review --reviewer codex` — Single reviewer only
-- `/review --reviewer gemini codex` — Explicit both (same as default)
 
----
-
-## Step 1: Parse Arguments & Determine Scope
+## Step 1: Determine Scope
 
 **Parse `$ARGUMENTS`:**
-- If contains `branch` → branch mode
-- If contains a file path (e.g., `path/to/file.py`) → single-file mode
-- If contains `--reviewer <name>` → use specified reviewer(s). Valid: `gemini`, `codex`
-- Default reviewers: `gemini` then `codex`
+- `branch` → branch mode
+- File path → single-file mode
+- `--reviewer <name>` → specified reviewer(s). Default: gemini + codex
 
-**Determine diff scope:**
+**Get changed files:**
 
-If branch mode:
-```bash
-git diff origin/master...HEAD --name-only --diff-filter=ACM
-```
+| Mode | Command |
+|------|---------|
+| Branch | `git diff origin/master...HEAD --name-only --diff-filter=ACM` |
+| Staged | `git diff --cached --name-only --diff-filter=ACM` |
+| Unstaged | `git diff --name-only` |
 
-Otherwise (staged changes):
-```bash
-git diff --cached --name-only --diff-filter=ACM
-```
+**Guards:** On master → STOP. No changes → STOP. No staged files (not branch mode) → ask user to stage or switch to branch mode.
 
-**Guard rails:**
-- If on master branch → tell user to create a feature branch first, STOP
-- If no changes found → tell user "No changes to review", STOP
-- If no files staged (and not branch mode) → ask user if they want to stage files or switch to branch mode
+Display file list before proceeding.
 
-**Display the file list to the user before proceeding.**
+## Step 2: Classify & Dispatch
 
----
+Classify based on changed files:
 
-## Step 2: Build Review Prompt
+| Condition | Review Type | Skill |
+|-----------|-------------|-------|
+| ALL files are docs (`.md`, `.txt`, files in `docs/`) | Plan review | Follow `/review-plan` instructions |
+| ANY file is source code (`.py`, `.sql`, `.yaml`, etc.) | Code review | Follow `/review-code` instructions |
+| Mixed (code + docs) | Code review | Follow `/review-code` instructions (superset) |
 
-**IMPORTANT: Do NOT pass diff content to reviewers.** Large diffs cause OOM crashes in reviewer CLIs. Instead, instruct reviewers to use git commands to discover and read changes themselves.
-
-For branch mode, set:
-- `GIT_SCOPE_CMD` = `git diff origin/master...HEAD`
-- `GIT_FILES_CMD` = `git diff origin/master...HEAD --name-only --diff-filter=ACM`
-
-For staged mode, set:
-- `GIT_SCOPE_CMD` = `git diff --cached`
-- `GIT_FILES_CMD` = `git diff --cached --name-only --diff-filter=ACM`
-
-For single-file mode (e.g., `/review path/to/file.py`), tell the reviewer to read and review that specific file:
-- Replace the "To discover what changed" block in the prompt with: `Review the file at: <relative-path>. Read it with: cat <relative-path>`
-- Skip the git commands — the reviewer reads the file directly
-
-**The prompt template (substitute GIT_SCOPE_CMD/GIT_FILES_CMD):**
-
-```
-You are reviewing code changes in a git repository. Do NOT expect the diff on stdin.
-
-To discover what changed, run these git commands yourself:
-- List changed files: <GIT_FILES_CMD>
-- View the full diff: <GIT_SCOPE_CMD>
-- View diff for a specific file: <GIT_SCOPE_CMD> -- <file>
-- Read a file directly: cat <file>
-
-Review all changes with comprehensive analysis:
-
-**Architecture & Design (HIGH):**
-- Design patterns and maintainability standards followed?
-- Integration impact on other components considered?
-
-**Trading Safety (CRITICAL):**
-- Circuit breaker checks before critical operations?
-- Client_order_id values deterministic and collision-free?
-- Per-symbol and total position limits enforced?
-- Order state transitions valid and checked?
-
-**Concurrency & Data Safety (HIGH):**
-- Redis WATCH/MULTI/EXEC for concurrent updates?
-- DB operations wrapped in proper transactions?
-- Read-modify-write sequences atomic?
-
-**Error Handling (HIGH):**
-- Exceptions caught, logged with context, re-raised?
-- Logs include strategy_id, client_order_id, symbol?
-
-**Security (HIGH):**
-- Credentials, API keys never hardcoded or logged?
-- SQL queries parameterized?
-- Input validation for external data?
-
-**Code Quality (MEDIUM):**
-- All function signatures properly typed?
-- Input data validated (Pydantic, assertions)?
-- Docstrings complete and accurate?
-- ADRs created for architectural changes?
-
-**Testing & Edge Cases (MEDIUM):**
-- All code paths and boundary conditions tested?
-- Failure modes handled correctly?
-
-**Domain-Specific (HIGH):**
-- Research and production share feature calculation code?
-- All timestamps UTC and timezone-aware?
-
-Provide comprehensive analysis with issues categorized by severity (CRITICAL/HIGH/MEDIUM/LOW).
-```
-
----
-
-## Step 3: First Reviewer (Direct CLI)
-
-Invoke the first reviewer directly via CLI. Which CLI to use depends on the reviewer list from Step 1 (default first reviewer: Gemini).
-
-Write the review prompt to a temp file:
-
-```bash
-PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/review-prompt-XXXXXX")
-trap 'rm -f "${PROMPT_FILE:-}"' EXIT
-cat > "$PROMPT_FILE" <<'ENDPROMPT'
-[REVIEW PROMPT FROM STEP 2 — with GIT_SCOPE_CMD/GIT_FILES_CMD substituted]
-ENDPROMPT
-```
-
-**Dispatch based on first reviewer from Step 1:**
-
-If first reviewer is **Gemini**:
-```bash
-cat "$PROMPT_FILE" | gemini
-```
-
-If first reviewer is **Codex** (e.g., `/review --reviewer codex`):
-```bash
-# Branch mode:
-codex review --base origin/master
-# Staged/uncommitted mode:
-codex review --uncommitted
-```
-
-**Shell safety rules:**
-- Always use single-quoted heredocs (`<<'ENDPROMPT'`) to prevent shell expansion
-- Never pass large diffs inline — reviewers discover changes via git commands
-- Validate any output before parsing
-
-**Save the reviewer's response. If the CLI returns a session ID, save it for re-reviews.**
-
----
-
-## Step 4: Second Reviewer
-
-**Skip if only one reviewer was requested.**
-
-**Dispatch based on second reviewer from Step 1 (default second reviewer: Codex):**
-
-If second reviewer is **Codex**:
-```bash
-# Branch mode:
-codex review --base origin/master
-# Staged/uncommitted mode:
-codex review --uncommitted
-```
-
-**Note:** Codex's `--uncommitted` reviews staged, unstaged, and untracked changes (broader than staged-only). This is a known Codex CLI limitation — there is no staged-only flag. Use `--base origin/master` for branch mode (preferred for precise scope). Codex uses its own built-in review rubric.
-
-If second reviewer is **Gemini** (e.g., `/review --reviewer codex gemini`):
-```bash
-cat "$PROMPT_FILE" | gemini
-```
-
----
-
-## Step 5: Summarize Findings
-
-**Parse ALL responses and create a combined issue list:**
-
-```
-Review Results:
-━━━━━━━━━━━━━━
-Files reviewed: X
-Total issues: Y
-
-CRITICAL: [count]
-HIGH:     [count]
-MEDIUM:   [count]
-LOW:      [count]
-
-Issues:
-1. [CRITICAL] file.py:123 — Description (Reviewer: gemini)
-2. [HIGH] file.py:456 — Description (Reviewer: codex)
-...
-```
-
-**Display this summary to the user.**
-
-**If zero issues → go to Step 7 (APPROVED).**
-
----
-
-## Step 6: Fix Issues & Re-Review
-
-**ZERO TOLERANCE — ALL issues must be fixed. No exceptions.**
-
-1. **Ask user:** "Found X issues. Should I fix them all?"
-2. Fix each issue systematically (read file → apply fix → mark done)
-3. Re-stage fixed files: `git add <fixed-files>`
-4. **Re-review using the same prompt (fresh invocation):**
-   - Send to first reviewer (same prompt — never mention fixes or previous rounds)
-   - Send to second reviewer (same prompt)
-   - Note: Each re-review is a fresh CLI invocation; reviewers use git to discover changes
-5. Summarize new findings
-6. **If new issues found → repeat from step 1**
-7. **If ALL reviewers approve → go to Step 7**
-
-**Critical:** Continue this loop until ALL reviewers explicitly approve within this iteration. Do NOT stop early.
-
----
-
-## Step 7: Report Result
-
-**When ALL reviewers approve with zero issues:**
-
-```
-Review APPROVED
-━━━━━━━━━━━━━━
-Reviewers: [list of reviewers who approved]
-
-Ready to commit. Include in commit message:
-
-zen-mcp-review: approved
-continuation-id: <generated-uuid>
-```
-
-Generate the continuation-id with `uuidgen` (or equivalent). This provides a unique audit trail per review iteration, independent of CLI session support.
-
-**If fixes were made during this iteration**, tell the user:
-
-```
-Fixes were made during this iteration.
-Run /review again for a fresh iteration to confirm.
-```
-
-**If zero issues on first try** (no fixes needed), the code is fully approved.
-
-**Clean up temp files** (also handled by the EXIT trap set in Step 3):
-```bash
-rm -f "$PROMPT_FILE"
-```
-
----
-
-## Error Handling
-
-**If a reviewer CLI is unavailable:**
-1. Tell user: "Reviewer unavailable: [error]"
-2. Offer options:
-   - **Wait and retry** (recommended)
-   - **Override** (requires explicit user approval — see CLAUDE.md policy)
-3. If override approved, include in commit message:
-   ```
-   ZEN_REVIEW_OVERRIDE: Server unavailable
-   User approved by: [user name]
-   ```
-
-**If only one reviewer available:**
-- Complete review with available reviewer
-- Note the gap to the user and recommend retrying the missing reviewer
-- If retries fail, allow an override with explicit user approval
-- Document in commit message:
-  ```
-  ZEN_REVIEW_OVERRIDE: [reviewer] unavailable after retries
-  User approved by: [user name]
-  ```
-
----
+**Pass through all arguments** (`$ARGUMENTS`) to the dispatched skill.
 
 ## Key Rules
 
 1. **Same prompt every time** — never bias reviewers with fix context
-2. **Same prompt within this invocation** — re-reviews use same prompt, fresh CLI invocations
-3. **Fresh start between /review invocations** — each `/review` call starts fresh
-4. **ALL approvals before completing** — don't report APPROVED until every reviewer approves
-5. **Fix ALL issues including LOW** — zero tolerance, no deferral
-6. **Single-quoted heredocs** — prevent shell injection in reviewer prompts
-7. **Never pass diff content to reviewers** — reviewers use git commands to discover changes themselves (prevents OOM on large diffs)
+2. **Fresh start per `/review` invocation** — each call starts fresh
+3. **ALL reviewers must approve** before reporting APPROVED
+4. **Fix ALL issues including LOW** — zero tolerance
+5. **Never pass diff content to reviewers** — they use git commands
+6. **Both reviewers get identical custom prompt** — Gemini via `cat | gemini`, Codex via `cat | codex exec -`
+7. **NEVER use `codex review --uncommitted` or `codex review --base`** — these prevent custom prompts
+
+See `/review-code` and `/review-plan` for full review procedures.


### PR DESCRIPTION
## Summary
- Split monolithic `review.md` (361 lines) into focused skills: `review-code.md` (148 lines) and `review-plan.md` (136 lines)
- `review.md` is now a lightweight dispatcher (58 lines) that classifies files and routes to the correct skill
- Fixed Codex dispatch: uses `codex exec -` instead of `codex review --uncommitted` so both reviewers get identical custom prompts

## Test plan
- [ ] Run `/review` on code changes — should route to `review-code`
- [ ] Run `/review` on doc-only changes — should route to `review-plan`
- [ ] Run `/review-code` and `/review-plan` directly
- [ ] Verify Codex receives custom prompt via `codex exec -`

🤖 Generated with [Claude Code](https://claude.com/claude-code)