### PR TITLE
fix: guard division-by-zero in research feature pipelines

### DIFF
--- a/research/strategies/_feature_constants.py
+++ b/research/strategies/_feature_constants.py
@@ -1,0 +1,10 @@
+"""
+Shared constants for feature engineering across all strategy modules.
+
+Centralised here to prevent drift between strategy implementations.
+"""
+
+# Epsilon for near-zero denominator guards.  Values below this threshold are
+# treated as zero to avoid numerically unstable divisions that could produce
+# extreme outliers on near-flat price windows.
+FEATURE_EPSILON = 1e-12

--- a/research/strategies/mean_reversion/config.py
+++ b/research/strategies/mean_reversion/config.py
@@ -291,7 +291,7 @@ class MeanReversionConfig:
 
     # Strategy metadata
     strategy_name: str = "mean_reversion"
-    version: str = "0.1.0"
+    version: str = "0.2.0"  # 0.2.0: epsilon guards for near-zero denominators (#173)
 
 
 # Default configuration instance

--- a/research/strategies/mean_reversion/features.py
+++ b/research/strategies/mean_reversion/features.py
@@ -24,6 +24,11 @@ import polars as pl
 
 logger = logging.getLogger(__name__)
 
+# Epsilon for near-zero denominator guards.  Values below this threshold are
+# treated as zero to avoid numerically unstable divisions that could produce
+# extreme outliers on near-flat price windows.
+_EPSILON = 1e-12
+
 
 def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -> pl.DataFrame:
     """
@@ -61,8 +66,8 @@ def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -
         - RSI < 30: Oversold (potential buy signal)
         - First `period` rows will have null RSI values
         - Uses Exponential Moving Average (EMA) for smoothing gains and losses
-        - Flat-price windows: When avg_loss=0 and avg_gain>0, RSI=100.
-          When both are zero (no price movement), RSI=50 (neutral).
+        - Flat/near-flat windows: When avg_loss~0 and avg_gain>0, RSI~100.
+          When both are near zero (no significant movement), RSI=50 (neutral).
 
     See Also:
         - https://www.investopedia.com/terms/r/rsi.asp
@@ -107,12 +112,11 @@ def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -
 
     # Calculate RSI using simplified formula: RSI = 100 * avg_gain / (avg_gain + avg_loss).
     # This avoids the intermediate RS division and naturally handles avg_loss=0 (RSI=100).
-    # Guard: when both avg_gain and avg_loss are exactly zero (flat-price window with no
-    # movement at all), the sum is zero and would produce NaN → emit 50.0 (neutral).
-    # Exact == 0 is correct here: these values come from EWM of non-negative series,
-    # so they are exactly zero only when all gains/losses in the window are zero.
+    # Guard: when the denominator (avg_gain + avg_loss) is near zero (flat or near-flat
+    # price window), the division would produce NaN or an extreme outlier → emit 50.0
+    # (neutral).  Uses _EPSILON threshold for numerical stability.
     df = df.with_columns(
-        pl.when((pl.col("avg_gain") + pl.col("avg_loss")) == 0)
+        pl.when((pl.col("avg_gain") + pl.col("avg_loss")) < _EPSILON)
         .then(50.0)
         .otherwise(100.0 * pl.col("avg_gain") / (pl.col("avg_gain") + pl.col("avg_loss")))
         .alias("rsi")
@@ -171,10 +175,10 @@ def compute_bollinger_bands(
         - Price touching lower band: Potential buy signal
         - Bollinger Squeeze (narrow bands): Volatility breakout may be imminent
         - First `period` rows will have null values
-        - Flat-price windows: When bb_upper == bb_lower (zero std), bb_pct=0.5
-          (neutral, price at mid-band). bb_width uses a simple difference
-          (upper - lower) rather than normalized bandwidth for consistency
-          with the mean-reversion signal thresholds.
+        - Flat/near-flat windows: When bb_upper ~= bb_lower (near-zero std),
+          bb_pct=0.5 (neutral, price at mid-band). bb_width uses a simple
+          difference (upper - lower) rather than normalized bandwidth for
+          consistency with the mean-reversion signal thresholds.
 
     See Also:
         - https://www.investopedia.com/terms/b/bollingerbands.asp
@@ -206,11 +210,10 @@ def compute_bollinger_bands(
     # %B > 1: Price above upper band
     # %B < 0: Price below lower band
     # %B = 0.5: Price at middle band
-    # Guard: when bb_upper == bb_lower (zero std on flat windows), emit 0.5 (neutral).
-    # Exact == is correct: bands differ only when rolling_std > 0, which is exactly
-    # zero only when all values in the window are identical.
+    # Guard: when bb_upper and bb_lower are within _EPSILON (near-zero std on flat or
+    # near-flat windows), the division would be unstable → emit 0.5 (neutral).
     df = df.with_columns(
-        pl.when(pl.col("bb_upper") == pl.col("bb_lower"))
+        pl.when((pl.col("bb_upper") - pl.col("bb_lower")).abs() < _EPSILON)
         .then(0.5)
         .otherwise(
             (pl.col(column) - pl.col("bb_lower")) / (pl.col("bb_upper") - pl.col("bb_lower"))
@@ -270,7 +273,7 @@ def compute_stochastic_oscillator(
         - < 20: Oversold (potential buy signal)
         - %K crossing above %D: Bullish crossover
         - %K crossing below %D: Bearish crossover
-        - Flat-price windows: When period_high == period_low, %K=50 (neutral).
+        - Flat/near-flat windows: When period_high ~= period_low, %K=50 (neutral).
 
     See Also:
         - https://www.investopedia.com/terms/s/stochasticoscillator.asp
@@ -285,11 +288,10 @@ def compute_stochastic_oscillator(
     )
 
     # Calculate %K (fast stochastic)
-    # Guard: when period_high == period_low (flat window), emit 50.0 (neutral).
-    # Exact == is correct: rolling max/min differ only when at least one value
-    # in the window differs, so equality means truly constant prices.
+    # Guard: when period_high and period_low are within _EPSILON (flat or near-flat
+    # window), the division would be unstable → emit 50.0 (neutral).
     df = df.with_columns(
-        pl.when(pl.col("period_high") == pl.col("period_low"))
+        pl.when((pl.col("period_high") - pl.col("period_low")).abs() < _EPSILON)
         .then(50.0)
         .otherwise(
             100.0
@@ -346,7 +348,7 @@ def compute_price_zscore(
         - Z-score < -2: Price is 2 std devs below mean (oversold)
         - Z-score near 0: Price close to mean (no clear signal)
         - First `period` rows will have null values
-        - Flat-price windows: When rolling_std=0, z-score=0 (price equals mean).
+        - Flat/near-flat windows: When rolling_std~0, z-score=0 (price at mean).
 
     See Also:
         - https://www.investopedia.com/terms/z/zscore.asp
@@ -361,11 +363,10 @@ def compute_price_zscore(
     )
 
     # Calculate Z-score
-    # Guard: when rolling_std is 0 (flat window), price equals mean → z-score = 0.
-    # Exact == 0 is correct: rolling_std is zero only when all values in the
-    # window are identical (sample variance = 0).
+    # Guard: when rolling_std is near zero (flat or near-flat window), the division
+    # would produce extreme outliers → emit 0.0 (price at mean).
     df = df.with_columns(
-        pl.when(pl.col("rolling_std") == 0)
+        pl.when(pl.col("rolling_std") < _EPSILON)
         .then(0.0)
         .otherwise((pl.col(column) - pl.col("rolling_mean")) / pl.col("rolling_std"))
         .alias("price_zscore")

--- a/research/strategies/mean_reversion/features.py
+++ b/research/strategies/mean_reversion/features.py
@@ -61,6 +61,8 @@ def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -
         - RSI < 30: Oversold (potential buy signal)
         - First `period` rows will have null RSI values
         - Uses Exponential Moving Average (EMA) for smoothing gains and losses
+        - Flat-price windows: When avg_loss=0 and avg_gain>0, RSI=100.
+          When both are zero (no price movement), RSI=50 (neutral).
 
     See Also:
         - https://www.investopedia.com/terms/r/rsi.asp
@@ -103,17 +105,16 @@ def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -
         ]
     )
 
-    # Calculate RS (Relative Strength) and RSI
-    # Guard: when avg_loss is 0 on flat-price windows, RS would be Inf/NaN.
-    # Convention: avg_loss=0 and avg_gain>0 → RSI=100; both zero → RSI=50 (neutral).
+    # Calculate RSI using simplified formula: RSI = 100 * avg_gain / (avg_gain + avg_loss).
+    # This avoids the intermediate RS division and naturally handles avg_loss=0 (RSI=100).
+    # Guard: when both avg_gain and avg_loss are exactly zero (flat-price window with no
+    # movement at all), the sum is zero and would produce NaN → emit 50.0 (neutral).
+    # Exact == 0 is correct here: these values come from EWM of non-negative series,
+    # so they are exactly zero only when all gains/losses in the window are zero.
     df = df.with_columns(
-        pl.when(pl.col("avg_loss") == 0)
-        .then(
-            pl.when(pl.col("avg_gain") == 0)
-            .then(50.0)
-            .otherwise(100.0)
-        )
-        .otherwise(100.0 - (100.0 / (1.0 + pl.col("avg_gain") / pl.col("avg_loss"))))
+        pl.when((pl.col("avg_gain") + pl.col("avg_loss")) == 0)
+        .then(50.0)
+        .otherwise(100.0 * pl.col("avg_gain") / (pl.col("avg_gain") + pl.col("avg_loss")))
         .alias("rsi")
     )
 
@@ -170,6 +171,10 @@ def compute_bollinger_bands(
         - Price touching lower band: Potential buy signal
         - Bollinger Squeeze (narrow bands): Volatility breakout may be imminent
         - First `period` rows will have null values
+        - Flat-price windows: When bb_upper == bb_lower (zero std), bb_pct=0.5
+          (neutral, price at mid-band). bb_width uses a simple difference
+          (upper - lower) rather than normalized bandwidth for consistency
+          with the mean-reversion signal thresholds.
 
     See Also:
         - https://www.investopedia.com/terms/b/bollingerbands.asp
@@ -202,6 +207,8 @@ def compute_bollinger_bands(
     # %B < 0: Price below lower band
     # %B = 0.5: Price at middle band
     # Guard: when bb_upper == bb_lower (zero std on flat windows), emit 0.5 (neutral).
+    # Exact == is correct: bands differ only when rolling_std > 0, which is exactly
+    # zero only when all values in the window are identical.
     df = df.with_columns(
         pl.when(pl.col("bb_upper") == pl.col("bb_lower"))
         .then(0.5)
@@ -263,6 +270,7 @@ def compute_stochastic_oscillator(
         - < 20: Oversold (potential buy signal)
         - %K crossing above %D: Bullish crossover
         - %K crossing below %D: Bearish crossover
+        - Flat-price windows: When period_high == period_low, %K=50 (neutral).
 
     See Also:
         - https://www.investopedia.com/terms/s/stochasticoscillator.asp
@@ -278,6 +286,8 @@ def compute_stochastic_oscillator(
 
     # Calculate %K (fast stochastic)
     # Guard: when period_high == period_low (flat window), emit 50.0 (neutral).
+    # Exact == is correct: rolling max/min differ only when at least one value
+    # in the window differs, so equality means truly constant prices.
     df = df.with_columns(
         pl.when(pl.col("period_high") == pl.col("period_low"))
         .then(50.0)
@@ -336,6 +346,7 @@ def compute_price_zscore(
         - Z-score < -2: Price is 2 std devs below mean (oversold)
         - Z-score near 0: Price close to mean (no clear signal)
         - First `period` rows will have null values
+        - Flat-price windows: When rolling_std=0, z-score=0 (price equals mean).
 
     See Also:
         - https://www.investopedia.com/terms/z/zscore.asp
@@ -351,6 +362,8 @@ def compute_price_zscore(
 
     # Calculate Z-score
     # Guard: when rolling_std is 0 (flat window), price equals mean → z-score = 0.
+    # Exact == 0 is correct: rolling_std is zero only when all values in the
+    # window are identical (sample variance = 0).
     df = df.with_columns(
         pl.when(pl.col("rolling_std") == 0)
         .then(0.0)

--- a/research/strategies/mean_reversion/features.py
+++ b/research/strategies/mean_reversion/features.py
@@ -22,12 +22,9 @@ from typing import Any
 
 import polars as pl
 
-logger = logging.getLogger(__name__)
+from research.strategies._feature_constants import FEATURE_EPSILON as _EPSILON
 
-# Epsilon for near-zero denominator guards.  Values below this threshold are
-# treated as zero to avoid numerically unstable divisions that could produce
-# extreme outliers on near-flat price windows.
-_EPSILON = 1e-12
+logger = logging.getLogger(__name__)
 
 
 def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -> pl.DataFrame:

--- a/research/strategies/mean_reversion/features.py
+++ b/research/strategies/mean_reversion/features.py
@@ -104,12 +104,21 @@ def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -
     )
 
     # Calculate RS (Relative Strength) and RSI
-    df = df.with_columns((pl.col("avg_gain") / pl.col("avg_loss")).alias("rs"))
-
-    df = df.with_columns((100.0 - (100.0 / (1.0 + pl.col("rs")))).alias("rsi"))
+    # Guard: when avg_loss is 0 on flat-price windows, RS would be Inf/NaN.
+    # Convention: avg_loss=0 and avg_gain>0 → RSI=100; both zero → RSI=50 (neutral).
+    df = df.with_columns(
+        pl.when(pl.col("avg_loss") == 0)
+        .then(
+            pl.when(pl.col("avg_gain") == 0)
+            .then(50.0)
+            .otherwise(100.0)
+        )
+        .otherwise(100.0 - (100.0 / (1.0 + pl.col("avg_gain") / pl.col("avg_loss"))))
+        .alias("rsi")
+    )
 
     # Drop intermediate columns
-    return df.drop(["price_change", "gain", "loss", "avg_gain", "avg_loss", "rs"])
+    return df.drop(["price_change", "gain", "loss", "avg_gain", "avg_loss"])
 
 
 def compute_bollinger_bands(
@@ -192,10 +201,14 @@ def compute_bollinger_bands(
     # %B > 1: Price above upper band
     # %B < 0: Price below lower band
     # %B = 0.5: Price at middle band
+    # Guard: when bb_upper == bb_lower (zero std on flat windows), emit 0.5 (neutral).
     df = df.with_columns(
-        ((pl.col(column) - pl.col("bb_lower")) / (pl.col("bb_upper") - pl.col("bb_lower"))).alias(
-            "bb_pct"
+        pl.when(pl.col("bb_upper") == pl.col("bb_lower"))
+        .then(0.5)
+        .otherwise(
+            (pl.col(column) - pl.col("bb_lower")) / (pl.col("bb_upper") - pl.col("bb_lower"))
         )
+        .alias("bb_pct")
     )
 
     # Drop intermediate column
@@ -264,12 +277,16 @@ def compute_stochastic_oscillator(
     )
 
     # Calculate %K (fast stochastic)
+    # Guard: when period_high == period_low (flat window), emit 50.0 (neutral).
     df = df.with_columns(
-        (
+        pl.when(pl.col("period_high") == pl.col("period_low"))
+        .then(50.0)
+        .otherwise(
             100.0
             * (pl.col("close") - pl.col("period_low"))
             / (pl.col("period_high") - pl.col("period_low"))
-        ).alias("stoch_k")
+        )
+        .alias("stoch_k")
     )
 
     # Calculate %D (slow stochastic - SMA of %K) per-symbol
@@ -333,8 +350,12 @@ def compute_price_zscore(
     )
 
     # Calculate Z-score
+    # Guard: when rolling_std is 0 (flat window), price equals mean → z-score = 0.
     df = df.with_columns(
-        ((pl.col(column) - pl.col("rolling_mean")) / pl.col("rolling_std")).alias("price_zscore")
+        pl.when(pl.col("rolling_std") == 0)
+        .then(0.0)
+        .otherwise((pl.col(column) - pl.col("rolling_mean")) / pl.col("rolling_std"))
+        .alias("price_zscore")
     )
 
     # Drop intermediate columns

--- a/research/strategies/mean_reversion/features.py
+++ b/research/strategies/mean_reversion/features.py
@@ -66,8 +66,10 @@ def compute_rsi(prices: pl.DataFrame, period: int = 14, column: str = "close") -
         - RSI < 30: Oversold (potential buy signal)
         - First `period` rows will have null RSI values
         - Uses Exponential Moving Average (EMA) for smoothing gains and losses
-        - Flat/near-flat windows: When avg_loss~0 and avg_gain>0, RSI~100.
-          When both are near zero (no significant movement), RSI=50 (neutral).
+        - Flat/near-flat windows: When avg_gain + avg_loss < _EPSILON (both
+          negligible), RSI=50 (neutral).  When avg_loss is near zero but
+          avg_gain is meaningfully positive (sum >= _EPSILON), RSI trends
+          toward 100 via the normal formula.
 
     See Also:
         - https://www.investopedia.com/terms/r/rsi.asp

--- a/research/strategies/momentum/config.py
+++ b/research/strategies/momentum/config.py
@@ -246,7 +246,7 @@ class MomentumConfig:
 
     # Strategy metadata
     strategy_name: str = "momentum"
-    version: str = "0.1.0"
+    version: str = "0.2.0"  # 0.2.0: epsilon guards for near-zero denominators (#173)
 
 
 # Default configuration instance

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -260,12 +260,14 @@ def compute_rate_of_change(
     # for consistency with other epsilon guards in the codebase.
     # Note: guard-hit detection uses expression-based filtering (not eager Series.abs())
     # to avoid InvalidOperationError on empty frames with Null-typed columns.
+    # Uses any() for fast short-circuit; full count/filter only on the rare guard-hit path.
     if len(df) > 0:
         guard_hit_expr = (
             pl.col("price_n_ago").is_not_null() & (pl.col("price_n_ago").abs() < _EPSILON)
         )
-        guard_hits = df.select(guard_hit_expr.sum()).item()
-        if guard_hits > 0:
+        has_guard_hits = df.select(guard_hit_expr.any()).item()
+        if has_guard_hits:
+            guard_hits = df.select(guard_hit_expr.sum()).item()
             _MAX_LOG_SYMBOLS = 10
             all_affected = (
                 df.filter(guard_hit_expr)["symbol"].unique().sort().to_list()

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -263,19 +263,23 @@ def compute_rate_of_change(
     guard_hit_rows = near_zero_mask & df["price_n_ago"].is_not_null()
     guard_hits = int(guard_hit_rows.sum())
     if guard_hits > 0:
-        affected_symbols = (
+        _MAX_LOG_SYMBOLS = 10
+        all_affected = (
             df.filter(guard_hit_rows)["symbol"].unique().sort().to_list()
         )
+        display_symbols = all_affected[:_MAX_LOG_SYMBOLS]
+        suffix = f" (+{len(all_affected) - _MAX_LOG_SYMBOLS} more)" if len(all_affected) > _MAX_LOG_SYMBOLS else ""
         logger.warning(
             "ROC guard: %d rows had near-zero price_n_ago (abs < %e), "
-            "emitting null; symbols=%s",
+            "emitting null; symbols=%s%s",
             guard_hits,
             _EPSILON,
-            affected_symbols,
+            display_symbols,
+            suffix,
             extra={
                 "guard": "roc_near_zero",
                 "count": guard_hits,
-                "symbols": affected_symbols,
+                "symbols": all_affected,
             },
         )
 

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -247,8 +247,9 @@ def compute_rate_of_change(
         - Magnitude indicates strength of momentum
         - Extreme values may signal overbought/oversold conditions
         - Near-zero-price guard: When abs(price_n_ago) < _EPSILON (invalid or
-          near-invalid data), ROC emits null to surface data quality issues.
-          Validated pipelines reject zero prices upstream via _validate_price_data.
+          near-invalid data), ROC emits null and logs a structured warning to
+          surface data quality issues.  Validated pipelines reject zero prices
+          upstream via _validate_price_data.
 
     See Also:
         - https://www.investopedia.com/terms/r/rateofchange.asp
@@ -260,6 +261,17 @@ def compute_rate_of_change(
     # Guard: when price_n_ago is near zero (invalid or near-invalid data that slipped
     # past validation), emit null to surface data quality issues.  Uses abs() < _EPSILON
     # for consistency with other epsilon guards in the codebase.
+    near_zero_mask = df["price_n_ago"].abs() < _EPSILON
+    # Exclude rows where price_n_ago is null (expected for first `period` rows)
+    guard_hits = int((near_zero_mask & df["price_n_ago"].is_not_null()).sum())
+    if guard_hits > 0:
+        logger.warning(
+            "ROC guard: %d rows had near-zero price_n_ago (abs < %e), emitting null",
+            guard_hits,
+            _EPSILON,
+            extra={"guard": "roc_near_zero", "count": guard_hits},
+        )
+
     df = df.with_columns(
         pl.when(pl.col("price_n_ago").abs() < _EPSILON)
         .then(pl.lit(None, dtype=pl.Float64))

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -360,20 +360,31 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
     )
 
     # Calculate +DI and -DI
+    # Guard: when atr is 0 (flat window, no range), emit 0.0 for DI values.
     df = df.with_columns(
         [
-            ((pl.col("plus_dm_smooth") / pl.col("atr")) * 100.0).alias("plus_di"),
-            ((pl.col("minus_dm_smooth") / pl.col("atr")) * 100.0).alias("minus_di"),
+            pl.when(pl.col("atr") == 0)
+            .then(0.0)
+            .otherwise((pl.col("plus_dm_smooth") / pl.col("atr")) * 100.0)
+            .alias("plus_di"),
+            pl.when(pl.col("atr") == 0)
+            .then(0.0)
+            .otherwise((pl.col("minus_dm_smooth") / pl.col("atr")) * 100.0)
+            .alias("minus_di"),
         ]
     )
 
     # Calculate DX
+    # Guard: when plus_di + minus_di is 0 (flat window), emit 0.0.
     df = df.with_columns(
-        (
+        pl.when((pl.col("plus_di") + pl.col("minus_di")) == 0)
+        .then(0.0)
+        .otherwise(
             (pl.col("plus_di") - pl.col("minus_di")).abs()
             / (pl.col("plus_di") + pl.col("minus_di"))
             * 100.0
-        ).alias("dx")
+        )
+        .alias("dx")
     )
 
     # Calculate ADX (smoothed DX using Wilder's smoothing for consistency)

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -286,7 +286,8 @@ def compute_rate_of_change(
                 extra={
                     "guard": "roc_near_zero",
                     "count": guard_hits,
-                    "symbols": all_affected,
+                    "symbols": display_symbols,
+                    "symbols_total": len(all_affected),
                     "strategy": "momentum",
                 },
             )

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -241,6 +241,9 @@ def compute_rate_of_change(
         - ROC < 0: Price lower than n periods ago (bearish)
         - Magnitude indicates strength of momentum
         - Extreme values may signal overbought/oversold conditions
+        - Zero-price guard: When price_n_ago=0 (invalid data), ROC emits null
+          to surface the data quality issue. Validated pipelines reject zero
+          prices upstream via _validate_price_data.
 
     See Also:
         - https://www.investopedia.com/terms/r/rateofchange.asp
@@ -249,8 +252,13 @@ def compute_rate_of_change(
     df = prices.with_columns(pl.col(column).shift(period).over("symbol").alias("price_n_ago"))
 
     # Calculate ROC as percentage change
+    # Guard: when price_n_ago is 0 (invalid data that slipped past validation),
+    # emit null to surface data quality issues rather than masking them as 0.
     df = df.with_columns(
-        ((pl.col(column) - pl.col("price_n_ago")) / pl.col("price_n_ago") * 100.0).alias("roc")
+        pl.when(pl.col("price_n_ago") == 0)
+        .then(pl.lit(None, dtype=pl.Float64))
+        .otherwise((pl.col(column) - pl.col("price_n_ago")) / pl.col("price_n_ago") * 100.0)
+        .alias("roc")
     )
 
     # Drop intermediate column
@@ -302,6 +310,8 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
         - ADX < 20: Weak trend (avoid trend-following)
         - ADX direction: Rising ADX = strengthening trend
         - +DI/-DI crossover: Potential trend reversal
+        - Flat-price windows: When ATR=0 (no price range), +DI and -DI=0.
+          When +DI + -DI = 0, DX=0. ADX then smooths to 0.
 
     See Also:
         - https://www.investopedia.com/terms/a/adx.asp
@@ -361,6 +371,8 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
 
     # Calculate +DI and -DI
     # Guard: when atr is 0 (flat window, no range), emit 0.0 for DI values.
+    # Exact == 0 is correct: ATR is EWM of true-range, which is exactly zero only
+    # when high==low==close for every bar in the smoothing window.
     df = df.with_columns(
         [
             pl.when(pl.col("atr") == 0)
@@ -376,6 +388,7 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
 
     # Calculate DX
     # Guard: when plus_di + minus_di is 0 (flat window), emit 0.0.
+    # Exact == 0 is correct: DI values are zero only via the ATR guard above.
     df = df.with_columns(
         pl.when((pl.col("plus_di") + pl.col("minus_di")) == 0)
         .then(0.0)

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -246,9 +246,9 @@ def compute_rate_of_change(
         - ROC < 0: Price lower than n periods ago (bearish)
         - Magnitude indicates strength of momentum
         - Extreme values may signal overbought/oversold conditions
-        - Zero-price guard: When price_n_ago=0 (invalid data), ROC emits null
-          to surface the data quality issue. Validated pipelines reject zero
-          prices upstream via _validate_price_data.
+        - Near-zero-price guard: When abs(price_n_ago) < _EPSILON (invalid or
+          near-invalid data), ROC emits null to surface data quality issues.
+          Validated pipelines reject zero prices upstream via _validate_price_data.
 
     See Also:
         - https://www.investopedia.com/terms/r/rateofchange.asp
@@ -257,10 +257,11 @@ def compute_rate_of_change(
     df = prices.with_columns(pl.col(column).shift(period).over("symbol").alias("price_n_ago"))
 
     # Calculate ROC as percentage change
-    # Guard: when price_n_ago is 0 (invalid data that slipped past validation),
-    # emit null to surface data quality issues rather than masking them as 0.
+    # Guard: when price_n_ago is near zero (invalid or near-invalid data that slipped
+    # past validation), emit null to surface data quality issues.  Uses abs() < _EPSILON
+    # for consistency with other epsilon guards in the codebase.
     df = df.with_columns(
-        pl.when(pl.col("price_n_ago") == 0)
+        pl.when(pl.col("price_n_ago").abs() < _EPSILON)
         .then(pl.lit(None, dtype=pl.Float64))
         .otherwise((pl.col(column) - pl.col("price_n_ago")) / pl.col("price_n_ago") * 100.0)
         .alias("roc")

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -258,30 +258,38 @@ def compute_rate_of_change(
     # Guard: when price_n_ago is near zero (invalid or near-invalid data that slipped
     # past validation), emit null to surface data quality issues.  Uses abs() < _EPSILON
     # for consistency with other epsilon guards in the codebase.
-    near_zero_mask = df["price_n_ago"].abs() < _EPSILON
-    # Exclude rows where price_n_ago is null (expected for first `period` rows)
-    guard_hit_rows = near_zero_mask & df["price_n_ago"].is_not_null()
-    guard_hits = int(guard_hit_rows.sum())
-    if guard_hits > 0:
-        _MAX_LOG_SYMBOLS = 10
-        all_affected = (
-            df.filter(guard_hit_rows)["symbol"].unique().sort().to_list()
+    # Note: guard-hit detection uses expression-based filtering (not eager Series.abs())
+    # to avoid InvalidOperationError on empty frames with Null-typed columns.
+    if len(df) > 0:
+        guard_hit_expr = (
+            pl.col("price_n_ago").is_not_null() & (pl.col("price_n_ago").abs() < _EPSILON)
         )
-        display_symbols = all_affected[:_MAX_LOG_SYMBOLS]
-        suffix = f" (+{len(all_affected) - _MAX_LOG_SYMBOLS} more)" if len(all_affected) > _MAX_LOG_SYMBOLS else ""
-        logger.warning(
-            "ROC guard: %d rows had near-zero price_n_ago (abs < %e), "
-            "emitting null; symbols=%s%s",
-            guard_hits,
-            _EPSILON,
-            display_symbols,
-            suffix,
-            extra={
-                "guard": "roc_near_zero",
-                "count": guard_hits,
-                "symbols": all_affected,
-            },
-        )
+        guard_hits = df.select(guard_hit_expr.sum()).item()
+        if guard_hits > 0:
+            _MAX_LOG_SYMBOLS = 10
+            all_affected = (
+                df.filter(guard_hit_expr)["symbol"].unique().sort().to_list()
+            )
+            display_symbols = all_affected[:_MAX_LOG_SYMBOLS]
+            suffix = (
+                f" (+{len(all_affected) - _MAX_LOG_SYMBOLS} more)"
+                if len(all_affected) > _MAX_LOG_SYMBOLS
+                else ""
+            )
+            logger.warning(
+                "ROC guard: %d rows had near-zero price_n_ago (abs < %e), "
+                "emitting null; symbols=%s%s",
+                guard_hits,
+                _EPSILON,
+                display_symbols,
+                suffix,
+                extra={
+                    "guard": "roc_near_zero",
+                    "count": guard_hits,
+                    "symbols": all_affected,
+                    "strategy": "momentum",
+                },
+            )
 
     df = df.with_columns(
         pl.when(pl.col("price_n_ago").abs() < _EPSILON)

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -288,7 +288,7 @@ def compute_rate_of_change(
                     "count": guard_hits,
                     "symbols": display_symbols,
                     "symbols_total": len(all_affected),
-                    "strategy": "momentum",
+                    "strategy_id": "momentum",
                 },
             )
 

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -23,12 +23,9 @@ from typing import Any
 
 import polars as pl
 
-logger = logging.getLogger(__name__)
+from research.strategies._feature_constants import FEATURE_EPSILON as _EPSILON
 
-# Epsilon for near-zero denominator guards.  Values below this threshold are
-# treated as zero to avoid numerically unstable divisions that could produce
-# extreme outliers on near-flat price windows.
-_EPSILON = 1e-12
+logger = logging.getLogger(__name__)
 
 
 def compute_moving_averages(
@@ -263,13 +260,23 @@ def compute_rate_of_change(
     # for consistency with other epsilon guards in the codebase.
     near_zero_mask = df["price_n_ago"].abs() < _EPSILON
     # Exclude rows where price_n_ago is null (expected for first `period` rows)
-    guard_hits = int((near_zero_mask & df["price_n_ago"].is_not_null()).sum())
+    guard_hit_rows = near_zero_mask & df["price_n_ago"].is_not_null()
+    guard_hits = int(guard_hit_rows.sum())
     if guard_hits > 0:
+        affected_symbols = (
+            df.filter(guard_hit_rows)["symbol"].unique().sort().to_list()
+        )
         logger.warning(
-            "ROC guard: %d rows had near-zero price_n_ago (abs < %e), emitting null",
+            "ROC guard: %d rows had near-zero price_n_ago (abs < %e), "
+            "emitting null; symbols=%s",
             guard_hits,
             _EPSILON,
-            extra={"guard": "roc_near_zero", "count": guard_hits},
+            affected_symbols,
+            extra={
+                "guard": "roc_near_zero",
+                "count": guard_hits,
+                "symbols": affected_symbols,
+            },
         )
 
     df = df.with_columns(

--- a/research/strategies/momentum/features.py
+++ b/research/strategies/momentum/features.py
@@ -25,6 +25,11 @@ import polars as pl
 
 logger = logging.getLogger(__name__)
 
+# Epsilon for near-zero denominator guards.  Values below this threshold are
+# treated as zero to avoid numerically unstable divisions that could produce
+# extreme outliers on near-flat price windows.
+_EPSILON = 1e-12
+
 
 def compute_moving_averages(
     prices: pl.DataFrame,
@@ -310,8 +315,8 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
         - ADX < 20: Weak trend (avoid trend-following)
         - ADX direction: Rising ADX = strengthening trend
         - +DI/-DI crossover: Potential trend reversal
-        - Flat-price windows: When ATR=0 (no price range), +DI and -DI=0.
-          When +DI + -DI = 0, DX=0. ADX then smooths to 0.
+        - Flat/near-flat windows: When ATR~0 (negligible price range), +DI
+          and -DI=0. When +DI + -DI ~ 0, DX=0. ADX then smooths to 0.
 
     See Also:
         - https://www.investopedia.com/terms/a/adx.asp
@@ -370,16 +375,15 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
     )
 
     # Calculate +DI and -DI
-    # Guard: when atr is 0 (flat window, no range), emit 0.0 for DI values.
-    # Exact == 0 is correct: ATR is EWM of true-range, which is exactly zero only
-    # when high==low==close for every bar in the smoothing window.
+    # Guard: when atr is near zero (flat or near-flat window, negligible range),
+    # the division would be unstable → emit 0.0 for DI values.
     df = df.with_columns(
         [
-            pl.when(pl.col("atr") == 0)
+            pl.when(pl.col("atr") < _EPSILON)
             .then(0.0)
             .otherwise((pl.col("plus_dm_smooth") / pl.col("atr")) * 100.0)
             .alias("plus_di"),
-            pl.when(pl.col("atr") == 0)
+            pl.when(pl.col("atr") < _EPSILON)
             .then(0.0)
             .otherwise((pl.col("minus_dm_smooth") / pl.col("atr")) * 100.0)
             .alias("minus_di"),
@@ -387,10 +391,10 @@ def compute_adx(prices: pl.DataFrame, period: int = 14) -> pl.DataFrame:
     )
 
     # Calculate DX
-    # Guard: when plus_di + minus_di is 0 (flat window), emit 0.0.
-    # Exact == 0 is correct: DI values are zero only via the ATR guard above.
+    # Guard: when plus_di + minus_di is near zero (flat or near-flat window),
+    # the division would be unstable → emit 0.0.
     df = df.with_columns(
-        pl.when((pl.col("plus_di") + pl.col("minus_di")) == 0)
+        pl.when((pl.col("plus_di") + pl.col("minus_di")) < _EPSILON)
         .then(0.0)
         .otherwise(
             (pl.col("plus_di") - pl.col("minus_di")).abs()

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -471,7 +471,7 @@ class TestEdgeCases:
             )
 
     @pytest.mark.parametrize(
-        "delta,description",
+        ("delta", "description"),
         [
             (1e-14, "sub-epsilon spread triggers guard (neutral output)"),
             (1e-10, "supra-epsilon spread bypasses guard (computed output)"),

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -401,6 +401,7 @@ class TestEdgeCases:
         # RSI: avg_loss=0 and avg_gain=0 → should be 50 (neutral), never NaN/Inf
         result_rsi = compute_rsi(prices)
         rsi_vals = result_rsi["rsi"].drop_nulls()
+        assert len(rsi_vals) > 0, "RSI must produce non-null values for 30-row flat input"
         assert not rsi_vals.is_nan().any(), "RSI must not contain NaN on flat prices"
         assert not rsi_vals.is_infinite().any(), "RSI must not contain Inf on flat prices"
         assert (rsi_vals == 50.0).all(), "RSI should be 50 (neutral) when prices are flat"
@@ -408,8 +409,10 @@ class TestEdgeCases:
         # Bollinger %B: bb_upper == bb_lower → should be 0.5, never NaN/Inf
         result_bb = compute_bollinger_bands(prices)
         bb_pct = result_bb["bb_pct"].drop_nulls()
+        assert len(bb_pct) > 0, "bb_pct must produce non-null values for 30-row flat input"
         assert not bb_pct.is_nan().any(), "bb_pct must not contain NaN on flat prices"
         assert not bb_pct.is_infinite().any(), "bb_pct must not contain Inf on flat prices"
+        assert (bb_pct == 0.5).all(), "bb_pct should be 0.5 (neutral) when prices are flat"
         bb_width = result_bb["bb_width"].drop_nulls()
         if len(bb_width) > 0:
             assert bb_width.mean() < 1.0, "Bollinger width should be small with constant prices"
@@ -417,14 +420,18 @@ class TestEdgeCases:
         # Stochastic %K: period_high == period_low → should be 50, never NaN/Inf
         result_stoch = compute_stochastic_oscillator(prices)
         stoch_k = result_stoch["stoch_k"].drop_nulls()
+        assert len(stoch_k) > 0, "stoch_k must produce non-null values for 30-row flat input"
         assert not stoch_k.is_nan().any(), "stoch_k must not contain NaN on flat prices"
         assert not stoch_k.is_infinite().any(), "stoch_k must not contain Inf on flat prices"
+        assert (stoch_k == 50.0).all(), "stoch_k should be 50 (neutral) when prices are flat"
 
         # Z-Score: rolling_std=0 → should be 0, never NaN/Inf
         result_zs = compute_price_zscore(prices)
         zscore = result_zs["price_zscore"].drop_nulls()
+        assert len(zscore) > 0, "price_zscore must produce non-null values for 30-row flat input"
         assert not zscore.is_nan().any(), "price_zscore must not contain NaN on flat prices"
         assert not zscore.is_infinite().any(), "price_zscore must not contain Inf on flat prices"
+        assert (zscore == 0.0).all(), "price_zscore should be 0 when prices are flat"
 
     def test_flat_window_combined_features_no_nan(self) -> None:
         """Test that combined features pipeline emits no NaN/Inf on flat prices (#173)."""
@@ -444,10 +451,24 @@ class TestEdgeCases:
 
         result = compute_mean_reversion_features(prices)
         feature_cols = ["rsi", "bb_pct", "bb_width", "stoch_k", "stoch_d", "price_zscore"]
+        # Expected neutral values for each indicator on flat prices
+        expected_neutrals = {
+            "rsi": 50.0,
+            "bb_pct": 0.5,
+            "bb_width": 0.0,
+            "stoch_k": 50.0,
+            "stoch_d": 50.0,
+            "price_zscore": 0.0,
+        }
         for col in feature_cols:
             vals = result[col].drop_nulls()
+            assert len(vals) > 0, f"{col} must produce non-null values for 30-row flat input"
             assert not vals.is_nan().any(), f"{col} must not contain NaN on flat prices"
             assert not vals.is_infinite().any(), f"{col} must not contain Inf on flat prices"
+            expected = expected_neutrals[col]
+            assert (vals == expected).all(), (
+                f"{col} should be {expected} on flat prices, got {vals.unique().to_list()}"
+            )
 
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -496,29 +496,35 @@ class TestEdgeCases:
             }
         )
 
