### PR TITLE
fix: preserve alert worker retry queue

### DIFF
--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -47,6 +47,8 @@ def _get_allowed_queues() -> tuple[str, ...]:
     listed has the highest polling priority in RQ.  Falls back to
     ``("alerts",)`` when the variable is unset or empty.  The result is
     cached in ``_ALLOWED_QUEUES`` for the lifetime of the process.
+
+    Call ``_reset_queue_state()`` to invalidate the cache (useful in tests).
     """
     global _ALLOWED_QUEUES
     if _ALLOWED_QUEUES is None:
@@ -59,6 +61,14 @@ def _get_allowed_queues() -> tuple[str, ...]:
         )
         _ALLOWED_QUEUES = parsed if parsed else ("alerts",)
     return _ALLOWED_QUEUES
+
+
+def _reset_queue_state() -> None:
+    """Reset all queue-related caches.  Intended for test teardown only."""
+    global _ALLOWED_QUEUES, _RQ_REDIS
+    _ALLOWED_QUEUES = None
+    _RQ_REDIS = None
+    _RQ_QUEUES.clear()
 
 
 @dataclass

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -15,7 +15,7 @@ import redis
 import redis.asyncio as redis_async
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
 from redis import Redis
-from rq import Queue, Worker
+from rq import Queue, Worker, get_current_job
 
 from libs.core.common.exceptions import ConfigurationError
 from libs.platform.alerts.channels import (
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # Sync singletons are safe to share across jobs because RQ invokes the job
 # function in the worker process without reusing asyncio event loops.
 _CHANNELS: dict[ChannelType, BaseChannel] | None = None
-_RQ_QUEUE: Queue | None = None
+_RQ_QUEUES: dict[str, Queue] = {}
 
 
 @dataclass
@@ -56,13 +56,18 @@ def _require_env(name: str) -> str:
     return value
 
 
-def _get_rq_queue() -> Queue:
-    global _RQ_QUEUE
-    if _RQ_QUEUE is None:
+def _get_rq_queue(queue_name: str | None = None) -> Queue:
+    if queue_name is None:
+        current_job = get_current_job()
+        queue_name = getattr(current_job, "origin", None) or "alerts"
+
+    queue = _RQ_QUEUES.get(queue_name)
+    if queue is None:
         redis_url = _require_env("REDIS_URL")
         redis_sync = Redis.from_url(redis_url)
-        _RQ_QUEUE = Queue("alerts", connection=redis_sync)
-    return _RQ_QUEUE
+        queue = Queue(queue_name, connection=redis_sync)
+        _RQ_QUEUES[queue_name] = queue
+    return queue
 
 
 async def _create_async_resources() -> AsyncResources:

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -111,7 +111,7 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
 
     The resolved name is validated against the set of queues this worker
     is allowed to process (``_get_allowed_queues``).  Unrecognised names
-    are replaced with the first allowed queue and a warning is logged so
+    are replaced with the first allowed queue and an error is logged so
     that a rogue ``origin`` value cannot cause unbounded cache growth.
     """
     allowed = _get_allowed_queues()
@@ -120,7 +120,7 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
     current_job = get_current_job()
 
     if queue_name is None:
-        queue_name = getattr(current_job, "origin", None) or default_queue
+        queue_name = (current_job.origin if current_job else None) or default_queue
 
     if queue_name not in allowed:
         job_id = getattr(current_job, "id", None)

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -80,24 +80,27 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
     """Return (and cache) an RQ ``Queue`` for the given *queue_name*.
 
     When *queue_name* is ``None`` the function infers the name from the
-    current RQ job's ``origin`` attribute, falling back to ``"alerts"``.
+    current RQ job's ``origin`` attribute, falling back to the first
+    queue in the allowed set.
 
     The resolved name is validated against the set of queues this worker
     is allowed to process (``_get_allowed_queues``).  Unrecognised names
-    are replaced with ``"alerts"`` and a warning is logged so that a
-    rogue ``origin`` value cannot cause unbounded cache growth.
+    are replaced with the first allowed queue and a warning is logged so
+    that a rogue ``origin`` value cannot cause unbounded cache growth.
     """
+    allowed = _get_allowed_queues()
+    default_queue = sorted(allowed)[0]
+
     if queue_name is None:
         current_job = get_current_job()
-        queue_name = getattr(current_job, "origin", None) or "alerts"
+        queue_name = getattr(current_job, "origin", None) or default_queue
 
-    allowed = _get_allowed_queues()
     if queue_name not in allowed:
         logger.warning(
             "queue_name_not_allowed",
             extra={"requested_queue": queue_name, "allowed_queues": sorted(allowed)},
         )
-        queue_name = "alerts"
+        queue_name = default_queue
 
     queue = _RQ_QUEUES.get(queue_name)
     if queue is None:
@@ -302,8 +305,7 @@ def main() -> None:
 
     asyncio.run(_sync_startup_metrics())
 
-    queues_env = os.getenv("RQ_QUEUES")
-    queues = [q.strip() for q in queues_env.split(",") if q.strip()] if queues_env else ["alerts"]
+    queues = sorted(_get_allowed_queues())
 
     worker = Worker(queues, connection=redis_client)
     logger.info("alert_worker_starting", extra={"queues": queues, "pid": os.getpid()})

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -36,6 +36,26 @@ logger = logging.getLogger(__name__)
 # function in the worker process without reusing asyncio event loops.
 _CHANNELS: dict[ChannelType, BaseChannel] | None = None
 _RQ_QUEUES: dict[str, Queue] = {}
