### PR TITLE
Fix #157: replace synthetic execution-vs-VWAP chart with real benchmark data

### DIFF
--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -144,6 +144,11 @@ async def shutdown() -> None:
     except (OSError, ConnectionError) as e:
         logger.warning("Failed to close Redis connection during shutdown: %s", e)
 
+    # Close shared httpx client used by TCA dashboard
+    from apps.web_console_ng.pages.execution_quality import close_shared_client
+
+    await close_shared_client()
+
 
 app.on_startup(startup)
 app.on_shutdown(shutdown)

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -800,6 +800,20 @@ async def _render_tca_dashboard(
                         and _is_valid_price(p.get("benchmark_price"))
                     ]
                     if valid_points:
+                        # Warn if the backend may have truncated data.
+                        # Prefer the ``truncated`` flag from the API
+                        # when present; fall back to comparing point
+                        # count against the known backend fill limit.
+                        is_truncated = benchmark_data.get("truncated")
+                        if is_truncated is None:
+                            raw_count = len(benchmark_data.get("points", []))
+                            is_truncated = raw_count >= _BACKEND_FILL_LIMIT
+                        if is_truncated:
+                            ui.label(
+                                "Note: benchmark data may be truncated "
+                                f"(showing first {len(valid_points)} fills)."
+                            ).classes("text-amber-500 text-xs mb-1")
+
                         create_benchmark_comparison_chart(
                             timestamps=[str(point.get("timestamp", "")) for point in valid_points],
                             execution_prices=[

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -46,6 +46,7 @@ def _stable_hash(value: str) -> int:
     """
     return int(hashlib.sha256(value.encode()).hexdigest(), 16)
 
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_RANGE_DAYS = 30
@@ -226,24 +227,26 @@ def _generate_demo_data(
         symbol = random.choice(symbols)
         side = random.choice(["buy", "sell"])
 
-        orders.append({
-            "client_order_id": f"demo-{i:04d}",
-            "symbol": symbol,
-            "side": side,
-            "execution_date": order_date.isoformat(),
-            "target_qty": random.randint(100, 2000),
-            "filled_qty": random.randint(80, 2000),
-            "fill_rate": random.uniform(0.85, 1.0),
-            "implementation_shortfall_bps": random.uniform(-5, 15),
-            "price_shortfall_bps": random.uniform(-3, 8),
-            "vwap_slippage_bps": random.uniform(-2, 5),
-            "fee_cost_bps": random.uniform(0.5, 2),
-            "opportunity_cost_bps": random.uniform(0, 3),
-            "timing_cost_bps": random.uniform(0.5, 2),
-            "market_impact_bps": random.uniform(0, 4),
-            "total_notional": random.uniform(10000, 100000),
-            "warnings": ["Demo data"],
-        })
+        orders.append(
+            {
+                "client_order_id": f"demo-{i:04d}",
+                "symbol": symbol,
+                "side": side,
+                "execution_date": order_date.isoformat(),
+                "target_qty": random.randint(100, 2000),
+                "filled_qty": random.randint(80, 2000),
+                "fill_rate": random.uniform(0.85, 1.0),
+                "implementation_shortfall_bps": random.uniform(-5, 15),
+                "price_shortfall_bps": random.uniform(-3, 8),
+                "vwap_slippage_bps": random.uniform(-2, 5),
+                "fee_cost_bps": random.uniform(0.5, 2),
+                "opportunity_cost_bps": random.uniform(0, 3),
+                "timing_cost_bps": random.uniform(0.5, 2),
+                "market_impact_bps": random.uniform(0, 4),
+                "total_notional": random.uniform(10000, 100000),
+                "warnings": ["Demo data"],
+            }
+        )
 
     # Compute averages - collect values explicitly to avoid mypy issues with dict typing
     is_values = [o["implementation_shortfall_bps"] for o in orders]
@@ -310,16 +313,31 @@ def _generate_demo_benchmark_data(order: dict[str, Any]) -> dict[str, Any]:
         "points": [
             {
                 "timestamp": f"{demo_date}T{10 + i // 12:02d}:{(i * 5) % 60:02d}:00Z",
-                "execution_price": round(
-                    base_price * (1 + random.uniform(-0.002, 0.003)), 2
-                ),
-                "benchmark_price": round(
-                    base_price * (1 + random.uniform(-0.001, 0.001)), 2
-                ),
+                "execution_price": round(base_price * (1 + random.uniform(-0.002, 0.003)), 2),
+                "benchmark_price": round(base_price * (1 + random.uniform(-0.001, 0.001)), 2),
             }
             for i in range(num_points)
         ],
     }
+
+
+def _is_cacheable_benchmark(data: dict[str, Any]) -> bool:
+    """Return True when *data* is well-formed enough to cache.
+
+    A benchmark response is cacheable when it contains at least one
+    dict-typed point with finite numeric prices.  This mirrors the
+    render-time validation so that malformed payloads are not cached
+    and will be retried on the next ``load_data`` invocation.
+    """
+    points = data.get("points")
+    if not isinstance(points, list):
+        return False
+    return any(
+        isinstance(p, dict)
+        and _is_numeric(p.get("execution_price"))
+        and _is_numeric(p.get("benchmark_price"))
+        for p in points
+    )
 
 
 def _should_fetch_benchmark(orders: list[dict[str, Any]], demo_mode: bool) -> str | None:
@@ -483,15 +501,9 @@ async def _render_tca_dashboard(
         # Parse dates
         try:
             start_dt = (
-                date.fromisoformat(start_input.value)
-                if start_input.value
-                else state["start_date"]
+                date.fromisoformat(start_input.value) if start_input.value else state["start_date"]
             )
-            end_dt = (
-                date.fromisoformat(end_input.value)
-                if end_input.value
-                else state["end_date"]
-            )
+            end_dt = date.fromisoformat(end_input.value) if end_input.value else state["end_date"]
         except ValueError:
             ui.notify("Invalid date format", type="negative")
             return
@@ -597,12 +609,16 @@ async def _render_tca_dashboard(
                 if current_generation != state["_load_generation"]:
                     return
 
-                if benchmark_data is not None:
+                # Only cache responses whose payload passes the same
+                # shape validation used at render time.  This prevents
+                # malformed-but-200 responses from being cached and
+                # reused, which would block retries on subsequent loads.
+                if benchmark_data is not None and _is_cacheable_benchmark(benchmark_data):
                     state["_benchmark_cache_key"] = fetch_order_id
                     state["_benchmark_cache_data"] = benchmark_data
                 else:
-                    # Clear stale cache so transient failures don't
-                    # stick if the order changes later.
+                    # Clear stale cache so transient failures or
+                    # malformed responses don't stick.
                     state["_benchmark_cache_key"] = None
                     state["_benchmark_cache_data"] = None
         elif orders and state.get("demo_mode"):
@@ -643,8 +659,7 @@ async def _render_tca_dashboard(
                         for d in sorted_dates
                     ]
                     fee_cost = [
-                        round(date_data[d]["fee"] / date_data[d]["count"], 2)
-                        for d in sorted_dates
+                        round(date_data[d]["fee"] / date_data[d]["count"], 2) for d in sorted_dates
                     ]
                     opportunity_cost = [
                         round(date_data[d]["opportunity"] / date_data[d]["count"], 2)
@@ -666,24 +681,16 @@ async def _render_tca_dashboard(
                     ui.label("No order data available").classes("text-gray-500 p-4")
 
             # Validate benchmark payload shape before rendering.
-            raw_points = (
-                benchmark_data.get("points", []) if benchmark_data else []
-            )
+            raw_points = benchmark_data.get("points", []) if benchmark_data else []
             # Guard: points must be a list of dict-like objects.
             if not isinstance(raw_points, list):
                 raw_points = []
-            validated_points: list[dict[str, Any]] = [
-                p for p in raw_points if isinstance(p, dict)
-            ]
+            validated_points: list[dict[str, Any]] = [p for p in raw_points if isinstance(p, dict)]
 
             if benchmark_data and validated_points:
                 with ui.card().classes("w-full p-4"):
-                    bm_symbol = str(
-                        benchmark_data.get("symbol", orders[0].get("symbol", ""))
-                    )
-                    bm_type = str(
-                        benchmark_data.get("benchmark_type", "VWAP")
-                    ).upper()
+                    bm_symbol = str(benchmark_data.get("symbol", orders[0].get("symbol", "")))
+                    bm_type = str(benchmark_data.get("benchmark_type", "VWAP")).upper()
                     chart_title = f"Execution vs {bm_type} — {bm_symbol}"
                     if state.get("demo_mode"):
                         chart_title += " (Demo)"
@@ -701,36 +708,25 @@ async def _render_tca_dashboard(
                     ]
                     if valid_points:
                         create_benchmark_comparison_chart(
-                            timestamps=[
-                                str(point.get("timestamp", ""))
-                                for point in valid_points
-                            ],
+                            timestamps=[str(point.get("timestamp", "")) for point in valid_points],
                             execution_prices=[
-                                _safe_float(point.get("execution_price"))
-                                for point in valid_points
+                                _safe_float(point.get("execution_price")) for point in valid_points
                             ],
                             benchmark_prices=[
-                                _safe_float(point.get("benchmark_price"))
-                                for point in valid_points
+                                _safe_float(point.get("benchmark_price")) for point in valid_points
                             ],
                             benchmark_type=bm_type,
                             symbol=bm_symbol,
                         )
                     else:
-                        ui.label("Benchmark data unavailable").classes(
-                            "text-gray-500 p-4"
-                        )
+                        ui.label("Benchmark data unavailable").classes("text-gray-500 p-4")
             elif orders:
                 # Benchmark API returned no data or invalid payload —
                 # show a diagnostic card so the user knows the section
                 # exists but data is missing.
                 with ui.card().classes("w-full p-4"):
-                    ui.label("Execution vs Benchmark").classes(
-                        "text-lg font-bold mb-2"
-                    )
-                    ui.label("Benchmark data unavailable").classes(
-                        "text-gray-500 p-4"
-                    )
+                    ui.label("Execution vs Benchmark").classes("text-lg font-bold mb-2")
+                    ui.label("Benchmark data unavailable").classes("text-gray-500 p-4")
 
         # Render orders table
         with orders_container:
@@ -752,10 +748,25 @@ async def _render_tca_dashboard(
                         {"field": "execution_date", "headerName": "Date", "sortable": True},
                         {"field": "symbol", "headerName": "Symbol", "sortable": True, "width": 100},
                         {"field": "side", "headerName": "Side", "sortable": True, "width": 80},
-                        {"field": "filled_qty", "headerName": "Filled", "sortable": True, "width": 100},
+                        {
+                            "field": "filled_qty",
+                            "headerName": "Filled",
+                            "sortable": True,
+                            "width": 100,
+                        },
                         {"field": "fill_rate_pct", "headerName": "Fill %", "width": 100},
-                        {"field": "is_bps", "headerName": "IS (bps)", "sortable": True, "width": 100},
-                        {"field": "vwap_bps", "headerName": "VWAP (bps)", "sortable": True, "width": 100},
+                        {
+                            "field": "is_bps",
+                            "headerName": "IS (bps)",
+                            "sortable": True,
+                            "width": 100,
+                        },
+                        {
+                            "field": "vwap_bps",
+                            "headerName": "VWAP (bps)",
+                            "sortable": True,
+                            "width": 100,
+                        },
                         {"field": "impact_bps", "headerName": "Impact (bps)", "width": 100},
                         {"field": "notional", "headerName": "Notional", "width": 120},
                     ]
@@ -768,35 +779,37 @@ async def _render_tca_dashboard(
                         else:
                             notional_str = f"${notional:.0f}"
 
-                        rows.append({
-                            "client_order_id": order.get("client_order_id", f"order-{idx}"),
-                            "execution_date": order.get("execution_date", ""),
-                            "symbol": order.get("symbol", ""),
-                            "side": order.get("side", "").upper(),
-                            "filled_qty": order.get("filled_qty", 0),
-                            "fill_rate_pct": f"{order.get('fill_rate', 0) * 100:.1f}%",
-                            "is_bps": f"{order.get('implementation_shortfall_bps', 0):+.2f}",
-                            "vwap_bps": f"{order.get('vwap_slippage_bps', 0):+.2f}",
-                            "impact_bps": f"{order.get('market_impact_bps', 0):+.2f}",
-                            "notional": notional_str,
-                        })
+                        rows.append(
+                            {
+                                "client_order_id": order.get("client_order_id", f"order-{idx}"),
+                                "execution_date": order.get("execution_date", ""),
+                                "symbol": order.get("symbol", ""),
+                                "side": order.get("side", "").upper(),
+                                "filled_qty": order.get("filled_qty", 0),
+                                "fill_rate_pct": f"{order.get('fill_rate', 0) * 100:.1f}%",
+                                "is_bps": f"{order.get('implementation_shortfall_bps', 0):+.2f}",
+                                "vwap_bps": f"{order.get('vwap_slippage_bps', 0):+.2f}",
+                                "impact_bps": f"{order.get('market_impact_bps', 0):+.2f}",
+                                "notional": notional_str,
+                            }
+                        )
 
                     # Create AG Grid with compact styling and global window registration
-                    grid_options = apply_compact_grid_options({
-                        "columnDefs": column_defs,
-                        "rowData": rows,
-                        "domLayout": "autoHeight",
-                        "rowSelection": "single",
-                        ":getRowId": "params => params.data.client_order_id",
-                        # Register API on window for GridExportToolbar
-                        ":onGridReady": "params => { window['tca-orders-grid'] = params.api; params.api.sizeColumnsToFit(); }",
-                    })
+                    grid_options = apply_compact_grid_options(
+                        {
+                            "columnDefs": column_defs,
+                            "rowData": rows,
+                            "domLayout": "autoHeight",
+                            "rowSelection": "single",
+                            ":getRowId": "params => params.data.client_order_id",
+                            # Register API on window for GridExportToolbar
+                            ":onGridReady": "params => { window['tca-orders-grid'] = params.api; params.api.sizeColumnsToFit(); }",
+                        }
+                    )
 
                     ui.aggrid(grid_options).classes("w-full ag-theme-alpine-dark")
                 else:
-                    ui.label("No orders found for selected filters").classes(
-                        "text-gray-500 p-4"
-                    )
+                    ui.label("No orders found for selected filters").classes("text-gray-500 p-4")
 
     # Preset button handlers
     async def set_preset(days: int) -> None:

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -260,12 +260,15 @@ async def _fetch_tca_benchmarks(
         "symbol": symbol,
         "strategy_id": strategy_id,
     }
-    # Reuse the shared client for connection pooling.
+    # Reuse the shared client for connection pooling.  Use a shorter
+    # per-request timeout (10s) because benchmark fetches block the
+    # dashboard render path and should not stall the UI.
     client = _get_shared_client()
     response = await client.get(
         f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
         params={"client_order_id": client_order_id, "benchmark": benchmark},
         headers=_build_tca_auth_headers(user_id, role, strategies),
+        timeout=10.0,
     )
     if response.status_code == 200:
         result = response.json()

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -51,6 +51,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
+# Time-to-live for cached benchmark data (seconds).  Active orders can
+# accumulate new fills while keeping the same order ID, so the cache
+# must expire periodically to pick up fresh data.
+_BENCHMARK_CACHE_TTL_SECONDS = 120
 # Backend default fill limit for TCA queries (database.py:get_trades_for_tca).
 # Used to detect potential data truncation in the benchmark chart.
 # Note: a "may be truncated" warning is shown when point count reaches this
@@ -482,9 +486,11 @@ async def _render_tca_dashboard(
         "data": None,
         "demo_mode": False,
         # Cache benchmark data to avoid re-fetching on filter changes
-        # when the first order hasn't changed.
+        # when the first order hasn't changed.  Expires after
+        # _BENCHMARK_CACHE_TTL_SECONDS to pick up new fills.
         "_benchmark_cache_key": None,
         "_benchmark_cache_data": None,
+        "_benchmark_cache_time": 0.0,
         # Request versioning to prevent stale async results from
         # overwriting newer UI state on rapid filter changes.
         "_load_generation": 0,
@@ -639,11 +645,18 @@ async def _render_tca_dashboard(
         benchmark_data: dict[str, Any] | None = None
         fetch_order_id = _should_fetch_benchmark(orders, bool(state.get("demo_mode")))
         if fetch_order_id:
+            import time as _time
+
             # Use cached benchmark data if the first order hasn't
-            # changed, avoiding redundant API calls on filter tweaks.
-            # Only cache successful responses so transient failures
-            # are retried on the next load_data invocation.
-            if state.get("_benchmark_cache_key") == fetch_order_id:
+            # changed AND the cache hasn't expired, avoiding redundant
+            # API calls on rapid filter tweaks while still refreshing
+            # periodically to pick up new fills.
+            cache_age = _time.monotonic() - state.get("_benchmark_cache_time", 0.0)
+            cache_valid = (
+                state.get("_benchmark_cache_key") == fetch_order_id
+                and cache_age < _BENCHMARK_CACHE_TTL_SECONDS
+            )
+            if cache_valid:
                 benchmark_data = state["_benchmark_cache_data"]
             else:
                 try:
@@ -694,11 +707,13 @@ async def _render_tca_dashboard(
                 if benchmark_data is not None and _is_cacheable_benchmark(benchmark_data):
                     state["_benchmark_cache_key"] = fetch_order_id
                     state["_benchmark_cache_data"] = benchmark_data
+                    state["_benchmark_cache_time"] = _time.monotonic()
                 else:
                     # Clear stale cache so transient failures or
                     # malformed responses don't stick.
                     state["_benchmark_cache_key"] = None
                     state["_benchmark_cache_data"] = None
+                    state["_benchmark_cache_time"] = 0.0
         elif orders and state.get("demo_mode"):
             # Generate deterministic demo benchmark data so the chart
             # section is still visible in demo/fallback mode.

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -147,6 +147,24 @@ def _is_numeric(value: Any) -> bool:
     return math.isfinite(result)
 
 
+def _is_valid_price(value: Any) -> bool:
+    """Return True if *value* is a finite positive price.
+
+    Rejects zero, negative, NaN, infinity, booleans, and non-numeric values.
+    This is stricter than ``_is_numeric`` because zero and negative values
+    are not valid prices and would distort charts.
+    """
+    import math
+
+    if isinstance(value, bool):
+        return False
+    try:
+        f = float(value)
+        return f > 0.0 and math.isfinite(f)
+    except (TypeError, ValueError):
+        return False
+
+
 def _build_tca_auth_headers(user_id: str, role: str, strategies: list[str]) -> dict[str, str]:
     """Build auth headers for TCA API requests."""
     return {
@@ -394,8 +412,8 @@ def _is_cacheable_benchmark(data: dict[str, Any]) -> bool:
         return False
     return any(
         isinstance(p, dict)
-        and _is_numeric(p.get("execution_price"))
-        and _is_numeric(p.get("benchmark_price"))
+        and _is_valid_price(p.get("execution_price"))
+        and _is_valid_price(p.get("benchmark_price"))
         for p in points
     )
 

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -60,6 +60,15 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
+def _is_numeric(value: Any) -> bool:
+    """Return True when *value* can be converted to a finite float."""
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _build_tca_auth_headers(user_id: str, role: str, strategies: list[str]) -> dict[str, str]:
     """Build auth headers for TCA API requests."""
     return {
@@ -121,6 +130,10 @@ async def _fetch_tca_benchmarks(
 
     Returns None on error or when the benchmark series is unavailable.
     """
+    log_ctx: dict[str, Any] = {
+        "client_order_id": client_order_id,
+        "benchmark": benchmark,
+    }
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(
@@ -133,20 +146,17 @@ async def _fetch_tca_benchmarks(
                 return result
             logger.warning(
                 "TCA benchmark API returned non-200",
-                extra={
-                    "status": response.status_code,
-                    "client_order_id": client_order_id,
-                },
+                extra={**log_ctx, "status": response.status_code},
             )
     except httpx.RequestError as e:
         logger.warning(
             "TCA benchmark API unavailable",
-            extra={"client_order_id": client_order_id, "error": str(e)},
+            extra={**log_ctx, "error": str(e)},
         )
-    except Exception:
-        logger.warning(
+    except (ValueError, KeyError, TypeError) as e:
+        logger.error(
             "TCA benchmark API response parse error",
-            extra={"client_order_id": client_order_id},
+            extra={**log_ctx, "error": str(e)},
             exc_info=True,
         )
     return None
@@ -510,18 +520,42 @@ async def _render_tca_dashboard(
                     bm_symbol = str(
                         benchmark_data.get("symbol", orders[0].get("symbol", ""))
                     )
+                    bm_type = str(
+                        benchmark_data.get("benchmark_type", "VWAP")
+                    ).upper()
                     ui.label(
-                        f"Execution vs VWAP — {bm_symbol} (First Order)"
+                        f"Execution vs {bm_type} — {bm_symbol} (First Order)"
                     ).classes("text-lg font-bold mb-2")
 
-                    points = benchmark_data.get("points", [])
-                    create_benchmark_comparison_chart(
-                        timestamps=[str(point.get("timestamp", "")) for point in points],
-                        execution_prices=[_safe_float(point.get("execution_price")) for point in points],
-                        benchmark_prices=[_safe_float(point.get("benchmark_price")) for point in points],
-                        benchmark_type=str(benchmark_data.get("benchmark_type", "VWAP")).upper(),
-                        symbol=bm_symbol,
-                    )
+                    # Filter out points with invalid prices to avoid
+                    # misleading zero-price dips on the chart.
+                    valid_points = [
+                        p
+                        for p in benchmark_data.get("points", [])
+                        if _is_numeric(p.get("execution_price"))
+                        and _is_numeric(p.get("benchmark_price"))
+                    ]
+                    if valid_points:
+                        create_benchmark_comparison_chart(
+                            timestamps=[
+                                str(point.get("timestamp", ""))
+                                for point in valid_points
+                            ],
+                            execution_prices=[
+                                _safe_float(point.get("execution_price"))
+                                for point in valid_points
+                            ],
+                            benchmark_prices=[
+                                _safe_float(point.get("benchmark_price"))
+                                for point in valid_points
+                            ],
+                            benchmark_type=bm_type,
+                            symbol=bm_symbol,
+                        )
+                    else:
+                        ui.label("Benchmark data unavailable").classes(
+                            "text-gray-500 p-4"
+                        )
 
         # Render orders table
         with orders_container:

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -142,20 +142,26 @@ async def _fetch_tca_benchmarks(
     role: str,
     strategies: list[str],
     benchmark: str = "vwap",
+    *,
+    symbol: str = "",
 ) -> dict[str, Any] | None:
     """Fetch benchmark comparison series for a specific order.
 
     Returns None on error or when the benchmark series is unavailable.
+
+    Args:
+        symbol: Optional symbol for structured log context (not sent to API).
     """
     log_ctx: dict[str, Any] = {
         "client_order_id": client_order_id,
         "benchmark": benchmark,
+        "symbol": symbol,
     }
     try:
-        # Use a shorter timeout than the main TCA analysis call since
-        # the benchmark chart is supplementary and should not block
-        # the rest of the dashboard from rendering.
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        # Use a short timeout since the benchmark chart is supplementary;
+        # a slow or unavailable benchmark API should not noticeably delay
+        # the main dashboard (summary cards + decomposition chart + table).
+        async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(
                 f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
                 params={"client_order_id": client_order_id, "benchmark": benchmark},
@@ -530,6 +536,8 @@ async def _render_tca_dashboard(
         if fetch_order_id:
             # Use cached benchmark data if the first order hasn't
             # changed, avoiding redundant API calls on filter tweaks.
+            # Only cache successful responses so transient failures
+            # are retried on the next load_data invocation.
             if state.get("_benchmark_cache_key") == fetch_order_id:
                 benchmark_data = state["_benchmark_cache_data"]
             else:
@@ -538,9 +546,16 @@ async def _render_tca_dashboard(
                     user_id=user_id,
                     role=role,
                     strategies=authorized_strategies,
+                    symbol=str(orders[0].get("symbol", "")),
                 )
-                state["_benchmark_cache_key"] = fetch_order_id
-                state["_benchmark_cache_data"] = benchmark_data
+                if benchmark_data is not None:
+                    state["_benchmark_cache_key"] = fetch_order_id
+                    state["_benchmark_cache_data"] = benchmark_data
+                else:
+                    # Clear stale cache so transient failures don't
+                    # stick if the order changes later.
+                    state["_benchmark_cache_key"] = None
+                    state["_benchmark_cache_data"] = None
         elif orders and state.get("demo_mode"):
             # Generate deterministic demo benchmark data so the chart
             # section is still visible in demo/fallback mode.

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -176,6 +176,18 @@ def _get_shared_client() -> httpx.AsyncClient:
     return _shared_client
 
 
+async def close_shared_client() -> None:
+    """Close the module-level shared httpx.AsyncClient.
+
+    Called during application shutdown to release pooled connections and
+    avoid unclosed-resource warnings / file-descriptor leaks.
+    """
+    global _shared_client  # noqa: PLW0603
+    if _shared_client is not None and not _shared_client.is_closed:
+        await _shared_client.aclose()
+    _shared_client = None
+
+
 async def _fetch_tca_data(
     start_date: date,
     end_date: date,
@@ -944,4 +956,4 @@ async def _render_tca_dashboard(
     await load_data()
 
 
-__all__ = ["execution_quality_page"]
+__all__ = ["close_shared_client", "execution_quality_page"]

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -52,6 +52,14 @@ DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
 
 
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Safely coerce a value to float, returning *default* on failure."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _build_tca_auth_headers(user_id: str, role: str, strategies: list[str]) -> dict[str, str]:
     """Build auth headers for TCA API requests."""
     return {
@@ -128,13 +136,18 @@ async def _fetch_tca_benchmarks(
                 extra={
                     "status": response.status_code,
                     "client_order_id": client_order_id,
-                    "body": response.text[:200],
                 },
             )
     except httpx.RequestError as e:
         logger.warning(
             "TCA benchmark API unavailable",
             extra={"client_order_id": client_order_id, "error": str(e)},
+        )
+    except Exception:
+        logger.warning(
+            "TCA benchmark API response parse error",
+            extra={"client_order_id": client_order_id},
+            exc_info=True,
         )
     return None
 
@@ -494,15 +507,20 @@ async def _render_tca_dashboard(
 
             if benchmark_data and benchmark_data.get("points"):
                 with ui.card().classes("w-full p-4"):
-                    ui.label("Execution vs VWAP").classes("text-lg font-bold mb-2")
+                    bm_symbol = str(
+                        benchmark_data.get("symbol", orders[0].get("symbol", ""))
+                    )
+                    ui.label(
+                        f"Execution vs VWAP — {bm_symbol} (First Order)"
+                    ).classes("text-lg font-bold mb-2")
 
                     points = benchmark_data.get("points", [])
                     create_benchmark_comparison_chart(
                         timestamps=[str(point.get("timestamp", "")) for point in points],
-                        execution_prices=[float(point.get("execution_price", 0.0)) for point in points],
-                        benchmark_prices=[float(point.get("benchmark_price", 0.0)) for point in points],
+                        execution_prices=[_safe_float(point.get("execution_price")) for point in points],
+                        benchmark_prices=[_safe_float(point.get("benchmark_price")) for point in points],
                         benchmark_type=str(benchmark_data.get("benchmark_type", "VWAP")).upper(),
-                        symbol=str(benchmark_data.get("symbol", orders[0].get("symbol", ""))),
+                        symbol=bm_symbol,
                     )
 
         # Render orders table

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -279,73 +279,6 @@ async def _fetch_tca_benchmarks(
     return None
 
 
-async def _fetch_tca_benchmarks(
-    client_order_id: str,
-    user_id: str,
-    role: str,
-    strategies: list[str],
-    benchmark: str = "vwap",
-    *,
-    symbol: str = "",
-    strategy_id: str = "",
-) -> dict[str, Any] | None:
-    """Fetch benchmark time series for an order.
-
-    Returns None on error so callers can hide the benchmark chart instead of
-    rendering synthetic data.
-    """
-    log_ctx: dict[str, Any] = {
-        "client_order_id": client_order_id,
-        "benchmark": benchmark,
-        "symbol": symbol,
-        "strategy_id": strategy_id,
-    }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(
-                f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
-                params={"client_order_id": client_order_id, "benchmark": benchmark},
-                headers=_build_tca_auth_headers(user_id, role, strategies),
-            )
-            if response.status_code == 200:
-                raw = response.json()
-                if not isinstance(raw, dict):
-                    logger.warning(
-                        "TCA benchmarks API returned non-dict JSON",
-                        extra=log_ctx,
-                    )
-                    return None
-                result: dict[str, Any] = raw
-                points = result.get("points")
-                if not isinstance(points, list):
-                    logger.warning(
-                        "TCA benchmarks API returned non-list points",
-                        extra={**log_ctx, "points_type": type(points).__name__},
-                    )
-                    return None
-                if not points:
-                    return None
-                # Discard entries that are not dicts to guard against
-                # schema drift from the upstream API.
-                result["points"] = [p for p in points if isinstance(p, dict)]
-                return result if result["points"] else None
-            logger.warning(
-                "TCA benchmarks API returned non-200",
-                extra={
-                    **log_ctx,
-                    "status": response.status_code,
-                    "body": response.text[:200],
-                },
-            )
-    except (httpx.RequestError, ValueError, KeyError, TypeError, AttributeError) as e:
-        logger.warning(
-            "TCA benchmarks API error",
-            extra={**log_ctx, "error": str(e)},
-        )
-        raise
-    return None
-
-
 def _generate_demo_data(
     start_date: date,
     end_date: date,
@@ -681,10 +614,6 @@ async def _render_tca_dashboard(
 
         # Discard results from superseded requests (rapid filter changes)
         if current_generation != state["_load_generation"]:
-            return
-
-        # Discard stale results if a newer load was triggered
-        if state["_load_version"] != current_version:
             return
 
         # Check for demo mode: API failure OR API returned demo data

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -52,6 +52,15 @@ DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
 
 
+def _build_tca_auth_headers(user_id: str, role: str, strategies: list[str]) -> dict[str, str]:
+    """Build auth headers for TCA API requests."""
+    return {
+        "X-User-ID": user_id,
+        "X-User-Role": role,
+        "X-User-Strategies": ",".join(strategies),
+    }
+
+
 async def _fetch_tca_data(
     start_date: date,
     end_date: date,
@@ -76,17 +85,10 @@ async def _fetch_tca_data(
             if strategy_id:
                 params["strategy_id"] = strategy_id
 
-            # Add auth headers
-            headers = {
-                "X-User-ID": user_id,
-                "X-User-Role": role,
-                "X-User-Strategies": ",".join(strategies),
-            }
-
             response = await client.get(
                 f"{EXECUTION_GATEWAY_URL}/api/v1/tca/analysis",
                 params=params,
-                headers=headers,
+                headers=_build_tca_auth_headers(user_id, role, strategies),
             )
             if response.status_code == 200:
                 result: dict[str, Any] = response.json()
@@ -97,6 +99,43 @@ async def _fetch_tca_data(
             )
     except httpx.RequestError as e:
         logger.warning("TCA API unavailable", extra={"error": str(e)})
+    return None
+
+
+async def _fetch_tca_benchmarks(
+    client_order_id: str,
+    user_id: str,
+    role: str,
+    strategies: list[str],
+    benchmark: str = "vwap",
+) -> dict[str, Any] | None:
+    """Fetch benchmark comparison series for a specific order.
+
+    Returns None on error or when the benchmark series is unavailable.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
+                params={"client_order_id": client_order_id, "benchmark": benchmark},
+                headers=_build_tca_auth_headers(user_id, role, strategies),
+            )
+            if response.status_code == 200:
+                result: dict[str, Any] = response.json()
+                return result
+            logger.warning(
+                "TCA benchmark API returned non-200",
+                extra={
+                    "status": response.status_code,
+                    "client_order_id": client_order_id,
+                    "body": response.text[:200],
+                },
+            )
+    except httpx.RequestError as e:
+        logger.warning(
+            "TCA benchmark API unavailable",
+            extra={"client_order_id": client_order_id, "error": str(e)},
+        )
     return None
 
 
@@ -387,6 +426,17 @@ async def _render_tca_dashboard(
                 total_orders=summary.get("total_orders", 0),
             )
 
+        benchmark_data: dict[str, Any] | None = None
+        if orders and not state.get("demo_mode"):
+            first_order_id = str(orders[0].get("client_order_id", "")).strip()
+            if first_order_id:
+                benchmark_data = await _fetch_tca_benchmarks(
+                    client_order_id=first_order_id,
+                    user_id=user_id,
+                    role=role,
+                    strategies=authorized_strategies,
+                )
+
         # Render charts
         with charts_container:
             # Shortfall decomposition chart
@@ -442,36 +492,17 @@ async def _render_tca_dashboard(
                 else:
                     ui.label("No order data available").classes("text-gray-500 p-4")
 
-            # Benchmark comparison (show for first order as example)
-            if orders:
+            if benchmark_data and benchmark_data.get("points"):
                 with ui.card().classes("w-full p-4"):
-                    ui.label("Sample Execution vs VWAP").classes("text-lg font-bold mb-2")
+                    ui.label("Execution vs VWAP").classes("text-lg font-bold mb-2")
 
-                    # Generate sample benchmark data for first order
-                    first_order = orders[0]
-                    import random
-
-                    # Use stable hash for deterministic demo data across restarts
-                    random.seed(_stable_hash(first_order.get("client_order_id", "")))
-
-                    num_points = 10
-                    base_price = 150.0
-                    timestamps = [f"10:{i * 5:02d}" for i in range(num_points)]
-                    exec_prices = [
-                        round(base_price * (1 + random.uniform(-0.002, 0.003)), 2)
-                        for _ in range(num_points)
-                    ]
-                    bench_prices = [
-                        round(base_price * (1 + random.uniform(-0.001, 0.001)), 2)
-                        for _ in range(num_points)
-                    ]
-
+                    points = benchmark_data.get("points", [])
                     create_benchmark_comparison_chart(
-                        timestamps=timestamps,
-                        execution_prices=exec_prices,
-                        benchmark_prices=bench_prices,
-                        benchmark_type="VWAP",
-                        symbol=first_order.get("symbol", ""),
+                        timestamps=[str(point.get("timestamp", "")) for point in points],
+                        execution_prices=[float(point.get("execution_price", 0.0)) for point in points],
+                        benchmark_prices=[float(point.get("benchmark_price", 0.0)) for point in points],
+                        benchmark_type=str(benchmark_data.get("benchmark_type", "VWAP")).upper(),
+                        symbol=str(benchmark_data.get("symbol", orders[0].get("symbol", ""))),
                     )
 
         # Render orders table

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -95,6 +95,21 @@ def _build_tca_auth_headers(user_id: str, role: str, strategies: list[str]) -> d
     }
 
 
+# Module-level shared httpx client for connection pooling.
+# Lazy-initialised on first use so that module import does not
+# perform I/O.  A single client is reused across all TCA requests
+# within the same process, improving connection reuse.
+_shared_client: httpx.AsyncClient | None = None
+
+
+def _get_shared_client() -> httpx.AsyncClient:
+    """Return the module-level shared httpx.AsyncClient, creating it on first call."""
+    global _shared_client  # noqa: PLW0603
+    if _shared_client is None or _shared_client.is_closed:
+        _shared_client = httpx.AsyncClient(timeout=30.0)
+    return _shared_client
+
+
 async def _fetch_tca_data(
     start_date: date,
     end_date: date,
@@ -106,33 +121,36 @@ async def _fetch_tca_data(
 ) -> dict[str, Any] | None:
     """Fetch TCA data from API.
 
-    Returns None on error, falls back to demo mode.
+    Returns None when the API returns a non-200 status.
+    Raises httpx.RequestError on connectivity issues so the caller
+    can decide whether to fall back to demo mode.
     """
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            params: dict[str, Any] = {
-                "start_date": str(start_date),
-                "end_date": str(end_date),
-            }
-            if symbol:
-                params["symbol"] = symbol
-            if strategy_id:
-                params["strategy_id"] = strategy_id
+    client = _get_shared_client()
+    params: dict[str, Any] = {
+        "start_date": str(start_date),
+        "end_date": str(end_date),
+    }
+    if symbol:
+        params["symbol"] = symbol
+    if strategy_id:
+        params["strategy_id"] = strategy_id
 
-            response = await client.get(
-                f"{EXECUTION_GATEWAY_URL}/api/v1/tca/analysis",
-                params=params,
-                headers=_build_tca_auth_headers(user_id, role, strategies),
-            )
-            if response.status_code == 200:
-                result: dict[str, Any] = response.json()
-                return result
-            logger.warning(
-                "TCA API returned non-200",
-                extra={"status": response.status_code, "body": response.text[:200]},
-            )
-    except httpx.RequestError as e:
-        logger.warning("TCA API unavailable", extra={"error": str(e)})
+    response = await client.get(
+        f"{EXECUTION_GATEWAY_URL}/api/v1/tca/analysis",
+        params=params,
+        headers=_build_tca_auth_headers(user_id, role, strategies),
+    )
+    if response.status_code == 200:
+        result: dict[str, Any] = response.json()
+        return result
+    logger.warning(
+        "TCA API returned non-200",
+        extra={
+            "status": response.status_code,
+            "strategy_id": strategy_id,
+            "body": response.text[:200],
+        },
+    )
     return None
 
 
@@ -144,11 +162,15 @@ async def _fetch_tca_benchmarks(
     benchmark: str = "vwap",
     *,
     symbol: str = "",
-    strategy_id: str = "",
+    strategy_id: str | None = "",
 ) -> dict[str, Any] | None:
     """Fetch benchmark comparison series for a specific order.
 
-    Returns None on error or when the benchmark series is unavailable.
+    Returns None when the API returns a non-200 status or an unexpected
+    payload type.
+    Raises httpx.RequestError on connectivity issues so the caller can
+    decide whether to fall back gracefully.
+    Raises ValueError / KeyError / TypeError on response parse errors.
 
     Args:
         symbol: Optional symbol for structured log context (not sent to API).
@@ -160,40 +182,26 @@ async def _fetch_tca_benchmarks(
         "symbol": symbol,
         "strategy_id": strategy_id,
     }
-    try:
-        # Use a short timeout since the benchmark chart is supplementary;
-        # a slow or unavailable benchmark API should not noticeably delay
-        # the main dashboard (summary cards + decomposition chart + table).
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.get(
-                f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
-                params={"client_order_id": client_order_id, "benchmark": benchmark},
-                headers=_build_tca_auth_headers(user_id, role, strategies),
-            )
-            if response.status_code == 200:
-                result = response.json()
-                if not isinstance(result, dict):
-                    logger.warning(
-                        "TCA benchmark API returned unexpected payload type",
-                        extra={**log_ctx, "type": type(result).__name__},
-                    )
-                    return None
-                return result
+    # Reuse the shared client for connection pooling.
+    client = _get_shared_client()
+    response = await client.get(
+        f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
+        params={"client_order_id": client_order_id, "benchmark": benchmark},
+        headers=_build_tca_auth_headers(user_id, role, strategies),
+    )
+    if response.status_code == 200:
+        result = response.json()
+        if not isinstance(result, dict):
             logger.warning(
-                "TCA benchmark API returned non-200",
-                extra={**log_ctx, "status": response.status_code},
+                "TCA benchmark API returned unexpected payload type",
+                extra={**log_ctx, "type": type(result).__name__},
             )
-    except httpx.RequestError as e:
-        logger.warning(
-            "TCA benchmark API unavailable",
-            extra={**log_ctx, "error": str(e)},
-        )
-    except (ValueError, KeyError, TypeError) as e:
-        logger.error(
-            "TCA benchmark API response parse error",
-            extra={**log_ctx, "error": str(e)},
-            exc_info=True,
-        )
+            return None
+        return result
+    logger.warning(
+        "TCA benchmark API returned non-200",
+        extra={**log_ctx, "status": response.status_code},
+    )
     return None
 
 
@@ -508,9 +516,16 @@ async def _render_tca_dashboard(
         state["strategy_id"] = strategy
 
         # Fetch data - use authorized_strategies for API auth (not raw session strategies)
-        data = await _fetch_tca_data(
-            start_dt, end_dt, symbol, strategy, user_id, role, authorized_strategies
-        )
+        try:
+            data = await _fetch_tca_data(
+                start_dt, end_dt, symbol, strategy, user_id, role, authorized_strategies
+            )
+        except httpx.RequestError as exc:
+            logger.warning(
+                "TCA API unavailable, falling back to demo data",
+                extra={"error": str(exc), "strategy_id": strategy},
+            )
+            data = None
 
         # Discard results from superseded requests (rapid filter changes)
         if current_generation != state["_load_generation"]:
@@ -558,14 +573,30 @@ async def _render_tca_dashboard(
             if state.get("_benchmark_cache_key") == fetch_order_id:
                 benchmark_data = state["_benchmark_cache_data"]
             else:
-                benchmark_data = await _fetch_tca_benchmarks(
-                    client_order_id=fetch_order_id,
-                    user_id=user_id,
-                    role=role,
-                    strategies=authorized_strategies,
-                    symbol=str(orders[0].get("symbol", "")),
-                    strategy_id=str(state.get("strategy_id") or ""),
-                )
+                try:
+                    benchmark_data = await _fetch_tca_benchmarks(
+                        client_order_id=fetch_order_id,
+                        user_id=user_id,
+                        role=role,
+                        strategies=authorized_strategies,
+                        strategy_id=str(state.get("strategy_id") or ""),
+                        symbol=str(orders[0].get("symbol", "")),
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "TCA benchmark fetch failed, skipping chart",
+                        extra={
+                            "client_order_id": fetch_order_id,
+                            "strategy_id": str(state.get("strategy_id") or ""),
+                            "error": str(exc),
+                        },
+                    )
+                    benchmark_data = None
+
+                # Discard results from superseded requests
+                if current_generation != state["_load_generation"]:
+                    return
+
                 if benchmark_data is not None:
                     state["_benchmark_cache_key"] = fetch_order_id
                     state["_benchmark_cache_data"] = benchmark_data

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -271,6 +271,36 @@ def _generate_demo_data(
     }
 
 
+def _generate_demo_benchmark_data(order: dict[str, Any]) -> dict[str, Any]:
+    """Generate deterministic demo benchmark comparison data for one order.
+
+    Used as fallback when in demo mode so the benchmark chart section
+    is still rendered with placeholder data.
+    """
+    import random
+
+    random.seed(_stable_hash(str(order.get("client_order_id", ""))))
+    num_points = 10
+    base_price = 150.0
+    return {
+        "client_order_id": order.get("client_order_id", "demo"),
+        "symbol": order.get("symbol", "DEMO"),
+        "benchmark_type": "vwap",
+        "points": [
+            {
+                "timestamp": f"10:{i * 5:02d}",
+                "execution_price": round(
+                    base_price * (1 + random.uniform(-0.002, 0.003)), 2
+                ),
+                "benchmark_price": round(
+                    base_price * (1 + random.uniform(-0.001, 0.001)), 2
+                ),
+            }
+            for i in range(num_points)
+        ],
+    }
+
+
 @ui.page("/execution-quality")
 @requires_auth
 @main_layout
@@ -484,6 +514,10 @@ async def _render_tca_dashboard(
                     role=role,
                     strategies=authorized_strategies,
                 )
+        elif orders and state.get("demo_mode"):
+            # Generate deterministic demo benchmark data so the chart
+            # section is still visible in demo/fallback mode.
+            benchmark_data = _generate_demo_benchmark_data(orders[0])
 
         # Render charts
         with charts_container:
@@ -559,9 +593,12 @@ async def _render_tca_dashboard(
                     bm_type = str(
                         benchmark_data.get("benchmark_type", "VWAP")
                     ).upper()
-                    ui.label(
-                        f"Execution vs {bm_type} — {bm_symbol} (First Order)"
-                    ).classes("text-lg font-bold mb-2")
+                    chart_title = f"Execution vs {bm_type} — {bm_symbol}"
+                    if state.get("demo_mode"):
+                        chart_title += " (Demo)"
+                    else:
+                        chart_title += " (First Order)"
+                    ui.label(chart_title).classes("text-lg font-bold mb-2")
 
                     # Filter out points with non-finite prices to avoid
                     # misleading zero-price dips on the chart.
@@ -592,6 +629,17 @@ async def _render_tca_dashboard(
                         ui.label("Benchmark data unavailable").classes(
                             "text-gray-500 p-4"
                         )
+            elif orders:
+                # Benchmark API returned no data or invalid payload —
+                # show a diagnostic card so the user knows the section
+                # exists but data is missing.
+                with ui.card().classes("w-full p-4"):
+                    ui.label("Execution vs Benchmark").classes(
+                        "text-lg font-bold mb-2"
+                    )
+                    ui.label("Benchmark data unavailable").classes(
+                        "text-gray-500 p-4"
+                    )
 
         # Render orders table
         with orders_container:

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -113,19 +113,6 @@ def _is_valid_price(value: Any) -> bool:
         return False
 
 
-def _build_tca_auth_headers(
-    user_id: str,
-    role: str,
-    strategies: list[str],
-) -> dict[str, str]:
-    """Build auth headers for TCA API calls."""
-    return {
-        "X-User-ID": user_id,
-        "X-User-Role": role,
-        "X-User-Strategies": ",".join(strategies),
-    }
-
-
 def _safe_float(value: Any, default: float = 0.0) -> float:
     """Safely coerce a value to a finite float, returning *default* on failure.
 
@@ -681,6 +668,23 @@ async def _render_tca_dashboard(
                 # Discard results from superseded requests
                 if current_generation != state["_load_generation"]:
                     return
+
+                # Validate that the response belongs to the requested
+                # order before caching.  An upstream cache/routing bug
+                # could return data for a different order, which would
+                # be silently cached under the wrong key.
+                if benchmark_data is not None:
+                    resp_order_id = str(benchmark_data.get("client_order_id", "")).strip()
+                    if resp_order_id and resp_order_id != fetch_order_id:
+                        logger.warning(
+                            "TCA benchmarks response order mismatch, discarding",
+                            extra={
+                                "requested": fetch_order_id,
+                                "received": resp_order_id,
+                                "strategy_id": str(state.get("strategy_id") or ""),
+                            },
+                        )
+                        benchmark_data = None
 
                 # Only cache responses whose payload passes the same
                 # shape validation used at render time.  This prevents

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -55,10 +55,12 @@ MAX_RANGE_DAYS = 90
 def _safe_float(value: Any, default: float = 0.0) -> float:
     """Safely coerce a value to a finite float, returning *default* on failure.
 
-    Returns *default* for None, non-numeric strings, NaN, and +/-inf.
+    Returns *default* for None, booleans, non-numeric strings, NaN, and +/-inf.
     """
     import math
 
+    if isinstance(value, bool):
+        return default
     try:
         result = float(value)
     except (TypeError, ValueError):
@@ -71,10 +73,12 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
 def _is_numeric(value: Any) -> bool:
     """Return True when *value* can be converted to a finite float.
 
-    Rejects None, non-numeric strings, NaN, and +/-inf.
+    Rejects None, booleans, non-numeric strings, NaN, and +/-inf.
     """
     import math
 
+    if isinstance(value, bool):
+        return False
     try:
         result = float(value)
     except (TypeError, ValueError):
@@ -146,6 +150,8 @@ async def _fetch_tca_benchmarks(
     log_ctx: dict[str, Any] = {
         "client_order_id": client_order_id,
         "benchmark": benchmark,
+        "user_id": user_id,
+        "strategies": strategies,
     }
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -155,7 +161,13 @@ async def _fetch_tca_benchmarks(
                 headers=_build_tca_auth_headers(user_id, role, strategies),
             )
             if response.status_code == 200:
-                result: dict[str, Any] = response.json()
+                result = response.json()
+                if not isinstance(result, dict):
+                    logger.warning(
+                        "TCA benchmark API returned unexpected payload type",
+                        extra={**log_ctx, "type": type(result).__name__},
+                    )
+                    return None
                 return result
             logger.warning(
                 "TCA benchmark API returned non-200",

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -96,23 +96,6 @@ def _format_benchmark_timestamp(value: Any, *, include_date: bool = False) -> st
     return dt.strftime(fmt)
 
 
-def _is_valid_price(value: Any) -> bool:
-    """Return True if *value* is a finite positive price.
-
-    Rejects zero, negative, NaN, infinity, booleans, and non-numeric values.
-    """
-    import math
-
-    # Reject booleans explicitly since float(True) == 1.0
-    if isinstance(value, bool):
-        return False
-    try:
-        f = float(value)
-        return f > 0.0 and math.isfinite(f)
-    except (TypeError, ValueError):
-        return False
-
-
 def _safe_float(value: Any, default: float = 0.0) -> float:
     """Safely coerce a value to a finite float, returning *default* on failure.
 
@@ -793,13 +776,13 @@ async def _render_tca_dashboard(
                         chart_title += " (First Order)"
                     ui.label(chart_title).classes("text-lg font-bold mb-2")
 
-                    # Filter out points with non-finite prices to avoid
-                    # misleading zero-price dips on the chart.
+                    # Filter out points with invalid prices (zero, negative,
+                    # NaN, null) to avoid misleading chart distortions.
                     valid_points = [
                         p
                         for p in validated_points
-                        if _is_numeric(p.get("execution_price"))
-                        and _is_numeric(p.get("benchmark_price"))
+                        if _is_valid_price(p.get("execution_price"))
+                        and _is_valid_price(p.get("benchmark_price"))
                     ]
                     if valid_points:
                         create_benchmark_comparison_chart(

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -53,20 +53,33 @@ MAX_RANGE_DAYS = 90
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:
-    """Safely coerce a value to float, returning *default* on failure."""
+    """Safely coerce a value to a finite float, returning *default* on failure.
+
+    Returns *default* for None, non-numeric strings, NaN, and +/-inf.
+    """
+    import math
+
     try:
-        return float(value)
+        result = float(value)
     except (TypeError, ValueError):
         return default
+    if not math.isfinite(result):
+        return default
+    return result
 
 
 def _is_numeric(value: Any) -> bool:
-    """Return True when *value* can be converted to a finite float."""
+    """Return True when *value* can be converted to a finite float.
+
+    Rejects None, non-numeric strings, NaN, and +/-inf.
+    """
+    import math
+
     try:
-        float(value)
+        result = float(value)
     except (TypeError, ValueError):
         return False
-    return True
+    return math.isfinite(result)
 
 
 def _build_tca_auth_headers(user_id: str, role: str, strategies: list[str]) -> dict[str, str]:
@@ -515,7 +528,18 @@ async def _render_tca_dashboard(
                 else:
                     ui.label("No order data available").classes("text-gray-500 p-4")
 
-            if benchmark_data and benchmark_data.get("points"):
+            # Validate benchmark payload shape before rendering.
+            raw_points = (
+                benchmark_data.get("points", []) if benchmark_data else []
+            )
+            # Guard: points must be a list of dict-like objects.
+            if not isinstance(raw_points, list):
+                raw_points = []
+            validated_points: list[dict[str, Any]] = [
+                p for p in raw_points if isinstance(p, dict)
+            ]
+
+            if benchmark_data and validated_points:
                 with ui.card().classes("w-full p-4"):
                     bm_symbol = str(
                         benchmark_data.get("symbol", orders[0].get("symbol", ""))
@@ -527,11 +551,11 @@ async def _render_tca_dashboard(
                         f"Execution vs {bm_type} — {bm_symbol} (First Order)"
                     ).classes("text-lg font-bold mb-2")
 
-                    # Filter out points with invalid prices to avoid
+                    # Filter out points with non-finite prices to avoid
                     # misleading zero-price dips on the chart.
                     valid_points = [
                         p
-                        for p in benchmark_data.get("points", [])
+                        for p in validated_points
                         if _is_numeric(p.get("execution_price"))
                         and _is_numeric(p.get("benchmark_price"))
                     ]

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -150,11 +150,12 @@ async def _fetch_tca_benchmarks(
     log_ctx: dict[str, Any] = {
         "client_order_id": client_order_id,
         "benchmark": benchmark,
-        "user_id": user_id,
-        "strategies": strategies,
     }
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        # Use a shorter timeout than the main TCA analysis call since
+        # the benchmark chart is supplementary and should not block
+        # the rest of the dashboard from rendering.
+        async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
                 f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
                 params={"client_order_id": client_order_id, "benchmark": benchmark},
@@ -275,20 +276,23 @@ def _generate_demo_benchmark_data(order: dict[str, Any]) -> dict[str, Any]:
     """Generate deterministic demo benchmark comparison data for one order.
 
     Used as fallback when in demo mode so the benchmark chart section
-    is still rendered with placeholder data.
+    is still rendered with placeholder data.  Timestamps use UTC ISO-8601
+    format to match the real API response shape.
     """
     import random
 
     random.seed(_stable_hash(str(order.get("client_order_id", ""))))
     num_points = 10
     base_price = 150.0
+    # Use a fixed demo date with UTC timestamps matching API format
+    demo_date = "2024-01-15"
     return {
         "client_order_id": order.get("client_order_id", "demo"),
         "symbol": order.get("symbol", "DEMO"),
         "benchmark_type": "vwap",
         "points": [
             {
-                "timestamp": f"10:{i * 5:02d}",
+                "timestamp": f"{demo_date}T{10 + i // 12:02d}:{(i * 5) % 60:02d}:00Z",
                 "execution_price": round(
                     base_price * (1 + random.uniform(-0.002, 0.003)), 2
                 ),
@@ -299,6 +303,19 @@ def _generate_demo_benchmark_data(order: dict[str, Any]) -> dict[str, Any]:
             for i in range(num_points)
         ],
     }
+
+
+def _should_fetch_benchmark(orders: list[dict[str, Any]], demo_mode: bool) -> str | None:
+    """Determine whether to fetch benchmark data and return the order ID.
+
+    Returns the client_order_id of the first order when a real benchmark
+    fetch should be made, or None when it should be skipped (demo mode,
+    no orders, or empty order ID).
+    """
+    if not orders or demo_mode:
+        return None
+    first_order_id = str(orders[0].get("client_order_id", "")).strip()
+    return first_order_id or None
 
 
 @ui.page("/execution-quality")
@@ -368,6 +385,10 @@ async def _render_tca_dashboard(
         "strategy_id": None,
         "data": None,
         "demo_mode": False,
+        # Cache benchmark data to avoid re-fetching on filter changes
+        # when the first order hasn't changed.
+        "_benchmark_cache_key": None,
+        "_benchmark_cache_data": None,
     }
 
     # Filters section
@@ -505,15 +526,21 @@ async def _render_tca_dashboard(
             )
 
         benchmark_data: dict[str, Any] | None = None
-        if orders and not state.get("demo_mode"):
-            first_order_id = str(orders[0].get("client_order_id", "")).strip()
-            if first_order_id:
+        fetch_order_id = _should_fetch_benchmark(orders, bool(state.get("demo_mode")))
+        if fetch_order_id:
+            # Use cached benchmark data if the first order hasn't
+            # changed, avoiding redundant API calls on filter tweaks.
+            if state.get("_benchmark_cache_key") == fetch_order_id:
+                benchmark_data = state["_benchmark_cache_data"]
+            else:
                 benchmark_data = await _fetch_tca_benchmarks(
-                    client_order_id=first_order_id,
+                    client_order_id=fetch_order_id,
                     user_id=user_id,
                     role=role,
                     strategies=authorized_strategies,
                 )
+                state["_benchmark_cache_key"] = fetch_order_id
+                state["_benchmark_cache_data"] = benchmark_data
         elif orders and state.get("demo_mode"):
             # Generate deterministic demo benchmark data so the chart
             # section is still visible in demo/fallback mode.

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -144,6 +144,7 @@ async def _fetch_tca_benchmarks(
     benchmark: str = "vwap",
     *,
     symbol: str = "",
+    strategy_id: str = "",
 ) -> dict[str, Any] | None:
     """Fetch benchmark comparison series for a specific order.
 
@@ -151,11 +152,13 @@ async def _fetch_tca_benchmarks(
 
     Args:
         symbol: Optional symbol for structured log context (not sent to API).
+        strategy_id: Optional strategy for structured log context (not sent to API).
     """
     log_ctx: dict[str, Any] = {
         "client_order_id": client_order_id,
         "benchmark": benchmark,
         "symbol": symbol,
+        "strategy_id": strategy_id,
     }
     try:
         # Use a short timeout since the benchmark chart is supplementary;
@@ -395,6 +398,9 @@ async def _render_tca_dashboard(
         # when the first order hasn't changed.
         "_benchmark_cache_key": None,
         "_benchmark_cache_data": None,
+        # Request versioning to prevent stale async results from
+        # overwriting newer UI state on rapid filter changes.
+        "_load_generation": 0,
     }
 
     # Filters section
@@ -454,7 +460,14 @@ async def _render_tca_dashboard(
     orders_container = ui.column().classes("w-full")
 
     async def load_data() -> None:
-        """Load TCA data and update UI."""
+        """Load TCA data and update UI.
+
+        Uses a generation counter to discard results from superseded
+        requests when rapid filter changes trigger overlapping loads.
+        """
+        state["_load_generation"] += 1
+        current_generation = state["_load_generation"]
+
         summary_container.clear()
         charts_container.clear()
         orders_container.clear()
@@ -498,6 +511,10 @@ async def _render_tca_dashboard(
         data = await _fetch_tca_data(
             start_dt, end_dt, symbol, strategy, user_id, role, authorized_strategies
         )
+
+        # Discard results from superseded requests (rapid filter changes)
+        if current_generation != state["_load_generation"]:
+            return
 
         # Check for demo mode: API failure OR API returned demo data
         summary = data.get("summary", {}) if data else {}
@@ -547,6 +564,7 @@ async def _render_tca_dashboard(
                     role=role,
                     strategies=authorized_strategies,
                     symbol=str(orders[0].get("symbol", "")),
+                    strategy_id=str(state.get("strategy_id") or ""),
                 )
                 if benchmark_data is not None:
                     state["_benchmark_cache_key"] = fetch_order_id

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -20,6 +20,7 @@ import pytest
 
 from apps.web_console_ng.pages.execution_quality import (
     DEFAULT_RANGE_DAYS,
+    _fetch_tca_benchmarks,
     _fetch_tca_data,
 )
 
@@ -197,6 +198,75 @@ class TestFetchTCAData:
             assert headers["X-User-ID"] == "test_user"
             assert headers["X-User-Role"] == "admin"
             assert headers["X-User-Strategies"] == "strat1,strat2"
+
+
+class TestFetchTCABenchmarks:
+    """Tests for _fetch_tca_benchmarks function."""
+
+    @pytest.mark.asyncio()
+    async def test_fetch_benchmarks_success(self) -> None:
+        """Successful fetch returns benchmark series data."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "symbol": "AAPL",
+            "benchmark_type": "vwap",
+            "points": [
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": 150.25,
+                    "benchmark_price": 150.1,
+                }
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+            call_args = mock_instance.get.call_args
+            params = call_args.kwargs.get("params", {})
+            headers = call_args.kwargs.get("headers", {})
+            assert params == {"client_order_id": "order-1", "benchmark": "vwap"}
+            assert headers["X-User-ID"] == "test_user"
+            assert headers["X-User-Role"] == "trader"
+            assert headers["X-User-Strategies"] == "alpha_baseline"
+
+        assert result is not None
+        assert result["points"][0]["execution_price"] == 150.25
+
+    @pytest.mark.asyncio()
+    async def test_fetch_benchmarks_api_error(self) -> None:
+        """API error returns None for benchmark fetches."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="missing-order",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
 
 
 class TestDefaultDateRange:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -23,6 +23,7 @@ from apps.web_console_ng.pages.execution_quality import (
     _fetch_tca_benchmarks,
     _fetch_tca_data,
     _generate_demo_benchmark_data,
+    _is_cacheable_benchmark,
     _is_numeric,
     _safe_float,
     _should_fetch_benchmark,
@@ -175,9 +176,7 @@ class TestFetchTCAData:
                 )
 
     @pytest.mark.asyncio()
-    async def test_fetch_sends_auth_headers(
-        self, mock_response_data: dict[str, Any]
-    ) -> None:
+    async def test_fetch_sends_auth_headers(self, mock_response_data: dict[str, Any]) -> None:
         """Fetch sends correct authentication headers."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -507,6 +506,80 @@ class TestShouldFetchBenchmark:
         # returns the raw payload so the render guard can do its job.
         assert result is not None
         assert result["points"] == "bad-data"
+
+
+class TestIsCacheableBenchmark:
+    """Tests for _is_cacheable_benchmark validation helper."""
+
+    def test_valid_payload_is_cacheable(self) -> None:
+        """Well-formed benchmark payload with valid prices is cacheable."""
+        data: dict[str, Any] = {
+            "client_order_id": "order-1",
+            "points": [
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": 150.25,
+                    "benchmark_price": 150.1,
+                }
+            ],
+        }
+        assert _is_cacheable_benchmark(data) is True
+
+    def test_empty_points_is_not_cacheable(self) -> None:
+        """Empty points list is not cacheable (nothing to render)."""
+        data: dict[str, Any] = {"client_order_id": "order-1", "points": []}
+        assert _is_cacheable_benchmark(data) is False
+
+    def test_non_list_points_is_not_cacheable(self) -> None:
+        """Non-list points field is not cacheable."""
+        data: dict[str, Any] = {"client_order_id": "order-1", "points": "bad"}
+        assert _is_cacheable_benchmark(data) is False
+
+    def test_missing_points_is_not_cacheable(self) -> None:
+        """Missing points key is not cacheable."""
+        data: dict[str, Any] = {"client_order_id": "order-1"}
+        assert _is_cacheable_benchmark(data) is False
+
+    def test_non_dict_points_only_is_not_cacheable(self) -> None:
+        """Points containing only non-dict entries is not cacheable."""
+        data: dict[str, Any] = {"points": ["bad", 42, None]}
+        assert _is_cacheable_benchmark(data) is False
+
+    def test_null_prices_not_cacheable(self) -> None:
+        """Points with null prices are not cacheable."""
+        data: dict[str, Any] = {
+            "points": [
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": None,
+                    "benchmark_price": None,
+                }
+            ],
+        }
+        assert _is_cacheable_benchmark(data) is False
+
+    def test_nan_prices_not_cacheable(self) -> None:
+        """Points with NaN prices are not cacheable."""
+        data: dict[str, Any] = {
+            "points": [
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": float("nan"),
+                    "benchmark_price": 150.0,
+                }
+            ],
+        }
+        assert _is_cacheable_benchmark(data) is False
+
+    def test_mixed_valid_and_invalid_is_cacheable(self) -> None:
+        """At least one valid point makes the payload cacheable."""
+        data: dict[str, Any] = {
+            "points": [
+                {"execution_price": None, "benchmark_price": None},
+                {"execution_price": 150.0, "benchmark_price": 149.5},
+            ],
+        }
+        assert _is_cacheable_benchmark(data) is True
 
 
 class TestBenchmarkFetchCacheContract:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -328,6 +328,14 @@ class TestSafeFloat:
         assert _safe_float("bad") == 0.0
         assert _safe_float(None, default=-1.0) == -1.0
 
+    def test_safe_float_rejects_nan_inf(self) -> None:
+        """NaN and inf are treated as invalid and return default."""
+        assert _safe_float(float("nan")) == 0.0
+        assert _safe_float(float("inf")) == 0.0
+        assert _safe_float(float("-inf")) == 0.0
+        assert _safe_float("nan") == 0.0
+        assert _safe_float("inf") == 0.0
+
     def test_is_numeric_valid(self) -> None:
         """_is_numeric returns True for convertible values."""
         assert _is_numeric(150.25) is True
@@ -340,16 +348,23 @@ class TestSafeFloat:
         assert _is_numeric("bad") is False
         assert _is_numeric([]) is False
 
+    def test_is_numeric_rejects_nan_inf(self) -> None:
+        """NaN and inf are rejected as non-finite."""
+        assert _is_numeric(float("nan")) is False
+        assert _is_numeric(float("inf")) is False
+        assert _is_numeric(float("-inf")) is False
+        assert _is_numeric("nan") is False
+
 
 class TestBenchmarkDemoModeGating:
-    """Tests that benchmark fetch is skipped in demo mode."""
+    """Tests that benchmark fetch is gated on demo mode and data validity."""
 
     @pytest.mark.asyncio()
-    async def test_benchmark_not_fetched_in_demo_mode(self) -> None:
-        """Benchmark API should not be called when TCA data comes from demo mode."""
-        # When the TCA analysis API fails, demo data is used and
-        # _fetch_tca_benchmarks should NOT be called (guarded by
-        # ``not state.get("demo_mode")``).
+    async def test_benchmark_not_fetched_when_tca_api_fails(self) -> None:
+        """When TCA analysis API fails (returns None), the caller enters demo
+        mode and should skip _fetch_tca_benchmarks.  We verify the precondition
+        by confirming _fetch_tca_data returns None and asserting
+        _fetch_tca_benchmarks is NOT invoked (via the demo_mode guard)."""
         tca_fail_response = MagicMock()
         tca_fail_response.status_code = 503
 
@@ -360,8 +375,7 @@ class TestBenchmarkDemoModeGating:
             mock_instance.__aexit__.return_value = None
             mock_client.return_value = mock_instance
 
-            # Fetch TCA data — will fail and caller should switch to demo mode
-            result = await _fetch_tca_data(
+            tca_result = await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
                 symbol=None,
@@ -371,8 +385,25 @@ class TestBenchmarkDemoModeGating:
                 strategies=[],
             )
 
-        # Confirm API failure returns None (triggers demo fallback)
-        assert result is None
+        # TCA API failure returns None -- caller must set demo_mode=True
+        assert tca_result is None
+
+        # Simulate the demo_mode guard used in _render_tca_dashboard:
+        # ``if orders and not state.get("demo_mode"): ...``
+        demo_mode = tca_result is None  # True when API failed
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._fetch_tca_benchmarks",
+            new_callable=AsyncMock,
+        ) as mock_bench:
+            if not demo_mode:
+                await mock_bench(
+                    client_order_id="order-1",
+                    user_id="test_user",
+                    role="trader",
+                    strategies=[],
+                )
+            # In demo mode the function must never be called
+            mock_bench.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_benchmark_fetched_for_real_orders(self) -> None:
@@ -408,6 +439,39 @@ class TestBenchmarkDemoModeGating:
 
         assert result is not None
         assert len(result["points"]) == 1
+
+    @pytest.mark.asyncio()
+    async def test_benchmark_malformed_points_shape(self) -> None:
+        """Malformed points (not a list of dicts) returns valid but empty data."""
+        # Simulate API returning points as a string instead of list
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "symbol": "AAPL",
+            "benchmark_type": "vwap",
+            "points": "bad-data",
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+        # The fetch succeeds but the render guard (isinstance checks)
+        # will filter out the invalid shape.  Verify the fetch itself
+        # returns the raw payload so the render guard can do its job.
+        assert result is not None
+        assert result["points"] == "bad-data"
 
 
 class TestDefaultDateRange:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -22,6 +22,8 @@ from apps.web_console_ng.pages.execution_quality import (
     DEFAULT_RANGE_DAYS,
     _fetch_tca_benchmarks,
     _fetch_tca_data,
+    _is_numeric,
+    _safe_float,
 )
 
 
@@ -309,6 +311,103 @@ class TestFetchTCABenchmarks:
             )
 
         assert result is None
+
+
+class TestSafeFloat:
+    """Tests for _safe_float and _is_numeric helpers."""
+
+    def test_safe_float_valid(self) -> None:
+        """Valid numeric values are converted correctly."""
+        assert _safe_float(3.14) == 3.14
+        assert _safe_float("2.5") == 2.5
+        assert _safe_float(0) == 0.0
+
+    def test_safe_float_invalid(self) -> None:
+        """Invalid values return the default."""
+        assert _safe_float(None) == 0.0
+        assert _safe_float("bad") == 0.0
+        assert _safe_float(None, default=-1.0) == -1.0
+
+    def test_is_numeric_valid(self) -> None:
+        """_is_numeric returns True for convertible values."""
+        assert _is_numeric(150.25) is True
+        assert _is_numeric("42") is True
+        assert _is_numeric(0) is True
+
+    def test_is_numeric_invalid(self) -> None:
+        """_is_numeric returns False for non-numeric values."""
+        assert _is_numeric(None) is False
+        assert _is_numeric("bad") is False
+        assert _is_numeric([]) is False
+
+
+class TestBenchmarkDemoModeGating:
+    """Tests that benchmark fetch is skipped in demo mode."""
+
+    @pytest.mark.asyncio()
+    async def test_benchmark_not_fetched_in_demo_mode(self) -> None:
+        """Benchmark API should not be called when TCA data comes from demo mode."""
+        # When the TCA analysis API fails, demo data is used and
+        # _fetch_tca_benchmarks should NOT be called (guarded by
+        # ``not state.get("demo_mode")``).
+        tca_fail_response = MagicMock()
+        tca_fail_response.status_code = 503
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = tca_fail_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            # Fetch TCA data — will fail and caller should switch to demo mode
+            result = await _fetch_tca_data(
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 31),
+                symbol=None,
+                strategy_id=None,
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        # Confirm API failure returns None (triggers demo fallback)
+        assert result is None
+
+    @pytest.mark.asyncio()
+    async def test_benchmark_fetched_for_real_orders(self) -> None:
+        """Benchmark API is called when real TCA data is available."""
+        benchmark_response = MagicMock()
+        benchmark_response.status_code = 200
+        benchmark_response.json.return_value = {
+            "client_order_id": "order-1",
+            "symbol": "AAPL",
+            "benchmark_type": "vwap",
+            "points": [
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": 150.25,
+                    "benchmark_price": 150.1,
+                }
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = benchmark_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+        assert result is not None
+        assert len(result["points"]) == 1
 
 
 class TestDefaultDateRange:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -493,12 +493,18 @@ class TestShouldFetchBenchmark:
         assert result["points"] == "bad-data"
 
 
-class TestBenchmarkCacheBehavior:
-    """Tests for benchmark cache contract (only cache successes, retry failures)."""
+class TestBenchmarkFetchCacheContract:
+    """Tests verifying _fetch_tca_benchmarks return value contract for caching.
+
+    The dashboard caches successful (non-None) responses and retries on
+    None.  These tests verify the return value contract that enables
+    that behavior.  Full dashboard cache-state-transition tests require
+    NiceGUI server context and are not feasible in unit tests.
+    """
 
     @pytest.mark.asyncio()
-    async def test_successful_fetch_is_cacheable(self) -> None:
-        """Successful benchmark response should be cached (non-None result)."""
+    async def test_successful_fetch_returns_dict_for_caching(self) -> None:
+        """Successful benchmark response returns dict (dashboard can cache it)."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -526,8 +532,8 @@ class TestBenchmarkCacheBehavior:
         assert result is not None
 
     @pytest.mark.asyncio()
-    async def test_failed_fetch_returns_none_for_retry(self) -> None:
-        """Failed benchmark fetch returns None so the dashboard does NOT cache it."""
+    async def test_failed_fetch_returns_none_enabling_retry(self) -> None:
+        """Failed benchmark fetch returns None so dashboard skips caching and retries."""
         mock_response = MagicMock()
         mock_response.status_code = 500
 

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -312,6 +312,29 @@ class TestFetchTCABenchmarks:
 
         assert result is None
 
+    @pytest.mark.asyncio()
+    async def test_fetch_benchmarks_non_dict_json(self) -> None:
+        """JSON response that is not a dict returns None."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ["unexpected", "list"]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+        assert result is None
+
 
 class TestSafeFloat:
     """Tests for _safe_float and _is_numeric helpers."""
@@ -336,6 +359,11 @@ class TestSafeFloat:
         assert _safe_float("nan") == 0.0
         assert _safe_float("inf") == 0.0
 
+    def test_safe_float_rejects_booleans(self) -> None:
+        """Booleans are not valid price values."""
+        assert _safe_float(True) == 0.0
+        assert _safe_float(False) == 0.0
+
     def test_is_numeric_valid(self) -> None:
         """_is_numeric returns True for convertible values."""
         assert _is_numeric(150.25) is True
@@ -355,16 +383,28 @@ class TestSafeFloat:
         assert _is_numeric(float("-inf")) is False
         assert _is_numeric("nan") is False
 
+    def test_is_numeric_rejects_booleans(self) -> None:
+        """Booleans are not valid numeric price values."""
+        assert _is_numeric(True) is False
+        assert _is_numeric(False) is False
+
 
 class TestBenchmarkDemoModeGating:
     """Tests that benchmark fetch is gated on demo mode and data validity."""
 
     @pytest.mark.asyncio()
-    async def test_benchmark_not_fetched_when_tca_api_fails(self) -> None:
-        """When TCA analysis API fails (returns None), the caller enters demo
-        mode and should skip _fetch_tca_benchmarks.  We verify the precondition
-        by confirming _fetch_tca_data returns None and asserting
-        _fetch_tca_benchmarks is NOT invoked (via the demo_mode guard)."""
+    async def test_tca_api_failure_returns_none_for_demo_fallback(self) -> None:
+        """When TCA analysis API returns non-200, _fetch_tca_data returns None.
+
+        The dashboard code uses this None result to enter demo mode and
+        skip _fetch_tca_benchmarks.  This test verifies the precondition
+        (API failure => None) that the dashboard guard depends on.
+
+        Note: Full end-to-end gating test of _render_tca_dashboard is not
+        feasible without NiceGUI server context; the guard logic is:
+            ``if orders and not state.get("demo_mode"):``
+        which is verified by code inspection.
+        """
         tca_fail_response = MagicMock()
         tca_fail_response.status_code = 503
 
@@ -385,25 +425,8 @@ class TestBenchmarkDemoModeGating:
                 strategies=[],
             )
 
-        # TCA API failure returns None -- caller must set demo_mode=True
+        # API failure returns None, which triggers demo_mode in the dashboard
         assert tca_result is None
-
-        # Simulate the demo_mode guard used in _render_tca_dashboard:
-        # ``if orders and not state.get("demo_mode"): ...``
-        demo_mode = tca_result is None  # True when API failed
-        with patch(
-            "apps.web_console_ng.pages.execution_quality._fetch_tca_benchmarks",
-            new_callable=AsyncMock,
-        ) as mock_bench:
-            if not demo_mode:
-                await mock_bench(
-                    client_order_id="order-1",
-                    user_id="test_user",
-                    role="trader",
-                    strategies=[],
-                )
-            # In demo mode the function must never be called
-            mock_bench.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_benchmark_fetched_for_real_orders(self) -> None:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -25,6 +25,7 @@ from apps.web_console_ng.pages.execution_quality import (
     _generate_demo_benchmark_data,
     _is_cacheable_benchmark,
     _is_numeric,
+    _is_valid_price,
     _safe_float,
     _should_fetch_benchmark,
 )
@@ -402,6 +403,51 @@ class TestSafeFloat:
         assert _is_numeric(False) is False
 
 
+class TestIsValidPrice:
+    """Tests for _is_valid_price — stricter than _is_numeric for chart data."""
+
+    def test_positive_float_is_valid(self) -> None:
+        """Positive float is a valid price."""
+        assert _is_valid_price(150.5) is True
+        assert _is_valid_price(0.01) is True
+
+    def test_positive_string_is_valid(self) -> None:
+        """Numeric string is valid."""
+        assert _is_valid_price("150.5") is True
+
+    def test_zero_is_invalid(self) -> None:
+        """Zero is not a valid price (placeholder data)."""
+        assert _is_valid_price(0.0) is False
+        assert _is_valid_price(0) is False
+
+    def test_negative_is_invalid(self) -> None:
+        """Negative price is not valid."""
+        assert _is_valid_price(-10.0) is False
+        assert _is_valid_price("-5") is False
+
+    def test_none_is_invalid(self) -> None:
+        """None is not valid."""
+        assert _is_valid_price(None) is False
+
+    def test_non_numeric_string_is_invalid(self) -> None:
+        """Non-numeric string is not valid."""
+        assert _is_valid_price("abc") is False
+
+    def test_boolean_is_invalid(self) -> None:
+        """Booleans are not valid prices (float(True) == 1.0)."""
+        assert _is_valid_price(True) is False
+        assert _is_valid_price(False) is False
+
+    def test_nan_is_invalid(self) -> None:
+        """NaN is not valid."""
+        assert _is_valid_price(float("nan")) is False
+
+    def test_inf_is_invalid(self) -> None:
+        """Infinity is not valid."""
+        assert _is_valid_price(float("inf")) is False
+        assert _is_valid_price(float("-inf")) is False
+
+
 class TestShouldFetchBenchmark:
     """Tests for the _should_fetch_benchmark gating function."""
 
@@ -670,12 +716,12 @@ class TestGenerateDemoBenchmarkData:
         assert r1["points"] == r2["points"]
 
     def test_demo_benchmark_points_have_valid_prices(self) -> None:
-        """All demo benchmark points have finite numeric prices."""
+        """All demo benchmark points have valid positive prices."""
         order = {"client_order_id": "demo-0002", "symbol": "MSFT"}
         result = _generate_demo_benchmark_data(order)
         for point in result["points"]:
-            assert _is_numeric(point["execution_price"])
-            assert _is_numeric(point["benchmark_price"])
+            assert _is_valid_price(point["execution_price"])
+            assert _is_valid_price(point["benchmark_price"])
 
 
 class TestDefaultDateRange:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -22,6 +22,7 @@ from apps.web_console_ng.pages.execution_quality import (
     DEFAULT_RANGE_DAYS,
     _fetch_tca_benchmarks,
     _fetch_tca_data,
+    _generate_demo_benchmark_data,
     _is_numeric,
     _safe_float,
 )
@@ -495,6 +496,36 @@ class TestBenchmarkDemoModeGating:
         # returns the raw payload so the render guard can do its job.
         assert result is not None
         assert result["points"] == "bad-data"
+
+
+class TestGenerateDemoBenchmarkData:
+    """Tests for _generate_demo_benchmark_data fallback."""
+
+    def test_demo_benchmark_returns_valid_structure(self) -> None:
+        """Demo benchmark data has expected keys and non-empty points."""
+        order = {"client_order_id": "demo-0001", "symbol": "AAPL"}
+        result = _generate_demo_benchmark_data(order)
+
+        assert isinstance(result, dict)
+        assert result["symbol"] == "AAPL"
+        assert result["benchmark_type"] == "vwap"
+        assert isinstance(result["points"], list)
+        assert len(result["points"]) == 10
+
+    def test_demo_benchmark_deterministic(self) -> None:
+        """Same order produces identical demo benchmark data."""
+        order = {"client_order_id": "demo-0001", "symbol": "AAPL"}
+        r1 = _generate_demo_benchmark_data(order)
+        r2 = _generate_demo_benchmark_data(order)
+        assert r1["points"] == r2["points"]
+
+    def test_demo_benchmark_points_have_valid_prices(self) -> None:
+        """All demo benchmark points have finite numeric prices."""
+        order = {"client_order_id": "demo-0002", "symbol": "MSFT"}
+        result = _generate_demo_benchmark_data(order)
+        for point in result["points"]:
+            assert _is_numeric(point["execution_price"])
+            assert _is_numeric(point["benchmark_price"])
 
 
 class TestDefaultDateRange:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -493,6 +493,62 @@ class TestShouldFetchBenchmark:
         assert result["points"] == "bad-data"
 
 
+class TestBenchmarkCacheBehavior:
+    """Tests for benchmark cache contract (only cache successes, retry failures)."""
+
+    @pytest.mark.asyncio()
+    async def test_successful_fetch_is_cacheable(self) -> None:
+        """Successful benchmark response should be cached (non-None result)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "symbol": "AAPL",
+            "benchmark_type": "vwap",
+            "points": [{"timestamp": "T", "execution_price": 100, "benchmark_price": 99}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["s1"],
+            )
+
+        # Result is not None so the dashboard can safely cache it
+        assert result is not None
+
+    @pytest.mark.asyncio()
+    async def test_failed_fetch_returns_none_for_retry(self) -> None:
+        """Failed benchmark fetch returns None so the dashboard does NOT cache it."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        # None tells the dashboard NOT to cache, enabling retry on next load
+        assert result is None
+
+
 class TestGenerateDemoBenchmarkData:
     """Tests for _generate_demo_benchmark_data fallback."""
 

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -71,13 +71,14 @@ class TestFetchTCAData:
         mock_response.status_code = 200
         mock_response.json.return_value = mock_response_data
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
@@ -100,13 +101,14 @@ class TestFetchTCAData:
         mock_response.status_code = 200
         mock_response.json.return_value = mock_response_data
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
@@ -118,7 +120,7 @@ class TestFetchTCAData:
             )
 
             # Check that filters were passed in query params
-            call_args = mock_instance.get.call_args
+            call_args = mock_client.get.call_args
             params = call_args.kwargs.get("params", {})
             assert params.get("symbol") == "AAPL"
 
@@ -130,13 +132,14 @@ class TestFetchTCAData:
         mock_response = MagicMock()
         mock_response.status_code = 500
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
@@ -151,25 +154,25 @@ class TestFetchTCAData:
 
     @pytest.mark.asyncio()
     async def test_fetch_connection_error(self) -> None:
-        """Connection error returns None."""
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.side_effect = httpx.RequestError("Connection refused")
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        """Connection error raises httpx.RequestError."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.RequestError("Connection refused")
+        mock_client.is_closed = False
 
-            result = await _fetch_tca_data(
-                start_date=date(2024, 1, 1),
-                end_date=date(2024, 1, 31),
-                symbol=None,
-                strategy_id=None,
-                user_id="test_user",
-                role="trader",
-                strategies=[],
-            )
-
-        assert result is None
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
+            with pytest.raises(httpx.RequestError, match="Connection refused"):
+                await _fetch_tca_data(
+                    start_date=date(2024, 1, 1),
+                    end_date=date(2024, 1, 31),
+                    symbol=None,
+                    strategy_id=None,
+                    user_id="test_user",
+                    role="trader",
+                    strategies=[],
+                )
 
     @pytest.mark.asyncio()
     async def test_fetch_sends_auth_headers(
@@ -180,13 +183,14 @@ class TestFetchTCAData:
         mock_response.status_code = 200
         mock_response.json.return_value = mock_response_data
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
@@ -197,7 +201,7 @@ class TestFetchTCAData:
                 strategies=["strat1", "strat2"],
             )
 
-            call_args = mock_instance.get.call_args
+            call_args = mock_client.get.call_args
             headers = call_args.kwargs.get("headers", {})
             assert headers["X-User-ID"] == "test_user"
             assert headers["X-User-Role"] == "admin"
@@ -225,21 +229,23 @@ class TestFetchTCABenchmarks:
             ],
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
                 user_id="test_user",
                 role="trader",
                 strategies=["alpha_baseline"],
+                strategy_id="alpha_baseline",
             )
 
-            call_args = mock_instance.get.call_args
+            call_args = mock_client.get.call_args
             params = call_args.kwargs.get("params", {})
             headers = call_args.kwargs.get("headers", {})
             assert params == {"client_order_id": "order-1", "benchmark": "vwap"}
@@ -256,63 +262,67 @@ class TestFetchTCABenchmarks:
         mock_response = MagicMock()
         mock_response.status_code = 404
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="missing-order",
                 user_id="test_user",
                 role="trader",
                 strategies=[],
+                strategy_id=None,
             )
 
         assert result is None
 
     @pytest.mark.asyncio()
     async def test_fetch_benchmarks_connection_error(self) -> None:
-        """Connection error returns None for benchmark fetches."""
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.side_effect = httpx.RequestError("Connection refused")
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        """Connection error raises httpx.RequestError."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.RequestError("Connection refused")
+        mock_client.is_closed = False
 
-            result = await _fetch_tca_benchmarks(
-                client_order_id="order-1",
-                user_id="test_user",
-                role="trader",
-                strategies=["alpha_baseline"],
-            )
-
-        assert result is None
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
+            with pytest.raises(httpx.RequestError, match="Connection refused"):
+                await _fetch_tca_benchmarks(
+                    client_order_id="order-1",
+                    user_id="test_user",
+                    role="trader",
+                    strategies=["alpha_baseline"],
+                    strategy_id="alpha_baseline",
+                )
 
     @pytest.mark.asyncio()
     async def test_fetch_benchmarks_malformed_json(self) -> None:
-        """Malformed JSON response returns None for benchmark fetches."""
+        """Malformed JSON response raises ValueError."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError("Invalid JSON")
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
-            result = await _fetch_tca_benchmarks(
-                client_order_id="order-1",
-                user_id="test_user",
-                role="trader",
-                strategies=["alpha_baseline"],
-            )
-
-        assert result is None
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                await _fetch_tca_benchmarks(
+                    client_order_id="order-1",
+                    user_id="test_user",
+                    role="trader",
+                    strategies=["alpha_baseline"],
+                    strategy_id="alpha_baseline",
+                )
 
     @pytest.mark.asyncio()
     async def test_fetch_benchmarks_non_dict_json(self) -> None:
@@ -321,18 +331,20 @@ class TestFetchTCABenchmarks:
         mock_response.status_code = 200
         mock_response.json.return_value = ["unexpected", "list"]
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
                 user_id="test_user",
                 role="trader",
                 strategies=["alpha_baseline"],
+                strategy_id="alpha_baseline",
             )
 
         assert result is None
@@ -442,18 +454,20 @@ class TestShouldFetchBenchmark:
             ],
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = benchmark_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = benchmark_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
                 user_id="test_user",
                 role="trader",
                 strategies=["alpha_baseline"],
+                strategy_id="alpha_baseline",
             )
 
         assert result is not None
@@ -472,18 +486,20 @@ class TestShouldFetchBenchmark:
             "points": "bad-data",
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
                 user_id="test_user",
                 role="trader",
                 strategies=["alpha_baseline"],
+                strategy_id="alpha_baseline",
             )
 
         # The fetch succeeds but the render guard (isinstance checks)
@@ -514,18 +530,20 @@ class TestBenchmarkFetchCacheContract:
             "points": [{"timestamp": "T", "execution_price": 100, "benchmark_price": 99}],
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
                 user_id="test_user",
                 role="trader",
                 strategies=["s1"],
+                strategy_id="s1",
             )
 
         # Result is not None so the dashboard can safely cache it
@@ -537,18 +555,20 @@ class TestBenchmarkFetchCacheContract:
         mock_response = MagicMock()
         mock_response.status_code = 500
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
                 user_id="test_user",
                 role="trader",
                 strategies=[],
+                strategy_id=None,
             )
 
         # None tells the dashboard NOT to cache, enabling retry on next load
@@ -625,13 +645,14 @@ class TestExecutionQualityPageIntegration:
             "orders": [],
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             result = await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
@@ -653,13 +674,14 @@ class TestExecutionQualityPageIntegration:
         mock_response.status_code = 200
         mock_response.json.return_value = {"summary": {}, "orders": []}
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
 
+        with patch(
+            "apps.web_console_ng.pages.execution_quality._get_shared_client",
+            return_value=mock_client,
+        ):
             await _fetch_tca_data(
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 31),
@@ -670,6 +692,6 @@ class TestExecutionQualityPageIntegration:
                 strategies=["alpha_baseline"],
             )
 
-            call_args = mock_instance.get.call_args
+            call_args = mock_client.get.call_args
             params = call_args.kwargs.get("params", {})
             assert params.get("strategy_id") == "alpha_baseline"

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -25,6 +25,7 @@ from apps.web_console_ng.pages.execution_quality import (
     _generate_demo_benchmark_data,
     _is_numeric,
     _safe_float,
+    _should_fetch_benchmark,
 )
 
 
@@ -390,44 +391,38 @@ class TestSafeFloat:
         assert _is_numeric(False) is False
 
 
-class TestBenchmarkDemoModeGating:
-    """Tests that benchmark fetch is gated on demo mode and data validity."""
+class TestShouldFetchBenchmark:
+    """Tests for the _should_fetch_benchmark gating function."""
 
-    @pytest.mark.asyncio()
-    async def test_tca_api_failure_returns_none_for_demo_fallback(self) -> None:
-        """When TCA analysis API returns non-200, _fetch_tca_data returns None.
+    def test_returns_order_id_for_real_mode(self) -> None:
+        """Returns first order's client_order_id when not in demo mode."""
+        orders = [{"client_order_id": "order-abc"}]
+        assert _should_fetch_benchmark(orders, demo_mode=False) == "order-abc"
 
-        The dashboard code uses this None result to enter demo mode and
-        skip _fetch_tca_benchmarks.  This test verifies the precondition
-        (API failure => None) that the dashboard guard depends on.
+    def test_returns_none_in_demo_mode(self) -> None:
+        """Returns None when in demo mode (benchmark fetch should be skipped)."""
+        orders = [{"client_order_id": "order-abc"}]
+        assert _should_fetch_benchmark(orders, demo_mode=True) is None
 
-        Note: Full end-to-end gating test of _render_tca_dashboard is not
-        feasible without NiceGUI server context; the guard logic is:
-            ``if orders and not state.get("demo_mode"):``
-        which is verified by code inspection.
-        """
-        tca_fail_response = MagicMock()
-        tca_fail_response.status_code = 503
+    def test_returns_none_with_no_orders(self) -> None:
+        """Returns None when there are no orders."""
+        assert _should_fetch_benchmark([], demo_mode=False) is None
+        assert _should_fetch_benchmark([], demo_mode=True) is None
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.get.return_value = tca_fail_response
-            mock_instance.__aenter__.return_value = mock_instance
-            mock_instance.__aexit__.return_value = None
-            mock_client.return_value = mock_instance
+    def test_returns_none_for_empty_order_id(self) -> None:
+        """Returns None when first order has empty client_order_id."""
+        orders: list[dict[str, Any]] = [{"client_order_id": ""}]
+        assert _should_fetch_benchmark(orders, demo_mode=False) is None
 
-            tca_result = await _fetch_tca_data(
-                start_date=date(2024, 1, 1),
-                end_date=date(2024, 1, 31),
-                symbol=None,
-                strategy_id=None,
-                user_id="test_user",
-                role="trader",
-                strategies=[],
-            )
+    def test_returns_none_for_whitespace_order_id(self) -> None:
+        """Returns None when first order has whitespace-only client_order_id."""
+        orders: list[dict[str, Any]] = [{"client_order_id": "   "}]
+        assert _should_fetch_benchmark(orders, demo_mode=False) is None
 
-        # API failure returns None, which triggers demo_mode in the dashboard
-        assert tca_result is None
+    def test_returns_none_for_missing_order_id(self) -> None:
+        """Returns None when first order has no client_order_id key."""
+        orders: list[dict[str, Any]] = [{"symbol": "AAPL"}]
+        assert _should_fetch_benchmark(orders, demo_mode=False) is None
 
     @pytest.mark.asyncio()
     async def test_benchmark_fetched_for_real_orders(self) -> None:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -268,6 +268,48 @@ class TestFetchTCABenchmarks:
 
         assert result is None
 
+    @pytest.mark.asyncio()
+    async def test_fetch_benchmarks_connection_error(self) -> None:
+        """Connection error returns None for benchmark fetches."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.side_effect = httpx.RequestError("Connection refused")
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio()
+    async def test_fetch_benchmarks_malformed_json(self) -> None:
+        """Malformed JSON response returns None for benchmark fetches."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+        assert result is None
+
 
 class TestDefaultDateRange:
     """Tests for default date range constant."""


### PR DESCRIPTION
## Summary
- replace the synthetic execution-vs-VWAP chart with data from `/api/v1/tca/benchmarks`
- reuse shared TCA auth headers for both analysis and benchmark requests
- add benchmark fetch tests for success and error cases

## Testing
- `.venv/bin/python -m pytest tests/apps/web_console_ng/pages/test_execution_quality.py -q`
- `.venv/bin/python -m ruff check apps/web_console_ng/pages/execution_quality.py tests/apps/web_console_ng/pages/test_execution_quality.py`

Closes #157