-        # RSI must be finite (either neutral 50 or a valid computed value)
+        # Collect non-null values for each indicator
         rsi_vals = compute_rsi(prices)["rsi"].drop_nulls()
-        assert len(rsi_vals) > 0, f"RSI must produce non-null values ({description})"
-        assert not rsi_vals.is_nan().any(), f"RSI NaN with {description}"
-        assert not rsi_vals.is_infinite().any(), f"RSI Inf with {description}"
-
-        # Bollinger %B must be finite
         bb_pct = compute_bollinger_bands(prices)["bb_pct"].drop_nulls()
-        assert len(bb_pct) > 0, f"bb_pct must produce non-null values ({description})"
-        assert not bb_pct.is_nan().any(), f"bb_pct NaN with {description}"
-        assert not bb_pct.is_infinite().any(), f"bb_pct Inf with {description}"
-
-        # Stochastic %K must be finite
         stoch_k = compute_stochastic_oscillator(prices)["stoch_k"].drop_nulls()
-        assert len(stoch_k) > 0, f"stoch_k must produce non-null values ({description})"
-        assert not stoch_k.is_nan().any(), f"stoch_k NaN with {description}"
-        assert not stoch_k.is_infinite().any(), f"stoch_k Inf with {description}"
-
-        # Z-score must be finite
         zscore = compute_price_zscore(prices)["price_zscore"].drop_nulls()