+_ALLOWED_QUEUES: frozenset[str] | None = None
+
+
+def _get_allowed_queues() -> frozenset[str]:
+    """Return the set of queue names this worker is configured to process.
+
+    Parsed from ``RQ_QUEUES`` env var (comma-separated).  Falls back to
+    ``{"alerts"}`` when the variable is unset or empty.  The result is
+    cached in ``_ALLOWED_QUEUES`` for the lifetime of the process.
+    """
+    global _ALLOWED_QUEUES
+    if _ALLOWED_QUEUES is None:
+        queues_env = os.getenv("RQ_QUEUES")
+        parsed = (
+            frozenset(q.strip() for q in queues_env.split(",") if q.strip())
+            if queues_env
+            else frozenset({"alerts"})
+        )
+        _ALLOWED_QUEUES = parsed if parsed else frozenset({"alerts"})
+    return _ALLOWED_QUEUES
 
 
 @dataclass
@@ -57,9 +77,27 @@ def _require_env(name: str) -> str:
 
 
 def _get_rq_queue(queue_name: str | None = None) -> Queue:
+    """Return (and cache) an RQ ``Queue`` for the given *queue_name*.
+
+    When *queue_name* is ``None`` the function infers the name from the
+    current RQ job's ``origin`` attribute, falling back to ``"alerts"``.
+
+    The resolved name is validated against the set of queues this worker
+    is allowed to process (``_get_allowed_queues``).  Unrecognised names
+    are replaced with ``"alerts"`` and a warning is logged so that a
+    rogue ``origin`` value cannot cause unbounded cache growth.
+    """
     if queue_name is None:
         current_job = get_current_job()
         queue_name = getattr(current_job, "origin", None) or "alerts"
+
+    allowed = _get_allowed_queues()
+    if queue_name not in allowed:
+        logger.warning(
+            "queue_name_not_allowed",
+            extra={"requested_queue": queue_name, "allowed_queues": sorted(allowed)},
+        )
+        queue_name = "alerts"
 
     queue = _RQ_QUEUES.get(queue_name)
     if queue is None:

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -36,25 +36,27 @@ logger = logging.getLogger(__name__)
 # function in the worker process without reusing asyncio event loops.
 _CHANNELS: dict[ChannelType, BaseChannel] | None = None
 _RQ_QUEUES: dict[str, Queue] = {}
-_ALLOWED_QUEUES: frozenset[str] | None = None
+_ALLOWED_QUEUES: tuple[str, ...] | None = None
 
 
-def _get_allowed_queues() -> frozenset[str]:
-    """Return the set of queue names this worker is configured to process.
+def _get_allowed_queues() -> tuple[str, ...]:
+    """Return queue names this worker is configured to process, in priority order.
 
-    Parsed from ``RQ_QUEUES`` env var (comma-separated).  Falls back to
-    ``{"alerts"}`` when the variable is unset or empty.  The result is
+    Parsed from ``RQ_QUEUES`` env var (comma-separated).  The first queue
+    listed has the highest polling priority in RQ.  Falls back to
+    ``("alerts",)`` when the variable is unset or empty.  The result is
     cached in ``_ALLOWED_QUEUES`` for the lifetime of the process.
     """
     global _ALLOWED_QUEUES
     if _ALLOWED_QUEUES is None:
         queues_env = os.getenv("RQ_QUEUES")
+        # Use dict.fromkeys to deduplicate while preserving insertion order
         parsed = (
-            frozenset(q.strip() for q in queues_env.split(",") if q.strip())
+            tuple(dict.fromkeys(q.strip() for q in queues_env.split(",") if q.strip()))
             if queues_env
-            else frozenset({"alerts"})
+            else ("alerts",)
         )
-        _ALLOWED_QUEUES = parsed if parsed else frozenset({"alerts"})
+        _ALLOWED_QUEUES = parsed if parsed else ("alerts",)
     return _ALLOWED_QUEUES
 
 
@@ -81,7 +83,7 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
 
     When *queue_name* is ``None`` the function infers the name from the
     current RQ job's ``origin`` attribute, falling back to the first
-    queue in the allowed set.
+    (highest-priority) queue in the allowed tuple.
 
     The resolved name is validated against the set of queues this worker
     is allowed to process (``_get_allowed_queues``).  Unrecognised names
@@ -89,7 +91,7 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
     that a rogue ``origin`` value cannot cause unbounded cache growth.
     """
     allowed = _get_allowed_queues()
-    default_queue = sorted(allowed)[0]
+    default_queue = allowed[0]
 
     if queue_name is None:
         current_job = get_current_job()
@@ -98,7 +100,7 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
     if queue_name not in allowed:
         logger.warning(
             "queue_name_not_allowed",
-            extra={"requested_queue": queue_name, "allowed_queues": sorted(allowed)},
+            extra={"requested_queue": queue_name, "allowed_queues": list(allowed)},
         )
         queue_name = default_queue
 
@@ -305,7 +307,7 @@ def main() -> None:
 
     asyncio.run(_sync_startup_metrics())
 
-    queues = sorted(_get_allowed_queues())
+    queues = list(_get_allowed_queues())
 
     worker = Worker(queues, connection=redis_client)
     logger.info("alert_worker_starting", extra={"queues": queues, "pid": os.getpid()})

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 # function in the worker process without reusing asyncio event loops.
 _CHANNELS: dict[ChannelType, BaseChannel] | None = None
 _RQ_QUEUES: dict[str, Queue] = {}
+_RQ_REDIS: Redis | None = None
 _ALLOWED_QUEUES: tuple[str, ...] | None = None
 
 
@@ -78,6 +79,19 @@ def _require_env(name: str) -> str:
     return value
 
 
