### PR TITLE
fix(model-registry): avoid token-derived service names

### DIFF
--- a/apps/model_registry/__init__.py
+++ b/apps/model_registry/__init__.py
@@ -6,5 +6,5 @@ This module provides REST API endpoints for:
 - Model validation
 - Model listing and status
 
-Authentication is via JWT bearer tokens with scopes.
+Authentication is via bearer tokens with scope-based authorization.
 """

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -27,7 +27,6 @@ MODEL_REGISTRY_CONFIG: dict[str, dict[str, str | float | int | list[str]]] = {
     "auth": {
         "type": "bearer",
         "token_env": "MODEL_REGISTRY_READ_TOKEN",
-        "scopes_required": ["model:read"],  # default scope
     },
     "timeout": {"connect": 5.0, "read": 30.0, "write": 60.0},
     "retry": {"max_attempts": 3, "backoff_base": 1.0, "backoff_factor": 2.0},
@@ -80,66 +79,59 @@ def _get_expected_tokens() -> dict[str, str]:
     return tokens
 
 
-def _parse_token_scopes(token: str) -> list[str]:
-    """Parse scopes from token.
+def _authenticate_token(
+    token: str,
+    expected_tokens: dict[str, str] | None = None,
+) -> tuple[list[str], str] | None:
+    """Authenticate a bearer token and return its scopes and role label.
+
+    Performs a single pass over configured tokens using constant-time
+    comparison.  Returns both the granted scopes and a safe, non-secret
+    role label (e.g. "admin", "read") so callers never need to iterate
+    the token list twice.
 
     DESIGN NOTE: For production systems requiring granular scope separation,
     implement JWT-based auth with scope claims. This helper only supports
     shared bearer tokens with two tiers of access.
 
     Current behavior:
-    - MODEL_REGISTRY_ADMIN_TOKEN -> admin scopes
-    - MODEL_REGISTRY_READ_TOKEN or legacy MODEL_REGISTRY_TOKEN -> read-only
-    - Unknown/unsigned tokens -> no scopes (fail closed)
+    - MODEL_REGISTRY_ADMIN_TOKEN -> admin scopes, role "admin"
+    - MODEL_REGISTRY_READ_TOKEN -> read-only scopes, role "read"
+    - Legacy MODEL_REGISTRY_TOKEN -> read-only scopes, role "legacy_read"
+    - Unknown/unsigned tokens -> ``None`` (fail closed)
+
+    The role label is never derived from token content to avoid leaking
+    credential material into logs (fixes #174).
 
     Args:
         token: Bearer token string.
+        expected_tokens: Pre-fetched token map.  When ``None`` the tokens
+            are loaded from environment variables via ``_get_expected_tokens``.
 
     Returns:
-        List of scopes.
+        ``(scopes, role)`` tuple when the token matches a configured
+        secret, or ``None`` for unrecognised tokens.
     """
-    expected_tokens = _get_expected_tokens()
-    admin_token = expected_tokens.get("admin")
-    read_tokens = [
-        expected_tokens.get("read"),
-        expected_tokens.get("legacy_read"),
-    ]
+    if expected_tokens is None:
+        expected_tokens = _get_expected_tokens()
 
     # Admin token is explicitly configured and grants full scopes
+    admin_token = expected_tokens.get("admin")
     if admin_token and secrets.compare_digest(token, admin_token):
-        return ["model:read", "model:write", "model:admin"]
+        return ["model:read", "model:write", "model:admin"], "admin"
 
     # Shared/legacy tokens are read-only for safety
-    for candidate in read_tokens:
+    for role in ("read", "legacy_read"):
+        candidate = expected_tokens.get(role)
         if candidate and secrets.compare_digest(token, candidate):
-            return ["model:read"]
+            return ["model:read"], role
 
-    # Unknown token -> no scopes.  IMPORTANT: Do **not** accept arbitrary
+    # Unknown token -> no match.  IMPORTANT: Do **not** accept arbitrary
     # "service:scope" bearer tokens here because the token value has not been
     # authenticated. Allowing free-form scopes would let any caller mint an
     # admin token by sending `foo:model:admin`. Until we introduce signed JWTs
     # or HMAC tokens, only configured secrets are trusted.
-    return []
-
-
-def _identify_token_role(token: str) -> str:
-    """Identify the access-level role of a verified token.
-
-    Returns a safe, non-secret label (e.g. "admin", "read") based on which
-    configured token matched.  Never derives the name from token content to
-    avoid leaking credential material into logs.
-
-    Args:
-        token: Bearer token string.
-
-    Returns:
-        Role label for the matched token, or "unknown".
-    """
-    expected_tokens = _get_expected_tokens()
-    for role, expected in expected_tokens.items():
-        if secrets.compare_digest(token, expected):
-            return role
-    return "unknown"
+    return None
 
 
 # =============================================================================
@@ -182,11 +174,11 @@ async def verify_token(
             ),
         )
 