-        assert len(zscore) > 0, f"price_zscore must produce non-null values ({description})"
-        assert not zscore.is_nan().any(), f"price_zscore NaN with {description}"
-        assert not zscore.is_infinite().any(), f"price_zscore Inf with {description}"
+
+        indicators = {"rsi": rsi_vals, "bb_pct": bb_pct, "stoch_k": stoch_k, "price_zscore": zscore}
+        neutrals = {"rsi": 50.0, "bb_pct": 0.5, "stoch_k": 50.0, "price_zscore": 0.0}
+
+        for name, vals in indicators.items():
+            assert len(vals) > 0, f"{name} must produce non-null values ({description})"
+            assert not vals.is_nan().any(), f"{name} NaN with {description}"
+            assert not vals.is_infinite().any(), f"{name} Inf with {description}"
+
+        # Branch behavior: sub-epsilon should produce all-neutral; supra-epsilon should
+        # produce at least one non-neutral value proving the guard was bypassed.
+        is_sub_epsilon = delta < 1e-12
+        if is_sub_epsilon:
+            for name, vals in indicators.items():
+                assert (vals == neutrals[name]).all(), (
+                    f"{name} should be neutral ({neutrals[name]}) with sub-epsilon delta"
+                )
+        else:
+            any_non_neutral = any(
+                not (vals == neutrals[name]).all() for name, vals in indicators.items()
+            )
+            assert any_non_neutral, (
+                "At least one indicator must produce non-neutral values with supra-epsilon delta"
+            )
 
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -470,6 +470,52 @@ class TestEdgeCases:
                 f"{col} should be {expected} on flat prices, got {vals.unique().to_list()}"
             )
 