+def _get_rq_redis() -> Redis:
+    """Return a shared sync Redis client for RQ queue operations.
+
+    A single connection is reused across all cached queues to avoid
+    creating unnecessary connection pools in multi-queue setups.
+    """
+    global _RQ_REDIS
+    if _RQ_REDIS is None:
+        redis_url = _require_env("REDIS_URL")
+        _RQ_REDIS = Redis.from_url(redis_url)
+    return _RQ_REDIS
+
+
 def _get_rq_queue(queue_name: str | None = None) -> Queue:
     """Return (and cache) an RQ ``Queue`` for the given *queue_name*.
 
@@ -93,21 +107,27 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
     allowed = _get_allowed_queues()
     default_queue = allowed[0]
 
+    current_job = get_current_job()
+
     if queue_name is None:
-        current_job = get_current_job()
         queue_name = getattr(current_job, "origin", None) or default_queue
 
     if queue_name not in allowed:
+        job_id = getattr(current_job, "id", None)
         logger.warning(
             "queue_name_not_allowed",
-            extra={"requested_queue": queue_name, "allowed_queues": list(allowed)},
+            extra={
+                "requested_queue": queue_name,
+                "fallback_queue": default_queue,
+                "allowed_queues": list(allowed),
+                "rq_job_id": job_id,
+            },
         )
         queue_name = default_queue
 
     queue = _RQ_QUEUES.get(queue_name)
     if queue is None:
-        redis_url = _require_env("REDIS_URL")
-        redis_sync = Redis.from_url(redis_url)
+        redis_sync = _get_rq_redis()
         queue = Queue(queue_name, connection=redis_sync)
         _RQ_QUEUES[queue_name] = queue
     return queue

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -124,7 +124,7 @@ def _get_rq_queue(queue_name: str | None = None) -> Queue:
 
     if queue_name not in allowed:
         job_id = getattr(current_job, "id", None)
-        logger.warning(
+        logger.error(
             "queue_name_not_allowed",
             extra={
                 "requested_queue": queue_name,

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -322,17 +322,25 @@ class TestGetCurrentJobContract:
     misrouting that would only surface in integration tests.
     """
 
-    def test_rq_job_has_origin_attribute(self):
-        """Verify rq.Job instances expose the 'origin' attribute we rely on."""
-        import inspect
+    def test_rq_job_exposes_origin_at_runtime(self):
+        """Verify rq.Job instances expose the 'origin' attribute at runtime."""
+        from unittest.mock import MagicMock
 
         from rq.job import Job
 
