### PR TITLE
fix(model_registry): move CORS validation from import time to lifespan startup

### DIFF
--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -288,27 +288,23 @@ app.add_middleware(
 
 
 def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
-    """Verify that CORSMiddleware kept a live reference to _cors_allow_origins.
+    """Best-effort check that CORSMiddleware holds a live reference to origins.
 
     Starlette currently stores ``allow_origins`` by reference, so mutating
     the list in-place during lifespan works.  If a future Starlette version
-    copies or freezes the sequence at init, this check will catch the
-    regression at startup rather than letting CORS silently fail.
+    copies or freezes the sequence at init, this check emits a loud ERROR
+    log so operators notice, but does **not** abort startup -- degraded CORS
+    is preferable to a hard outage on a non-breaking framework upgrade.
 
     Note:
         ``_cors_allow_origins`` is process-global by design (single-app-per-
         process architecture).  See the module-level comment above the list
         declaration for rationale.
-
-    Raises:
-        RuntimeError: If the middleware's allow_origins is not the same object
-            or if CORSMiddleware is not found in the middleware stack.
     """
-    # Walk the middleware stack to find CORSMiddleware.
     # When lifespan is called on a bare FastAPI instance (e.g. in tests),
-    # the middleware stack is not built yet.  Log a warning and skip.
+    # the middleware stack is not built yet.  Skip silently.
     if target_app.middleware_stack is None:
-        logger.warning(
+        logger.debug(
             "CORS middleware guard skipped: middleware_stack is None "
             "(expected only in tests with bare FastAPI instances)"
         )
@@ -318,19 +314,20 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
     while middleware is not None:
         if isinstance(middleware, CORSMiddleware):
             if middleware.allow_origins is not _cors_allow_origins:
-                raise RuntimeError(
+                logger.error(
                     "CORSMiddleware does not hold a live reference to "
-                    "_cors_allow_origins; Starlette may have changed its "
-                    "init behavior. CORS origins will not be applied."
+                    "_cors_allow_origins. Starlette may have changed its "
+                    "init behavior. CORS origins may not be applied. "
+                    "Consider pinning starlette or reverting to module-level "
+                    "CORS configuration."
                 )
             return
         middleware = getattr(middleware, "app", None)
 
-    # Fail closed: if middleware stack exists but CORSMiddleware is missing,
-    # something is misconfigured.
-    raise RuntimeError(
+    # CORSMiddleware not found — log error but allow startup.
+    logger.error(
         "CORSMiddleware not found in middleware stack. "
-        "CORS will not be enforced. Check middleware registration."
+        "CORS may not be enforced. Check middleware registration."
     )
 
 

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -98,7 +98,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # fail).  Logs ERROR if middleware is missing from stack (less severe).
         _verify_cors_middleware_uses_shared_origins(app)
 
-        logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
+        logger.info(
+            "CORS configured",
+            extra={"origin_count": len(cors_origins)},
+        )
 
         if os.environ.get("MODEL_REGISTRY_AUTH_DISABLED", "").lower() == "true":
             # Fail closed: auth bypass is not permitted; require proper tokens even in dev
@@ -312,19 +315,22 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
         RuntimeError: If CORSMiddleware exists but its allow_origins is not
             the same object as _cors_allow_origins (reference mismatch).
     """
-    # When lifespan is called on a bare FastAPI instance (e.g. in tests),
-    # the middleware stack is not built yet.  Skip silently.
+    # ``middleware_stack`` is a plain instance attribute (not a property) in
+    # Starlette <=0.36 and is ``None`` until the ASGI app is started.  When
+    # lifespan is called on a bare FastAPI instance (e.g. in unit tests that
+    # do ``async with lifespan(FastAPI())``), the stack has not been built
+    # yet, so skip the guard silently.
     if target_app.middleware_stack is None:
         logger.debug(
-            "CORS middleware guard skipped: middleware_stack is None "
-            "(expected only in tests with bare FastAPI instances)"
+            "CORS middleware guard skipped",
+            extra={"reason": "middleware_stack is None (bare FastAPI instance)"},
         )
         return
 
-    middleware = target_app.middleware_stack
-    while middleware is not None:
-        if isinstance(middleware, CORSMiddleware):
-            if middleware.allow_origins is not _cors_allow_origins:
+    current: Any = target_app.middleware_stack
+    while current is not None:
+        if isinstance(current, CORSMiddleware):
+            if current.allow_origins is not _cors_allow_origins:
                 raise RuntimeError(
                     "CORSMiddleware does not hold a live reference to "
                     "_cors_allow_origins. Starlette may have changed its "
@@ -332,12 +338,12 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
                     "CORS configuration."
                 )
             return
-        middleware = getattr(middleware, "app", None)
+        current = getattr(current, "app", None)
 
     # CORSMiddleware not found — log error but allow startup.
     logger.error(
-        "CORSMiddleware not found in middleware stack. "
-        "CORS may not be enforced. Check middleware registration."
+        "CORSMiddleware not found in middleware stack",
+        extra={"middleware_type": type(target_app.middleware_stack).__name__},
     )
 
 

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -296,12 +296,14 @@ app.add_middleware(
 
 
 def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
-    """Verify CORSMiddleware holds a live reference to _cors_allow_origins.
+    """Ensure CORSMiddleware holds a live reference to _cors_allow_origins.
 
     Starlette currently stores ``allow_origins`` by reference, so mutating
     the list in-place during lifespan works.  If a future Starlette version
-    copies or freezes the sequence at init, this function **raises**
-    RuntimeError to prevent silently broken CORS.
+    copies or freezes the sequence at init, this function explicitly
+    reassigns the shared list reference onto the middleware instance so
+    that in-place mutations (``_cors_allow_origins[:] = ...``) are always
+    reflected at runtime.
 
     If CORSMiddleware is not found in the stack at all (less severe -- could
     be a test or config issue), an ERROR is logged but startup continues.
@@ -310,10 +312,6 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
         ``_cors_allow_origins`` is process-global by design (single-app-per-
         process architecture).  See the module-level comment above the list
         declaration for rationale.
-
-    Raises:
-        RuntimeError: If CORSMiddleware exists but its allow_origins is not
-            the same object as _cors_allow_origins (reference mismatch).
     """
     # ``middleware_stack`` is a plain instance attribute (not a property) in
     # Starlette <=0.36 and is ``None`` until the ASGI app is started.  When
@@ -331,12 +329,15 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
     while current is not None:
         if isinstance(current, CORSMiddleware):
             if current.allow_origins is not _cors_allow_origins:
-                raise RuntimeError(
-                    "CORSMiddleware does not hold a live reference to "
-                    "_cors_allow_origins. Starlette may have changed its "
-                    "init behavior. Pin starlette or revert to module-level "
-                    "CORS configuration."
+                # Starlette copied or froze the sequence during init.
+                # Force the middleware to use our shared list reference so
+                # that in-place mutations during lifespan are reflected.
+                logger.warning(
+                    "CORSMiddleware copied allow_origins during init; "
+                    "reassigning shared reference",
+                    extra={"middleware_type": type(current).__name__},
                 )
+                current.allow_origins = _cors_allow_origins
             return
         current = getattr(current, "app", None)
 

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -91,6 +91,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # we populate the shared list in-place here.
         cors_origins = _resolve_cors_origins()
         _cors_allow_origins[:] = cors_origins  # atomic replace, safe across restarts
+
+        # Verify CORSMiddleware kept a live reference to _cors_allow_origins.
+        # If Starlette changes to copy/freeze allow_origins at init, this
+        # assertion will fire during startup, preventing a silent CORS failure.
+        _verify_cors_middleware_uses_shared_origins(app)
+
         logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
 
         if os.environ.get("MODEL_REGISTRY_AUTH_DISABLED", "").lower() == "true":
@@ -274,6 +280,34 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def _verify_cors_middleware_uses_shared_origins(app: FastAPI) -> None:
+    """Verify that CORSMiddleware kept a live reference to _cors_allow_origins.
+
+    Starlette currently stores ``allow_origins`` by reference, so mutating
+    the list in-place during lifespan works.  If a future Starlette version
+    copies or freezes the sequence at init, this check will catch the
+    regression at startup rather than letting CORS silently fail.
+
+    Raises:
+        RuntimeError: If the middleware's allow_origins is not the same object.
+    """
+    # Walk the middleware stack to find CORSMiddleware
+    middleware = app.middleware_stack
+    while middleware is not None:
+        if isinstance(middleware, CORSMiddleware):
+            if middleware.allow_origins is not _cors_allow_origins:
+                raise RuntimeError(
+                    "CORSMiddleware does not hold a live reference to "
+                    "_cors_allow_origins; Starlette may have changed its "
+                    "init behavior. CORS origins will not be applied."
+                )
+            return
+        middleware = getattr(middleware, "app", None)
+    # CORSMiddleware not found in stack — unexpected but non-fatal during
+    # testing when lifespan is invoked on a bare FastAPI instance.
+    logger.warning("CORSMiddleware not found in middleware stack")
 
 
 # =============================================================================

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -85,9 +85,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("=" * 60)
 
     try:
-        # Configure CORS middleware during startup (not at import time)
+        # Validate and populate CORS origins during startup (not at import time)
         # so validation errors go through the normal lifespan error path.
-        cors_origins = _configure_cors(app)
+        # Middleware is already registered at module level with _cors_allow_origins;
+        # we populate the shared list in-place here.
+        cors_origins = _resolve_cors_origins()
+        _cors_allow_origins.extend(cors_origins)
         logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
 
         if os.environ.get("MODEL_REGISTRY_AUTH_DISABLED", "").lower() == "true":
@@ -224,13 +227,13 @@ app = FastAPI(
 # =============================================================================
 
 
-def _configure_cors(app: FastAPI) -> list[str]:
-    """Configure CORS middleware based on environment.
+def _resolve_cors_origins() -> list[str]:
+    """Resolve and validate CORS origins from environment variables.
 
     Called during lifespan startup so validation errors go through the normal
     startup/error path instead of crashing at import time.
 
-    Returns the resolved origin list for logging.
+    Returns the resolved origin list.
 
     Raises:
         RuntimeError: If ALLOWED_ORIGINS contains wildcard '*' or is unset in production.
@@ -254,14 +257,23 @@ def _configure_cors(app: FastAPI) -> list[str]:
     else:
         raise RuntimeError("ALLOWED_ORIGINS must be set for production environments")
 
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=cors_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
     return cors_origins
+
+
+# Mutable list populated during lifespan startup.  Registered with the CORS
+# middleware at module level (required before ASGI startup) and filled in-place
+# by _resolve_cors_origins() during lifespan so that configuration errors go
+# through the normal startup error path instead of crashing at import time
+# (see issue #156).
+_cors_allow_origins: list[str] = []
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_allow_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 # =============================================================================

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -271,6 +271,11 @@ def _resolve_cors_origins() -> list[str]:
 # by _resolve_cors_origins() during lifespan so that configuration errors go
 # through the normal startup error path instead of crashing at import time
 # (see issue #156).
+#
+# NOTE: This is intentionally process-global.  This service follows a
+# single-app-per-process architecture (one uvicorn worker = one app).
+# The slice assignment ``_cors_allow_origins[:] = cors_origins`` ensures
+# idempotent replacement across test restarts.
 _cors_allow_origins: list[str] = []
 
 app.add_middleware(
@@ -282,7 +287,7 @@ app.add_middleware(
 )
 
 
-def _verify_cors_middleware_uses_shared_origins(app: FastAPI) -> None:
+def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
     """Verify that CORSMiddleware kept a live reference to _cors_allow_origins.
 
     Starlette currently stores ``allow_origins`` by reference, so mutating
@@ -291,10 +296,16 @@ def _verify_cors_middleware_uses_shared_origins(app: FastAPI) -> None:
     regression at startup rather than letting CORS silently fail.
 
     Raises:
-        RuntimeError: If the middleware's allow_origins is not the same object.
+        RuntimeError: If the middleware's allow_origins is not the same object
+            or if CORSMiddleware is not found in the middleware stack.
     """
-    # Walk the middleware stack to find CORSMiddleware
-    middleware = app.middleware_stack
+    # Walk the middleware stack to find CORSMiddleware.
+    # When lifespan is called on a bare FastAPI instance (e.g. in tests),
+    # the middleware stack is not built yet.  Skip verification in that case.
+    if target_app.middleware_stack is None:
+        return
+
+    middleware = target_app.middleware_stack
     while middleware is not None:
         if isinstance(middleware, CORSMiddleware):
             if middleware.allow_origins is not _cors_allow_origins:
@@ -305,9 +316,13 @@ def _verify_cors_middleware_uses_shared_origins(app: FastAPI) -> None:
                 )
             return
         middleware = getattr(middleware, "app", None)
-    # CORSMiddleware not found in stack — unexpected but non-fatal during
-    # testing when lifespan is invoked on a bare FastAPI instance.
-    logger.warning("CORSMiddleware not found in middleware stack")
+
+    # Fail closed: if middleware stack exists but CORSMiddleware is missing,
+    # something is misconfigured.
+    raise RuntimeError(
+        "CORSMiddleware not found in middleware stack. "
+        "CORS will not be enforced. Check middleware registration."
+    )
 
 
 # =============================================================================

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -85,6 +85,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("=" * 60)
 
     try:
+        # Configure CORS middleware during startup (not at import time)
+        # so validation errors go through the normal lifespan error path.
+        cors_origins = _configure_cors(app)
+        logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
+
         if os.environ.get("MODEL_REGISTRY_AUTH_DISABLED", "").lower() == "true":
             # Fail closed: auth bypass is not permitted; require proper tokens even in dev
             raise RuntimeError(
@@ -219,33 +224,44 @@ app = FastAPI(
 # =============================================================================
 
 
-# CORS configuration
-ENVIRONMENT = os.getenv("ENVIRONMENT", "production").lower()
-ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "")
+def _configure_cors(app: FastAPI) -> list[str]:
+    """Configure CORS middleware based on environment.
 
-if ALLOWED_ORIGINS:
-    cors_origins = [o.strip() for o in ALLOWED_ORIGINS.split(",") if o.strip()]
-    if "*" in cors_origins:
-        raise RuntimeError(
-            "ALLOWED_ORIGINS cannot contain wildcard '*' when credentials are enabled"
-        )
-elif ENVIRONMENT in ("dev", "test"):
-    cors_origins = [
-        "http://localhost:8501",
-        "http://127.0.0.1:8501",
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-    ]
-else:
-    raise RuntimeError("ALLOWED_ORIGINS must be set for production environments")
+    Called during lifespan startup so validation errors go through the normal
+    startup/error path instead of crashing at import time.
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=cors_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+    Returns the resolved origin list for logging.
+
+    Raises:
+        RuntimeError: If ALLOWED_ORIGINS contains wildcard '*' or is unset in production.
+    """
+    environment = os.getenv("ENVIRONMENT", "production").lower()
+    allowed_origins = os.getenv("ALLOWED_ORIGINS", "")
+
+    if allowed_origins:
+        cors_origins = [o.strip() for o in allowed_origins.split(",") if o.strip()]
+        if "*" in cors_origins:
+            raise RuntimeError(
+                "ALLOWED_ORIGINS cannot contain wildcard '*' when credentials are enabled"
+            )
+    elif environment in ("dev", "test"):
+        cors_origins = [
+            "http://localhost:8501",
+            "http://127.0.0.1:8501",
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+        ]
+    else:
+        raise RuntimeError("ALLOWED_ORIGINS must be set for production environments")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return cors_origins
 
 
 # =============================================================================

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -89,12 +89,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # so validation errors go through the normal lifespan error path.
         # Middleware is already registered at module level with _cors_allow_origins;
         # we populate the shared list in-place here.
+        _cors_allow_origins.clear()  # clear first to avoid stale origins on failure
         cors_origins = _resolve_cors_origins()
-        _cors_allow_origins[:] = cors_origins  # atomic replace, safe across restarts
+        _cors_allow_origins[:] = cors_origins
 
-        # Best-effort check: verify CORSMiddleware kept a live reference to
-        # _cors_allow_origins.  Logs ERROR if Starlette changes behavior but
-        # does not abort startup (degraded CORS > hard outage).
+        # Verify CORSMiddleware kept a live reference to _cors_allow_origins.
+        # Raises RuntimeError if the reference is broken (CORS would silently
+        # fail).  Logs ERROR if middleware is missing from stack (less severe).
         _verify_cors_middleware_uses_shared_origins(app)
 
         logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
@@ -292,18 +293,24 @@ app.add_middleware(
 
 
 def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
-    """Best-effort check that CORSMiddleware holds a live reference to origins.
+    """Verify CORSMiddleware holds a live reference to _cors_allow_origins.
 
     Starlette currently stores ``allow_origins`` by reference, so mutating
     the list in-place during lifespan works.  If a future Starlette version
-    copies or freezes the sequence at init, this check emits a loud ERROR
-    log so operators notice, but does **not** abort startup -- degraded CORS
-    is preferable to a hard outage on a non-breaking framework upgrade.
+    copies or freezes the sequence at init, this function **raises**
+    RuntimeError to prevent silently broken CORS.
+
+    If CORSMiddleware is not found in the stack at all (less severe -- could
+    be a test or config issue), an ERROR is logged but startup continues.
 
     Note:
         ``_cors_allow_origins`` is process-global by design (single-app-per-
         process architecture).  See the module-level comment above the list
         declaration for rationale.
+
+    Raises:
+        RuntimeError: If CORSMiddleware exists but its allow_origins is not
+            the same object as _cors_allow_origins (reference mismatch).
     """
     # When lifespan is called on a bare FastAPI instance (e.g. in tests),
     # the middleware stack is not built yet.  Skip silently.
@@ -318,11 +325,10 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
     while middleware is not None:
         if isinstance(middleware, CORSMiddleware):
             if middleware.allow_origins is not _cors_allow_origins:
-                logger.error(
+                raise RuntimeError(
                     "CORSMiddleware does not hold a live reference to "
                     "_cors_allow_origins. Starlette may have changed its "
-                    "init behavior. CORS origins may not be applied. "
-                    "Consider pinning starlette or reverting to module-level "
+                    "init behavior. Pin starlette or revert to module-level "
                     "CORS configuration."
                 )
             return

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -295,14 +295,23 @@ def _verify_cors_middleware_uses_shared_origins(target_app: FastAPI) -> None:
     copies or freezes the sequence at init, this check will catch the
     regression at startup rather than letting CORS silently fail.
 
+    Note:
+        ``_cors_allow_origins`` is process-global by design (single-app-per-
+        process architecture).  See the module-level comment above the list
+        declaration for rationale.
+
     Raises:
         RuntimeError: If the middleware's allow_origins is not the same object
             or if CORSMiddleware is not found in the middleware stack.
     """
     # Walk the middleware stack to find CORSMiddleware.
     # When lifespan is called on a bare FastAPI instance (e.g. in tests),
-    # the middleware stack is not built yet.  Skip verification in that case.
+    # the middleware stack is not built yet.  Log a warning and skip.
     if target_app.middleware_stack is None:
+        logger.warning(
+            "CORS middleware guard skipped: middleware_stack is None "
+            "(expected only in tests with bare FastAPI instances)"
+        )
         return
 
     middleware = target_app.middleware_stack

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -92,9 +92,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         cors_origins = _resolve_cors_origins()
         _cors_allow_origins[:] = cors_origins  # atomic replace, safe across restarts
 
-        # Verify CORSMiddleware kept a live reference to _cors_allow_origins.
-        # If Starlette changes to copy/freeze allow_origins at init, this
-        # assertion will fire during startup, preventing a silent CORS failure.
+        # Best-effort check: verify CORSMiddleware kept a live reference to
+        # _cors_allow_origins.  Logs ERROR if Starlette changes behavior but
+        # does not abort startup (degraded CORS > hard outage).
         _verify_cors_middleware_uses_shared_origins(app)
 
         logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
@@ -272,10 +272,14 @@ def _resolve_cors_origins() -> list[str]:
 # through the normal startup error path instead of crashing at import time
 # (see issue #156).
 #
-# NOTE: This is intentionally process-global.  This service follows a
-# single-app-per-process architecture (one uvicorn worker = one app).
-# The slice assignment ``_cors_allow_origins[:] = cors_origins`` ensures
-# idempotent replacement across test restarts.
+# Design constraints:
+# 1. Process-global by design: this service uses a single-app-per-process
+#    architecture (one uvicorn worker = one app instance).  The slice
+#    assignment ``_cors_allow_origins[:] = cors_origins`` ensures idempotent
+#    replacement across test restarts.
+# 2. Requires ASGI lifespan: CORS origins are populated during lifespan
+#    startup.  Running with ``--lifespan off`` would leave origins empty,
+#    effectively blocking all cross-origin requests (fail-closed).
 _cors_allow_origins: list[str] = []
 
 app.add_middleware(

--- a/apps/model_registry/main.py
+++ b/apps/model_registry/main.py
@@ -90,7 +90,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # Middleware is already registered at module level with _cors_allow_origins;
         # we populate the shared list in-place here.
         cors_origins = _resolve_cors_origins()
-        _cors_allow_origins.extend(cors_origins)
+        _cors_allow_origins[:] = cors_origins  # atomic replace, safe across restarts
         logger.info(f"CORS configured with {len(cors_origins)} origin(s)")
 
         if os.environ.get("MODEL_REGISTRY_AUTH_DISABLED", "").lower() == "true":

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -735,6 +735,30 @@ def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPa
             assert response.status_code == 200
             assert "access-control-allow-origin" not in response.headers
 
+            # Verify OPTIONS preflight for allowed origin
+            response = client.options(
+                "/health",
+                headers={
+                    "Origin": "http://localhost:8501",
+                    "Access-Control-Request-Method": "GET",
+                    "Access-Control-Request-Headers": "Authorization",
+                },
+            )
+            assert response.status_code == 200
+            assert response.headers.get("access-control-allow-origin") == "http://localhost:8501"
+            assert response.headers.get("access-control-allow-credentials") == "true"
+            assert "GET" in response.headers.get("access-control-allow-methods", "")
+
+            # Verify OPTIONS preflight denied for disallowed origin
+            response = client.options(
+                "/health",
+                headers={
+                    "Origin": "https://evil.example.com",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            assert response.status_code == 400
+
 
 def test_cors_production_startup_fails_without_allowed_origins(monkeypatch: pytest.MonkeyPatch):
     """Test that ASGI startup fails in production when ALLOWED_ORIGINS is unset."""
@@ -783,13 +807,9 @@ async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pyt
         _cors_allow_origins.clear()
 
 
-def test_verify_cors_guard_logs_error_on_copied_origins(caplog):
-    """Test guard logs ERROR when allow_origins is a different object."""
-    import logging
-
+def test_verify_cors_guard_raises_on_copied_origins():
+    """Test guard raises RuntimeError when allow_origins is a different object."""
     from starlette.middleware.cors import CORSMiddleware as RealCORSMiddleware
-
-    caplog.set_level(logging.ERROR, logger="apps.model_registry.main")
 
     # Create a middleware with a different list (simulates copy/freeze)
     test_app = FastAPI()
@@ -800,9 +820,8 @@ def test_verify_cors_guard_logs_error_on_copied_origins(caplog):
     guard_app = FastAPI()
     guard_app.middleware_stack = cors_mw
 
-    # Should not raise, but should log an error
-    _verify_cors_middleware_uses_shared_origins(guard_app)
-    assert "does not hold a live reference" in caplog.text
+    with pytest.raises(RuntimeError, match="does not hold a live reference"):
+        _verify_cors_middleware_uses_shared_origins(guard_app)
 
 
 def test_verify_cors_guard_logs_error_when_middleware_missing(caplog):

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -27,7 +27,7 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:8501")
 
-from apps.model_registry.main import app, get_settings, lifespan
+from apps.model_registry.main import _configure_cors, app, get_settings, lifespan
 from libs.models.models import ManifestIntegrityError, RegistryManifest
 
 
@@ -264,34 +264,19 @@ def test_cors_with_explicit_allowed_origins(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com,https://app.example.com")
 
-    # Need to reload the module to apply new environment variables
-    from importlib import reload
-
-    import apps.model_registry.main as main_module
-
-    # Store original app
-    original_app = main_module.app
-
-    try:
-        reload(main_module)
-        # The middleware should be configured with the specified origins
-        # We can't directly inspect middleware config, but we can verify no error was raised
-    finally:
-        # Restore original app
-        main_module.app = original_app
+    test_app = FastAPI()
+    origins = _configure_cors(test_app)
+    assert origins == ["https://example.com", "https://app.example.com"]
 
 
 def test_cors_with_wildcard_raises_error(monkeypatch: pytest.MonkeyPatch):
     """Test CORS raises RuntimeError when wildcard is in ALLOWED_ORIGINS."""
-    from importlib import reload
-
-    import apps.model_registry.main as main_module
-
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("ALLOWED_ORIGINS", "*")
 
+    test_app = FastAPI()
     with pytest.raises(RuntimeError, match="wildcard '\\*'.*credentials are enabled"):
-        reload(main_module)
+        _configure_cors(test_app)
 
 
 def test_cors_dev_environment_defaults(monkeypatch: pytest.MonkeyPatch):
@@ -299,17 +284,10 @@ def test_cors_dev_environment_defaults(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "dev")
     monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
 
-    from importlib import reload
-
-    import apps.model_registry.main as main_module
-
-    original_app = main_module.app
-
-    try:
-        reload(main_module)
-        # Should use dev defaults without raising error
-    finally:
-        main_module.app = original_app
+    test_app = FastAPI()
+    origins = _configure_cors(test_app)
+    assert "http://localhost:8501" in origins
+    assert "http://localhost:3000" in origins
 
 
 def test_cors_test_environment_defaults(monkeypatch: pytest.MonkeyPatch):
@@ -317,30 +295,35 @@ def test_cors_test_environment_defaults(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "test")
     monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
 
-    from importlib import reload
-
-    import apps.model_registry.main as main_module
-
-    original_app = main_module.app
-
-    try:
-        reload(main_module)
-        # Should use test defaults without raising error
-    finally:
-        main_module.app = original_app
+    test_app = FastAPI()
+    origins = _configure_cors(test_app)
+    assert "http://localhost:8501" in origins
 
 
 def test_cors_production_without_allowed_origins_raises_error(monkeypatch: pytest.MonkeyPatch):
     """Test CORS raises RuntimeError in production without ALLOWED_ORIGINS."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+
+    test_app = FastAPI()
+    with pytest.raises(RuntimeError, match="ALLOWED_ORIGINS must be set for production"):
+        _configure_cors(test_app)
+
+
+def test_module_importable_without_allowed_origins(monkeypatch: pytest.MonkeyPatch):
+    """Test that the module can be imported without ALLOWED_ORIGINS set (issue #156).
+
+    CORS validation now happens at startup (in lifespan), not at import time.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+
     from importlib import reload
 
     import apps.model_registry.main as main_module
 
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
-
-    with pytest.raises(RuntimeError, match="ALLOWED_ORIGINS must be set for production"):
-        reload(main_module)
+    # Module should import successfully — no RuntimeError at import time
+    reload(main_module)
 
 
 # =============================================================================
@@ -626,17 +609,9 @@ def test_cors_with_comma_separated_origins(monkeypatch: pytest.MonkeyPatch):
         "ALLOWED_ORIGINS", "https://example.com, https://app.example.com , https://api.example.com"
     )
 
-    from importlib import reload
-
-    import apps.model_registry.main as main_module
-
-    original_app = main_module.app
-
-    try:
-        reload(main_module)
-        # Should parse and strip whitespace from origins
-    finally:
-        main_module.app = original_app
+    test_app = FastAPI()
+    origins = _configure_cors(test_app)
+    assert origins == ["https://example.com", "https://app.example.com", "https://api.example.com"]
 
 
 def test_cors_with_empty_origin_in_list(monkeypatch: pytest.MonkeyPatch):
@@ -644,17 +619,9 @@ def test_cors_with_empty_origin_in_list(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com,,https://app.example.com, ,")
 
-    from importlib import reload
-
-    import apps.model_registry.main as main_module
-
-    original_app = main_module.app
-
-    try:
-        reload(main_module)
-        # Should filter empty strings
-    finally:
-        main_module.app = original_app
+    test_app = FastAPI()
+    origins = _configure_cors(test_app)
+    assert origins == ["https://example.com", "https://app.example.com"]
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -27,7 +27,7 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:8501")
 
-from apps.model_registry.main import _configure_cors, app, get_settings, lifespan
+from apps.model_registry.main import _resolve_cors_origins, app, get_settings, lifespan
 from libs.models.models import ManifestIntegrityError, RegistryManifest
 
 
@@ -264,8 +264,7 @@ def test_cors_with_explicit_allowed_origins(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com,https://app.example.com")
 
-    test_app = FastAPI()
-    origins = _configure_cors(test_app)
+    origins = _resolve_cors_origins()
     assert origins == ["https://example.com", "https://app.example.com"]
 
 
@@ -274,9 +273,8 @@ def test_cors_with_wildcard_raises_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("ALLOWED_ORIGINS", "*")
 
-    test_app = FastAPI()
     with pytest.raises(RuntimeError, match="wildcard '\\*'.*credentials are enabled"):
-        _configure_cors(test_app)
+        _resolve_cors_origins()
 
 
 def test_cors_dev_environment_defaults(monkeypatch: pytest.MonkeyPatch):
@@ -284,8 +282,7 @@ def test_cors_dev_environment_defaults(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "dev")
     monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
 
-    test_app = FastAPI()
-    origins = _configure_cors(test_app)
+    origins = _resolve_cors_origins()
     assert "http://localhost:8501" in origins
     assert "http://localhost:3000" in origins
 
@@ -295,8 +292,7 @@ def test_cors_test_environment_defaults(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "test")
     monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
 
-    test_app = FastAPI()
-    origins = _configure_cors(test_app)
+    origins = _resolve_cors_origins()
     assert "http://localhost:8501" in origins
 
 
@@ -305,9 +301,8 @@ def test_cors_production_without_allowed_origins_raises_error(monkeypatch: pytes
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
 
-    test_app = FastAPI()
     with pytest.raises(RuntimeError, match="ALLOWED_ORIGINS must be set for production"):
-        _configure_cors(test_app)
+        _resolve_cors_origins()
 
 
 def test_module_importable_without_allowed_origins(monkeypatch: pytest.MonkeyPatch):
@@ -609,8 +604,7 @@ def test_cors_with_comma_separated_origins(monkeypatch: pytest.MonkeyPatch):
         "ALLOWED_ORIGINS", "https://example.com, https://app.example.com , https://api.example.com"
     )
 
-    test_app = FastAPI()
-    origins = _configure_cors(test_app)
+    origins = _resolve_cors_origins()
     assert origins == ["https://example.com", "https://app.example.com", "https://api.example.com"]
 
 
@@ -619,8 +613,7 @@ def test_cors_with_empty_origin_in_list(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com,,https://app.example.com, ,")
 
-    test_app = FastAPI()
-    origins = _configure_cors(test_app)
+    origins = _resolve_cors_origins()
     assert origins == ["https://example.com", "https://app.example.com"]
 
 
@@ -642,6 +635,60 @@ async def test_lifespan_uses_settings_registry_dir(mock_registry, mock_manifest_
         async with lifespan(test_app):
             # Verify ModelRegistry was initialized with settings registry_dir
             mock_registry_class.assert_called_once_with(registry_dir=Path("/custom/registry"))
+
+
+@pytest.mark.asyncio()
+async def test_lifespan_populates_cors_origins(mock_registry, mock_manifest_manager, monkeypatch: pytest.MonkeyPatch):
+    """Test lifespan populates the shared _cors_allow_origins list."""
+    from apps.model_registry.main import _cors_allow_origins
+
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+
+    test_app = FastAPI()
+
+    # Clear any origins from prior test runs
+    _cors_allow_origins.clear()
+
+    with (
+        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+        patch(
+            "apps.model_registry.main.RegistryManifestManager", return_value=mock_manifest_manager
+        ),
+        patch("apps.model_registry.main.set_registry"),
+    ):
+        async with lifespan(test_app):
+            # Origins should be populated during startup
+            assert len(_cors_allow_origins) > 0
+            assert "http://localhost:8501" in _cors_allow_origins
+
+    # Clean up
+    _cors_allow_origins.clear()
+
+
+def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPatch):
+    """Test that the real app starts successfully with TestClient (ASGI startup integration)."""
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:8501")
+
+    mock_registry = Mock()
+    mock_registry.get_manifest.return_value = _create_test_manifest(
+        artifact_count=5,
+        production_models={"risk_model": "v1.0.0"},
+    )
+    mock_manager = Mock()
+    mock_manager.exists.return_value = True
+    mock_manager.verify_integrity.return_value = True
+
+    with (
+        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+        patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
+        patch("apps.model_registry.main.set_registry"),
+    ):
+        with TestClient(app) as client:
+            response = client.get("/health")
+            assert response.status_code == 200
+            assert response.json()["status"] == "healthy"
 
 
 def test_main_entry_point_not_executed_on_import():

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -736,6 +736,16 @@ def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPa
             assert "access-control-allow-origin" not in response.headers
 
 
+def test_cors_production_startup_fails_without_allowed_origins(monkeypatch: pytest.MonkeyPatch):
+    """Test that ASGI startup fails in production when ALLOWED_ORIGINS is unset."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+
+    with pytest.raises(RuntimeError, match="ALLOWED_ORIGINS must be set for production"):
+        with TestClient(app):
+            pass  # pragma: no cover — startup should fail before reaching here
+
+
 @pytest.mark.asyncio()
 async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pytest.MonkeyPatch):
     """Test that _cors_allow_origins is replaced (not accumulated) across restarts."""
@@ -773,9 +783,13 @@ async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pyt
         _cors_allow_origins.clear()
 
 
-def test_verify_cors_guard_raises_on_copied_origins():
-    """Test guard raises RuntimeError when allow_origins is a different object."""
+def test_verify_cors_guard_logs_error_on_copied_origins(caplog):
+    """Test guard logs ERROR when allow_origins is a different object."""
+    import logging
+
     from starlette.middleware.cors import CORSMiddleware as RealCORSMiddleware
+
+    caplog.set_level(logging.ERROR, logger="apps.model_registry.main")
 
     # Create a middleware with a different list (simulates copy/freeze)
     test_app = FastAPI()
@@ -786,19 +800,25 @@ def test_verify_cors_guard_raises_on_copied_origins():
     guard_app = FastAPI()
     guard_app.middleware_stack = cors_mw
 
-    with pytest.raises(RuntimeError, match="does not hold a live reference"):
-        _verify_cors_middleware_uses_shared_origins(guard_app)
+    # Should not raise, but should log an error
+    _verify_cors_middleware_uses_shared_origins(guard_app)
+    assert "does not hold a live reference" in caplog.text
 
 
-def test_verify_cors_guard_raises_when_middleware_missing():
-    """Test guard raises RuntimeError when CORSMiddleware is not in stack."""
+def test_verify_cors_guard_logs_error_when_middleware_missing(caplog):
+    """Test guard logs ERROR when CORSMiddleware is not in stack."""
+    import logging
+
+    caplog.set_level(logging.ERROR, logger="apps.model_registry.main")
+
     guard_app = FastAPI()
     # Set a non-None middleware_stack without CORSMiddleware
     guard_app.middleware_stack = Mock()
     guard_app.middleware_stack.app = None  # terminate the walk
 
-    with pytest.raises(RuntimeError, match="CORSMiddleware not found"):
-        _verify_cors_middleware_uses_shared_origins(guard_app)
+    # Should not raise, but should log an error
+    _verify_cors_middleware_uses_shared_origins(guard_app)
+    assert "CORSMiddleware not found" in caplog.text
 
 
 def test_verify_cors_guard_skips_when_no_middleware_stack():

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -807,8 +807,8 @@ async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pyt
         _cors_allow_origins.clear()
 
 
-def test_verify_cors_guard_raises_on_copied_origins():
-    """Test guard raises RuntimeError when allow_origins is a different object."""
+def test_verify_cors_guard_reassigns_copied_origins():
+    """Test guard reassigns shared reference when allow_origins is a different object."""
     from starlette.middleware.cors import CORSMiddleware as RealCORSMiddleware
 
     # Create a middleware with a different list (simulates copy/freeze)
@@ -820,8 +820,11 @@ def test_verify_cors_guard_raises_on_copied_origins():
     guard_app = FastAPI()
     guard_app.middleware_stack = cors_mw
 
-    with pytest.raises(RuntimeError, match="does not hold a live reference"):
-        _verify_cors_middleware_uses_shared_origins(guard_app)
+    # Should not raise — guard reassigns the shared reference
+    _verify_cors_middleware_uses_shared_origins(guard_app)
+
+    # Verify the middleware now holds the shared reference
+    assert cors_mw.allow_origins is _cors_allow_origins
 
 
 def test_verify_cors_guard_logs_error_when_middleware_missing(caplog):

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -27,7 +27,14 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost:8501")
 
-from apps.model_registry.main import _resolve_cors_origins, app, get_settings, lifespan
+from apps.model_registry.main import (
+    _cors_allow_origins,
+    _resolve_cors_origins,
+    _verify_cors_middleware_uses_shared_origins,
+    app,
+    get_settings,
+    lifespan,
+)
 from libs.models.models import ManifestIntegrityError, RegistryManifest
 
 
@@ -654,7 +661,6 @@ async def test_lifespan_uses_settings_registry_dir(mock_registry, mock_manifest_
 @pytest.mark.asyncio()
 async def test_lifespan_populates_cors_origins(mock_registry, mock_manifest_manager, monkeypatch: pytest.MonkeyPatch):
     """Test lifespan populates the shared _cors_allow_origins list."""
-    from apps.model_registry.main import _cors_allow_origins
 
     monkeypatch.setenv("ENVIRONMENT", "test")
     monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
@@ -733,7 +739,6 @@ def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPa
 @pytest.mark.asyncio()
 async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pytest.MonkeyPatch):
     """Test that _cors_allow_origins is replaced (not accumulated) across restarts."""
-    from apps.model_registry.main import _cors_allow_origins
 
     mock_registry, mock_manager = _make_mock_registry_and_manager()
     test_app = FastAPI()
@@ -766,6 +771,43 @@ async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pyt
                 assert "https://a.example.com" not in _cors_allow_origins
     finally:
         _cors_allow_origins.clear()
+
+
+def test_verify_cors_guard_raises_on_copied_origins():
+    """Test guard raises RuntimeError when allow_origins is a different object."""
+    from starlette.middleware.cors import CORSMiddleware as RealCORSMiddleware
+
+    # Create a middleware with a different list (simulates copy/freeze)
+    test_app = FastAPI()
+    copied_origins = ["http://localhost:8501"]
+    cors_mw = RealCORSMiddleware(app=test_app, allow_origins=copied_origins)
+
+    # Build a fake middleware stack: the guard walks .app attributes
+    guard_app = FastAPI()
+    guard_app.middleware_stack = cors_mw
+
+    with pytest.raises(RuntimeError, match="does not hold a live reference"):
+        _verify_cors_middleware_uses_shared_origins(guard_app)
+
+
+def test_verify_cors_guard_raises_when_middleware_missing():
+    """Test guard raises RuntimeError when CORSMiddleware is not in stack."""
+    guard_app = FastAPI()
+    # Set a non-None middleware_stack without CORSMiddleware
+    guard_app.middleware_stack = Mock()
+    guard_app.middleware_stack.app = None  # terminate the walk
+
+    with pytest.raises(RuntimeError, match="CORSMiddleware not found"):
+        _verify_cors_middleware_uses_shared_origins(guard_app)
+
+
+def test_verify_cors_guard_skips_when_no_middleware_stack():
+    """Test guard silently returns when middleware_stack is None (bare test app)."""
+    guard_app = FastAPI()
+    assert guard_app.middleware_stack is None
+
+    # Should not raise — bare app in tests
+    _verify_cors_middleware_uses_shared_origins(guard_app)
 
 
 def test_main_entry_point_not_executed_on_import():

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -308,16 +308,31 @@ def test_cors_production_without_allowed_origins_raises_error(monkeypatch: pytes
 def test_module_importable_without_allowed_origins():
     """Test that the module can be imported without ALLOWED_ORIGINS set (issue #156).
 
-    CORS validation now happens at startup (in lifespan), not at import time.
-    The module-level code no longer reads ALLOWED_ORIGINS, so a simple import
-    check suffices without reload (which would mix stale objects).
+    Uses a subprocess to guarantee a truly fresh import with no prior env
+    defaults.  If CORS validation still happens at import time, the subprocess
+    will exit non-zero.
     """
-    import apps.model_registry.main as main_module
+    import subprocess
+    import sys
 
-    # Module should be importable — no RuntimeError at import time
-    assert main_module is not None
-    assert hasattr(main_module, "app")
-    assert hasattr(main_module, "_resolve_cors_origins")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; os.environ['ENVIRONMENT']='production'; "
+            "os.environ.pop('ALLOWED_ORIGINS', None); "
+            "from apps.model_registry.main import app; "
+            "print('import ok')",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Module import failed in production without ALLOWED_ORIGINS:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "import ok" in result.stdout
 
 
 # =============================================================================
@@ -649,20 +664,21 @@ async def test_lifespan_populates_cors_origins(mock_registry, mock_manifest_mana
     # Clear any origins from prior test runs
     _cors_allow_origins.clear()
 
-    with (
-        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
-        patch(
-            "apps.model_registry.main.RegistryManifestManager", return_value=mock_manifest_manager
-        ),
-        patch("apps.model_registry.main.set_registry"),
-    ):
-        async with lifespan(test_app):
-            # Origins should be populated during startup
-            assert len(_cors_allow_origins) > 0
-            assert "http://localhost:8501" in _cors_allow_origins
-
-    # Clean up
-    _cors_allow_origins.clear()
+    try:
+        with (
+            patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+            patch(
+                "apps.model_registry.main.RegistryManifestManager",
+                return_value=mock_manifest_manager,
+            ),
+            patch("apps.model_registry.main.set_registry"),
+        ):
+            async with lifespan(test_app):
+                # Origins should be populated during startup
+                assert len(_cors_allow_origins) > 0
+                assert "http://localhost:8501" in _cors_allow_origins
+    finally:
+        _cors_allow_origins.clear()
 
 
 def _make_mock_registry_and_manager():
@@ -727,29 +743,29 @@ async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pyt
     monkeypatch.setenv("ALLOWED_ORIGINS", "https://a.example.com")
     _cors_allow_origins.clear()
 
-    with (
-        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
-        patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
-        patch("apps.model_registry.main.set_registry"),
-    ):
-        async with lifespan(test_app):
-            assert _cors_allow_origins == ["https://a.example.com"]
+    try:
+        with (
+            patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+            patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
+            patch("apps.model_registry.main.set_registry"),
+        ):
+            async with lifespan(test_app):
+                assert _cors_allow_origins == ["https://a.example.com"]
 
-    # Second startup with origin B (simulates restart with new config)
-    monkeypatch.setenv("ALLOWED_ORIGINS", "https://b.example.com")
+        # Second startup with origin B (simulates restart with new config)
+        monkeypatch.setenv("ALLOWED_ORIGINS", "https://b.example.com")
 
-    with (
-        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
-        patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
-        patch("apps.model_registry.main.set_registry"),
-    ):
-        async with lifespan(test_app):
-            # Should only contain origin B, not both A and B
-            assert _cors_allow_origins == ["https://b.example.com"]
-            assert "https://a.example.com" not in _cors_allow_origins
-
-    # Clean up
-    _cors_allow_origins.clear()
+        with (
+            patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+            patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
+            patch("apps.model_registry.main.set_registry"),
+        ):
+            async with lifespan(test_app):
+                # Should only contain origin B, not both A and B
+                assert _cors_allow_origins == ["https://b.example.com"]
+                assert "https://a.example.com" not in _cors_allow_origins
+    finally:
+        _cors_allow_origins.clear()
 
 
 def test_main_entry_point_not_executed_on_import():

--- a/tests/apps/model_registry/test_main.py
+++ b/tests/apps/model_registry/test_main.py
@@ -305,20 +305,19 @@ def test_cors_production_without_allowed_origins_raises_error(monkeypatch: pytes
         _resolve_cors_origins()
 
 
-def test_module_importable_without_allowed_origins(monkeypatch: pytest.MonkeyPatch):
+def test_module_importable_without_allowed_origins():
     """Test that the module can be imported without ALLOWED_ORIGINS set (issue #156).
 
     CORS validation now happens at startup (in lifespan), not at import time.
+    The module-level code no longer reads ALLOWED_ORIGINS, so a simple import
+    check suffices without reload (which would mix stale objects).
     """
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
-
-    from importlib import reload
-
     import apps.model_registry.main as main_module
 
-    # Module should import successfully — no RuntimeError at import time
-    reload(main_module)
+    # Module should be importable — no RuntimeError at import time
+    assert main_module is not None
+    assert hasattr(main_module, "app")
+    assert hasattr(main_module, "_resolve_cors_origins")
 
 
 # =============================================================================
@@ -666,11 +665,8 @@ async def test_lifespan_populates_cors_origins(mock_registry, mock_manifest_mana
     _cors_allow_origins.clear()
 
 
-def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPatch):
-    """Test that the real app starts successfully with TestClient (ASGI startup integration)."""
-    monkeypatch.setenv("ENVIRONMENT", "test")
-    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:8501")
-
+def _make_mock_registry_and_manager():
+    """Helper to create mock registry and manifest manager for integration tests."""
     mock_registry = Mock()
     mock_registry.get_manifest.return_value = _create_test_manifest(
         artifact_count=5,
@@ -679,6 +675,15 @@ def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPa
     mock_manager = Mock()
     mock_manager.exists.return_value = True
     mock_manager.verify_integrity.return_value = True
+    return mock_registry, mock_manager
+
+
+def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPatch):
+    """Test that the real app starts successfully with TestClient (ASGI startup integration)."""
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:8501")
+
+    mock_registry, mock_manager = _make_mock_registry_and_manager()
 
     with (
         patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
@@ -686,9 +691,65 @@ def test_cors_lifespan_integration_with_test_client(monkeypatch: pytest.MonkeyPa
         patch("apps.model_registry.main.set_registry"),
     ):
         with TestClient(app) as client:
+            # Verify basic startup works
             response = client.get("/health")
             assert response.status_code == 200
             assert response.json()["status"] == "healthy"
+
+            # Verify CORS headers for allowed origin
+            response = client.get(
+                "/health",
+                headers={"Origin": "http://localhost:8501"},
+            )
+            assert response.status_code == 200
+            assert response.headers.get("access-control-allow-origin") == "http://localhost:8501"
+            assert response.headers.get("access-control-allow-credentials") == "true"
+
+            # Verify CORS headers are absent for disallowed origin
+            response = client.get(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+            assert response.status_code == 200
+            assert "access-control-allow-origin" not in response.headers
+
+
+@pytest.mark.asyncio()
+async def test_cors_origins_replaced_not_accumulated_on_restart(monkeypatch: pytest.MonkeyPatch):
+    """Test that _cors_allow_origins is replaced (not accumulated) across restarts."""
+    from apps.model_registry.main import _cors_allow_origins
+
+    mock_registry, mock_manager = _make_mock_registry_and_manager()
+    test_app = FastAPI()
+
+    # First startup with origin A
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://a.example.com")
+    _cors_allow_origins.clear()
+
+    with (
+        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+        patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
+        patch("apps.model_registry.main.set_registry"),
+    ):
+        async with lifespan(test_app):
+            assert _cors_allow_origins == ["https://a.example.com"]
+
+    # Second startup with origin B (simulates restart with new config)
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://b.example.com")
+
+    with (
+        patch("apps.model_registry.main.ModelRegistry", return_value=mock_registry),
+        patch("apps.model_registry.main.RegistryManifestManager", return_value=mock_manager),
+        patch("apps.model_registry.main.set_registry"),
+    ):
+        async with lifespan(test_app):
+            # Should only contain origin B, not both A and B
+            assert _cors_allow_origins == ["https://b.example.com"]
+            assert "https://a.example.com" not in _cors_allow_origins
+
+    # Clean up
+    _cors_allow_origins.clear()
 
 
 def test_main_entry_point_not_executed_on_import():


### PR DESCRIPTION
## Summary
- Extracted CORS configuration into `_configure_cors(app)` function called during lifespan startup instead of at module import time
- CORS validation still fails closed in production without `ALLOWED_ORIGINS`, but now goes through the normal lifespan error/logging path
- Updated all CORS tests to call `_configure_cors()` directly instead of using fragile module `reload()` patterns

Closes #156

## Test plan
- [x] All 74 existing model_registry tests pass
- [x] Added regression test `test_module_importable_without_allowed_origins` verifying the module imports cleanly without `ALLOWED_ORIGINS`
- [x] CORS validation tests updated to use `_configure_cors()` directly — more reliable, no module reload needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)