+    @pytest.mark.parametrize(
+        "delta,description",
+        [
+            (1e-14, "sub-epsilon spread triggers guard (neutral output)"),
+            (1e-10, "supra-epsilon spread bypasses guard (computed output)"),
+        ],
+    )
+    def test_near_epsilon_boundary_no_nan(self, delta: float, description: str) -> None:
+        """Test epsilon boundary: near-flat windows must never produce NaN/Inf."""
+        base = 100.0
+        # Alternate between base and base+delta to create a tiny but non-zero spread
+        close_vals = [base + delta * (i % 2) for i in range(30)]
+        prices = pl.DataFrame(
+            {
+                "symbol": ["TEST"] * 30,
+                "date": pl.date_range(
+                    start=pl.date(2024, 1, 1), end=pl.date(2024, 1, 30), interval="1d", eager=True
+                ),
+                "close": close_vals,
+                "high": [max(close_vals[i], base + delta) for i in range(30)],
+                "low": [min(close_vals[i], base) for i in range(30)],
+                "open": close_vals,
+                "volume": [1000000] * 30,
+            }
+        )
+
+        # RSI must be finite (either neutral 50 or a valid computed value)
+        rsi_vals = compute_rsi(prices)["rsi"].drop_nulls()
+        assert not rsi_vals.is_nan().any(), f"RSI NaN with {description}"
+        assert not rsi_vals.is_infinite().any(), f"RSI Inf with {description}"
+
+        # Bollinger %B must be finite
+        bb_pct = compute_bollinger_bands(prices)["bb_pct"].drop_nulls()
+        assert not bb_pct.is_nan().any(), f"bb_pct NaN with {description}"
+        assert not bb_pct.is_infinite().any(), f"bb_pct Inf with {description}"
+
+        # Stochastic %K must be finite
+        stoch_k = compute_stochastic_oscillator(prices)["stoch_k"].drop_nulls()
+        assert not stoch_k.is_nan().any(), f"stoch_k NaN with {description}"
+        assert not stoch_k.is_infinite().any(), f"stoch_k Inf with {description}"
+
+        # Z-score must be finite
+        zscore = compute_price_zscore(prices)["price_zscore"].drop_nulls()
+        assert not zscore.is_nan().any(), f"price_zscore NaN with {description}"
+        assert not zscore.is_infinite().any(), f"price_zscore Inf with {description}"
+
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""
         # Missing 'high' and 'low' columns needed for Stochastic

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -498,21 +498,25 @@ class TestEdgeCases:
 
         # RSI must be finite (either neutral 50 or a valid computed value)
         rsi_vals = compute_rsi(prices)["rsi"].drop_nulls()