-        # origin is set as an instance attribute in Job.__init__
-        init_source = inspect.getsource(Job.__init__)
-        assert "self.origin" in init_source, (
-            "rq.Job.__init__ no longer sets 'self.origin'; "
+        # Create a minimal Job instance with a mock connection to verify
+        # 'origin' is a real instance attribute set during init
+        mock_conn = MagicMock()
+        mock_conn.pipeline.return_value.__enter__ = MagicMock()
+        mock_conn.pipeline.return_value.__exit__ = MagicMock()
+        job = Job(connection=mock_conn)
+        assert hasattr(job, "origin"), (
+            "rq.Job no longer exposes 'origin' attribute; "
             "_get_rq_queue queue routing will not work correctly"
+        )
+        # origin should be a string (empty by default for a fresh job)
+        assert isinstance(job.origin, str), (
+            f"rq.Job.origin has unexpected type {type(job.origin).__name__}; " "expected str"
         )
 
     def test_get_current_job_returns_none_outside_worker(self):
@@ -340,6 +348,60 @@ class TestGetCurrentJobContract:
         from rq import get_current_job
 
         assert get_current_job() is None
+
+
+class TestRetryRoutingEndToEnd:
+    """Verify the full retry scheduling path enqueues to the correct queue.
+
+    This simulates the _build_executor -> schedule_retry path to confirm
+    retries are enqueued to the originating queue, not a hard-coded default.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_retry_enqueues_to_origin_queue(self):
+        """Verify schedule_retry callback enqueues to the current job's origin queue."""
+        mock_db_pool = AsyncMock()
+        mock_redis = AsyncMock()
+        mock_poison = Mock()
+        mock_limiter = Mock()
+        mock_queue = Mock()
+
+        resources = AsyncResources(
+            db_pool=mock_db_pool,
+            redis_client=mock_redis,
+            poison_queue=mock_poison,
+            rate_limiter=mock_limiter,
+        )
+
+        with (
+            patch("apps.alert_worker.entrypoint._get_rq_queue") as mock_get_queue,
+            patch("apps.alert_worker.entrypoint._get_channels"),
+            patch("apps.alert_worker.entrypoint.DeliveryExecutor") as mock_executor_class,
+            patch("apps.alert_worker.entrypoint.asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_get_queue.return_value = mock_queue
+            mock_to_thread.return_value = None
+
+            await _build_executor(
+                resources=resources,
+                delivery_id="test-id",
+                channel="email",
+                recipient="test@example.com",
+                subject="Test Subject",
+                body="Test Body",
+            )
+
+            # Verify _get_rq_queue was called (inherits current job's origin)
+            mock_get_queue.assert_called_once()
+
+            # Get the retry_scheduler and invoke it
+            retry_scheduler = mock_executor_class.call_args[1]["retry_scheduler"]
+            await retry_scheduler(delay=30, next_attempt=1)
+
+            # Verify the retry was enqueued to the queue from _get_rq_queue
+            mock_to_thread.assert_called_once()
+            enqueue_fn = mock_to_thread.call_args[0][0]
+            assert enqueue_fn == mock_queue.enqueue_in
 
 
 class TestCreateAsyncResources:

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -17,6 +17,7 @@ from apps.alert_worker.entrypoint import (
     _get_allowed_queues,
     _get_channels,
     _get_rq_queue,
+    _get_rq_redis,
     _require_env,
     _reset_queue_state,
     execute_delivery_job,
@@ -119,7 +120,7 @@ class TestGetRQQueue:
             assert result == mock_queue
 
     def test_get_rq_queue_falls_back_for_unrecognised_origin(self, monkeypatch):
-        """Test that an unrecognised origin falls back to first allowed queue and logs a warning."""
+        """Test that an unrecognised origin falls back to first allowed queue and logs an error."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
         mock_redis = Mock()
 
@@ -140,14 +141,14 @@ class TestGetRQQueue:
 
             result = _get_rq_queue()
 
-            # Should fall back to "alerts" (first allowed queue) and log warning
+            # Should fall back to "alerts" (first allowed queue) and log error
             mock_queue_class.assert_called_once_with("alerts", connection=mock_redis)
             assert result == mock_queue
-            mock_logger.warning.assert_called_once()
-            warning_extra = mock_logger.warning.call_args[1]["extra"]
-            assert warning_extra["requested_queue"] == "rogue_queue"
-            assert warning_extra["fallback_queue"] == "alerts"
-            assert warning_extra["rq_job_id"] == "job-123"
+            mock_logger.error.assert_called_once()
+            error_extra = mock_logger.error.call_args[1]["extra"]
+            assert error_extra["requested_queue"] == "rogue_queue"
+            assert error_extra["fallback_queue"] == "alerts"
+            assert error_extra["rq_job_id"] == "job-123"
 
     def test_get_rq_queue_falls_back_to_first_allowed_when_alerts_not_configured(self, monkeypatch):
         """Test fallback uses first (highest-priority) allowed queue when 'alerts' is not in RQ_QUEUES."""
@@ -176,7 +177,7 @@ class TestGetRQQueue:
             # Should fall back to first allowed queue ("alerts_low" - highest priority)
             mock_queue_class.assert_called_once_with("alerts_low", connection=mock_redis)
             assert result == mock_queue
-            mock_logger.warning.assert_called_once()
+            mock_logger.error.assert_called_once()
 
     def test_get_rq_queue_default_uses_first_allowed_when_no_job(self, monkeypatch):
         """Test default queue is first allowed queue when no current job exists."""
@@ -350,36 +351,77 @@ class TestGetCurrentJobContract:
         assert get_current_job() is None
 
 
+class TestGetRqRedis:
+    """Test _get_rq_redis function."""
+
+    def test_creates_redis_from_env(self, monkeypatch):
+        """Test _get_rq_redis creates Redis client from REDIS_URL env var."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        with (
+            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", None),
+        ):
+            mock_redis = Mock()
+            mock_redis_class.from_url.return_value = mock_redis
+
+            result = _get_rq_redis()
+
+            mock_redis_class.from_url.assert_called_once_with("redis://localhost:6379")
+            assert result is mock_redis
+
+    def test_returns_cached_client(self):
+        """Test _get_rq_redis returns cached client on subsequent calls."""
+        mock_redis = Mock()
+
+        with patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis):
+            result = _get_rq_redis()
+            assert result is mock_redis
+
+
 class TestRetryRoutingEndToEnd:
     """Verify the full retry scheduling path enqueues to the correct queue.
 
-    This simulates the _build_executor -> schedule_retry path to confirm
-    retries are enqueued to the originating queue, not a hard-coded default.
+    Uses the real _get_rq_queue (not mocked) to verify origin resolution
+    through _build_executor -> schedule_retry.
     """
 
     @pytest.mark.asyncio()
     async def test_retry_enqueues_to_origin_queue(self):
-        """Verify schedule_retry callback enqueues to the current job's origin queue."""
+        """Verify schedule_retry uses the queue resolved from current job's origin."""
         mock_db_pool = AsyncMock()
-        mock_redis = AsyncMock()
+        mock_redis_async = AsyncMock()
         mock_poison = Mock()
         mock_limiter = Mock()
+        mock_redis_sync = Mock()
         mock_queue = Mock()
 
         resources = AsyncResources(
             db_pool=mock_db_pool,
-            redis_client=mock_redis,
+            redis_client=mock_redis_async,
             poison_queue=mock_poison,
             rate_limiter=mock_limiter,
         )
 
         with (
-            patch("apps.alert_worker.entrypoint._get_rq_queue") as mock_get_queue,
+            # Use real _get_rq_queue, mock its dependencies
+            patch(
+                "apps.alert_worker.entrypoint.get_current_job",
+                return_value=Mock(origin="alerts_high", id="job-456"),
+            ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis_sync),
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                ("alerts", "alerts_high"),
+            ),
+            patch(
+                "apps.alert_worker.entrypoint.Queue", return_value=mock_queue
+            ) as mock_queue_class,
             patch("apps.alert_worker.entrypoint._get_channels"),
             patch("apps.alert_worker.entrypoint.DeliveryExecutor") as mock_executor_class,
             patch("apps.alert_worker.entrypoint.asyncio.to_thread") as mock_to_thread,
         ):
-            mock_get_queue.return_value = mock_queue
             mock_to_thread.return_value = None
 
             await _build_executor(
@@ -391,14 +433,14 @@ class TestRetryRoutingEndToEnd:
                 body="Test Body",
             )
 
-            # Verify _get_rq_queue was called (inherits current job's origin)
-            mock_get_queue.assert_called_once()
+            # _get_rq_queue should have resolved to "alerts_high" from job origin
+            mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis_sync)
 
             # Get the retry_scheduler and invoke it
             retry_scheduler = mock_executor_class.call_args[1]["retry_scheduler"]
             await retry_scheduler(delay=30, next_attempt=1)
 