-    scopes = _parse_token_scopes(token)
-    if not scopes:
+    result = _authenticate_token(token, expected_tokens=configured_tokens)
+    if result is None:
         logger.warning(
             "Token verification failed: token not recognized for configured scopes",
-            extra={"token_prefix": token[:8] + "..." if len(token) > 8 else "***"},
+            extra={"token_prefix": token[:4] + "..." if len(token) > 8 else "***"},
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -194,7 +186,7 @@ async def verify_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    service = _identify_token_role(token)
+    scopes, service = result
 
     return ServiceToken(token=token, scopes=scopes, service_name=service)
 

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -178,7 +178,7 @@ async def verify_token(
     if result is None:
         logger.warning(
             "Token verification failed: token not recognized for configured scopes",
-            extra={"token_prefix": token[:4] + "..." if len(token) > 8 else "***"},
+            extra={"token_length": len(token)},
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -185,9 +185,9 @@ async def verify_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    scopes, service = result
+    scopes, role = result
 
-    return ServiceToken(scopes=scopes, auth_role=service)
+    return ServiceToken(scopes=scopes, auth_role=role)
 
 
 async def verify_read_scope(
@@ -204,6 +204,8 @@ async def verify_read_scope(
     Raises:
         HTTPException 403: If scope is missing.
     """
+    # Defense-in-depth: admin tokens already include model:read, but we check
+    # model:admin explicitly so scope gates remain correct if tier assignments change.
     if "model:read" not in token.scopes and "model:admin" not in token.scopes:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -226,6 +228,7 @@ async def verify_write_scope(
     Raises:
         HTTPException 403: If scope is missing.
     """
+    # Defense-in-depth: admin tokens already include model:write.
     if "model:write" not in token.scopes and "model:admin" not in token.scopes:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -1,7 +1,7 @@
 """
 Authentication for Model Registry API.
 
-Provides JWT bearer token verification with scope-based authorization.
+Provides bearer token verification with scope-based authorization.
 """
 
 from __future__ import annotations

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -122,17 +122,23 @@ def _parse_token_scopes(token: str) -> list[str]:
     return []
 
 
-def _parse_service_name(token: str) -> str:
-    """Parse service name from token.
+def _identify_token_role(token: str) -> str:
+    """Identify the access-level role of a verified token.
+
+    Returns a safe, non-secret label (e.g. "admin", "read") based on which
+    configured token matched.  Never derives the name from token content to
+    avoid leaking credential material into logs.
 
     Args:
         token: Bearer token string.
 
     Returns:
-        Service name.
+        Role label for the matched token, or "unknown".
     """
-    if ":" in token:
-        return token.split(":")[0]
+    expected_tokens = _get_expected_tokens()
+    for role, expected in expected_tokens.items():
+        if secrets.compare_digest(token, expected):
+            return role
     return "unknown"
 
 
@@ -188,7 +194,7 @@ async def verify_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    service = _parse_service_name(token)
+    service = _identify_token_role(token)
 
     return ServiceToken(token=token, scopes=scopes, service_name=service)
 

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -46,7 +46,6 @@ _ADMIN_TOKEN_ENV_VAR = "MODEL_REGISTRY_ADMIN_TOKEN"
 class ServiceToken:
     """Verified service token with scopes."""
 
-    token: str
     scopes: list[str]
     auth_role: str
 
@@ -188,7 +187,7 @@ async def verify_token(
 
     scopes, service = result
 
-    return ServiceToken(token=token, scopes=scopes, auth_role=service)
+    return ServiceToken(scopes=scopes, auth_role=service)
 
 
 async def verify_read_scope(

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -6,14 +6,15 @@ Provides bearer token verification with scope-based authorization.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import secrets
-from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -23,21 +24,45 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-MODEL_REGISTRY_CONFIG: dict[str, dict[str, str | float | int | list[str]]] = {
-    "auth": {
-        "type": "bearer",
-        "token_env": "MODEL_REGISTRY_READ_TOKEN",
-    },
-    "timeout": {"connect": 5.0, "read": 30.0, "write": 60.0},
-    "retry": {"max_attempts": 3, "backoff_base": 1.0, "backoff_factor": 2.0},
-}
+class _AuthConfig(BaseModel, frozen=True):
+    """Auth section of model registry configuration."""
+
+    type: str = "bearer"
+    token_env: str = "MODEL_REGISTRY_READ_TOKEN"
+
+
+class _TimeoutConfig(BaseModel, frozen=True):
+    """Timeout section of model registry configuration."""
+
+    connect: float = 5.0
+    read: float = 30.0
+    write: float = 60.0
+
+
+class _RetryConfig(BaseModel, frozen=True):
+    """Retry section of model registry configuration."""
+
+    max_attempts: int = 3
+    backoff_base: float = 1.0
+    backoff_factor: float = 2.0
+
+
+class ModelRegistryConfig(BaseModel, frozen=True):
+    """Model registry configuration."""
+
+    auth: _AuthConfig = _AuthConfig()
+    timeout: _TimeoutConfig = _TimeoutConfig()
+    retry: _RetryConfig = _RetryConfig()
+
+
+MODEL_REGISTRY_CONFIG: ModelRegistryConfig = ModelRegistryConfig()
 
 _AUTH_TOKEN_ENV_VAR = "MODEL_REGISTRY_TOKEN"  # Legacy shared token (read-only fallback)
 _READ_TOKEN_ENV_VAR = "MODEL_REGISTRY_READ_TOKEN"
 _ADMIN_TOKEN_ENV_VAR = "MODEL_REGISTRY_ADMIN_TOKEN"
 
-_ADMIN_SCOPES: list[str] = ["model:read", "model:write", "model:admin"]
-_READ_SCOPES: list[str] = ["model:read"]
+_ADMIN_SCOPES: tuple[str, ...] = ("model:read", "model:write", "model:admin")
+_READ_SCOPES: tuple[str, ...] = ("model:read",)
 
 
 # =============================================================================
@@ -45,8 +70,7 @@ _READ_SCOPES: list[str] = ["model:read"]
 # =============================================================================
 
 
-@dataclass
-class ServiceToken:
+class ServiceToken(BaseModel, frozen=True):
     """Verified service token with scopes."""
 
     scopes: list[str]
@@ -61,8 +85,14 @@ class ServiceToken:
 security = HTTPBearer(auto_error=False)
 
 
+@functools.lru_cache(maxsize=1)
 def _get_expected_tokens() -> dict[str, str]:
-    """Get configured tokens keyed by access level."""
+    """Get configured tokens keyed by access level.
+
+    Results are cached for the process lifetime.  Call
+    ``_get_expected_tokens.cache_clear()`` when environment variables
+    change (e.g. in tests).
+    """
 
     tokens: dict[str, str] = {}
 

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -48,7 +48,7 @@ class ServiceToken:
 
     token: str
     scopes: list[str]
-    service_name: str
+    auth_role: str
 
 
 # =============================================================================
@@ -188,7 +188,7 @@ async def verify_token(
 
     scopes, service = result
 
-    return ServiceToken(token=token, scopes=scopes, service_name=service)
+    return ServiceToken(token=token, scopes=scopes, auth_role=service)
 
 
 async def verify_read_scope(

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -36,6 +36,9 @@ _AUTH_TOKEN_ENV_VAR = "MODEL_REGISTRY_TOKEN"  # Legacy shared token (read-only f
 _READ_TOKEN_ENV_VAR = "MODEL_REGISTRY_READ_TOKEN"
 _ADMIN_TOKEN_ENV_VAR = "MODEL_REGISTRY_ADMIN_TOKEN"
 
+_ADMIN_SCOPES: list[str] = ["model:read", "model:write", "model:admin"]
+_READ_SCOPES: list[str] = ["model:read"]
+
 
 # =============================================================================
 # Auth Types
@@ -117,13 +120,13 @@ def _authenticate_token(
     # Admin token is explicitly configured and grants full scopes
     admin_token = expected_tokens.get("admin")
     if admin_token and secrets.compare_digest(token, admin_token):
-        return ["model:read", "model:write", "model:admin"], "admin"
+        return list(_ADMIN_SCOPES), "admin"
 
     # Shared/legacy tokens are read-only for safety
     for role in ("read", "legacy_read"):
         candidate = expected_tokens.get(role)
         if candidate and secrets.compare_digest(token, candidate):
-            return ["model:read"], role
+            return list(_READ_SCOPES), role
 
     # Unknown token -> no match.  IMPORTANT: Do **not** accept arbitrary
     # "service:scope" bearer tokens here because the token value has not been

--- a/apps/model_registry/auth.py
+++ b/apps/model_registry/auth.py
@@ -28,7 +28,6 @@ class _AuthConfig(BaseModel, frozen=True):
     """Auth section of model registry configuration."""
 
     type: str = "bearer"
-    token_env: str = "MODEL_REGISTRY_READ_TOKEN"
 
 
 class _TimeoutConfig(BaseModel, frozen=True):
@@ -73,7 +72,7 @@ _READ_SCOPES: tuple[str, ...] = ("model:read",)
 class ServiceToken(BaseModel, frozen=True):
     """Verified service token with scopes."""
 
-    scopes: list[str]
+    scopes: tuple[str, ...]
     auth_role: str
 
 
@@ -114,7 +113,7 @@ def _get_expected_tokens() -> dict[str, str]:
 def _authenticate_token(
     token: str,
     expected_tokens: dict[str, str] | None = None,
-) -> tuple[list[str], str] | None:
+) -> tuple[tuple[str, ...], str] | None:
     """Authenticate a bearer token and return its scopes and role label.
 
     Performs a single pass over configured tokens using constant-time
@@ -150,13 +149,13 @@ def _authenticate_token(
     # Admin token is explicitly configured and grants full scopes
     admin_token = expected_tokens.get("admin")
     if admin_token and secrets.compare_digest(token, admin_token):
-        return list(_ADMIN_SCOPES), "admin"
+        return _ADMIN_SCOPES, "admin"
 
     # Shared/legacy tokens are read-only for safety
     for role in ("read", "legacy_read"):
         candidate = expected_tokens.get(role)
         if candidate and secrets.compare_digest(token, candidate):
-            return list(_READ_SCOPES), role
+            return _READ_SCOPES, role
 
     # Unknown token -> no match.  IMPORTANT: Do **not** accept arbitrary
     # "service:scope" bearer tokens here because the token value has not been

--- a/apps/model_registry/routes.py
+++ b/apps/model_registry/routes.py
@@ -207,7 +207,7 @@ def get_current_model(
         extra={
             "model_type": model_type.value,
             "version": metadata.version,
-            "auth_role": auth.service_name,
+            "auth_role": auth.auth_role,
         },
     )
 
@@ -282,7 +282,7 @@ def get_model_metadata(
             "model_type": model_type.value,
             "version": version,
             "model_id": metadata.model_id,
-            "auth_role": auth.service_name,
+            "auth_role": auth.auth_role,
         },
     )
 
@@ -362,7 +362,7 @@ def validate_model(
             "valid": result.valid,
             "checksum_ok": result.checksum_verified,
             "load_ok": result.load_successful,
-            "auth_role": auth.service_name,
+            "auth_role": auth.auth_role,
         },
     )
 
@@ -463,7 +463,7 @@ def list_models(
             "model_type": model_type.value,
             "status_filter": status_filter.value if status_filter else None,
             "count": len(models),
-            "auth_role": auth.service_name,
+            "auth_role": auth.auth_role,
         },
     )
 

--- a/apps/model_registry/routes.py
+++ b/apps/model_registry/routes.py
@@ -40,6 +40,8 @@ from .schemas import (
 
 logger = logging.getLogger(__name__)
 
+_SERVICE_NAME = "model_registry"
+
 
 # =============================================================================
 # Router Setup
@@ -208,7 +210,7 @@ def get_current_model(
             "model_type": model_type.value,
             "version": metadata.version,
             "auth_role": auth.auth_role,
-            "service": "model_registry",
+            "service": _SERVICE_NAME,
         },
     )
 
@@ -284,7 +286,7 @@ def get_model_metadata(
             "version": version,
             "model_id": metadata.model_id,
             "auth_role": auth.auth_role,
-            "service": "model_registry",
+            "service": _SERVICE_NAME,
         },
     )
 
@@ -365,7 +367,7 @@ def validate_model(
             "checksum_ok": result.checksum_verified,
             "load_ok": result.load_successful,
             "auth_role": auth.auth_role,
-            "service": "model_registry",
+            "service": _SERVICE_NAME,
         },
     )
 
@@ -467,7 +469,7 @@ def list_models(
             "status_filter": status_filter.value if status_filter else None,
             "count": len(models),
             "auth_role": auth.auth_role,
-            "service": "model_registry",
+            "service": _SERVICE_NAME,
         },
     )
 