+        assert len(rsi_vals) > 0, f"RSI must produce non-null values ({description})"
         assert not rsi_vals.is_nan().any(), f"RSI NaN with {description}"
         assert not rsi_vals.is_infinite().any(), f"RSI Inf with {description}"
 
         # Bollinger %B must be finite
         bb_pct = compute_bollinger_bands(prices)["bb_pct"].drop_nulls()
+        assert len(bb_pct) > 0, f"bb_pct must produce non-null values ({description})"
         assert not bb_pct.is_nan().any(), f"bb_pct NaN with {description}"
         assert not bb_pct.is_infinite().any(), f"bb_pct Inf with {description}"
 
         # Stochastic %K must be finite
         stoch_k = compute_stochastic_oscillator(prices)["stoch_k"].drop_nulls()
+        assert len(stoch_k) > 0, f"stoch_k must produce non-null values ({description})"
         assert not stoch_k.is_nan().any(), f"stoch_k NaN with {description}"
         assert not stoch_k.is_infinite().any(), f"stoch_k Inf with {description}"
 
         # Z-score must be finite
         zscore = compute_price_zscore(prices)["price_zscore"].drop_nulls()
+        assert len(zscore) > 0, f"price_zscore must produce non-null values ({description})"
         assert not zscore.is_nan().any(), f"price_zscore NaN with {description}"
         assert not zscore.is_infinite().any(), f"price_zscore Inf with {description}"
 

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -383,7 +383,7 @@ class TestEdgeCases:
         assert result["rsi"].null_count() == 10
 
     def test_constant_prices(self) -> None:
