### PR TITLE
fix: forward strategy_id in orchestrator multi-strategy signal fetch

### DIFF
--- a/apps/orchestrator/clients.py
+++ b/apps/orchestrator/clients.py
@@ -295,6 +295,7 @@ class SignalServiceClient:
                 "as_of_date": payload.get("as_of_date"),
                 "top_n": top_n,
                 "bottom_n": bottom_n,
+                "strategy_id": strategy_id,
             },
         )
 
@@ -317,7 +318,7 @@ class SignalServiceClient:
         if response.status_code != 200:
             logger.error(
                 f"Signal Service returned error: {response.status_code}",
-                extra={"response": response.text},
+                extra={"response": response.text, "strategy_id": strategy_id},
             )
             response.raise_for_status()
 

--- a/apps/orchestrator/orchestrator.py
+++ b/apps/orchestrator/orchestrator.py
@@ -662,18 +662,18 @@ class TradingOrchestrator:
         Notes:
             - In single-strategy mode, strategy_id is None and default model is used
             - In multi-strategy mode, strategy_id differentiates signal sources
-            - TODO: Pass strategy_id to signal_client once it supports multiple strategies
         """
         logger.info(
             f"Fetching signals for {len(symbols)} symbols"
             + (f" (strategy: {strategy_id})" if strategy_id else "")
         )
 
-        # TODO: Once SignalServiceClient supports strategy_id parameter, pass it here
-        # For MVP, all strategies use the same signal service endpoint
-        # In production, this would route to different strategy services or pass strategy_id
         signal_response = await self.signal_client.fetch_signals(
-            symbols=symbols, as_of_date=as_of_date, top_n=top_n, bottom_n=bottom_n
+            symbols=symbols,
+            as_of_date=as_of_date,
+            top_n=top_n,
+            bottom_n=bottom_n,
+            strategy_id=strategy_id,
         )
 
         logger.info(

--- a/apps/orchestrator/orchestrator.py
+++ b/apps/orchestrator/orchestrator.py
@@ -339,6 +339,8 @@ class TradingOrchestrator:
 
         # Normalize strategy_id to list for consistent handling
         strategy_ids = [strategy_id] if isinstance(strategy_id, str) else strategy_id
+        if not strategy_ids:
+            raise ValueError("strategy_id must not be an empty list")
         is_multi_strategy = len(strategy_ids) > 1
 
         logger.info(
@@ -664,8 +666,10 @@ class TradingOrchestrator:
             httpx.HTTPError: If Signal Service request fails
 
         Notes:
-            - In single-strategy mode, strategy_id is None and default model is used
+            - In single-strategy mode, strategy_id identifies the single active strategy
             - In multi-strategy mode, strategy_id differentiates signal sources
+            - strategy_id is forwarded to SignalServiceClient for S2S auth context;
+              signal service model routing by strategy is not yet implemented
         """
         logger.info(
             f"Fetching signals for {len(symbols)} symbols"

--- a/apps/orchestrator/orchestrator.py
+++ b/apps/orchestrator/orchestrator.py
@@ -368,7 +368,11 @@ class TradingOrchestrator:
             else:
                 # Single strategy: use signals directly (backward compatible)
                 signal_response = await self._fetch_signals(
-                    symbols=symbols, as_of_date=as_of_date, top_n=top_n, bottom_n=bottom_n
+                    symbols=symbols,
+                    as_of_date=as_of_date,
+                    top_n=top_n,
+                    bottom_n=bottom_n,
+                    strategy_id=strategy_ids[0],
                 )
                 final_signals = signal_response.signals
                 validated_as_of_date = signal_response.metadata.as_of_date

--- a/apps/orchestrator/orchestrator.py
+++ b/apps/orchestrator/orchestrator.py
@@ -340,7 +340,7 @@ class TradingOrchestrator:
         # Normalize strategy_id to list for consistent handling
         strategy_ids = [strategy_id] if isinstance(strategy_id, str) else strategy_id
         if not strategy_ids:
-            raise ValueError("strategy_id must not be an empty list")
+            raise ValueError("strategy_id must be a non-empty string or list of strings")
         is_multi_strategy = len(strategy_ids) > 1
 
         logger.info(
@@ -672,8 +672,8 @@ class TradingOrchestrator:
               signal service model routing by strategy is not yet implemented
         """
         logger.info(
-            f"Fetching signals for {len(symbols)} symbols"
-            + (f" (strategy: {strategy_id})" if strategy_id else "")
+            f"Fetching signals for {len(symbols)} symbols",
+            extra={"strategy_id": strategy_id} if strategy_id else {},
         )
 
         signal_response = await self.signal_client.fetch_signals(

--- a/tests/apps/orchestrator/test_orchestrator.py
+++ b/tests/apps/orchestrator/test_orchestrator.py
@@ -306,10 +306,17 @@ class TestTradingOrchestratorRun:
         assert "as_of_date mismatch across strategies" in result.error_message
 
         # Verify each fetch_signals call received the correct strategy_id
+        # Use a set comparison since asyncio.gather may invoke tasks in any order
         calls = orchestrator.signal_client.fetch_signals.call_args_list
         assert len(calls) == 2
-        assert calls[0].kwargs["strategy_id"] == "alpha_baseline"
-        assert calls[1].kwargs["strategy_id"] == "momentum"
+        called_strategy_ids = {c.kwargs["strategy_id"] for c in calls}
+        assert called_strategy_ids == {"alpha_baseline", "momentum"}
+
+    @pytest.mark.asyncio()
+    async def test_run_rejects_empty_strategy_list(self, orchestrator):
+        """Test that run() raises ValueError when given an empty strategy list."""
+        with pytest.raises(ValueError, match="strategy_id must not be an empty list"):
+            await orchestrator.run(symbols=["AAPL"], strategy_id=[])
 
 
 class TestFetchSignals:

--- a/tests/apps/orchestrator/test_orchestrator.py
+++ b/tests/apps/orchestrator/test_orchestrator.py
@@ -315,7 +315,7 @@ class TestTradingOrchestratorRun:
     @pytest.mark.asyncio()
     async def test_run_rejects_empty_strategy_list(self, orchestrator):
         """Test that run() raises ValueError when given an empty strategy list."""
-        with pytest.raises(ValueError, match="strategy_id must not be an empty list"):
+        with pytest.raises(ValueError, match="strategy_id must be a non-empty string or list of strings"):
             await orchestrator.run(symbols=["AAPL"], strategy_id=[])
 
 

--- a/tests/apps/orchestrator/test_orchestrator.py
+++ b/tests/apps/orchestrator/test_orchestrator.py
@@ -289,9 +289,8 @@ class TestTradingOrchestratorRun:
             ),
         )
 
-        # Mock fetch_signals to return different responses on sequential calls
-        # Note: strategy_id is not yet passed to signal_client.fetch_signals (TODO in orchestrator),
-        # so we use side_effect list to return different responses in order
+        # Mock fetch_signals to return different responses on sequential calls.
+        # We still use a side_effect list because asyncio.gather preserves task order.
         orchestrator.signal_client.fetch_signals = AsyncMock(side_effect=[response1, response2])
 
         # Run with multiple strategies - should fail due to date mismatch
@@ -340,13 +339,22 @@ class TestFetchSignals:
         orchestrator.signal_client.fetch_signals = AsyncMock(return_value=signal_response)
 
         result = await orchestrator._fetch_signals(
-            symbols=["AAPL", "MSFT"], as_of_date=date(2024, 10, 19)
+            symbols=["AAPL", "MSFT"],
+            as_of_date=date(2024, 10, 19),
+            strategy_id="alpha_baseline",
         )
 
         assert len(result.signals) == 2
         assert result.metadata.num_signals == 2
         assert result.metadata.top_n == 1
         assert result.metadata.bottom_n == 1
+        orchestrator.signal_client.fetch_signals.assert_awaited_once_with(
+            symbols=["AAPL", "MSFT"],
+            as_of_date=date(2024, 10, 19),
+            top_n=None,
+            bottom_n=None,
+            strategy_id="alpha_baseline",
+        )
 
 
 class TestMapSignalsToOrders:

--- a/tests/apps/orchestrator/test_orchestrator.py
+++ b/tests/apps/orchestrator/test_orchestrator.py
@@ -305,6 +305,12 @@ class TestTradingOrchestratorRun:
         assert result.num_orders_submitted == 0
         assert "as_of_date mismatch across strategies" in result.error_message
 
+        # Verify each fetch_signals call received the correct strategy_id
+        calls = orchestrator.signal_client.fetch_signals.call_args_list
+        assert len(calls) == 2
+        assert calls[0].kwargs["strategy_id"] == "alpha_baseline"
+        assert calls[1].kwargs["strategy_id"] == "momentum"
+
 
 class TestFetchSignals:
     """Tests for signal fetching."""


### PR DESCRIPTION
## Summary
- forward `strategy_id` from orchestrator `_fetch_signals()` into `SignalServiceClient.fetch_signals()`
- remove stale TODO/comments that claimed the client was not strategy-aware
- tighten orchestrator test coverage to assert the forwarded `strategy_id`

## Testing
- `PYTHONPATH=. poetry run pytest tests/apps/orchestrator/test_orchestrator.py -q`
- `PYTHONPATH=. poetry run pytest tests/apps/orchestrator/test_orchestrator.py tests/apps/orchestrator/test_clients.py -q`

Closes #161