--- a/apps/model_registry/routes.py
+++ b/apps/model_registry/routes.py
@@ -208,6 +208,7 @@ def get_current_model(
             "model_type": model_type.value,
             "version": metadata.version,
             "auth_role": auth.auth_role,
+            "service": "model_registry",
         },
     )
 
@@ -283,6 +284,7 @@ def get_model_metadata(
             "version": version,
             "model_id": metadata.model_id,
             "auth_role": auth.auth_role,
+            "service": "model_registry",
         },
     )
 
@@ -363,6 +365,7 @@ def validate_model(
             "checksum_ok": result.checksum_verified,
             "load_ok": result.load_successful,
             "auth_role": auth.auth_role,
+            "service": "model_registry",
         },
     )
 
@@ -464,6 +467,7 @@ def list_models(
             "status_filter": status_filter.value if status_filter else None,
             "count": len(models),
             "auth_role": auth.auth_role,
+            "service": "model_registry",
         },
     )
 

--- a/apps/model_registry/routes.py
+++ b/apps/model_registry/routes.py
@@ -207,7 +207,7 @@ def get_current_model(
         extra={
             "model_type": model_type.value,
             "version": metadata.version,
-            "service": auth.service_name,
+            "auth_role": auth.service_name,
         },
     )
 
@@ -282,7 +282,7 @@ def get_model_metadata(
             "model_type": model_type.value,
             "version": version,
             "model_id": metadata.model_id,
-            "service": auth.service_name,
+            "auth_role": auth.service_name,
         },
     )
 