-        """Test behavior with constant prices (no movement)."""
+        """Test that flat-price windows do not emit NaN or Inf (issue #173)."""
         prices = pl.DataFrame(
             {
                 "symbol": ["TEST"] * 30,
@@ -398,16 +398,56 @@ class TestEdgeCases:
             }
         )
 
-        # Bollinger Bands width should be ~0 (no volatility)
+        # RSI: avg_loss=0 and avg_gain=0 → should be 50 (neutral), never NaN/Inf
+        result_rsi = compute_rsi(prices)
+        rsi_vals = result_rsi["rsi"].drop_nulls()
+        assert not rsi_vals.is_nan().any(), "RSI must not contain NaN on flat prices"
+        assert not rsi_vals.is_infinite().any(), "RSI must not contain Inf on flat prices"
+        assert (rsi_vals == 50.0).all(), "RSI should be 50 (neutral) when prices are flat"
+
+        # Bollinger %B: bb_upper == bb_lower → should be 0.5, never NaN/Inf
         result_bb = compute_bollinger_bands(prices)
-
-        # Note: RSI with constant prices produces NaN due to division by zero
-        # This is expected behavior - we only test Bollinger width here
-
-        # Check Bollinger width is small (near zero volatility)
+        bb_pct = result_bb["bb_pct"].drop_nulls()
+        assert not bb_pct.is_nan().any(), "bb_pct must not contain NaN on flat prices"
+        assert not bb_pct.is_infinite().any(), "bb_pct must not contain Inf on flat prices"
         bb_width = result_bb["bb_width"].drop_nulls()
         if len(bb_width) > 0:
             assert bb_width.mean() < 1.0, "Bollinger width should be small with constant prices"
+
+        # Stochastic %K: period_high == period_low → should be 50, never NaN/Inf
+        result_stoch = compute_stochastic_oscillator(prices)
+        stoch_k = result_stoch["stoch_k"].drop_nulls()
+        assert not stoch_k.is_nan().any(), "stoch_k must not contain NaN on flat prices"
+        assert not stoch_k.is_infinite().any(), "stoch_k must not contain Inf on flat prices"
+
+        # Z-Score: rolling_std=0 → should be 0, never NaN/Inf
+        result_zs = compute_price_zscore(prices)
+        zscore = result_zs["price_zscore"].drop_nulls()
+        assert not zscore.is_nan().any(), "price_zscore must not contain NaN on flat prices"
+        assert not zscore.is_infinite().any(), "price_zscore must not contain Inf on flat prices"
+
+    def test_flat_window_combined_features_no_nan(self) -> None:
+        """Test that combined features pipeline emits no NaN/Inf on flat prices (#173)."""
+        prices = pl.DataFrame(
+            {
+                "symbol": ["TEST"] * 30,
+                "date": pl.date_range(
+                    start=pl.date(2024, 1, 1), end=pl.date(2024, 1, 30), interval="1d", eager=True
+                ),
+                "close": [100.0] * 30,
+                "high": [100.0] * 30,
+                "low": [100.0] * 30,
+                "open": [100.0] * 30,
+                "volume": [1000000] * 30,
+            }
+        )
+
+        result = compute_mean_reversion_features(prices)
+        feature_cols = ["rsi", "bb_pct", "bb_width", "stoch_k", "stoch_d", "price_zscore"]
+        for col in feature_cols:
+            vals = result[col].drop_nulls()
+            assert not vals.is_nan().any(), f"{col} must not contain NaN on flat prices"
+            assert not vals.is_infinite().any(), f"{col} must not contain Inf on flat prices"
 
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""

--- a/tests/research/strategies/mean_reversion/test_features.py
+++ b/tests/research/strategies/mean_reversion/test_features.py
@@ -16,6 +16,7 @@ import numpy as np
 import polars as pl
 import pytest
 