-            # Verify the retry was enqueued to the queue from _get_rq_queue
+            # Verify the retry was enqueued to the origin queue
             mock_to_thread.assert_called_once()
             enqueue_fn = mock_to_thread.call_args[0][0]
             assert enqueue_fn == mock_queue.enqueue_in

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -58,7 +58,7 @@ class TestGetRQQueue:
         with (
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
-            patch("apps.alert_worker.entrypoint._RQ_QUEUE", None),
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -78,6 +78,7 @@ class TestGetRQQueue:
         with (
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -89,9 +90,30 @@ class TestGetRQQueue:
             # Second call
             result2 = _get_rq_queue()
 
-            # Should only create once
-            assert mock_redis_class.from_url.call_count <= 2  # May be called during import
+            assert mock_redis_class.from_url.call_count == 1
+            assert mock_queue_class.call_count == 1
             assert result1 == result2
+
+    def test_get_rq_queue_uses_current_job_origin_when_available(self, monkeypatch):
+        """Test retries target the current job's origin queue instead of hard-coded alerts."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        with (
+            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
+            patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+        ):
+            mock_redis = Mock()
+            mock_redis_class.from_url.return_value = mock_redis
+            mock_queue = Mock()
+            mock_queue_class.return_value = mock_queue
+            mock_get_current_job.return_value = Mock(origin="alerts_high")
+
+            result = _get_rq_queue()
+
+            mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis)
+            assert result == mock_queue
 
 
 class TestCreateAsyncResources:

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -60,7 +60,7 @@ class TestGetRQQueue:
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
-            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", frozenset({"alerts"})),
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", ("alerts",)),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -81,7 +81,7 @@ class TestGetRQQueue:
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
-            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", frozenset({"alerts"})),
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", ("alerts",)),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -108,7 +108,7 @@ class TestGetRQQueue:
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch(
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
-                frozenset({"alerts", "alerts_high"}),
+                ("alerts", "alerts_high"),
             ),
         ):
             mock_redis = Mock()
@@ -133,7 +133,7 @@ class TestGetRQQueue:
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch(
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
-                frozenset({"alerts"}),
+                ("alerts",),
             ),
             patch("apps.alert_worker.entrypoint.logger") as mock_logger,
         ):
@@ -153,7 +153,7 @@ class TestGetRQQueue:
             assert warning_extra["requested_queue"] == "rogue_queue"
 
     def test_get_rq_queue_falls_back_to_first_allowed_when_alerts_not_configured(self, monkeypatch):
-        """Test fallback uses first allowed queue when 'alerts' is not in RQ_QUEUES."""
+        """Test fallback uses first (highest-priority) allowed queue when 'alerts' is not in RQ_QUEUES."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
 
         with (
@@ -161,9 +161,10 @@ class TestGetRQQueue:
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            # alerts_low listed first = highest priority
             patch(
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
-                frozenset({"alerts_high", "alerts_low"}),
+                ("alerts_low", "alerts_high"),
             ),
             patch("apps.alert_worker.entrypoint.logger") as mock_logger,
         ):
@@ -176,8 +177,8 @@ class TestGetRQQueue:
 
             result = _get_rq_queue()
 
-            # Should fall back to first sorted allowed queue ("alerts_high")
-            mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis)
+            # Should fall back to first allowed queue ("alerts_low" - highest priority)
+            mock_queue_class.assert_called_once_with("alerts_low", connection=mock_redis)
             assert result == mock_queue
             mock_logger.warning.assert_called_once()
 
@@ -192,7 +193,7 @@ class TestGetRQQueue:
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch(
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
-                frozenset({"alerts_high"}),
+                ("alerts_high",),
             ),
         ):
             mock_redis = Mock()
@@ -218,7 +219,7 @@ class TestGetRQQueue:
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch(
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
-                frozenset({"alerts", "alerts_high"}),
+                ("alerts", "alerts_high"),
             ),
         ):
             mock_redis = Mock()
@@ -247,22 +248,29 @@ class TestGetAllowedQueues:
     """Test _get_allowed_queues function."""
 
     def test_defaults_to_alerts_when_env_unset(self, monkeypatch):
-        """Test _get_allowed_queues returns {'alerts'} when RQ_QUEUES is unset."""
+        """Test _get_allowed_queues returns ('alerts',) when RQ_QUEUES is unset."""
         monkeypatch.delenv("RQ_QUEUES", raising=False)
         with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None):
             result = _get_allowed_queues()
-            assert result == frozenset({"alerts"})
+            assert result == ("alerts",)
 
-    def test_parses_comma_separated_env(self, monkeypatch):
-        """Test _get_allowed_queues parses RQ_QUEUES env var."""
-        monkeypatch.setenv("RQ_QUEUES", "alerts, alerts_high, alerts_low")
+    def test_parses_comma_separated_env_preserving_order(self, monkeypatch):
+        """Test _get_allowed_queues parses RQ_QUEUES preserving operator-defined priority order."""
+        monkeypatch.setenv("RQ_QUEUES", "alerts_high, alerts, alerts_low")
         with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None):
             result = _get_allowed_queues()
-            assert result == frozenset({"alerts", "alerts_high", "alerts_low"})
+            assert result == ("alerts_high", "alerts", "alerts_low")
+
+    def test_deduplicates_preserving_first_occurrence(self, monkeypatch):
+        """Test _get_allowed_queues deduplicates while preserving first occurrence order."""
+        monkeypatch.setenv("RQ_QUEUES", "alerts_high, alerts, alerts_high, alerts_low")
+        with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None):
+            result = _get_allowed_queues()
+            assert result == ("alerts_high", "alerts", "alerts_low")
 
     def test_returns_cached_result(self, monkeypatch):
         """Test _get_allowed_queues caches result."""
-        cached = frozenset({"cached_queue"})
+        cached = ("cached_queue",)
         with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", cached):
             result = _get_allowed_queues()
             assert result is cached
@@ -801,11 +809,12 @@ class TestMain:
             mock_worker_class.assert_called_once_with(["alerts"], connection=mock_redis)
             mock_worker.work.assert_called_once_with(with_scheduler=True)
 