@@ -362,7 +362,7 @@ def validate_model(
             "valid": result.valid,
             "checksum_ok": result.checksum_verified,
             "load_ok": result.load_successful,
-            "service": auth.service_name,
+            "auth_role": auth.service_name,
         },
     )
 
@@ -463,7 +463,7 @@ def list_models(
             "model_type": model_type.value,
             "status_filter": status_filter.value if status_filter else None,
             "count": len(models),
-            "service": auth.service_name,
+            "auth_role": auth.service_name,
         },
     )
 

--- a/apps/model_registry/routes.py
+++ b/apps/model_registry/routes.py
@@ -208,6 +208,7 @@ def get_current_model(
             "model_type": model_type.value,
             "version": metadata.version,
             "auth_role": auth.auth_role,
+            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 
@@ -283,6 +284,7 @@ def get_model_metadata(
             "version": version,
             "model_id": metadata.model_id,
             "auth_role": auth.auth_role,
+            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 
@@ -363,6 +365,7 @@ def validate_model(
             "checksum_ok": result.checksum_verified,
             "load_ok": result.load_successful,
             "auth_role": auth.auth_role,
+            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 
@@ -464,6 +467,7 @@ def list_models(
             "status_filter": status_filter.value if status_filter else None,
             "count": len(models),
             "auth_role": auth.auth_role,
+            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 

--- a/apps/model_registry/routes.py
+++ b/apps/model_registry/routes.py
@@ -208,7 +208,6 @@ def get_current_model(
             "model_type": model_type.value,
             "version": metadata.version,
             "auth_role": auth.auth_role,
-            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 
@@ -284,7 +283,6 @@ def get_model_metadata(
             "version": version,
             "model_id": metadata.model_id,
             "auth_role": auth.auth_role,
-            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 
@@ -365,7 +363,6 @@ def validate_model(
             "checksum_ok": result.checksum_verified,
             "load_ok": result.load_successful,
             "auth_role": auth.auth_role,
-            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 
@@ -467,7 +464,6 @@ def list_models(
             "status_filter": status_filter.value if status_filter else None,
             "count": len(models),
             "auth_role": auth.auth_role,
-            "service": auth.auth_role,  # deprecated: use auth_role
         },
     )
 

--- a/docs/ARCHITECTURE/system_map.config.json
+++ b/docs/ARCHITECTURE/system_map.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./system_map.schema.json",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Configuration for architecture visualization generation",
 
   "layers": [

--- a/docs/GETTING_STARTED/REPO_MAP.md
+++ b/docs/GETTING_STARTED/REPO_MAP.md
@@ -1,6 +1,6 @@
 # Repository Map
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-04-06
 
 This document provides a comprehensive map of the trading platform repository structure, explaining the purpose of each directory and key files.
 

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -115,11 +115,16 @@ async def test_verify_token_invalid_token_does_not_log_token_material(
         with pytest.raises(HTTPException):
             await auth.verify_token(creds)
 
-    # Ensure at least one warning was emitted
-    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warning_records) >= 1, "Expected at least one WARNING log record"
+    # Filter to the specific auth failure warning by message content
+    auth_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "token not recognized" in r.getMessage()
+    ]
+    assert len(auth_warnings) >= 1, "Expected auth failure WARNING log record"
 
-    for record in warning_records:
+    for record in auth_warnings:
         # No token material should appear in the log message
         assert secret_token not in record.getMessage()
         assert secret_token[:4] not in record.getMessage()

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
@@ -82,6 +84,30 @@ async def test_verify_token_invalid_token_raises_401(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio()
+async def test_verify_token_invalid_token_does_not_log_token_material(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ensure auth failure logs never contain token material (repo rule)."""
+    secret_token = "super-secret-credential-value"
+    monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, "read-secret")
+    creds = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=secret_token
+    )
+
+    with caplog.at_level(logging.WARNING, logger="apps.model_registry.auth"):
+        with pytest.raises(HTTPException):
+            await auth.verify_token(creds)
+
+    for record in caplog.records:
+        assert secret_token not in record.getMessage()
+        assert secret_token[:4] not in record.getMessage()
+        # Only token_length should appear, not any token bytes
+        if hasattr(record, "token_length"):
+            assert record.token_length == len(secret_token)
+
+
+@pytest.mark.asyncio()
 async def test_verify_token_valid_token_returns_service_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -94,8 +120,8 @@ async def test_verify_token_valid_token_returns_service_token(
     assert isinstance(result, ServiceToken)
     assert result.token == token
     assert result.scopes == ["model:read"]
-    # service_name is derived from the role key, not token content (fixes #174)
-    assert result.service_name == "read"
+    # auth_role is derived from the role key, not token content (fixes #174)
+    assert result.auth_role == "read"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +136,7 @@ async def test_verify_token_admin_token_returns_admin_role(
 
     assert isinstance(result, ServiceToken)
     assert result.scopes == ["model:read", "model:write", "model:admin"]
-    assert result.service_name == "admin"
+    assert result.auth_role == "admin"
 
 
 @pytest.mark.asyncio()
@@ -125,7 +151,7 @@ async def test_verify_token_legacy_token_returns_legacy_read_role(
 
     assert isinstance(result, ServiceToken)
     assert result.scopes == ["model:read"]
-    assert result.service_name == "legacy_read"
+    assert result.auth_role == "legacy_read"
 
 
 def test_authenticate_token_returns_role_not_token_content(
@@ -150,14 +176,14 @@ def test_authenticate_token_returns_role_not_token_content(
 
 @pytest.mark.asyncio()
 async def test_verify_read_scope_accepts_admin_scope() -> None:
-    token = ServiceToken(token="admin", scopes=["model:admin"], service_name="svc")
+    token = ServiceToken(token="admin", scopes=["model:admin"], auth_role="svc")
 
     assert await auth.verify_read_scope(token) is token
 
 
 @pytest.mark.asyncio()
 async def test_verify_read_scope_rejects_missing_scope() -> None:
-    token = ServiceToken(token="read", scopes=[], service_name="svc")
+    token = ServiceToken(token="read", scopes=[], auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_read_scope(token)
@@ -167,7 +193,7 @@ async def test_verify_read_scope_rejects_missing_scope() -> None:
 
 @pytest.mark.asyncio()
 async def test_verify_write_scope_rejects_read_only_scope() -> None:
-    token = ServiceToken(token="read", scopes=["model:read"], service_name="svc")
+    token = ServiceToken(token="read", scopes=["model:read"], auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_write_scope(token)
@@ -177,7 +203,7 @@ async def test_verify_write_scope_rejects_read_only_scope() -> None:
 
 @pytest.mark.asyncio()
 async def test_verify_admin_scope_rejects_missing_scope() -> None:
-    token = ServiceToken(token="read", scopes=["model:read"], service_name="svc")
+    token = ServiceToken(token="read", scopes=["model:read"], auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_admin_scope(token)

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Generator
 
 import pytest
 from fastapi import HTTPException
@@ -9,13 +10,16 @@ from apps.model_registry.auth import ServiceToken
 
 
 @pytest.fixture(autouse=True)
-def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     for var in [
         auth._ADMIN_TOKEN_ENV_VAR,
         auth._READ_TOKEN_ENV_VAR,
         auth._AUTH_TOKEN_ENV_VAR,
     ]:
         monkeypatch.delenv(var, raising=False)
+    auth._get_expected_tokens.cache_clear()
+    yield
+    auth._get_expected_tokens.cache_clear()
 
 
 def test_get_expected_tokens_handles_admin_read_and_legacy(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -79,7 +79,7 @@ async def test_verify_token_invalid_token_raises_401(monkeypatch: pytest.MonkeyP
 async def test_verify_token_valid_token_returns_service_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    token = "svc:read-secret"
+    token = "read-secret"
     monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, token)
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
@@ -88,7 +88,20 @@ async def test_verify_token_valid_token_returns_service_token(
     assert isinstance(result, ServiceToken)
     assert result.token == token
     assert result.scopes == ["model:read"]
-    assert result.service_name == "svc"
+    # service_name is derived from the role key, not token content (fixes #174)
+    assert result.service_name == "read"
+
+
+def test_identify_token_role_returns_role_not_token_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure _identify_token_role never leaks token content (fixes #174)."""
+    monkeypatch.setenv(auth._ADMIN_TOKEN_ENV_VAR, "secretprefix:admin-key")
+    monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, "othersecret:read-key")
+
+    assert auth._identify_token_role("secretprefix:admin-key") == "admin"
+    assert auth._identify_token_role("othersecret:read-key") == "read"
+    assert auth._identify_token_role("unknown-token") == "unknown"
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -99,12 +99,19 @@ async def test_verify_token_invalid_token_does_not_log_token_material(
         with pytest.raises(HTTPException):
             await auth.verify_token(creds)
 
-    for record in caplog.records:
+    # Ensure at least one warning was emitted
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) >= 1, "Expected at least one WARNING log record"
+
+    for record in warning_records:
+        # No token material should appear in the log message
         assert secret_token not in record.getMessage()
         assert secret_token[:4] not in record.getMessage()
-        # Only token_length should appear, not any token bytes
-        if hasattr(record, "token_length"):
-            assert record.token_length == len(secret_token)
+        # token_length must be present instead of token content
+        assert hasattr(record, "token_length"), (
+            "Expected 'token_length' in log record extras"
+        )
+        assert record.token_length == len(secret_token)
 
 
 @pytest.mark.asyncio()
@@ -118,7 +125,6 @@ async def test_verify_token_valid_token_returns_service_token(
     result = await auth.verify_token(creds)
 
     assert isinstance(result, ServiceToken)
-    assert result.token == token
     assert result.scopes == ["model:read"]
     # auth_role is derived from the role key, not token content (fixes #174)
     assert result.auth_role == "read"
@@ -176,14 +182,14 @@ def test_authenticate_token_returns_role_not_token_content(
 
 @pytest.mark.asyncio()
 async def test_verify_read_scope_accepts_admin_scope() -> None:
-    token = ServiceToken(token="admin", scopes=["model:admin"], auth_role="svc")
+    token = ServiceToken(scopes=["model:admin"], auth_role="svc")
 
     assert await auth.verify_read_scope(token) is token
 
 
 @pytest.mark.asyncio()
 async def test_verify_read_scope_rejects_missing_scope() -> None:
-    token = ServiceToken(token="read", scopes=[], auth_role="svc")
+    token = ServiceToken(scopes=[], auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_read_scope(token)
@@ -193,7 +199,7 @@ async def test_verify_read_scope_rejects_missing_scope() -> None:
 
 @pytest.mark.asyncio()
 async def test_verify_write_scope_rejects_read_only_scope() -> None:
-    token = ServiceToken(token="read", scopes=["model:read"], auth_role="svc")
+    token = ServiceToken(scopes=["model:read"], auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_write_scope(token)
@@ -203,7 +209,7 @@ async def test_verify_write_scope_rejects_read_only_scope() -> None:
 
 @pytest.mark.asyncio()
 async def test_verify_admin_scope_rejects_missing_scope() -> None:
-    token = ServiceToken(token="read", scopes=["model:read"], auth_role="svc")
+    token = ServiceToken(scopes=["model:read"], auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_admin_scope(token)

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -30,17 +30,23 @@ def test_get_expected_tokens_handles_admin_read_and_legacy(monkeypatch: pytest.M
     }
 
 
-def test_parse_token_scopes_prefers_admin_over_read(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_authenticate_token_prefers_admin_over_read(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(auth._ADMIN_TOKEN_ENV_VAR, "admin-secret")
     monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, "read-secret")
 
-    assert auth._parse_token_scopes("admin-secret") == [
-        "model:read",
-        "model:write",
-        "model:admin",
-    ]
-    assert auth._parse_token_scopes("read-secret") == ["model:read"]
-    assert auth._parse_token_scopes("unknown") == []
+    result = auth._authenticate_token("admin-secret")
+    assert result is not None
+    scopes, role = result
+    assert scopes == ["model:read", "model:write", "model:admin"]
+    assert role == "admin"
+
+    result = auth._authenticate_token("read-secret")
+    assert result is not None
+    scopes, role = result
+    assert scopes == ["model:read"]
+    assert role == "read"
+
+    assert auth._authenticate_token("unknown") is None
 
 
 @pytest.mark.asyncio()
@@ -92,16 +98,54 @@ async def test_verify_token_valid_token_returns_service_token(
     assert result.service_name == "read"
 
 
-def test_identify_token_role_returns_role_not_token_content(
+@pytest.mark.asyncio()
+async def test_verify_token_admin_token_returns_admin_role(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Ensure _identify_token_role never leaks token content (fixes #174)."""
+    token = "admin-secret"
+    monkeypatch.setenv(auth._ADMIN_TOKEN_ENV_VAR, token)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    result = await auth.verify_token(creds)
+
+    assert isinstance(result, ServiceToken)
+    assert result.scopes == ["model:read", "model:write", "model:admin"]
+    assert result.service_name == "admin"
+
+
+@pytest.mark.asyncio()
+async def test_verify_token_legacy_token_returns_legacy_read_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "legacy-secret"
+    monkeypatch.setenv(auth._AUTH_TOKEN_ENV_VAR, token)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    result = await auth.verify_token(creds)
+
+    assert isinstance(result, ServiceToken)
+    assert result.scopes == ["model:read"]
+    assert result.service_name == "legacy_read"
+
+
+def test_authenticate_token_returns_role_not_token_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure _authenticate_token never leaks token content (fixes #174)."""
     monkeypatch.setenv(auth._ADMIN_TOKEN_ENV_VAR, "secretprefix:admin-key")
     monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, "othersecret:read-key")
 
-    assert auth._identify_token_role("secretprefix:admin-key") == "admin"
-    assert auth._identify_token_role("othersecret:read-key") == "read"
-    assert auth._identify_token_role("unknown-token") == "unknown"
+    result = auth._authenticate_token("secretprefix:admin-key")
+    assert result is not None
+    _, role = result
+    assert role == "admin"
+
+    result = auth._authenticate_token("othersecret:read-key")
+    assert result is not None
+    _, role = result
+    assert role == "read"
+
+    assert auth._authenticate_token("unknown-token") is None
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -43,13 +43,13 @@ def test_authenticate_token_returns_correct_scopes_and_roles(monkeypatch: pytest
     result = auth._authenticate_token("admin-secret")
     assert result is not None
     scopes, role = result
-    assert scopes == ["model:read", "model:write", "model:admin"]
+    assert scopes == ("model:read", "model:write", "model:admin")
     assert role == "admin"
 
     result = auth._authenticate_token("read-secret")
     assert result is not None
     scopes, role = result
-    assert scopes == ["model:read"]
+    assert scopes == ("model:read",)
     assert role == "read"
 
     assert auth._authenticate_token("unknown") is None
@@ -67,7 +67,7 @@ def test_authenticate_token_admin_takes_precedence_over_read(
     assert result is not None
     scopes, role = result
     # Admin is checked first, so admin scopes should be returned
-    assert scopes == ["model:read", "model:write", "model:admin"]
+    assert scopes == ("model:read", "model:write", "model:admin")
     assert role == "admin"
 
 
@@ -150,7 +150,7 @@ async def test_verify_token_valid_token_returns_service_token(
     result = await auth.verify_token(creds)
 
     assert isinstance(result, ServiceToken)
-    assert result.scopes == ["model:read"]
+    assert result.scopes == ("model:read",)
     # auth_role is derived from the role key, not token content (fixes #174)
     assert result.auth_role == "read"
 
@@ -166,7 +166,7 @@ async def test_verify_token_admin_token_returns_admin_role(
     result = await auth.verify_token(creds)
 
     assert isinstance(result, ServiceToken)
-    assert result.scopes == ["model:read", "model:write", "model:admin"]
+    assert result.scopes == ("model:read", "model:write", "model:admin")
     assert result.auth_role == "admin"
 
 
@@ -181,7 +181,7 @@ async def test_verify_token_legacy_token_returns_legacy_read_role(
     result = await auth.verify_token(creds)
 
     assert isinstance(result, ServiceToken)
-    assert result.scopes == ["model:read"]
+    assert result.scopes == ("model:read",)
     assert result.auth_role == "legacy_read"
 
 
@@ -207,14 +207,14 @@ def test_authenticate_token_returns_role_not_token_content(
 
 @pytest.mark.asyncio()
 async def test_verify_read_scope_accepts_admin_scope() -> None:
-    token = ServiceToken(scopes=["model:admin"], auth_role="svc")
+    token = ServiceToken(scopes=("model:admin",), auth_role="svc")
 
     assert await auth.verify_read_scope(token) is token
 
 
 @pytest.mark.asyncio()
 async def test_verify_read_scope_rejects_missing_scope() -> None:
-    token = ServiceToken(scopes=[], auth_role="svc")
+    token = ServiceToken(scopes=(), auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_read_scope(token)
@@ -224,7 +224,7 @@ async def test_verify_read_scope_rejects_missing_scope() -> None:
 
 @pytest.mark.asyncio()
 async def test_verify_write_scope_rejects_read_only_scope() -> None:
-    token = ServiceToken(scopes=["model:read"], auth_role="svc")
+    token = ServiceToken(scopes=("model:read",), auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_write_scope(token)
@@ -234,7 +234,7 @@ async def test_verify_write_scope_rejects_read_only_scope() -> None:
 
 @pytest.mark.asyncio()
 async def test_verify_admin_scope_rejects_missing_scope() -> None:
-    token = ServiceToken(scopes=["model:read"], auth_role="svc")
+    token = ServiceToken(scopes=("model:read",), auth_role="svc")
 
     with pytest.raises(HTTPException) as excinfo:
         await auth.verify_admin_scope(token)

--- a/tests/apps/model_registry/test_auth.py
+++ b/tests/apps/model_registry/test_auth.py
@@ -32,7 +32,7 @@ def test_get_expected_tokens_handles_admin_read_and_legacy(monkeypatch: pytest.M
     }
 
 
-def test_authenticate_token_prefers_admin_over_read(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_authenticate_token_returns_correct_scopes_and_roles(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(auth._ADMIN_TOKEN_ENV_VAR, "admin-secret")
     monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, "read-secret")
 
@@ -49,6 +49,22 @@ def test_authenticate_token_prefers_admin_over_read(monkeypatch: pytest.MonkeyPa
     assert role == "read"
 
     assert auth._authenticate_token("unknown") is None
+
+
+def test_authenticate_token_admin_takes_precedence_over_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When admin and read tokens are the same, admin scopes take precedence."""
+    shared_token = "shared-secret"
+    monkeypatch.setenv(auth._ADMIN_TOKEN_ENV_VAR, shared_token)
+    monkeypatch.setenv(auth._READ_TOKEN_ENV_VAR, shared_token)
+
+    result = auth._authenticate_token(shared_token)
+    assert result is not None
+    scopes, role = result
+    # Admin is checked first, so admin scopes should be returned
+    assert scopes == ["model:read", "model:write", "model:admin"]
+    assert role == "admin"
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/model_registry/test_routes.py
+++ b/tests/apps/model_registry/test_routes.py
@@ -62,10 +62,10 @@ def _client_with_registry(registry: MagicMock) -> TestClient:
     app = FastAPI()
     app.include_router(routes.router)
     app.dependency_overrides[routes.verify_read_scope] = lambda: ServiceToken(
-        scopes=["model:read"], auth_role="svc"
+        scopes=("model:read",), auth_role="svc"
     )
     app.dependency_overrides[routes.verify_write_scope] = lambda: ServiceToken(
-        scopes=["model:write"], auth_role="svc"
+        scopes=("model:write",), auth_role="svc"
     )
     app.dependency_overrides[routes.get_registry] = lambda: registry
     return TestClient(app)

--- a/tests/apps/model_registry/test_routes.py
+++ b/tests/apps/model_registry/test_routes.py
@@ -61,10 +61,10 @@ def _client_with_registry(registry: MagicMock) -> TestClient:
     app = FastAPI()
     app.include_router(routes.router)
     app.dependency_overrides[routes.verify_read_scope] = lambda: ServiceToken(
-        token="read", scopes=["model:read"], auth_role="svc"
+        scopes=["model:read"], auth_role="svc"
     )
     app.dependency_overrides[routes.verify_write_scope] = lambda: ServiceToken(
-        token="write", scopes=["model:write"], auth_role="svc"
+        scopes=["model:write"], auth_role="svc"
     )
     app.dependency_overrides[routes.get_registry] = lambda: registry
     return TestClient(app)

--- a/tests/apps/model_registry/test_routes.py
+++ b/tests/apps/model_registry/test_routes.py
@@ -111,6 +111,9 @@ def _assert_auth_role_in_logs(
     for record in matching:
         assert hasattr(record, "auth_role"), "Log record must include auth_role"
         assert record.auth_role == "svc"
+        # Verify constant service identifier for log query compatibility
+        assert hasattr(record, "service"), "Log record must include service"
+        assert record.service == "model_registry"
 
 
 def test_get_current_model_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
@@ -164,6 +167,25 @@ def test_list_models_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
 
     assert response.status_code == 200
     _assert_auth_role_in_logs(caplog, "Listed models")
+
+
+def test_validate_model_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure validate endpoint logs include auth_role field."""
+    registry = MagicMock()
+    registry.validate_model.return_value = ValidationResult(
+        valid=True,
+        model_id="model-v1",
+        checksum_verified=True,
+        load_successful=True,
+        errors=[],
+    )
+    client = _client_with_registry(registry)
+
+    with caplog.at_level(logging.INFO, logger="apps.model_registry.routes"):
+        response = client.post("/api/v1/models/risk_model/v1.0.0/validate")
+
+    assert response.status_code == 200
+    _assert_auth_role_in_logs(caplog, "Validated model")
 
 
 def test_get_current_model_handles_lock_error() -> None:

--- a/tests/apps/model_registry/test_routes.py
+++ b/tests/apps/model_registry/test_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
@@ -92,6 +93,23 @@ def test_get_current_model_success() -> None:
     assert payload["model_type"] == "risk_model"
     assert payload["version"] == "v1.0.0"
     assert payload["checksum"] == "checksum"
+
+
+def test_get_current_model_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure route logs include auth_role field and never 'service' (fixes #174)."""
+    registry = MagicMock()
+    registry.get_current_production.return_value = _build_metadata()
+    client = _client_with_registry(registry)
+
+    with caplog.at_level(logging.INFO, logger="apps.model_registry.routes"):
+        response = client.get("/api/v1/models/risk_model/current")
+
+    assert response.status_code == 200
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(info_records) >= 1, "Expected at least one INFO log from route"
+    record = info_records[0]
+    assert hasattr(record, "auth_role"), "Log record must include auth_role"
+    assert record.auth_role == "svc"
 
 
 def test_get_current_model_handles_lock_error() -> None:

--- a/tests/apps/model_registry/test_routes.py
+++ b/tests/apps/model_registry/test_routes.py
@@ -61,10 +61,10 @@ def _client_with_registry(registry: MagicMock) -> TestClient:
     app = FastAPI()
     app.include_router(routes.router)
     app.dependency_overrides[routes.verify_read_scope] = lambda: ServiceToken(
-        token="read", scopes=["model:read"], service_name="svc"
+        token="read", scopes=["model:read"], auth_role="svc"
     )
     app.dependency_overrides[routes.verify_write_scope] = lambda: ServiceToken(
-        token="write", scopes=["model:write"], service_name="svc"
+        token="write", scopes=["model:write"], auth_role="svc"
     )
     app.dependency_overrides[routes.get_registry] = lambda: registry
     return TestClient(app)

--- a/tests/apps/model_registry/test_routes.py
+++ b/tests/apps/model_registry/test_routes.py
@@ -95,8 +95,26 @@ def test_get_current_model_success() -> None:
     assert payload["checksum"] == "checksum"
 
 
+def _assert_auth_role_in_logs(
+    caplog: pytest.LogCaptureFixture,
+    expected_message: str,
+) -> None:
+    """Assert that a log record with the given message includes auth_role."""
+    matching = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and expected_message in r.getMessage()
+    ]
+    assert len(matching) >= 1, (
+        f"Expected INFO record containing '{expected_message}'"
+    )
+    for record in matching:
+        assert hasattr(record, "auth_role"), "Log record must include auth_role"
+        assert record.auth_role == "svc"
+
+
 def test_get_current_model_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
-    """Ensure route logs include auth_role field and never 'service' (fixes #174)."""
+    """Ensure route logs include auth_role field (fixes #174)."""
     registry = MagicMock()
     registry.get_current_production.return_value = _build_metadata()
     client = _client_with_registry(registry)
@@ -105,11 +123,47 @@ def test_get_current_model_logs_auth_role(caplog: pytest.LogCaptureFixture) -> N
         response = client.get("/api/v1/models/risk_model/current")
 
     assert response.status_code == 200
-    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
-    assert len(info_records) >= 1, "Expected at least one INFO log from route"
-    record = info_records[0]
-    assert hasattr(record, "auth_role"), "Log record must include auth_role"
-    assert record.auth_role == "svc"
+    _assert_auth_role_in_logs(caplog, "Retrieved current production model")
+
+
+def test_get_model_metadata_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure metadata endpoint logs include auth_role field."""
+    metadata = _build_metadata()
+    registry = MagicMock()
+    registry.get_model_metadata.return_value = metadata
+    registry.get_model_info.return_value = {
+        "status": "production",
+        "artifact_path": "/tmp/artifact",
+        "promoted_at": datetime(2024, 2, 1, tzinfo=UTC),
+    }
+    client = _client_with_registry(registry)
+
+    with caplog.at_level(logging.INFO, logger="apps.model_registry.routes"):
+        response = client.get("/api/v1/models/risk_model/v1.0.0")
+
+    assert response.status_code == 200
+    _assert_auth_role_in_logs(caplog, "Retrieved model metadata")
+
+
+def test_list_models_logs_auth_role(caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure list endpoint logs include auth_role field."""
+    metadata = _build_metadata()
+    registry = MagicMock()
+    registry.list_models.return_value = [metadata]
+    registry.get_model_info_bulk.return_value = {
+        metadata.version: {
+            "status": ModelStatus.production.value,
+            "artifact_path": "/tmp/artifact",
+            "promoted_at": None,
+        },
+    }
+    client = _client_with_registry(registry)
+
+    with caplog.at_level(logging.INFO, logger="apps.model_registry.routes"):
+        response = client.get("/api/v1/models/risk_model")
+
+    assert response.status_code == 200
+    _assert_auth_role_in_logs(caplog, "Listed models")
 
 
 def test_get_current_model_handles_lock_error() -> None:


### PR DESCRIPTION
## Summary
- stop deriving model-registry `service_name` from bearer token content
- map verified tokens to safe role labels (`admin`, `read`, `legacy_read`) instead
- add regression tests proving token content is not reflected in the returned service name

## Testing
- ../../.venv/bin/python -m pytest -q -o addopts='' tests/apps/model_registry/test_auth.py tests/apps/model_registry/test_routes.py

Closes #174