+from research.strategies._feature_constants import FEATURE_EPSILON
 from research.strategies.mean_reversion.features import (
     compute_bollinger_bands,
     compute_mean_reversion_features,
@@ -512,7 +513,7 @@ class TestEdgeCases:
 
         # Branch behavior: sub-epsilon should produce all-neutral; supra-epsilon should
         # produce at least one non-neutral value proving the guard was bypassed.
-        is_sub_epsilon = delta < 1e-12
+        is_sub_epsilon = delta < FEATURE_EPSILON
         if is_sub_epsilon:
             for name, vals in indicators.items():
                 assert (vals == neutrals[name]).all(), (

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -267,6 +267,31 @@ class TestRateOfChange:
 
         assert null_count_7 < null_count_14
 
+    def test_roc_zero_price_emits_null(self) -> None:
+        """Test that ROC emits null when price_n_ago is 0 (data quality guard)."""
+        prices = pl.DataFrame(
+            {
+                "symbol": ["TEST"] * 10,
+                "date": pl.date_range(
+                    start=pl.date(2024, 1, 1),
+                    end=pl.date(2024, 1, 10),
+                    interval="1d",
+                    eager=True,
+                ),
+                "close": [0.0] * 5 + [100.0] * 5,
+            }
+        )
+
+        result = compute_rate_of_change(prices, period=5)
+
+        # Rows where price_n_ago=0 should have null ROC (not 0.0)
+        # Rows 5-9 have close=100 but price_n_ago=0 → ROC should be null
+        for i in range(5, 10):
+            assert result["roc"][i] is None, (
+                f"ROC at row {i} should be null when price_n_ago is 0, "
+                f"got {result['roc'][i]}"
+            )
+
 
 class TestADX:
     """Tests for ADX (Average Directional Index)."""
@@ -531,6 +556,7 @@ class TestEdgeCases:
         result_adx = compute_adx(prices)
         for col in ["adx", "plus_di", "minus_di"]:
             vals = result_adx[col].drop_nulls()
+            assert len(vals) > 0, f"{col} must produce non-null values for 30-row flat input"
             assert not vals.is_nan().any(), f"{col} must not contain NaN on flat prices"
             assert not vals.is_infinite().any(), f"{col} must not contain Inf on flat prices"
 
@@ -555,10 +581,24 @@ class TestEdgeCases:
 
         result = compute_momentum_features(prices)
         feature_cols = ["adx", "plus_di", "minus_di", "roc", "macd_line", "macd_hist"]
+        # Expected neutral values for each indicator on flat prices
+        expected_neutrals = {
+            "adx": 0.0,
+            "plus_di": 0.0,
+            "minus_di": 0.0,
+            "roc": 0.0,
+            "macd_line": 0.0,
+            "macd_hist": 0.0,
+        }
         for col in feature_cols:
             vals = result[col].drop_nulls()
+            assert len(vals) > 0, f"{col} must produce non-null values for 30-row flat input"
             assert not vals.is_nan().any(), f"{col} must not contain NaN on flat prices"
             assert not vals.is_infinite().any(), f"{col} must not contain Inf on flat prices"
+            expected = expected_neutrals[col]
+            assert (vals == expected).all(), (
+                f"{col} should be {expected} on flat prices, got {vals.unique().to_list()}"
+            )
 
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -267,8 +267,8 @@ class TestRateOfChange:
 
         assert null_count_7 < null_count_14
 
-    def test_roc_zero_price_emits_null(self) -> None:
-        """Test that ROC emits null when price_n_ago is 0 (data quality guard)."""
+    def test_roc_zero_price_emits_null_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that ROC emits null and logs warning when price_n_ago is 0."""
         prices = pl.DataFrame(
             {
                 "symbol": ["TEST"] * 10,
@@ -282,7 +282,8 @@ class TestRateOfChange:
             }
         )
 
-        result = compute_rate_of_change(prices, period=5)
+        with caplog.at_level("WARNING", logger="research.strategies.momentum.features"):
+            result = compute_rate_of_change(prices, period=5)
 
         # Rows where price_n_ago=0 should have null ROC (not 0.0)
         # Rows 5-9 have close=100 but price_n_ago=0 → ROC should be null
@@ -291,6 +292,11 @@ class TestRateOfChange:
                 f"ROC at row {i} should be null when price_n_ago is 0, "
                 f"got {result['roc'][i]}"
             )
+
+        # Verify structured warning was emitted
+        assert any("ROC guard" in rec.message for rec in caplog.records), (
+            "ROC guard should emit a warning when near-zero prices are encountered"
+        )
 
 
 class TestADX:
@@ -633,20 +639,38 @@ class TestEdgeCases:
             }
         )
 
-        # ADX / DI must be finite (either guarded neutral or valid computed value)
+        # Collect non-null values for each indicator
         result_adx = compute_adx(prices)
-        for col in ["adx", "plus_di", "minus_di"]:
-            vals = result_adx[col].drop_nulls()
-            assert len(vals) > 0, f"{col} must produce non-null values ({description})"
-            assert not vals.is_nan().any(), f"{col} NaN with {description}"
-            assert not vals.is_infinite().any(), f"{col} Inf with {description}"
-
-        # ROC must be finite (or null for invalid lag)
         result_roc = compute_rate_of_change(prices)
-        roc_vals = result_roc["roc"].drop_nulls()
-        assert len(roc_vals) > 0, f"ROC must produce non-null values ({description})"
-        assert not roc_vals.is_nan().any(), f"ROC NaN with {description}"
-        assert not roc_vals.is_infinite().any(), f"ROC Inf with {description}"
+
+        indicators = {
+            "adx": result_adx["adx"].drop_nulls(),
+            "plus_di": result_adx["plus_di"].drop_nulls(),
+            "minus_di": result_adx["minus_di"].drop_nulls(),
+            "roc": result_roc["roc"].drop_nulls(),
+        }
+
+        for name, vals in indicators.items():
+            assert len(vals) > 0, f"{name} must produce non-null values ({description})"
+            assert not vals.is_nan().any(), f"{name} NaN with {description}"
+            assert not vals.is_infinite().any(), f"{name} Inf with {description}"
+
+        # Branch behavior: sub-epsilon should produce all-neutral (0.0); supra-epsilon
+        # should produce at least one non-neutral value proving the guard was bypassed.
+        is_sub_epsilon = delta < 1e-12
+        if is_sub_epsilon:
+            for name, vals in indicators.items():
+                assert (vals == 0.0).all(), (
+                    f"{name} should be 0.0 (neutral) with sub-epsilon delta"
+                )
+        else:
+            # ADX/DI should produce non-zero values with meaningful high/low spread
+            any_non_neutral = any(
+                not (vals == 0.0).all() for name, vals in indicators.items()
+            )
+            assert any_non_neutral, (
+                "At least one indicator must produce non-neutral values with supra-epsilon delta"
+            )
 
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -601,7 +601,7 @@ class TestEdgeCases:
             )
 
     @pytest.mark.parametrize(
-        "delta,description",
+        ("delta", "description"),
         [
             (1e-14, "sub-epsilon spread triggers guard (neutral output)"),
             (1e-10, "supra-epsilon spread bypasses guard (computed output)"),

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -17,6 +17,7 @@ import numpy as np
 import polars as pl
 import pytest
 
+from research.strategies._feature_constants import FEATURE_EPSILON
 from research.strategies.momentum.features import (
     compute_adx,
     compute_macd,
@@ -665,7 +666,7 @@ class TestEdgeCases:
 
         # Branch behavior: sub-epsilon should produce all-neutral (0.0); supra-epsilon
         # should produce at least one non-neutral value proving the guard was bypassed.
-        is_sub_epsilon = delta < 1e-12
+        is_sub_epsilon = delta < FEATURE_EPSILON
         if is_sub_epsilon:
             for name, vals in indicators.items():
                 assert (vals == 0.0).all(), (

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -306,6 +306,17 @@ class TestRateOfChange:
         assert rec.count == 5, "count should be 5 (rows 5-9 have price_n_ago=0)"
         assert hasattr(rec, "symbols"), "Warning must include 'symbols' extra field"
         assert rec.symbols == ["TEST"], "symbols should list affected symbols"
+        assert hasattr(rec, "strategy"), "Warning must include 'strategy' extra field"
+        assert rec.strategy == "momentum", "strategy field must be 'momentum'"
+
+    def test_roc_empty_dataframe_no_error(self) -> None:
+        """Test that ROC handles empty DataFrames without raising (regression guard)."""
+        empty_prices = pl.DataFrame(
+            schema={"symbol": pl.Utf8, "date": pl.Date, "close": pl.Float64}
+        )
+        result = compute_rate_of_change(empty_prices, period=5)
+        assert len(result) == 0, "Empty input should produce empty output"
+        assert "roc" in result.columns, "ROC column must be present even on empty input"
 
 
 class TestADX:

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -320,6 +320,56 @@ class TestRateOfChange:
         assert len(result) == 0, "Empty input should produce empty output"
         assert "roc" in result.columns, "ROC column must be present even on empty input"
 
+    def test_roc_normal_data_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that ROC does not emit warning on normal (non-zero) price data."""
+        prices = pl.DataFrame(
+            {
+                "symbol": ["TEST"] * 10,
+                "date": pl.date_range(
+                    start=pl.date(2024, 1, 1),
+                    end=pl.date(2024, 1, 10),
+                    interval="1d",
+                    eager=True,
+                ),
+                "close": [100.0 + i for i in range(10)],
+            }
+        )
+        with caplog.at_level("WARNING", logger="research.strategies.momentum.features"):
+            compute_rate_of_change(prices, period=5)
+
+        guard_records = [rec for rec in caplog.records if "ROC guard" in rec.message]
+        assert len(guard_records) == 0, "No warning should be emitted on normal price data"
+
+    def test_roc_many_symbols_caps_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that ROC warning caps displayed symbols at 10 and includes suffix."""
+        # Create 15 symbols each with zero prices followed by non-zero
+        rows: dict[str, list[object]] = {"symbol": [], "date": [], "close": []}
+        for i in range(15):
+            sym = f"SYM{i:02d}"
+            dates = pl.date_range(
+                start=pl.date(2024, 1, 1),
+                end=pl.date(2024, 1, 10),
+                interval="1d",
+                eager=True,
+            ).to_list()
+            rows["symbol"].extend([sym] * 10)
+            rows["date"].extend(dates)
+            rows["close"].extend([0.0] * 5 + [100.0] * 5)
+
+        prices = pl.DataFrame(rows)
+
+        with caplog.at_level("WARNING", logger="research.strategies.momentum.features"):
+            compute_rate_of_change(prices, period=5)
+
+        guard_records = [rec for rec in caplog.records if "ROC guard" in rec.message]
+        assert len(guard_records) > 0, "Warning should be emitted with zero-price data"
+        rec = guard_records[0]
+        # symbols in extra should be capped at 10
+        assert len(rec.symbols) == 10, "symbols extra should be capped at 10"
+        assert rec.symbols_total == 15, "symbols_total should be 15 (all affected)"
+        # Message should contain suffix indicating more symbols
+        assert "+5 more" in rec.message, "Message should indicate truncated symbol list"
+
 
 class TestADX:
     """Tests for ADX (Average Directional Index)."""

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -308,8 +308,8 @@ class TestRateOfChange:
         assert rec.symbols == ["TEST"], "symbols should list affected symbols (capped)"
         assert hasattr(rec, "symbols_total"), "Warning must include 'symbols_total' extra field"
         assert rec.symbols_total == 1, "symbols_total should be 1 for single-symbol input"
-        assert hasattr(rec, "strategy"), "Warning must include 'strategy' extra field"
-        assert rec.strategy == "momentum", "strategy field must be 'momentum'"
+        assert hasattr(rec, "strategy_id"), "Warning must include 'strategy_id' extra field"
+        assert rec.strategy_id == "momentum", "strategy_id field must be 'momentum'"
 
     def test_roc_empty_dataframe_no_error(self) -> None:
         """Test that ROC handles empty DataFrames without raising (regression guard)."""

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -600,6 +600,48 @@ class TestEdgeCases:
                 f"{col} should be {expected} on flat prices, got {vals.unique().to_list()}"
             )
 
+    @pytest.mark.parametrize(
+        "delta,description",
+        [
+            (1e-14, "sub-epsilon spread triggers guard (neutral output)"),
+            (1e-10, "supra-epsilon spread bypasses guard (computed output)"),
+        ],
+    )
+    def test_near_epsilon_boundary_no_nan(self, delta: float, description: str) -> None:
+        """Test epsilon boundary: near-flat windows must never produce NaN/Inf."""
+        base = 100.0
+        # Alternate between base and base+delta to create a tiny but non-zero spread
+        close_vals = [base + delta * (i % 2) for i in range(30)]
+        prices = pl.DataFrame(
+            {
+                "symbol": ["TEST"] * 30,
+                "date": pl.date_range(
+                    start=pl.date(2024, 1, 1),
+                    end=pl.date(2024, 1, 30),
+                    interval="1d",
+                    eager=True,
+                ),
+                "close": close_vals,
+                "high": [max(close_vals[i], base + delta) for i in range(30)],
+                "low": [min(close_vals[i], base) for i in range(30)],
+                "open": close_vals,
+                "volume": [1000000] * 30,
+            }
+        )
+
+        # ADX / DI must be finite (either guarded neutral or valid computed value)
+        result_adx = compute_adx(prices)
+        for col in ["adx", "plus_di", "minus_di"]:
+            vals = result_adx[col].drop_nulls()
+            assert not vals.is_nan().any(), f"{col} NaN with {description}"
+            assert not vals.is_infinite().any(), f"{col} Inf with {description}"
+
+        # ROC must be finite (or null for invalid lag)
+        result_roc = compute_rate_of_change(prices)
+        roc_vals = result_roc["roc"].drop_nulls()
+        assert not roc_vals.is_nan().any(), f"ROC NaN with {description}"
+        assert not roc_vals.is_infinite().any(), f"ROC Inf with {description}"
+
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""
         # Missing 'volume' column needed for OBV

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -495,7 +495,7 @@ class TestEdgeCases:
         assert result["ma_slow"].null_count() == 10
 
     def test_constant_prices(self) -> None:
-        """Test behavior with constant prices (no movement)."""
+        """Test that flat-price windows do not emit NaN or Inf (issue #173)."""
         prices = pl.DataFrame(
             {
                 "symbol": ["TEST"] * 30,
@@ -526,6 +526,39 @@ class TestEdgeCases:
 
         if len(roc_values) > 0:
             assert roc_values.abs().mean() < 0.1, "ROC should be near zero"
+
+        # ADX: atr=0 and DI sum=0 → should not emit NaN/Inf
+        result_adx = compute_adx(prices)
+        for col in ["adx", "plus_di", "minus_di"]:
+            vals = result_adx[col].drop_nulls()
+            assert not vals.is_nan().any(), f"{col} must not contain NaN on flat prices"
+            assert not vals.is_infinite().any(), f"{col} must not contain Inf on flat prices"
+
+    def test_flat_window_combined_features_no_nan(self) -> None:
+        """Test that combined features pipeline emits no NaN/Inf on flat prices (#173)."""
+        prices = pl.DataFrame(
+            {
+                "symbol": ["TEST"] * 30,
+                "date": pl.date_range(
+                    start=pl.date(2024, 1, 1),
+                    end=pl.date(2024, 1, 30),
+                    interval="1d",
+                    eager=True,
+                ),
+                "close": [100.0] * 30,
+                "high": [100.0] * 30,
+                "low": [100.0] * 30,
+                "open": [100.0] * 30,
+                "volume": [1000000] * 30,
+            }
+        )
+
+        result = compute_momentum_features(prices)
+        feature_cols = ["adx", "plus_di", "minus_di", "roc", "macd_line", "macd_hist"]
+        for col in feature_cols:
+            vals = result[col].drop_nulls()
+            assert not vals.is_nan().any(), f"{col} must not contain NaN on flat prices"
+            assert not vals.is_infinite().any(), f"{col} must not contain Inf on flat prices"
 
     def test_missing_required_columns(self) -> None:
         """Test error handling when required columns are missing."""

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -610,8 +610,12 @@ class TestEdgeCases:
     def test_near_epsilon_boundary_no_nan(self, delta: float, description: str) -> None:
         """Test epsilon boundary: near-flat windows must never produce NaN/Inf."""
         base = 100.0
-        # Alternate between base and base+delta to create a tiny but non-zero spread
+        # Alternate between base and base+delta to create a tiny but non-zero spread.
+        # high/low use a proportional spread so ADX sees real directional movement
+        # in the supra-epsilon case rather than constant high==low==close.
         close_vals = [base + delta * (i % 2) for i in range(30)]
+        high_vals = [c + delta for c in close_vals]
+        low_vals = [c - delta for c in close_vals]
         prices = pl.DataFrame(
             {
                 "symbol": ["TEST"] * 30,
@@ -622,8 +626,8 @@ class TestEdgeCases:
                     eager=True,
                 ),
                 "close": close_vals,
-                "high": [max(close_vals[i], base + delta) for i in range(30)],
-                "low": [min(close_vals[i], base) for i in range(30)],
+                "high": high_vals,
+                "low": low_vals,
                 "open": close_vals,
                 "volume": [1000000] * 30,
             }
@@ -633,12 +637,14 @@ class TestEdgeCases:
         result_adx = compute_adx(prices)
         for col in ["adx", "plus_di", "minus_di"]:
             vals = result_adx[col].drop_nulls()
+            assert len(vals) > 0, f"{col} must produce non-null values ({description})"
             assert not vals.is_nan().any(), f"{col} NaN with {description}"
             assert not vals.is_infinite().any(), f"{col} Inf with {description}"
 
         # ROC must be finite (or null for invalid lag)
         result_roc = compute_rate_of_change(prices)
         roc_vals = result_roc["roc"].drop_nulls()
+        assert len(roc_vals) > 0, f"ROC must produce non-null values ({description})"
         assert not roc_vals.is_nan().any(), f"ROC NaN with {description}"
         assert not roc_vals.is_infinite().any(), f"ROC Inf with {description}"
 

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -293,10 +293,18 @@ class TestRateOfChange:
                 f"got {result['roc'][i]}"
             )
 
-        # Verify structured warning was emitted
-        assert any("ROC guard" in rec.message for rec in caplog.records), (
+        # Verify structured warning was emitted with correct metadata
+        guard_records = [rec for rec in caplog.records if "ROC guard" in rec.message]
+        assert len(guard_records) > 0, (
             "ROC guard should emit a warning when near-zero prices are encountered"
         )
+        rec = guard_records[0]
+        assert hasattr(rec, "guard"), "Warning must include 'guard' extra field"
+        assert rec.guard == "roc_near_zero", "guard field must be 'roc_near_zero'"
+        assert hasattr(rec, "count"), "Warning must include 'count' extra field"
+        assert rec.count == 5, "count should be 5 (rows 5-9 have price_n_ago=0)"
+        assert hasattr(rec, "symbols"), "Warning must include 'symbols' extra field"
+        assert rec.symbols == ["TEST"], "symbols should list affected symbols"
 
 
 class TestADX:

--- a/tests/research/strategies/momentum/test_features.py
+++ b/tests/research/strategies/momentum/test_features.py
@@ -305,7 +305,9 @@ class TestRateOfChange:
         assert hasattr(rec, "count"), "Warning must include 'count' extra field"
         assert rec.count == 5, "count should be 5 (rows 5-9 have price_n_ago=0)"
         assert hasattr(rec, "symbols"), "Warning must include 'symbols' extra field"
-        assert rec.symbols == ["TEST"], "symbols should list affected symbols"
+        assert rec.symbols == ["TEST"], "symbols should list affected symbols (capped)"
+        assert hasattr(rec, "symbols_total"), "Warning must include 'symbols_total' extra field"
+        assert rec.symbols_total == 1, "symbols_total should be 1 for single-symbol input"
         assert hasattr(rec, "strategy"), "Warning must include 'strategy' extra field"
         assert rec.strategy == "momentum", "strategy field must be 'momentum'"
 


### PR DESCRIPTION
## Summary
- guard flat-window division-by-zero paths in mean reversion and momentum feature calculations
- return neutral/zero-safe values instead of NaN/Inf for flat-price windows
- add regression tests covering constant-price inputs across both feature pipelines

## Testing
- uv run pytest -q tests/research/strategies/mean_reversion/test_features.py tests/research/strategies/momentum/test_features.py

Fixes #173