-    def test_main_starts_worker_with_custom_queues(self, monkeypatch):
-        """Test main starts RQ worker with custom queues from RQ_QUEUES env."""
+    def test_main_starts_worker_with_custom_queues_preserving_priority_order(self, monkeypatch):
+        """Test main starts RQ worker with custom queues in operator-defined priority order."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
         monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost/db")
-        monkeypatch.setenv("RQ_QUEUES", "alerts,high_priority,low_priority")
+        # Intentionally non-alphabetical: high_priority first = highest polling priority
+        monkeypatch.setenv("RQ_QUEUES", "high_priority,alerts,low_priority")
 
         with (
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
@@ -831,9 +840,9 @@ class TestMain:
 
             main()
 
-            # Verify worker was created with custom queues (sorted)
+            # Verify worker was created with queues in operator-defined order (not sorted)
             mock_worker_class.assert_called_once_with(
-                ["alerts", "high_priority", "low_priority"], connection=mock_redis
+                ["high_priority", "alerts", "low_priority"], connection=mock_redis
             )
             mock_worker.work.assert_called_once_with(with_scheduler=True)
 

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -14,6 +14,7 @@ from apps.alert_worker.entrypoint import (
     _close_async_resources,
     _create_async_resources,
     _execute_delivery_job,
+    _get_allowed_queues,
     _get_channels,
     _get_rq_queue,
     _require_env,
@@ -59,6 +60,7 @@ class TestGetRQQueue:
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", frozenset({"alerts"})),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -79,6 +81,7 @@ class TestGetRQQueue:
             patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", frozenset({"alerts"})),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -103,6 +106,10 @@ class TestGetRQQueue:
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                frozenset({"alerts", "alerts_high"}),
+            ),
         ):
             mock_redis = Mock()
             mock_redis_class.from_url.return_value = mock_redis
@@ -114,6 +121,95 @@ class TestGetRQQueue:
 
             mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis)
             assert result == mock_queue
+
+    def test_get_rq_queue_falls_back_for_unrecognised_origin(self, monkeypatch):
+        """Test that an unrecognised origin falls back to 'alerts' and logs a warning."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        with (
+            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
+            patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                frozenset({"alerts"}),
+            ),
+            patch("apps.alert_worker.entrypoint.logger") as mock_logger,
+        ):
+            mock_redis = Mock()
+            mock_redis_class.from_url.return_value = mock_redis
+            mock_queue = Mock()
+            mock_queue_class.return_value = mock_queue
+            mock_get_current_job.return_value = Mock(origin="rogue_queue")
+
+            result = _get_rq_queue()
+
+            # Should fall back to "alerts" and log warning
+            mock_queue_class.assert_called_once_with("alerts", connection=mock_redis)
+            assert result == mock_queue
+            mock_logger.warning.assert_called_once()
+            warning_extra = mock_logger.warning.call_args[1]["extra"]
+            assert warning_extra["requested_queue"] == "rogue_queue"
+
+    def test_get_rq_queue_caches_per_origin_without_cross_contamination(self, monkeypatch):
+        """Test multiple distinct origins each get their own cached Queue."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        with (
+            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
+            patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                frozenset({"alerts", "alerts_high"}),
+            ),
+        ):
+            mock_redis = Mock()
+            mock_redis_class.from_url.return_value = mock_redis
+
+            queue_alerts = Mock(name="queue_alerts")
+            queue_high = Mock(name="queue_alerts_high")
+            mock_queue_class.side_effect = [queue_alerts, queue_high]
+
+            result_alerts = _get_rq_queue("alerts")
+            result_high = _get_rq_queue("alerts_high")
+            # Re-fetch to verify caching
+            result_alerts_again = _get_rq_queue("alerts")
+            result_high_again = _get_rq_queue("alerts_high")
+
+            # Each queue created exactly once
+            assert mock_queue_class.call_count == 2
+            # No cross-contamination
+            assert result_alerts is queue_alerts
+            assert result_high is queue_high
+            assert result_alerts_again is queue_alerts
+            assert result_high_again is queue_high
+
+
+class TestGetAllowedQueues:
+    """Test _get_allowed_queues function."""
+
+    def test_defaults_to_alerts_when_env_unset(self, monkeypatch):
+        """Test _get_allowed_queues returns {'alerts'} when RQ_QUEUES is unset."""
+        monkeypatch.delenv("RQ_QUEUES", raising=False)
+        with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None):
+            result = _get_allowed_queues()
+            assert result == frozenset({"alerts"})
+
+    def test_parses_comma_separated_env(self, monkeypatch):
+        """Test _get_allowed_queues parses RQ_QUEUES env var."""
+        monkeypatch.setenv("RQ_QUEUES", "alerts, alerts_high, alerts_low")
+        with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None):
+            result = _get_allowed_queues()
+            assert result == frozenset({"alerts", "alerts_high", "alerts_low"})
+
+    def test_returns_cached_result(self, monkeypatch):
+        """Test _get_allowed_queues caches result."""
+        cached = frozenset({"cached_queue"})
+        with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", cached):
+            result = _get_allowed_queues()
+            assert result is cached
 
 
 class TestCreateAsyncResources:

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -18,6 +18,7 @@ from apps.alert_worker.entrypoint import (
     _get_channels,
     _get_rq_queue,
     _require_env,
+    _reset_queue_state,
     execute_delivery_job,
     main,
 )
@@ -290,6 +291,55 @@ class TestGetAllowedQueues:
         with patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", cached):
             result = _get_allowed_queues()
             assert result is cached
+
+
+class TestResetQueueState:
+    """Test _reset_queue_state function."""
+
+    def test_reset_clears_all_queue_caches(self, monkeypatch):
+        """Test _reset_queue_state clears allowed queues, Redis client, and queue cache."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        import apps.alert_worker.entrypoint as mod
+
+        # Set some state
+        mod._ALLOWED_QUEUES = ("test",)
+        mod._RQ_REDIS = Mock()
+        mod._RQ_QUEUES["test"] = Mock()
+
+        _reset_queue_state()
+
+        assert mod._ALLOWED_QUEUES is None
+        assert mod._RQ_REDIS is None
+        assert len(mod._RQ_QUEUES) == 0
+
+
+class TestGetCurrentJobContract:
+    """Verify rq.get_current_job contract assumptions.
+
+    These tests ensure our assumptions about the RQ API remain valid
+    across library version upgrades, reducing the risk of silent
+    misrouting that would only surface in integration tests.
+    """
+
+    def test_rq_job_has_origin_attribute(self):
+        """Verify rq.Job instances expose the 'origin' attribute we rely on."""
+        import inspect
+
+        from rq.job import Job
+
+        # origin is set as an instance attribute in Job.__init__
+        init_source = inspect.getsource(Job.__init__)
+        assert "self.origin" in init_source, (
+            "rq.Job.__init__ no longer sets 'self.origin'; "
+            "_get_rq_queue queue routing will not work correctly"
+        )
+
+    def test_get_current_job_returns_none_outside_worker(self):
+        """Verify get_current_job() returns None when not inside a worker."""
+        from rq import get_current_job
+
+        assert get_current_job() is None
 
 
 class TestCreateAsyncResources:

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -55,36 +55,33 @@ class TestGetRQQueue:
     def test_get_rq_queue_creates_queue(self, monkeypatch):
         """Test _get_rq_queue creates Queue with correct parameters."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", ("alerts",)),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
             mock_queue = Mock()
             mock_queue_class.return_value = mock_queue
 
             result = _get_rq_queue()
 
-            mock_redis_class.from_url.assert_called_once_with("redis://localhost:6379")
             mock_queue_class.assert_called_once_with("alerts", connection=mock_redis)
             assert result == mock_queue
 
     def test_get_rq_queue_returns_cached_instance(self, monkeypatch):
         """Test _get_rq_queue returns cached instance on subsequent calls."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", ("alerts",)),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
             mock_queue = Mock()
             mock_queue_class.return_value = mock_queue
 
