### PR TITLE
fix: use real TCA benchmark chart data

### DIFF
--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -224,16 +224,12 @@ async def _fetch_tca_benchmarks(
                     "body": response.text[:200],
                 },
             )
-    except httpx.RequestError as e:
+    except (httpx.RequestError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(
-            "TCA benchmarks API unavailable",
+            "TCA benchmarks API error",
             extra={**log_ctx, "error": str(e)},
         )
-    except (ValueError, KeyError, TypeError, AttributeError) as e:
-        logger.warning(
-            "TCA benchmarks API returned malformed response",
-            extra={**log_ctx, "error": str(e)},
-        )
+        raise
     return None
 
 
@@ -604,14 +600,23 @@ async def _render_tca_dashboard(
 
                     benchmark_data = None
                     if not state["demo_mode"] and client_order_id:
-                        benchmark_data = await _fetch_tca_benchmarks(
-                            client_order_id=client_order_id,
-                            user_id=user_id,
-                            role=role,
-                            strategies=authorized_strategies,
-                            symbol=str(first_order.get("symbol", "")),
-                            strategy_id=str(first_order.get("strategy_id", "")),
-                        )
+                        try:
+                            benchmark_data = await _fetch_tca_benchmarks(
+                                client_order_id=client_order_id,
+                                user_id=user_id,
+                                role=role,
+                                strategies=authorized_strategies,
+                                symbol=str(first_order.get("symbol", "")),
+                                strategy_id=str(first_order.get("strategy_id", "")),
+                            )
+                        except (
+                            httpx.RequestError,
+                            ValueError,
+                            KeyError,
+                            TypeError,
+                            AttributeError,
+                        ):
+                            benchmark_data = None
 
                     # Discard stale results if a newer load was triggered
                     if state["_load_version"] != current_version:

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -76,12 +76,17 @@ def _is_valid_timestamp(value: Any) -> bool:
     return _parse_utc(value) != _DATETIME_MIN_UTC
 
 
-def _format_benchmark_timestamp(value: Any) -> str:
-    """Format a benchmark point timestamp as ``HH:MM UTC``."""
+def _format_benchmark_timestamp(value: Any, *, include_date: bool = False) -> str:
+    """Format a benchmark point timestamp as ``HH:MM:SS UTC``.
+
+    When *include_date* is True the output includes the date prefix
+    (``YYYY-MM-DD HH:MM:SS UTC``) for multi-day fill windows.
+    """
     dt = _parse_utc(value)
     if dt == _DATETIME_MIN_UTC:
         return str(value)
-    return dt.strftime("%H:%M UTC")
+    fmt = "%Y-%m-%d %H:%M:%S UTC" if include_date else "%H:%M:%S UTC"
+    return dt.strftime(fmt)
 
 
 def _is_valid_price(value: Any) -> bool:
@@ -602,9 +607,25 @@ async def _render_tca_dashboard(
                         )
 
                         if valid_points:
+                            # Detect multi-day fills to include date in labels
+                            first_dt = _parse_utc(valid_points[0].get("timestamp", ""))
+                            last_dt = _parse_utc(valid_points[-1].get("timestamp", ""))
+                            multi_day = first_dt.date() != last_dt.date()
+
+                            # Warn if data may be truncated (backend
+                            # default fill limit is 500).
+                            if len(raw_points) >= 500:
+                                ui.label(
+                                    "Note: benchmark data may be truncated "
+                                    "(showing first 500 fills)."
+                                ).classes("text-amber-500 text-xs mb-1")
+
                             create_benchmark_comparison_chart(
                                 timestamps=[
-                                    _format_benchmark_timestamp(p.get("timestamp", ""))
+                                    _format_benchmark_timestamp(
+                                        p.get("timestamp", ""),
+                                        include_date=multi_day,
+                                    )
                                     for p in valid_points
                                 ],
                                 execution_prices=[
@@ -630,7 +651,9 @@ async def _render_tca_dashboard(
                         ).classes("text-gray-500 p-4")
                     else:
                         ui.label(
-                            "Benchmark chart unavailable for the first order."
+                            "Benchmark chart unavailable — the TCA benchmarks "
+                            "API did not return data for this order. Check logs "
+                            "for details."
                         ).classes("text-gray-500 p-4")
 
         # Render orders table

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -52,6 +52,19 @@ DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
 
 
+def _build_tca_auth_headers(
+    user_id: str,
+    role: str,
+    strategies: list[str],
+) -> dict[str, str]:
+    """Build auth headers for TCA API calls."""
+    return {
+        "X-User-ID": user_id,
+        "X-User-Role": role,
+        "X-User-Strategies": ",".join(strategies),
+    }
+
+
 async def _fetch_tca_data(
     start_date: date,
     end_date: date,
@@ -76,17 +89,10 @@ async def _fetch_tca_data(
             if strategy_id:
                 params["strategy_id"] = strategy_id
 
-            # Add auth headers
-            headers = {
-                "X-User-ID": user_id,
-                "X-User-Role": role,
-                "X-User-Strategies": ",".join(strategies),
-            }
-
             response = await client.get(
                 f"{EXECUTION_GATEWAY_URL}/api/v1/tca/analysis",
                 params=params,
-                headers=headers,
+                headers=_build_tca_auth_headers(user_id, role, strategies),
             )
             if response.status_code == 200:
                 result: dict[str, Any] = response.json()
@@ -97,6 +103,44 @@ async def _fetch_tca_data(
             )
     except httpx.RequestError as e:
         logger.warning("TCA API unavailable", extra={"error": str(e)})
+    return None
+
+
+async def _fetch_tca_benchmarks(
+    client_order_id: str,
+    user_id: str,
+    role: str,
+    strategies: list[str],
+    benchmark: str = "vwap",
+) -> dict[str, Any] | None:
+    """Fetch benchmark time series for an order.
+
+    Returns None on error so callers can hide the benchmark chart instead of
+    rendering synthetic data.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
+                params={"client_order_id": client_order_id, "benchmark": benchmark},
+                headers=_build_tca_auth_headers(user_id, role, strategies),
+            )
+            if response.status_code == 200:
+                result: dict[str, Any] = response.json()
+                return result if result.get("points") else None
+            logger.warning(
+                "TCA benchmarks API returned non-200",
+                extra={
+                    "status": response.status_code,
+                    "client_order_id": client_order_id,
+                    "body": response.text[:200],
+                },
+            )
+    except httpx.RequestError as e:
+        logger.warning(
+            "TCA benchmarks API unavailable",
+            extra={"error": str(e), "client_order_id": client_order_id},
+        )
     return None
 
 
@@ -442,37 +486,58 @@ async def _render_tca_dashboard(
                 else:
                     ui.label("No order data available").classes("text-gray-500 p-4")
 
-            # Benchmark comparison (show for first order as example)
+            # Benchmark comparison (real TCA benchmark data for first order)
             if orders:
                 with ui.card().classes("w-full p-4"):
-                    ui.label("Sample Execution vs VWAP").classes("text-lg font-bold mb-2")
+                    ui.label("Execution vs Benchmark").classes("text-lg font-bold mb-2")
 
-                    # Generate sample benchmark data for first order
                     first_order = orders[0]
-                    import random
+                    client_order_id = str(first_order.get("client_order_id", "")).strip()
 
-                    # Use stable hash for deterministic demo data across restarts
-                    random.seed(_stable_hash(first_order.get("client_order_id", "")))
+                    benchmark_data = None
+                    if not state["demo_mode"] and client_order_id:
+                        benchmark_data = await _fetch_tca_benchmarks(
+                            client_order_id=client_order_id,
+                            user_id=user_id,
+                            role=role,
+                            strategies=authorized_strategies,
+                        )
 
-                    num_points = 10
-                    base_price = 150.0
-                    timestamps = [f"10:{i * 5:02d}" for i in range(num_points)]
-                    exec_prices = [
-                        round(base_price * (1 + random.uniform(-0.002, 0.003)), 2)
-                        for _ in range(num_points)
-                    ]
-                    bench_prices = [
-                        round(base_price * (1 + random.uniform(-0.001, 0.001)), 2)
-                        for _ in range(num_points)
-                    ]
+                    if benchmark_data:
+                        points = benchmark_data.get("points", [])
+                        summary = benchmark_data.get("summary", {})
+                        benchmark_type = str(
+                            benchmark_data.get("benchmark_type") or "vwap"
+                        ).upper()
 
-                    create_benchmark_comparison_chart(
-                        timestamps=timestamps,
-                        execution_prices=exec_prices,
-                        benchmark_prices=bench_prices,
-                        benchmark_type="VWAP",
-                        symbol=first_order.get("symbol", ""),
-                    )
+                        def _format_timestamp(value: Any) -> str:
+                            text = str(value)
+                            try:
+                                return datetime.fromisoformat(text.replace("Z", "+00:00")).strftime(
+                                    "%H:%M"
+                                )
+                            except ValueError:
+                                return text
+
+                        create_benchmark_comparison_chart(
+                            timestamps=[_format_timestamp(p.get("timestamp", "")) for p in points],
+                            execution_prices=[float(p.get("execution_price", 0.0)) for p in points],
+                            benchmark_prices=[float(p.get("benchmark_price", 0.0)) for p in points],
+                            benchmark_type=benchmark_type,
+                            symbol=str(
+                                benchmark_data.get("symbol")
+                                or summary.get("symbol")
+                                or first_order.get("symbol", "")
+                            ),
+                        )
+                    elif state["demo_mode"]:
+                        ui.label(
+                            "Benchmark chart hidden in demo mode to avoid showing synthetic data."
+                        ).classes("text-gray-500 p-4")
+                    else:
+                        ui.label(
+                            "Benchmark chart unavailable for the selected order."
+                        ).classes("text-gray-500 p-4")
 
         # Render orders table
         with orders_container:

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -533,8 +533,9 @@ async def _render_tca_dashboard(
                         )
 
                     if benchmark_data:
-                        points = benchmark_data.get("points", [])
-                        summary = benchmark_data.get("summary", {})
+                        raw_points = benchmark_data.get("points", [])
+                        raw_summary = benchmark_data.get("summary")
+                        summary = raw_summary if isinstance(raw_summary, dict) else {}
                         benchmark_type = str(
                             benchmark_data.get("benchmark_type") or "vwap"
                         ).upper()
@@ -555,23 +556,47 @@ async def _render_tca_dashboard(
                             except ValueError:
                                 return text
 
-                        def _safe_float(value: Any, default: float = 0.0) -> float:
+                        def _is_valid_price(value: Any) -> bool:
+                            """Return True if value can be converted to a non-zero float."""
                             try:
-                                return float(value)
+                                return float(value) != 0.0
                             except (TypeError, ValueError):
-                                return default
+                                return False
 
-                        create_benchmark_comparison_chart(
-                            timestamps=[_format_timestamp(p.get("timestamp", "")) for p in points],
-                            execution_prices=[_safe_float(p.get("execution_price", 0.0)) for p in points],
-                            benchmark_prices=[_safe_float(p.get("benchmark_price", 0.0)) for p in points],
-                            benchmark_type=benchmark_type,
-                            symbol=str(
-                                benchmark_data.get("symbol")
-                                or summary.get("symbol")
-                                or first_order.get("symbol", "")
-                            ),
-                        )
+                        # Drop points with missing or invalid price fields
+                        # to avoid rendering misleading zero-price data.
+                        valid_points = [
+                            p for p in raw_points
+                            if _is_valid_price(p.get("execution_price"))
+                            and _is_valid_price(p.get("benchmark_price"))
+                        ]
+
+                        # Sort by timestamp to ensure chronological plotting
+                        valid_points.sort(key=lambda p: str(p.get("timestamp", "")))
+
+                        if valid_points:
+                            create_benchmark_comparison_chart(
+                                timestamps=[
+                                    _format_timestamp(p.get("timestamp", ""))
+                                    for p in valid_points
+                                ],
+                                execution_prices=[
+                                    float(p["execution_price"]) for p in valid_points
+                                ],
+                                benchmark_prices=[
+                                    float(p["benchmark_price"]) for p in valid_points
+                                ],
+                                benchmark_type=benchmark_type,
+                                symbol=str(
+                                    benchmark_data.get("symbol")
+                                    or summary.get("symbol")
+                                    or first_order.get("symbol", "")
+                                ),
+                            )
+                        else:
+                            ui.label(
+                                "Benchmark chart unavailable: no valid data points."
+                            ).classes("text-gray-500 p-4")
                     elif state["demo_mode"]:
                         ui.label(
                             "Benchmark chart hidden in demo mode to avoid showing synthetic data."

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -617,6 +617,22 @@ async def _render_tca_dashboard(
                     if state["_load_version"] != current_version:
                         return
 
+                    # Verify the response matches the requested order to
+                    # guard against upstream cache/routing bugs.
+                    if benchmark_data:
+                        resp_order_id = str(
+                            benchmark_data.get("client_order_id", "")
+                        ).strip()
+                        if resp_order_id and resp_order_id != client_order_id:
+                            logger.warning(
+                                "TCA benchmarks response order mismatch",
+                                extra={
+                                    "requested": client_order_id,
+                                    "received": resp_order_id,
+                                },
+                            )
+                            benchmark_data = None
+
                     if benchmark_data:
                         raw_points = benchmark_data.get("points", [])
                         raw_summary = benchmark_data.get("summary")
@@ -646,12 +662,20 @@ async def _render_tca_dashboard(
                             last_dt = _parse_utc(valid_points[-1].get("timestamp", ""))
                             multi_day = first_dt.date() != last_dt.date()
 
-                            # Warn if data may be truncated (backend
-                            # default fill limit is 500).
-                            if len(raw_points) >= _BACKEND_FILL_LIMIT:
+                            # Warn if data may be truncated.  Prefer the
+                            # ``truncated`` flag from the API response when
+                            # available; fall back to heuristic comparison
+                            # against _BACKEND_FILL_LIMIT.
+                            # TODO: Add ``truncated`` field to
+                            # TCABenchmarkResponse so UI does not depend on
+                            # hardcoded backend limit.
+                            is_truncated = benchmark_data.get("truncated")
+                            if is_truncated is None:
+                                is_truncated = len(raw_points) >= _BACKEND_FILL_LIMIT
+                            if is_truncated:
                                 ui.label(
                                     "Note: benchmark data may be truncated "
-                                    f"(showing first {_BACKEND_FILL_LIMIT} fills)."
+                                    f"(showing first {len(raw_points)} fills)."
                                 ).classes("text-amber-500 text-xs mb-1")
 
                             create_benchmark_comparison_chart(

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -52,11 +52,14 @@ DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
 
 
+_DATETIME_MIN_UTC = datetime.min.replace(tzinfo=UTC)
+
+
 def _parse_utc(value: Any) -> datetime:
     """Parse a timestamp to a UTC-aware datetime.
 
     Naive values are assumed UTC.  Unparseable values map to
-    ``datetime.min`` so they sort first.
+    ``_DATETIME_MIN_UTC`` so they sort first.
     """
     text = str(value)
     try:
@@ -65,21 +68,32 @@ def _parse_utc(value: Any) -> datetime:
             return dt.replace(tzinfo=UTC)
         return dt.astimezone(UTC)
     except ValueError:
-        return datetime.min.replace(tzinfo=UTC)
+        return _DATETIME_MIN_UTC
+
+
+def _is_valid_timestamp(value: Any) -> bool:
+    """Return True if *value* can be parsed to a real UTC datetime."""
+    return _parse_utc(value) != _DATETIME_MIN_UTC
 
 
 def _format_benchmark_timestamp(value: Any) -> str:
     """Format a benchmark point timestamp as ``HH:MM UTC``."""
     dt = _parse_utc(value)
-    if dt == datetime.min.replace(tzinfo=UTC):
+    if dt == _DATETIME_MIN_UTC:
         return str(value)
     return dt.strftime("%H:%M UTC")
 
 
 def _is_valid_price(value: Any) -> bool:
-    """Return True if *value* can be converted to a non-zero float."""
+    """Return True if *value* is a finite positive price.
+
+    Rejects zero, negative, NaN, infinity, and non-numeric values.
+    """
+    import math
+
     try:
-        return float(value) != 0.0
+        f = float(value)
+        return f > 0.0 and math.isfinite(f)
     except (TypeError, ValueError):
         return False
 
@@ -160,7 +174,7 @@ async def _fetch_tca_benchmarks(
         "strategy_id": strategy_id,
     }
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(
                 f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
                 params={"client_order_id": client_order_id, "benchmark": benchmark},
@@ -572,11 +586,12 @@ async def _render_tca_dashboard(
                             benchmark_data.get("benchmark_type") or "vwap"
                         ).upper()
 
-                        # Drop points with missing or invalid price fields
-                        # to avoid rendering misleading zero-price data.
+                        # Drop points with invalid timestamps or price fields
+                        # to avoid rendering misleading data.
                         valid_points = [
                             p for p in raw_points
-                            if _is_valid_price(p.get("execution_price"))
+                            if _is_valid_timestamp(p.get("timestamp"))
+                            and _is_valid_price(p.get("execution_price"))
                             and _is_valid_price(p.get("benchmark_price"))
                         ]
 

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -127,24 +127,39 @@ async def _fetch_tca_benchmarks(
             )
             if response.status_code == 200:
                 result: dict[str, Any] = response.json()
-                return result if result.get("points") else None
+                points = result.get("points")
+                if not isinstance(points, list) or not points:
+                    return None
+                # Discard entries that are not dicts to guard against
+                # schema drift from the upstream API.
+                result["points"] = [p for p in points if isinstance(p, dict)]
+                return result if result["points"] else None
             logger.warning(
                 "TCA benchmarks API returned non-200",
                 extra={
                     "status": response.status_code,
                     "client_order_id": client_order_id,
+                    "benchmark": benchmark,
                     "body": response.text[:200],
                 },
             )
     except httpx.RequestError as e:
         logger.warning(
             "TCA benchmarks API unavailable",
-            extra={"error": str(e), "client_order_id": client_order_id},
+            extra={
+                "error": str(e),
+                "client_order_id": client_order_id,
+                "benchmark": benchmark,
+            },
         )
     except (ValueError, KeyError, TypeError) as e:
         logger.warning(
             "TCA benchmarks API returned malformed response",
-            extra={"error": str(e), "client_order_id": client_order_id},
+            extra={
+                "error": str(e),
+                "client_order_id": client_order_id,
+                "benchmark": benchmark,
+            },
         )
     return None
 
@@ -518,9 +533,10 @@ async def _render_tca_dashboard(
                         def _format_timestamp(value: Any) -> str:
                             text = str(value)
                             try:
-                                return datetime.fromisoformat(text.replace("Z", "+00:00")).strftime(
-                                    "%H:%M"
-                                )
+                                dt = datetime.fromisoformat(
+                                    text.replace("Z", "+00:00")
+                                ).astimezone(UTC)
+                                return dt.strftime("%H:%M UTC")
                             except ValueError:
                                 return text
 

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -50,6 +50,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
+# Backend default fill limit for TCA queries (database.py:get_trades_for_tca).
+# Used to detect potential data truncation in the benchmark chart.
+_BACKEND_FILL_LIMIT = 500
 
 
 _DATETIME_MIN_UTC = datetime.min.replace(tzinfo=UTC)
@@ -179,7 +182,7 @@ async def _fetch_tca_benchmarks(
         "strategy_id": strategy_id,
     }
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
                 f"{EXECUTION_GATEWAY_URL}/api/v1/tca/benchmarks",
                 params={"client_order_id": client_order_id, "benchmark": benchmark},
@@ -373,6 +376,7 @@ async def _render_tca_dashboard(
         "strategy_id": None,
         "data": None,
         "demo_mode": False,
+        "_load_version": 0,
     }
 
     # Filters section
@@ -432,7 +436,14 @@ async def _render_tca_dashboard(
     orders_container = ui.column().classes("w-full")
 
     async def load_data() -> None:
-        """Load TCA data and update UI."""
+        """Load TCA data and update UI.
+
+        Uses a version counter to discard results from stale requests
+        when rapid filter changes overlap async fetches.
+        """
+        state["_load_version"] += 1
+        current_version = state["_load_version"]
+
         summary_container.clear()
         charts_container.clear()
         orders_container.clear()
@@ -476,6 +487,10 @@ async def _render_tca_dashboard(
         data = await _fetch_tca_data(
             start_dt, end_dt, symbol, strategy, user_id, role, authorized_strategies
         )
+
+        # Discard stale results if a newer load was triggered
+        if state["_load_version"] != current_version:
+            return
 
         # Check for demo mode: API failure OR API returned demo data
         summary = data.get("summary", {}) if data else {}
@@ -567,10 +582,13 @@ async def _render_tca_dashboard(
             # Benchmark comparison (real TCA benchmark data for first order)
             if orders:
                 with ui.card().classes("w-full p-4"):
-                    ui.label("Execution vs Benchmark").classes("text-lg font-bold mb-2")
-
                     first_order = orders[0]
                     client_order_id = str(first_order.get("client_order_id", "")).strip()
+                    order_symbol = str(first_order.get("symbol", ""))
+                    order_label = order_symbol or client_order_id or "first order"
+                    ui.label(
+                        f"Execution vs Benchmark ({order_label})"
+                    ).classes("text-lg font-bold mb-2")
 
                     benchmark_data = None
                     if not state["demo_mode"] and client_order_id:
@@ -582,6 +600,10 @@ async def _render_tca_dashboard(
                             symbol=str(first_order.get("symbol", "")),
                             strategy_id=str(first_order.get("strategy_id", "")),
                         )
+
+                    # Discard stale results if a newer load was triggered
+                    if state["_load_version"] != current_version:
+                        return
 
                     if benchmark_data:
                         raw_points = benchmark_data.get("points", [])
@@ -614,10 +636,10 @@ async def _render_tca_dashboard(
 
                             # Warn if data may be truncated (backend
                             # default fill limit is 500).
-                            if len(raw_points) >= 500:
+                            if len(raw_points) >= _BACKEND_FILL_LIMIT:
                                 ui.label(
                                     "Note: benchmark data may be truncated "
-                                    "(showing first 500 fills)."
+                                    f"(showing first {_BACKEND_FILL_LIMIT} fills)."
                                 ).classes("text-amber-500 text-xs mb-1")
 
                             create_benchmark_comparison_chart(

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -52,6 +52,38 @@ DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
 
 
+def _parse_utc(value: Any) -> datetime:
+    """Parse a timestamp to a UTC-aware datetime.
+
+    Naive values are assumed UTC.  Unparseable values map to
+    ``datetime.min`` so they sort first.
+    """
+    text = str(value)
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+
+
+def _format_benchmark_timestamp(value: Any) -> str:
+    """Format a benchmark point timestamp as ``HH:MM UTC``."""
+    dt = _parse_utc(value)
+    if dt == datetime.min.replace(tzinfo=UTC):
+        return str(value)
+    return dt.strftime("%H:%M UTC")
+
+
+def _is_valid_price(value: Any) -> bool:
+    """Return True if *value* can be converted to a non-zero float."""
+    try:
+        return float(value) != 0.0
+    except (TypeError, ValueError):
+        return False
+
+
 def _build_tca_auth_headers(
     user_id: str,
     role: str,
@@ -540,29 +572,6 @@ async def _render_tca_dashboard(
                             benchmark_data.get("benchmark_type") or "vwap"
                         ).upper()
 
-                        def _format_timestamp(value: Any) -> str:
-                            text = str(value)
-                            try:
-                                dt = datetime.fromisoformat(
-                                    text.replace("Z", "+00:00")
-                                )
-                                # Treat naive timestamps as UTC to avoid
-                                # silent local-timezone shifts.
-                                if dt.tzinfo is None:
-                                    dt = dt.replace(tzinfo=UTC)
-                                else:
-                                    dt = dt.astimezone(UTC)
-                                return dt.strftime("%H:%M UTC")
-                            except ValueError:
-                                return text
-
-                        def _is_valid_price(value: Any) -> bool:
-                            """Return True if value can be converted to a non-zero float."""
-                            try:
-                                return float(value) != 0.0
-                            except (TypeError, ValueError):
-                                return False
-
                         # Drop points with missing or invalid price fields
                         # to avoid rendering misleading zero-price data.
                         valid_points = [
@@ -571,13 +580,16 @@ async def _render_tca_dashboard(
                             and _is_valid_price(p.get("benchmark_price"))
                         ]
 
-                        # Sort by timestamp to ensure chronological plotting
-                        valid_points.sort(key=lambda p: str(p.get("timestamp", "")))
+                        # Sort by normalized UTC datetime for correct
+                        # chronological plotting regardless of offset format.
+                        valid_points.sort(
+                            key=lambda p: _parse_utc(p.get("timestamp", ""))
+                        )
 
                         if valid_points:
                             create_benchmark_comparison_chart(
                                 timestamps=[
-                                    _format_timestamp(p.get("timestamp", ""))
+                                    _format_benchmark_timestamp(p.get("timestamp", ""))
                                     for p in valid_points
                                 ],
                                 execution_prices=[
@@ -603,7 +615,7 @@ async def _render_tca_dashboard(
                         ).classes("text-gray-500 p-4")
                     else:
                         ui.label(
-                            "Benchmark chart unavailable for the selected order."
+                            "Benchmark chart unavailable for the first order."
                         ).classes("text-gray-500 p-4")
 
         # Render orders table

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -141,6 +141,11 @@ async def _fetch_tca_benchmarks(
             "TCA benchmarks API unavailable",
             extra={"error": str(e), "client_order_id": client_order_id},
         )
+    except (ValueError, KeyError, TypeError) as e:
+        logger.warning(
+            "TCA benchmarks API returned malformed response",
+            extra={"error": str(e), "client_order_id": client_order_id},
+        )
     return None
 
 
@@ -519,10 +524,16 @@ async def _render_tca_dashboard(
                             except ValueError:
                                 return text
 
+                        def _safe_float(value: Any, default: float = 0.0) -> float:
+                            try:
+                                return float(value)
+                            except (TypeError, ValueError):
+                                return default
+
                         create_benchmark_comparison_chart(
                             timestamps=[_format_timestamp(p.get("timestamp", "")) for p in points],
-                            execution_prices=[float(p.get("execution_price", 0.0)) for p in points],
-                            benchmark_prices=[float(p.get("benchmark_price", 0.0)) for p in points],
+                            execution_prices=[_safe_float(p.get("execution_price", 0.0)) for p in points],
+                            benchmark_prices=[_safe_float(p.get("benchmark_price", 0.0)) for p in points],
                             benchmark_type=benchmark_type,
                             symbol=str(
                                 benchmark_data.get("symbol")

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -112,12 +112,21 @@ async def _fetch_tca_benchmarks(
     role: str,
     strategies: list[str],
     benchmark: str = "vwap",
+    *,
+    symbol: str = "",
+    strategy_id: str = "",
 ) -> dict[str, Any] | None:
     """Fetch benchmark time series for an order.
 
     Returns None on error so callers can hide the benchmark chart instead of
     rendering synthetic data.
     """
+    log_ctx: dict[str, Any] = {
+        "client_order_id": client_order_id,
+        "benchmark": benchmark,
+        "symbol": symbol,
+        "strategy_id": strategy_id,
+    }
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(
@@ -126,7 +135,14 @@ async def _fetch_tca_benchmarks(
                 headers=_build_tca_auth_headers(user_id, role, strategies),
             )
             if response.status_code == 200:
-                result: dict[str, Any] = response.json()
+                raw = response.json()
+                if not isinstance(raw, dict):
+                    logger.warning(
+                        "TCA benchmarks API returned non-dict JSON",
+                        extra=log_ctx,
+                    )
+                    return None
+                result: dict[str, Any] = raw
                 points = result.get("points")
                 if not isinstance(points, list) or not points:
                     return None
@@ -137,29 +153,20 @@ async def _fetch_tca_benchmarks(
             logger.warning(
                 "TCA benchmarks API returned non-200",
                 extra={
+                    **log_ctx,
                     "status": response.status_code,
-                    "client_order_id": client_order_id,
-                    "benchmark": benchmark,
                     "body": response.text[:200],
                 },
             )
     except httpx.RequestError as e:
         logger.warning(
             "TCA benchmarks API unavailable",
-            extra={
-                "error": str(e),
-                "client_order_id": client_order_id,
-                "benchmark": benchmark,
-            },
+            extra={**log_ctx, "error": str(e)},
         )
-    except (ValueError, KeyError, TypeError) as e:
+    except (ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(
             "TCA benchmarks API returned malformed response",
-            extra={
-                "error": str(e),
-                "client_order_id": client_order_id,
-                "benchmark": benchmark,
-            },
+            extra={**log_ctx, "error": str(e)},
         )
     return None
 
@@ -521,6 +528,8 @@ async def _render_tca_dashboard(
                             user_id=user_id,
                             role=role,
                             strategies=authorized_strategies,
+                            symbol=str(first_order.get("symbol", "")),
+                            strategy_id=str(first_order.get("strategy_id", "")),
                         )
 
                     if benchmark_data:
@@ -535,7 +544,13 @@ async def _render_tca_dashboard(
                             try:
                                 dt = datetime.fromisoformat(
                                     text.replace("Z", "+00:00")
-                                ).astimezone(UTC)
+                                )
+                                # Treat naive timestamps as UTC to avoid
+                                # silent local-timezone shifts.
+                                if dt.tzinfo is None:
+                                    dt = dt.replace(tzinfo=UTC)
+                                else:
+                                    dt = dt.astimezone(UTC)
                                 return dt.strftime("%H:%M UTC")
                             except ValueError:
                                 return text

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -52,6 +52,9 @@ DEFAULT_RANGE_DAYS = 30
 MAX_RANGE_DAYS = 90
 # Backend default fill limit for TCA queries (database.py:get_trades_for_tca).
 # Used to detect potential data truncation in the benchmark chart.
+# Note: a "may be truncated" warning is shown when point count reaches this
+# limit. This can false-positive when there are exactly _BACKEND_FILL_LIMIT
+# fills, but under-warning is worse than over-warning for TCA accuracy.
 _BACKEND_FILL_LIMIT = 500
 
 
@@ -95,10 +98,13 @@ def _format_benchmark_timestamp(value: Any, *, include_date: bool = False) -> st
 def _is_valid_price(value: Any) -> bool:
     """Return True if *value* is a finite positive price.
 
-    Rejects zero, negative, NaN, infinity, and non-numeric values.
+    Rejects zero, negative, NaN, infinity, booleans, and non-numeric values.
     """
     import math
 
+    # Reject booleans explicitly since float(True) == 1.0
+    if isinstance(value, bool):
+        return False
     try:
         f = float(value)
         return f > 0.0 and math.isfinite(f)
@@ -198,7 +204,13 @@ async def _fetch_tca_benchmarks(
                     return None
                 result: dict[str, Any] = raw
                 points = result.get("points")
-                if not isinstance(points, list) or not points:
+                if not isinstance(points, list):
+                    logger.warning(
+                        "TCA benchmarks API returned non-list points",
+                        extra={**log_ctx, "points_type": type(points).__name__},
+                    )
+                    return None
+                if not points:
                     return None
                 # Discard entries that are not dicts to guard against
                 # schema drift from the upstream API.

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -336,6 +336,69 @@ class TestFetchTCABenchmarks:
 
         assert result is None
 
+    @pytest.mark.asyncio()
+    async def test_fetch_filters_non_dict_points(self) -> None:
+        """Non-dict entries in points are filtered out (schema drift guard)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "points": [
+                "not-a-dict",
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": 150.1,
+                    "benchmark_price": 150.0,
+                },
+                42,
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is not None
+        # Only the valid dict entry should remain
+        assert len(result["points"]) == 1
+        assert result["points"][0]["execution_price"] == 150.1
+
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_when_all_points_non_dict(self) -> None:
+        """Returns None when all points entries are non-dict."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "points": ["bad", 123, None],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
+
 
 class TestDefaultDateRange:
     """Tests for default date range constant."""

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -455,8 +455,8 @@ class TestBenchmarkHelpers:
         assert dt.tzinfo is not None
 
     def test_format_benchmark_timestamp_zulu(self) -> None:
-        """Zulu timestamp formatted as HH:MM UTC."""
-        assert _format_benchmark_timestamp("2024-01-15T10:30:00Z") == "10:30 UTC"
+        """Zulu timestamp formatted as HH:MM:SS UTC."""
+        assert _format_benchmark_timestamp("2024-01-15T10:30:00Z") == "10:30:00 UTC"
 
     def test_format_benchmark_timestamp_invalid(self) -> None:
         """Invalid timestamp returned as-is."""
@@ -464,7 +464,14 @@ class TestBenchmarkHelpers:
 
     def test_format_benchmark_timestamp_with_offset(self) -> None:
         """Offset timestamp converted to UTC before formatting."""
-        assert _format_benchmark_timestamp("2024-01-15T15:30:00-05:00") == "20:30 UTC"
+        assert _format_benchmark_timestamp("2024-01-15T15:30:00-05:00") == "20:30:00 UTC"
+
+    def test_format_benchmark_timestamp_include_date(self) -> None:
+        """Include date when requested for multi-day fills."""
+        result = _format_benchmark_timestamp(
+            "2024-01-15T10:30:00Z", include_date=True
+        )
+        assert result == "2024-01-15 10:30:00 UTC"
 
     def test_is_valid_price_positive(self) -> None:
         """Positive float is valid."""

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -571,7 +571,15 @@ class TestDefaultDateRange:
 
 
 class TestExecutionQualityPageIntegration:
-    """Integration tests for the execution quality page."""
+    """Integration tests for the execution quality page.
+
+    NOTE: Full render-path tests (benchmark chart shown/hidden/demo,
+    stale-load discard via ``_load_version``) require a running NiceGUI
+    server and are not feasible in unit-test scope.  The helpers that
+    drive those render branches (``_parse_utc``, ``_is_valid_price``,
+    ``_is_valid_timestamp``, ``_format_benchmark_timestamp``,
+    ``_fetch_tca_benchmarks``) are thoroughly covered above.
+    """
 
     @pytest.mark.asyncio()
     async def test_page_handles_no_data(self) -> None:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -24,6 +24,7 @@ from apps.web_console_ng.pages.execution_quality import (
     _fetch_tca_data,
     _format_benchmark_timestamp,
     _is_valid_price,
+    _is_valid_timestamp,
     _parse_utc,
 )
 
@@ -431,8 +432,6 @@ class TestBenchmarkHelpers:
 
     def test_parse_utc_zulu(self) -> None:
         """Zulu suffix is parsed as UTC."""
-        from datetime import UTC
-
         dt = _parse_utc("2024-01-15T10:30:00Z")
         assert dt.strftime("%H:%M") == "10:30"
         assert dt.tzinfo is not None
@@ -449,10 +448,11 @@ class TestBenchmarkHelpers:
 
     def test_parse_utc_invalid(self) -> None:
         """Invalid string returns datetime.min (UTC)."""
-        from datetime import UTC, datetime
-
         dt = _parse_utc("not-a-date")
-        assert dt == datetime.min.replace(tzinfo=UTC)
+        assert dt.year == 1
+        assert dt.month == 1
+        assert dt.day == 1
+        assert dt.tzinfo is not None
 
     def test_format_benchmark_timestamp_zulu(self) -> None:
         """Zulu timestamp formatted as HH:MM UTC."""
@@ -486,6 +486,31 @@ class TestBenchmarkHelpers:
     def test_is_valid_price_numeric_string(self) -> None:
         """Numeric string is valid."""
         assert _is_valid_price("150.5") is True
+
+    def test_is_valid_price_negative(self) -> None:
+        """Negative price is not valid."""
+        assert _is_valid_price(-10.0) is False
+
+    def test_is_valid_price_nan(self) -> None:
+        """NaN is not valid."""
+        assert _is_valid_price(float("nan")) is False
+
+    def test_is_valid_price_inf(self) -> None:
+        """Infinity is not valid."""
+        assert _is_valid_price(float("inf")) is False
+        assert _is_valid_price(float("-inf")) is False
+
+    def test_is_valid_timestamp_valid(self) -> None:
+        """Valid ISO timestamp returns True."""
+        assert _is_valid_timestamp("2024-01-15T10:00:00Z") is True
+
+    def test_is_valid_timestamp_invalid(self) -> None:
+        """Non-parseable string returns False."""
+        assert _is_valid_timestamp("not-a-date") is False
+
+    def test_is_valid_timestamp_none(self) -> None:
+        """None returns False."""
+        assert _is_valid_timestamp(None) is False
 
     def test_sort_with_mixed_offsets(self) -> None:
         """Points with different timezone offsets sort chronologically."""

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -294,6 +294,48 @@ class TestFetchTCABenchmarks:
 
         assert result is None
 
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_on_request_error(self) -> None:
+        """Network-level error returns None (httpx.RequestError)."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.side_effect = httpx.ConnectError("connection refused")
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_on_malformed_json(self) -> None:
+        """Malformed JSON body on 200 returns None."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("invalid json")
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
+
 
 class TestDefaultDateRange:
     """Tests for default date range constant."""

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -399,6 +399,29 @@ class TestFetchTCABenchmarks:
 
         assert result is None
 
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_when_json_is_not_dict(self) -> None:
+        """Non-dict top-level JSON (e.g. list) returns None."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ["unexpected", "list"]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
+
 
 class TestDefaultDateRange:
     """Tests for default date range constant."""

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -234,6 +234,7 @@ class TestFetchTCABenchmarks:
 
             result = await _fetch_tca_benchmarks(
                 client_order_id="order-1",
+                strategy_id="alpha_baseline",
                 user_id="test_user",
                 role="trader",
                 strategies=["alpha_baseline"],
@@ -299,8 +300,8 @@ class TestFetchTCABenchmarks:
         assert result is None
 
     @pytest.mark.asyncio()
-    async def test_fetch_returns_none_on_request_error(self) -> None:
-        """Network-level error returns None (httpx.RequestError)."""
+    async def test_fetch_raises_on_request_error(self) -> None:
+        """Network-level error is logged and re-raised (never swallowed)."""
         with patch("httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.get.side_effect = httpx.ConnectError("connection refused")
@@ -308,18 +309,17 @@ class TestFetchTCABenchmarks:
             mock_instance.__aexit__.return_value = None
             mock_client.return_value = mock_instance
 
-            result = await _fetch_tca_benchmarks(
-                client_order_id="order-1",
-                user_id="test_user",
-                role="trader",
-                strategies=[],
-            )
-
-        assert result is None
+            with pytest.raises(httpx.ConnectError):
+                await _fetch_tca_benchmarks(
+                    client_order_id="order-1",
+                    user_id="test_user",
+                    role="trader",
+                    strategies=[],
+                )
 
     @pytest.mark.asyncio()
-    async def test_fetch_returns_none_on_malformed_json(self) -> None:
-        """Malformed JSON body on 200 returns None."""
+    async def test_fetch_raises_on_malformed_json(self) -> None:
+        """Malformed JSON body on 200 is logged and re-raised."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError("invalid json")
@@ -331,14 +331,13 @@ class TestFetchTCABenchmarks:
             mock_instance.__aexit__.return_value = None
             mock_client.return_value = mock_instance
 
-            result = await _fetch_tca_benchmarks(
-                client_order_id="order-1",
-                user_id="test_user",
-                role="trader",
-                strategies=[],
-            )
-
-        assert result is None
+            with pytest.raises(ValueError, match="invalid json"):
+                await _fetch_tca_benchmarks(
+                    client_order_id="order-1",
+                    user_id="test_user",
+                    role="trader",
+                    strategies=[],
+                )
 
     @pytest.mark.asyncio()
     async def test_fetch_filters_non_dict_points(self) -> None:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -20,6 +20,7 @@ import pytest
 
 from apps.web_console_ng.pages.execution_quality import (
     DEFAULT_RANGE_DAYS,
+    _fetch_tca_benchmarks,
     _fetch_tca_data,
 )
 
@@ -197,6 +198,101 @@ class TestFetchTCAData:
             assert headers["X-User-ID"] == "test_user"
             assert headers["X-User-Role"] == "admin"
             assert headers["X-User-Strategies"] == "strat1,strat2"
+
+
+class TestFetchTCABenchmarks:
+    """Tests for _fetch_tca_benchmarks function."""
+
+    @pytest.mark.asyncio()
+    async def test_fetch_success(self) -> None:
+        """Successful fetch returns benchmark data."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "symbol": "AAPL",
+            "benchmark_type": "vwap",
+            "points": [
+                {
+                    "timestamp": "2024-01-15T10:00:00Z",
+                    "execution_price": 150.1,
+                    "benchmark_price": 150.0,
+                }
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=["alpha_baseline"],
+            )
+
+            call_args = mock_instance.get.call_args
+            params = call_args.kwargs.get("params", {})
+            headers = call_args.kwargs.get("headers", {})
+            assert params == {"client_order_id": "order-1", "benchmark": "vwap"}
+            assert headers["X-User-ID"] == "test_user"
+            assert headers["X-User-Role"] == "trader"
+            assert headers["X-User-Strategies"] == "alpha_baseline"
+
+        assert result is not None
+        assert result["client_order_id"] == "order-1"
+
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_when_no_points(self) -> None:
+        """Empty benchmark series returns None so UI hides chart."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "points": [],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_on_error(self) -> None:
+        """API error returns None."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
 
 
 class TestDefaultDateRange:

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -426,6 +426,32 @@ class TestFetchTCABenchmarks:
 
         assert result is None
 
+    @pytest.mark.asyncio()
+    async def test_fetch_returns_none_when_points_not_list(self) -> None:
+        """Non-list 'points' field returns None and logs warning."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "client_order_id": "order-1",
+            "points": "not-a-list",
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.return_value = mock_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await _fetch_tca_benchmarks(
+                client_order_id="order-1",
+                user_id="test_user",
+                role="trader",
+                strategies=[],
+            )
+
+        assert result is None
+
 
 class TestBenchmarkHelpers:
     """Tests for module-level benchmark transformation helpers."""
@@ -497,6 +523,11 @@ class TestBenchmarkHelpers:
     def test_is_valid_price_negative(self) -> None:
         """Negative price is not valid."""
         assert _is_valid_price(-10.0) is False
+
+    def test_is_valid_price_boolean(self) -> None:
+        """Booleans are not valid prices (float(True) == 1.0)."""
+        assert _is_valid_price(True) is False
+        assert _is_valid_price(False) is False
 
     def test_is_valid_price_nan(self) -> None:
         """NaN is not valid."""

--- a/tests/apps/web_console_ng/pages/test_execution_quality.py
+++ b/tests/apps/web_console_ng/pages/test_execution_quality.py
@@ -22,6 +22,9 @@ from apps.web_console_ng.pages.execution_quality import (
     DEFAULT_RANGE_DAYS,
     _fetch_tca_benchmarks,
     _fetch_tca_data,
+    _format_benchmark_timestamp,
+    _is_valid_price,
+    _parse_utc,
 )
 
 
@@ -421,6 +424,78 @@ class TestFetchTCABenchmarks:
             )
 
         assert result is None
+
+
+class TestBenchmarkHelpers:
+    """Tests for module-level benchmark transformation helpers."""
+
+    def test_parse_utc_zulu(self) -> None:
+        """Zulu suffix is parsed as UTC."""
+        from datetime import UTC
+
+        dt = _parse_utc("2024-01-15T10:30:00Z")
+        assert dt.strftime("%H:%M") == "10:30"
+        assert dt.tzinfo is not None
+
+    def test_parse_utc_offset(self) -> None:
+        """Explicit offset is normalized to UTC."""
+        dt = _parse_utc("2024-01-15T15:30:00-05:00")
+        assert dt.strftime("%H:%M") == "20:30"
+
+    def test_parse_utc_naive(self) -> None:
+        """Naive datetime is assumed UTC (no local-timezone shift)."""
+        dt = _parse_utc("2024-01-15T10:30:00")
+        assert dt.strftime("%H:%M") == "10:30"
+
+    def test_parse_utc_invalid(self) -> None:
+        """Invalid string returns datetime.min (UTC)."""
+        from datetime import UTC, datetime
+
+        dt = _parse_utc("not-a-date")
+        assert dt == datetime.min.replace(tzinfo=UTC)
+
+    def test_format_benchmark_timestamp_zulu(self) -> None:
+        """Zulu timestamp formatted as HH:MM UTC."""
+        assert _format_benchmark_timestamp("2024-01-15T10:30:00Z") == "10:30 UTC"
+
+    def test_format_benchmark_timestamp_invalid(self) -> None:
+        """Invalid timestamp returned as-is."""
+        assert _format_benchmark_timestamp("bad") == "bad"
+
+    def test_format_benchmark_timestamp_with_offset(self) -> None:
+        """Offset timestamp converted to UTC before formatting."""
+        assert _format_benchmark_timestamp("2024-01-15T15:30:00-05:00") == "20:30 UTC"
+
+    def test_is_valid_price_positive(self) -> None:
+        """Positive float is valid."""
+        assert _is_valid_price(150.5) is True
+
+    def test_is_valid_price_zero(self) -> None:
+        """Zero is not valid (used to detect missing data)."""
+        assert _is_valid_price(0.0) is False
+        assert _is_valid_price(0) is False
+
+    def test_is_valid_price_none(self) -> None:
+        """None is not valid."""
+        assert _is_valid_price(None) is False
+
+    def test_is_valid_price_string(self) -> None:
+        """Non-numeric string is not valid."""
+        assert _is_valid_price("abc") is False
+
+    def test_is_valid_price_numeric_string(self) -> None:
+        """Numeric string is valid."""
+        assert _is_valid_price("150.5") is True
+
+    def test_sort_with_mixed_offsets(self) -> None:
+        """Points with different timezone offsets sort chronologically."""
+        points = [
+            {"timestamp": "2024-01-15T15:30:00-05:00", "val": "later"},  # 20:30 UTC
+            {"timestamp": "2024-01-15T10:00:00Z", "val": "earlier"},  # 10:00 UTC
+        ]
+        points.sort(key=lambda p: _parse_utc(p["timestamp"]))
+        assert points[0]["val"] == "earlier"
+        assert points[1]["val"] == "later"
 
 
 class TestDefaultDateRange:


### PR DESCRIPTION
## Summary
- replace the synthetic benchmark chart on Execution Quality with a real fetch from `/api/v1/tca/benchmarks`
- reuse shared TCA auth headers for both analysis and benchmark API calls
- hide the chart in demo mode or when benchmark points are unavailable instead of rendering fake data
- add unit coverage for the new benchmark fetch helper

Closes #157

## Validation
- `python3 -m py_compile apps/web_console_ng/pages/execution_quality.py tests/apps/web_console_ng/pages/test_execution_quality.py`
- attempted `poetry install --no-interaction --with dev` but local Python 3.14 dependency resolution/build failed on `pyarrow`
- attempted targeted `poetry run pytest --override-ini addopts= tests/apps/web_console_ng/pages/test_execution_quality.py` but local env still lacked full deps (`psycopg`) after the install failure