@@ -93,16 +90,15 @@ class TestGetRQQueue:
             # Second call
             result2 = _get_rq_queue()
 
-            assert mock_redis_class.from_url.call_count == 1
             assert mock_queue_class.call_count == 1
             assert result1 == result2
 
     def test_get_rq_queue_uses_current_job_origin_when_available(self, monkeypatch):
         """Test retries target the current job's origin queue instead of hard-coded alerts."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
@@ -110,9 +106,8 @@ class TestGetRQQueue:
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
                 ("alerts", "alerts_high"),
             ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
             mock_queue = Mock()
             mock_queue_class.return_value = mock_queue
             mock_get_current_job.return_value = Mock(origin="alerts_high")
@@ -125,9 +120,9 @@ class TestGetRQQueue:
     def test_get_rq_queue_falls_back_for_unrecognised_origin(self, monkeypatch):
         """Test that an unrecognised origin falls back to first allowed queue and logs a warning."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
@@ -135,13 +130,12 @@ class TestGetRQQueue:
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
                 ("alerts",),
             ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
             patch("apps.alert_worker.entrypoint.logger") as mock_logger,
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
             mock_queue = Mock()
             mock_queue_class.return_value = mock_queue
-            mock_get_current_job.return_value = Mock(origin="rogue_queue")
+            mock_get_current_job.return_value = Mock(origin="rogue_queue", id="job-123")
 
             result = _get_rq_queue()
 
@@ -151,13 +145,15 @@ class TestGetRQQueue:
             mock_logger.warning.assert_called_once()
             warning_extra = mock_logger.warning.call_args[1]["extra"]
             assert warning_extra["requested_queue"] == "rogue_queue"
+            assert warning_extra["fallback_queue"] == "alerts"
+            assert warning_extra["rq_job_id"] == "job-123"
 
     def test_get_rq_queue_falls_back_to_first_allowed_when_alerts_not_configured(self, monkeypatch):
         """Test fallback uses first (highest-priority) allowed queue when 'alerts' is not in RQ_QUEUES."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
@@ -166,10 +162,9 @@ class TestGetRQQueue:
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
                 ("alerts_low", "alerts_high"),
             ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
             patch("apps.alert_worker.entrypoint.logger") as mock_logger,
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
             mock_queue = Mock()
             mock_queue_class.return_value = mock_queue
             # Simulate rogue origin when "alerts" is not even in the allowed set
@@ -185,9 +180,9 @@ class TestGetRQQueue:
     def test_get_rq_queue_default_uses_first_allowed_when_no_job(self, monkeypatch):
         """Test default queue is first allowed queue when no current job exists."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
@@ -195,9 +190,8 @@ class TestGetRQQueue:
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
                 ("alerts_high",),
             ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
             mock_queue = Mock()
             mock_queue_class.return_value = mock_queue
             # No current job
@@ -209,22 +203,44 @@ class TestGetRQQueue:
             mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis)
             assert result == mock_queue
 
-    def test_get_rq_queue_caches_per_origin_without_cross_contamination(self, monkeypatch):
-        """Test multiple distinct origins each get their own cached Queue."""
+    def test_get_rq_queue_shares_single_redis_connection(self, monkeypatch):
+        """Test all cached queues share a single Redis connection."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
 
         with (
-            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
             patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
             patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
             patch(
                 "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
                 ("alerts", "alerts_high"),
             ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
         ):
-            mock_redis = Mock()
-            mock_redis_class.from_url.return_value = mock_redis
+            mock_queue_class.side_effect = [Mock(name="q1"), Mock(name="q2")]
 
+            _get_rq_queue("alerts")
+            _get_rq_queue("alerts_high")
+
+            # Both queues should share the same Redis connection
+            calls = mock_queue_class.call_args_list
+            assert calls[0][1]["connection"] is mock_redis
+            assert calls[1][1]["connection"] is mock_redis
+
+    def test_get_rq_queue_caches_per_origin_without_cross_contamination(self, monkeypatch):
+        """Test multiple distinct origins each get their own cached Queue."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        mock_redis = Mock()
+
+        with (
+            patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                ("alerts", "alerts_high"),
+            ),
+            patch("apps.alert_worker.entrypoint._RQ_REDIS", mock_redis),
+        ):
             queue_alerts = Mock(name="queue_alerts")
             queue_high = Mock(name="queue_alerts_high")
             mock_queue_class.side_effect = [queue_alerts, queue_high]

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -123,7 +123,7 @@ class TestGetRQQueue:
             assert result == mock_queue
 
     def test_get_rq_queue_falls_back_for_unrecognised_origin(self, monkeypatch):
-        """Test that an unrecognised origin falls back to 'alerts' and logs a warning."""
+        """Test that an unrecognised origin falls back to first allowed queue and logs a warning."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
 
         with (
@@ -145,12 +145,68 @@ class TestGetRQQueue:
 
             result = _get_rq_queue()
 
-            # Should fall back to "alerts" and log warning
+            # Should fall back to "alerts" (first allowed queue) and log warning
             mock_queue_class.assert_called_once_with("alerts", connection=mock_redis)
             assert result == mock_queue
             mock_logger.warning.assert_called_once()
             warning_extra = mock_logger.warning.call_args[1]["extra"]
             assert warning_extra["requested_queue"] == "rogue_queue"
+
+    def test_get_rq_queue_falls_back_to_first_allowed_when_alerts_not_configured(self, monkeypatch):
+        """Test fallback uses first allowed queue when 'alerts' is not in RQ_QUEUES."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        with (
+            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
+            patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                frozenset({"alerts_high", "alerts_low"}),
+            ),
+            patch("apps.alert_worker.entrypoint.logger") as mock_logger,
+        ):
+            mock_redis = Mock()
+            mock_redis_class.from_url.return_value = mock_redis
+            mock_queue = Mock()
+            mock_queue_class.return_value = mock_queue
+            # Simulate rogue origin when "alerts" is not even in the allowed set
+            mock_get_current_job.return_value = Mock(origin="rogue_queue")
+
+            result = _get_rq_queue()
+
+            # Should fall back to first sorted allowed queue ("alerts_high")
+            mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis)
+            assert result == mock_queue
+            mock_logger.warning.assert_called_once()
+
+    def test_get_rq_queue_default_uses_first_allowed_when_no_job(self, monkeypatch):
+        """Test default queue is first allowed queue when no current job exists."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+        with (
+            patch("apps.alert_worker.entrypoint.Redis") as mock_redis_class,
+            patch("apps.alert_worker.entrypoint.Queue") as mock_queue_class,
+            patch("apps.alert_worker.entrypoint.get_current_job") as mock_get_current_job,
+            patch.dict("apps.alert_worker.entrypoint._RQ_QUEUES", {}, clear=True),
+            patch(
+                "apps.alert_worker.entrypoint._ALLOWED_QUEUES",
+                frozenset({"alerts_high"}),
+            ),
+        ):
+            mock_redis = Mock()
+            mock_redis_class.from_url.return_value = mock_redis
+            mock_queue = Mock()
+            mock_queue_class.return_value = mock_queue
+            # No current job
+            mock_get_current_job.return_value = None
+
+            result = _get_rq_queue()
+
+            # Should default to "alerts_high" (only allowed queue)
+            mock_queue_class.assert_called_once_with("alerts_high", connection=mock_redis)
+            assert result == mock_queue
 
     def test_get_rq_queue_caches_per_origin_without_cross_contamination(self, monkeypatch):
         """Test multiple distinct origins each get their own cached Queue."""
@@ -722,6 +778,7 @@ class TestMain:
             patch("apps.alert_worker.entrypoint.ConnectionPool") as mock_pool_class,
             patch("apps.alert_worker.entrypoint.Worker") as mock_worker_class,
             patch("apps.alert_worker.entrypoint.asyncio.run") as mock_asyncio_run,
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None),
         ):
             mock_redis = Mock()
             mock_redis.ping.return_value = True
@@ -755,6 +812,7 @@ class TestMain:
             patch("apps.alert_worker.entrypoint.ConnectionPool") as mock_pool_class,
             patch("apps.alert_worker.entrypoint.Worker") as mock_worker_class,
             patch("apps.alert_worker.entrypoint.asyncio.run") as mock_asyncio_run,
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None),
         ):
             mock_redis = Mock()
             mock_redis.ping.return_value = True
@@ -773,7 +831,7 @@ class TestMain:
 
             main()
 
-            # Verify worker was created with custom queues
+            # Verify worker was created with custom queues (sorted)
             mock_worker_class.assert_called_once_with(
                 ["alerts", "high_priority", "low_priority"], connection=mock_redis
             )
@@ -789,6 +847,7 @@ class TestMain:
             patch("apps.alert_worker.entrypoint.ConnectionPool") as mock_pool_class,
             patch("apps.alert_worker.entrypoint.Worker") as mock_worker_class,
             patch("apps.alert_worker.entrypoint.asyncio.run") as mock_asyncio_run,
+            patch("apps.alert_worker.entrypoint._ALLOWED_QUEUES", None),
         ):
             mock_redis = Mock()
             mock_redis.ping.return_value = True


### PR DESCRIPTION
## Summary
- preserve the originating RQ queue when scheduling alert retries
- fall back to the default alerts queue only when there is no current job origin
- add regression coverage for per-queue caching and retry queue selection

## Testing
- poetry run pytest -q tests/apps/alert_worker/test_entrypoint.py
- poetry run ruff check apps/alert_worker/entrypoint.py tests/apps/alert_worker/test_entrypoint.py

Fixes #155