### PR TITLE
fix(export): replace placeholder Excel workbook with real grid data

### DIFF
--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1031,7 +1031,13 @@ def _apply_date_filter(
         fragments.append(f"{col} < %s::timestamp")
         params.append(date_from)
     elif op == "inRange" and date_from and date_to:
-        fragments.append(f"{col} >= %s::timestamp AND {col} < %s::timestamp")
+        # AG Grid sends dateTo as the selected calendar day (midnight).
+        # Use ``dateTo::date + interval '1 day'`` so the entire end date
+        # is included and single-day ranges (same dateFrom/dateTo) return
+        # rows from that day.
+        fragments.append(
+            f"{col} >= %s::timestamp AND {col} < (%s::date + interval '1 day')"
+        )
         params.append(date_from)
         params.append(date_to)
 
@@ -1374,7 +1380,7 @@ async def _generate_excel_content(
         NotImplementedError: If grid type not supported or openpyxl missing
     """
     try:
-        from openpyxl import Workbook  # type: ignore[import-untyped]
+        from openpyxl import Workbook
     except ImportError as e:
         raise NotImplementedError("Excel export requires openpyxl: pip install openpyxl") from e
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -23,6 +23,7 @@ import asyncio
 import io
 import json
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Literal
 from uuid import UUID
@@ -34,6 +35,7 @@ from pydantic import BaseModel, Field
 from apps.execution_gateway.api.dependencies import build_gateway_authenticator
 from apps.execution_gateway.api.utils import get_client_ip, get_user_agent
 from apps.execution_gateway.app_context import AppContext
+from apps.execution_gateway.database import PENDING_STATUSES
 from apps.execution_gateway.dependencies import get_context
 from apps.execution_gateway.services.auth_helpers import build_user_context
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
@@ -64,9 +66,7 @@ export_auth = api_auth(
 class ExportAuditCreateRequest(BaseModel):
     """Request to create an export audit record."""
 
-    export_type: Literal["csv", "excel", "clipboard"] = Field(
-        ..., description="Type of export"
-    )
+    export_type: Literal["csv", "excel", "clipboard"] = Field(..., description="Type of export")
     grid_name: str = Field(
         ..., description="Name of grid being exported (positions, orders, fills, audit, tca)"
     )
@@ -82,9 +82,7 @@ class ExportAuditCreateRequest(BaseModel):
     export_scope: Literal["visible", "full"] = Field(
         default="visible", description="Export scope: visible rows or all filtered"
     )
-    estimated_row_count: int | None = Field(
-        default=None, description="Client-estimated row count"
-    )
+    estimated_row_count: int | None = Field(default=None, description="Client-estimated row count")
 
 
 class ExportAuditCreateResponse(BaseModel):
@@ -102,9 +100,7 @@ class ExportAuditCompleteRequest(BaseModel):
     status: Literal["completed", "failed"] = Field(
         default="completed", description="Final export status"
     )
-    error_message: str | None = Field(
-        default=None, description="Error details if status=failed"
-    )
+    error_message: str | None = Field(default=None, description="Error details if status=failed")
 
 
 class ExportAuditResponse(BaseModel):
@@ -180,11 +176,7 @@ async def _create_export_audit(
                         if request_data.visible_columns
                         else None
                     ),
-                    (
-                        json.dumps(request_data.sort_model)
-                        if request_data.sort_model
-                        else None
-                    ),
+                    (json.dumps(request_data.sort_model) if request_data.sort_model else None),
                     json.dumps(strategy_ids) if strategy_ids else None,
                     request_data.export_scope,
                     request_data.estimated_row_count,
@@ -326,9 +318,7 @@ async def _claim_export_audit(ctx: AppContext, audit_id: UUID) -> bool:
             return row is not None
 
 
-async def _fail_export_audit(
-    ctx: AppContext, audit_id: UUID, error_message: str
-) -> None:
+async def _fail_export_audit(ctx: AppContext, audit_id: UUID, error_message: str) -> None:
     """Mark export audit as failed with error message."""
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
@@ -550,9 +540,7 @@ async def complete_export_audit(
     tags=["Export"],
     responses={
         200: {
-            "content": {
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {}
-            },
+            "content": {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {}},
             "description": "Excel file download",
         },
         404: {"description": "Audit record not found or expired"},
@@ -751,11 +739,15 @@ _GRID_COLUMNS: dict[str, list[str]] = {
         "reason",
     ],
     # NOTE: The TCA grid in the web console displays computed metrics
-    # (e.g. ``is_bps``, ``fill_rate_pct``) that are derived client-side.
-    # The export provides the raw underlying trade/order data so users
-    # can compute their own analytics.  When the grid sends computed
-    # column names via ``visible_columns``, ``_validate_columns`` drops
-    # them and falls back to this full raw-data allowlist.
+    # (e.g. ``is_bps``, ``fill_rate_pct``, ``vwap_bps``) that are
+    # derived client-side.  The export provides the raw underlying
+    # trade/order data so users can compute their own analytics.
+    # Frontend display names are mapped via ``_COLUMN_ALIASES["tca"]``
+    # (e.g. ``execution_date`` → ``executed_at``, ``filled_qty`` →
+    # ``qty``).  Purely computed columns like ``is_bps`` have no DB
+    # backing and are dropped by ``_validate_columns``, which falls
+    # back to this full raw-data allowlist when all columns are
+    # unrecognised.
     "tca": [
         "trade_id",
         "client_order_id",
@@ -788,12 +780,18 @@ _COLUMN_ALIASES: dict[str, dict[str, str]] = {
     "fills": {
         "time": "executed_at",
     },
+    "tca": {
+        # The TCA grid displays computed metrics (fill_rate_pct, is_bps,
+        # vwap_bps) derived client-side.  Map the grid's display column
+        # names to the raw DB columns so _validate_columns does not drop
+        # them.
+        "execution_date": "executed_at",
+        "filled_qty": "qty",
+    },
 }
 
 
-def _validate_columns(
-    grid_name: str, visible_columns: list[str] | None
-) -> list[str]:
+def _validate_columns(grid_name: str, visible_columns: list[str] | None) -> list[str]:
     """Return the export column list, validated against the server allowlist.
 
     Frontend column aliases are resolved first (e.g. ``"time"`` →
@@ -829,6 +827,128 @@ def _build_order_clause(
     return ", ".join(parts) if parts else default_order
 
 
+def _build_filter_clauses(
+    filter_params: dict[str, Any] | None,
+    allowed_columns: list[str],
+    *,
+    col_prefix: str = "",
+) -> tuple[str, list[Any]]:
+    """Translate an AG Grid filter model into SQL WHERE fragments.
+
+    Returns a tuple of ``(where_fragment, params)`` where
+    *where_fragment* is a string of ``AND ...`` clauses (empty string
+    if no filters) and *params* is a list of bind values.
+
+    Only columns present in *allowed_columns* are accepted; unknown
+    columns are silently ignored to prevent SQL injection.
+
+    Supported AG Grid filter types:
+
+    * ``text``   -- ``contains``, ``equals``, ``startsWith``, ``endsWith``
+    * ``number`` -- ``equals``, ``greaterThan``, ``lessThan``
+    * ``date``   -- ``equals``, ``greaterThan``, ``lessThan``, ``inRange``
+    * ``set``    -- membership filter (``values`` list)
+    """
+    if not filter_params:
+        return "", []
+
+    fragments: list[str] = []
+    params: list[Any] = []
+
+    for col, spec in filter_params.items():
+        if col not in allowed_columns:
+            continue
+        qualified = f"{col_prefix}{col}" if col_prefix else col
+        filter_type = spec.get("filterType", spec.get("type", ""))
+
+        if filter_type == "text":
+            _apply_text_filter(qualified, spec, fragments, params)
+        elif filter_type == "number":
+            _apply_number_filter(qualified, spec, fragments, params)
+        elif filter_type == "date":
+            _apply_date_filter(qualified, spec, fragments, params)
+        elif filter_type == "set":
+            values = spec.get("values")
+            if isinstance(values, list) and values:
+                fragments.append(f"{qualified} = ANY(%s)")
+                params.append(values)
+
+    where = " ".join(f"AND {f}" for f in fragments)
+    return where, params
+
+
+def _apply_text_filter(
+    col: str,
+    spec: dict[str, Any],
+    fragments: list[str],
+    params: list[Any],
+) -> None:
+    """Add a text-type AG Grid filter clause."""
+    op = spec.get("type", "contains")
+    val = spec.get("filter", "")
+    if not isinstance(val, str) or not val:
+        return
+    if op == "contains":
+        fragments.append(f"{col} ILIKE %s")
+        params.append(f"%{val}%")
+    elif op == "equals":
+        fragments.append(f"{col} = %s")
+        params.append(val)
+    elif op == "startsWith":
+        fragments.append(f"{col} ILIKE %s")
+        params.append(f"{val}%")
+    elif op == "endsWith":
+        fragments.append(f"{col} ILIKE %s")
+        params.append(f"%{val}")
+
+
+def _apply_number_filter(
+    col: str,
+    spec: dict[str, Any],
+    fragments: list[str],
+    params: list[Any],
+) -> None:
+    """Add a number-type AG Grid filter clause."""
+    op = spec.get("type", "equals")
+    val = spec.get("filter")
+    if val is None:
+        return
+    if op == "equals":
+        fragments.append(f"{col} = %s")
+        params.append(val)
+    elif op == "greaterThan":
+        fragments.append(f"{col} > %s")
+        params.append(val)
+    elif op == "lessThan":
+        fragments.append(f"{col} < %s")
+        params.append(val)
+
+
+def _apply_date_filter(
+    col: str,
+    spec: dict[str, Any],
+    fragments: list[str],
+    params: list[Any],
+) -> None:
+    """Add a date-type AG Grid filter clause."""
+    op = spec.get("type", "equals")
+    date_from = spec.get("dateFrom")
+    date_to = spec.get("dateTo")
+    if op == "equals" and date_from:
+        fragments.append(f"{col}::date = %s::date")
+        params.append(date_from)
+    elif op == "greaterThan" and date_from:
+        fragments.append(f"{col} >= %s::timestamp")
+        params.append(date_from)
+    elif op == "lessThan" and date_from:
+        fragments.append(f"{col} < %s::timestamp")
+        params.append(date_from)
+    elif op == "inRange" and date_from and date_to:
+        fragments.append(f"{col} >= %s::timestamp AND {col} < %s::timestamp")
+        params.append(date_from)
+        params.append(date_to)
+
+
 # ---------------------------------------------------------------------------
 # Per-grid data fetchers
 # ---------------------------------------------------------------------------
@@ -839,6 +959,7 @@ def _fetch_positions_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch positions data scoped to authorized strategies.
 
@@ -859,9 +980,16 @@ def _fetch_positions_data(
         ]
     qualified_columns = [f"p.{c}" for c in columns]
     order_clause = _build_order_clause(
-        qualified_sort, qualified_columns, "p.symbol ASC",
+        qualified_sort,
+        qualified_columns,
+        "p.symbol ASC",
     )
     col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
+    filter_clause, filter_params_list = _build_filter_clauses(
+        filter_params,
+        columns,
+        col_prefix="p.",
+    )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -869,9 +997,10 @@ def _fetch_positions_data(
                 f"SELECT {col_list} FROM positions p "
                 f"JOIN symbol_strategy ss ON p.symbol = ss.symbol "
                 f"WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
+                f"{filter_clause} "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -882,18 +1011,32 @@ def _fetch_orders_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch orders scoped to authorized strategies."""
+    """Fetch orders scoped to authorized strategies.
+
+    Only working/pending orders are returned to match the dashboard's
+    Working-orders grid (which is populated from
+    ``/api/v1/orders/pending``).  The status filter uses the same
+    ``PENDING_STATUSES`` tuple defined in
+    ``apps.execution_gateway.database``.
+    """
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
     col_list = ", ".join(columns)
+    filter_clause, filter_params_list = _build_filter_clauses(
+        filter_params,
+        columns,
+    )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM orders "  # noqa: S608
                 f"WHERE strategy_id = ANY(%s) "
+                f"AND status = ANY(%s) "
+                f"{filter_clause} "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                (strategy_ids, list(PENDING_STATUSES), *filter_params_list, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -904,19 +1047,26 @@ def _fetch_fills_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch fills (trades) scoped to authorized strategies."""
     order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
     col_list = ", ".join(f"t.{c}" for c in columns)
+    filter_clause, filter_params_list = _build_filter_clauses(
+        filter_params,
+        columns,
+        col_prefix="t.",
+    )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM trades t "  # noqa: S608
                 f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
                 f"AND t.strategy_id = ANY(%s) "
+                f"{filter_clause} "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -927,6 +1077,7 @@ def _fetch_audit_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch audit log entries scoped to authorized strategies.
 
@@ -940,14 +1091,19 @@ def _fetch_audit_data(
     """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
+    filter_clause, filter_params_list = _build_filter_clauses(
+        filter_params,
+        columns,
+    )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM audit_log "  # noqa: S608
                 f"WHERE details->>'strategy_id' = ANY(%s) "
+                f"{filter_clause} "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -958,8 +1114,17 @@ def _fetch_tca_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch TCA trade data with order context, scoped to authorized strategies."""
+    """Fetch TCA trade data with order context, scoped to authorized strategies.
+
+    The TCA grid in the web console displays computed metrics
+    (``fill_rate_pct``, ``is_bps``, ``vwap_bps``) derived client-side.
+    The export provides the raw underlying trade/order data so users
+    can compute their own analytics.  Frontend column aliases are
+    resolved via ``_COLUMN_ALIASES["tca"]`` before reaching this
+    fetcher, so mapped columns are included correctly.
+    """
     # Map column names to their qualified table references
     tca_col_map: dict[str, str] = {
         "trade_id": "t.trade_id",
@@ -974,23 +1139,35 @@ def _fetch_tca_data(
         "order_qty": "o.qty",
         "filled_avg_price": "o.filled_avg_price",
     }
-    select_cols = ", ".join(
-        f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns
-    )
+    select_cols = ", ".join(f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns)
     # Qualify sort columns with table aliases via tca_col_map to
     # avoid ambiguity when trades and orders share column names
     # (e.g. symbol, qty, client_order_id).
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": tca_col_map.get(item.get("colId", ""), f"t.{item.get('colId', '')}")}
-            if item.get("colId") in columns
-            else item
+            (
+                {
+                    **item,
+                    "colId": tca_col_map.get(item.get("colId", ""), f"t.{item.get('colId', '')}"),
+                }
+                if item.get("colId") in columns
+                else item
+            )
             for item in sort_model
         ]
     qualified_tca_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
     order_clause = _build_order_clause(
-        qualified_sort, qualified_tca_columns, "t.executed_at DESC",
+        qualified_sort,
+        qualified_tca_columns,
+        "t.executed_at DESC",
+    )
+    # For TCA filters, qualify column names via tca_col_map so the
+    # WHERE clause references the correct table alias.
+    filter_clause, filter_params_list = _build_filter_clauses(
+        filter_params,
+        columns,
+        col_prefix="t.",
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
@@ -1000,16 +1177,23 @@ def _fetch_tca_data(
                 f"LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
                 f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
                 f"AND t.strategy_id = ANY(%s) "
+                f"{filter_clause} "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
+# Type alias for grid data fetcher functions
+_GridFetcher = Callable[
+    [AppContext, list[str], list[str], list[dict[str, Any]] | None, dict[str, Any] | None],
+    list[dict[str, Any]],
+]
+
 # Dispatch table for grid data fetchers
-_GRID_FETCHERS = {
+_GRID_FETCHERS: dict[str, _GridFetcher] = {
     "positions": _fetch_positions_data,
     "orders": _fetch_orders_data,
     "fills": _fetch_fills_data,
@@ -1036,7 +1220,7 @@ async def _generate_excel_content(
         ctx: Application context with database access
         grid_name: Name of grid to export
         strategy_ids: Authorized strategy IDs for filtering
-        filter_params: AG Grid filter model (reserved for future use)
+        filter_params: AG Grid filter model (translated to SQL WHERE clauses)
         visible_columns: Columns to include (validated against allowlist)
         sort_model: AG Grid sort model
 
@@ -1049,9 +1233,7 @@ async def _generate_excel_content(
     try:
         from openpyxl import Workbook  # type: ignore[import-untyped]
     except ImportError as e:
-        raise NotImplementedError(
-            "Excel export requires openpyxl: pip install openpyxl"
-        ) from e
+        raise NotImplementedError("Excel export requires openpyxl: pip install openpyxl") from e
 
     if grid_name not in _GRID_FETCHERS:
         raise NotImplementedError(f"Excel export not implemented for grid: {grid_name}")
@@ -1059,22 +1241,30 @@ async def _generate_excel_content(
     # Validate requested columns against server allowlist
     columns = _validate_columns(grid_name, visible_columns)
 
-    # Log when filter_params are provided but not yet applied.
-    # AG Grid filter model support is not yet implemented; exports
-    # return strategy-scoped data without additional column filters.
+    # Resolve filter column aliases so that frontend filter keys
+    # (e.g. "type" for orders, "time" for fills) map to the DB column
+    # names expected by the fetchers.
+    resolved_filters: dict[str, Any] | None = None
     if filter_params:
-        logger.warning(
-            "export_filter_params_not_applied",
-            extra={
-                "grid_name": grid_name,
-                "filter_keys": list(filter_params.keys()),
-            },
-        )
+        aliases = _COLUMN_ALIASES.get(grid_name, {})
+        allowed = _GRID_COLUMNS[grid_name]
+        resolved_filters = {}
+        for key, spec in filter_params.items():
+            resolved_key = aliases.get(key, key)
+            if resolved_key in allowed:
+                resolved_filters[resolved_key] = spec
 
     # Offload synchronous DB fetch to a worker thread to avoid blocking
     # the FastAPI event loop.
     fetcher = _GRID_FETCHERS[grid_name]
-    rows = await asyncio.to_thread(fetcher, ctx, strategy_ids, columns, sort_model)
+    rows = await asyncio.to_thread(
+        fetcher,
+        ctx,
+        strategy_ids,
+        columns,
+        sort_model,
+        resolved_filters,
+    )
 
     # Build workbook (CPU-bound; done in worker thread below)
     def _build_workbook() -> bytes:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -36,6 +36,7 @@ from apps.execution_gateway.app_context import AppContext
 from apps.execution_gateway.dependencies import get_context
 from apps.execution_gateway.services.auth_helpers import build_user_context
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
+from libs.data.sql.strategy_mapping_sql import SYMBOL_STRATEGY_CTE
 from libs.platform.security import sanitize_for_export
 from libs.platform.web_console_auth.permissions import Permission, get_authorized_strategies
 
@@ -815,27 +816,28 @@ def _fetch_positions_data(
 ) -> list[dict[str, Any]]:
     """Fetch positions data scoped to authorized strategies.
 
-    Positions are scoped by filtering to symbols that have at least one
-    order for the given *strategy_ids*.  The ``positions`` table does not
-    carry a ``strategy_id`` column itself, so a subquery against
-    ``orders`` is used.
+    The ``positions`` table is symbol-scoped (no ``strategy_id`` column),
+    so ownership is inferred via the shared fail-closed mapping from
+    ``libs.data.sql.strategy_mapping_sql``: a symbol is attributed to a
+    strategy only when exactly ONE strategy has ever traded it.  Symbols
+    traded by multiple strategies are excluded to prevent cross-strategy
+    data leakage.
     """
-    order_clause = _build_order_clause(sort_model, columns, "symbol ASC")
-    col_list = ", ".join(columns)
+    order_clause = _build_order_clause(sort_model, columns, "p.symbol ASC")
+    col_list = ", ".join(f"p.{c}" for c in columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                f"SELECT {col_list} FROM positions "  # noqa: S608
-                f"WHERE symbol IN ("
-                f"  SELECT DISTINCT symbol FROM orders "
-                f"  WHERE strategy_id = ANY(%s)"
-                f") AND qty != 0 "
+                f"WITH {SYMBOL_STRATEGY_CTE} "  # noqa: S608
+                f"SELECT {col_list} FROM positions p "
+                f"JOIN symbol_strategy ss ON p.symbol = ss.symbol "
+                f"WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_orders_data(
@@ -857,7 +859,7 @@ def _fetch_orders_data(
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_fills_data(
@@ -880,7 +882,7 @@ def _fetch_fills_data(
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_audit_data(
@@ -894,8 +896,10 @@ def _fetch_audit_data(
     Audit entries are scoped by matching the ``strategy_id`` key inside
     the ``details`` JSONB column against the authorized *strategy_ids*.
     System-level entries (those without a ``strategy_id`` in their
-    details, e.g. kill-switch operations) are included as well so that
-    the full operational context is preserved.
+    details) are excluded to enforce least-privilege -- exporting only
+    strategy-related audit entries prevents leaking sensitive system
+    operations to users who may only be authorized for specific
+    strategies.
     """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
@@ -904,13 +908,12 @@ def _fetch_audit_data(
             cur.execute(
                 f"SELECT {col_list} FROM audit_log "  # noqa: S608
                 f"WHERE details->>'strategy_id' = ANY(%s) "
-                f"   OR details->>'strategy_id' IS NULL "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_tca_data(
@@ -951,7 +954,7 @@ def _fetch_tca_data(
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 # Dispatch table for grid data fetchers
@@ -1034,8 +1037,9 @@ async def _generate_excel_content(
             elif raw_value is None:
                 value_to_set = ""
             elif isinstance(raw_value, datetime):
-                # openpyxl does not support timezone-aware datetimes
-                value_to_set = raw_value.replace(tzinfo=None)
+                # openpyxl does not support timezone-aware datetimes.
+                # Ensure UTC first, then strip for Excel compatibility.
+                value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
             else:
                 value_to_set = raw_value
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -19,6 +19,7 @@ Design Pattern:
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import logging
@@ -749,6 +750,12 @@ _GRID_COLUMNS: dict[str, list[str]] = {
         "details",
         "reason",
     ],
+    # NOTE: The TCA grid in the web console displays computed metrics
+    # (e.g. ``is_bps``, ``fill_rate_pct``) that are derived client-side.
+    # The export provides the raw underlying trade/order data so users
+    # can compute their own analytics.  When the grid sends computed
+    # column names via ``visible_columns``, ``_validate_columns`` drops
+    # them and falls back to this full raw-data allowlist.
     "tca": [
         "trade_id",
         "client_order_id",
@@ -1008,53 +1015,70 @@ async def _generate_excel_content(
     # Validate requested columns against server allowlist
     columns = _validate_columns(grid_name, visible_columns)
 
-    # Fetch real data
+    # Log when filter_params are provided but not yet applied.
+    # AG Grid filter model support is not yet implemented; exports
+    # return strategy-scoped data without additional column filters.
+    if filter_params:
+        logger.warning(
+            "export_filter_params_not_applied",
+            extra={
+                "grid_name": grid_name,
+                "filter_keys": list(filter_params.keys()),
+            },
+        )
+
+    # Offload synchronous DB fetch to a worker thread to avoid blocking
+    # the FastAPI event loop.
     fetcher = _GRID_FETCHERS[grid_name]
-    rows = fetcher(ctx, strategy_ids, columns, sort_model)
+    rows = await asyncio.to_thread(fetcher, ctx, strategy_ids, columns, sort_model)
 
-    # Build workbook
-    wb = Workbook()
-    ws = wb.active
-    ws.title = grid_name.title()
+    # Build workbook (CPU-bound; done in worker thread below)
+    def _build_workbook() -> bytes:
+        wb = Workbook()
+        ws = wb.active
+        ws.title = grid_name.title()
 
-    # Header row — sanitize headers
-    for col_idx, header in enumerate(columns, 1):
-        ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
+        # Header row -- sanitize headers
+        for col_idx, header in enumerate(columns, 1):
+            ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Data rows — sanitize only string values to prevent formula injection
-    # while preserving native Excel types (numbers, dates) for proper
-    # formatting and calculations.
-    for row_idx, row_data in enumerate(rows, 2):
-        for col_idx, col_name in enumerate(columns, 1):
-            raw_value = row_data.get(col_name)
-            if isinstance(raw_value, dict | list):
-                raw_value = json.dumps(raw_value, default=str)
+        # Data rows -- sanitize only string values to prevent formula
+        # injection while preserving native Excel types (numbers, dates)
+        # for proper formatting and calculations.
+        for row_idx, row_data in enumerate(rows, 2):
+            for col_idx, col_name in enumerate(columns, 1):
+                raw_value = row_data.get(col_name)
+                if isinstance(raw_value, dict | list):
+                    raw_value = json.dumps(raw_value, default=str)
 
-            # Only sanitize strings to prevent formula injection while
-            # preserving numeric/date types that openpyxl handles natively.
-            if isinstance(raw_value, str):
-                value_to_set: Any = sanitize_for_export(raw_value)
-            elif raw_value is None:
-                value_to_set = ""
-            elif isinstance(raw_value, datetime):
-                # openpyxl does not support timezone-aware datetimes.
-                # Ensure UTC first, then strip for Excel compatibility.
-                value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
-            else:
-                value_to_set = raw_value
+                # Only sanitize strings to prevent formula injection
+                # while preserving numeric/date types that openpyxl
+                # handles natively.
+                if isinstance(raw_value, str):
+                    value_to_set: Any = sanitize_for_export(raw_value)
+                elif raw_value is None:
+                    value_to_set = ""
+                elif isinstance(raw_value, datetime):
+                    # openpyxl does not support timezone-aware datetimes.
+                    # Ensure UTC first, then strip for Excel compatibility.
+                    value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+                else:
+                    value_to_set = raw_value
 
-            ws.cell(
-                row=row_idx,
-                column=col_idx,
-                value=value_to_set,
-            )
+                ws.cell(
+                    row=row_idx,
+                    column=col_idx,
+                    value=value_to_set,
+                )
 
-    output = io.BytesIO()
-    wb.save(output)
-    output.seek(0)
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        return buf.getvalue()
 
+    excel_bytes = await asyncio.to_thread(_build_workbook)
     row_count = len(rows)
-    return output.getvalue(), row_count
+    return excel_bytes, row_count
 
 
 @router.get(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -700,6 +700,251 @@ async def download_excel_export(
 # This ensures a single source of truth for formula injection protection.
 
 
+# ---------------------------------------------------------------------------
+# Allowed columns per grid — server-side allowlist for export security.
+# Only columns in these sets may appear in exported files.
+# ---------------------------------------------------------------------------
+_GRID_COLUMNS: dict[str, list[str]] = {
+    "positions": [
+        "symbol",
+        "qty",
+        "avg_entry_price",
+        "current_price",
+        "unrealized_pl",
+        "realized_pl",
+        "updated_at",
+    ],
+    "orders": [
+        "client_order_id",
+        "strategy_id",
+        "symbol",
+        "side",
+        "qty",
+        "order_type",
+        "limit_price",
+        "stop_price",
+        "time_in_force",
+        "status",
+        "filled_qty",
+        "filled_avg_price",
+        "created_at",
+        "filled_at",
+    ],
+    "fills": [
+        "trade_id",
+        "client_order_id",
+        "strategy_id",
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "executed_at",
+    ],
+    "audit": [
+        "id",
+        "timestamp",
+        "user_id",
+        "action",
+        "details",
+        "reason",
+    ],
+    "tca": [
+        "trade_id",
+        "client_order_id",
+        "strategy_id",
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "executed_at",
+        "order_submitted_at",
+        "order_qty",
+        "filled_avg_price",
+    ],
+}
+
+# Maximum rows per export to prevent excessive memory / query time
+_EXPORT_ROW_LIMIT = 10_000
+
+
+def _validate_columns(
+    grid_name: str, visible_columns: list[str] | None
+) -> list[str]:
+    """Return the export column list, validated against the server allowlist.
+
+    If *visible_columns* is provided, only columns that exist in the
+    allowlist are kept (in the requested order).  Unknown columns are
+    silently dropped to prevent SQL injection or data leakage.
+    """
+    allowed = _GRID_COLUMNS[grid_name]
+    if not visible_columns:
+        return allowed
+    return [c for c in visible_columns if c in allowed] or allowed
+
+
+def _build_order_clause(
+    sort_model: list[dict[str, Any]] | None,
+    allowed_columns: list[str],
+    default_order: str,
+) -> str:
+    """Build a safe ORDER BY clause from an AG Grid sort model.
+
+    Only column names that appear in *allowed_columns* are accepted.
+    """
+    if not sort_model:
+        return default_order
+    parts: list[str] = []
+    for item in sort_model:
+        col = item.get("colId", "")
+        direction = "DESC" if item.get("sort") == "desc" else "ASC"
+        if col in allowed_columns:
+            parts.append(f"{col} {direction}")
+    return ", ".join(parts) if parts else default_order
+
+
+# ---------------------------------------------------------------------------
+# Per-grid data fetchers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_positions_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch positions data scoped to authorized strategies."""
+    order_clause = _build_order_clause(sort_model, columns, "symbol ASC")
+    col_list = ", ".join(columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM positions "  # noqa: S608
+                f"WHERE qty != 0 ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (_EXPORT_ROW_LIMIT,),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_orders_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch orders scoped to authorized strategies."""
+    order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
+    col_list = ", ".join(columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM orders "  # noqa: S608
+                f"WHERE strategy_id = ANY(%s) "
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (strategy_ids, _EXPORT_ROW_LIMIT),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_fills_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch fills (trades) scoped to authorized strategies."""
+    order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
+    col_list = ", ".join(f"t.{c}" for c in columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM trades t "  # noqa: S608
+                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                f"AND t.strategy_id = ANY(%s) "
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (strategy_ids, _EXPORT_ROW_LIMIT),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_audit_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch audit log entries."""
+    order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
+    col_list = ", ".join(columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM audit_log "  # noqa: S608
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (_EXPORT_ROW_LIMIT,),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_tca_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch TCA trade data with order context, scoped to authorized strategies."""
+    # Map column names to their qualified table references
+    tca_col_map: dict[str, str] = {
+        "trade_id": "t.trade_id",
+        "client_order_id": "t.client_order_id",
+        "strategy_id": "t.strategy_id",
+        "symbol": "t.symbol",
+        "side": "t.side",
+        "qty": "t.qty",
+        "price": "t.price",
+        "executed_at": "t.executed_at",
+        "order_submitted_at": "o.submitted_at",
+        "order_qty": "o.qty",
+        "filled_avg_price": "o.filled_avg_price",
+    }
+    select_cols = ", ".join(
+        f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns
+    )
+    order_clause = _build_order_clause(sort_model, columns, "t.executed_at DESC")
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {select_cols} "  # noqa: S608
+                f"FROM trades t "
+                f"LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
+                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                f"AND t.strategy_id = ANY(%s) "
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (strategy_ids, _EXPORT_ROW_LIMIT),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+# Dispatch table for grid data fetchers
+_GRID_FETCHERS = {
+    "positions": _fetch_positions_data,
+    "orders": _fetch_orders_data,
+    "fills": _fetch_fills_data,
+    "audit": _fetch_audit_data,
+    "tca": _fetch_tca_data,
+}
+
+
 async def _generate_excel_content(
     ctx: AppContext,
     grid_name: str,
@@ -710,27 +955,24 @@ async def _generate_excel_content(
 ) -> tuple[bytes, int]:
     """Generate Excel file content for a grid.
 
-    This is a placeholder that will be implemented for each grid type.
-    Uses openpyxl for Excel generation with formula sanitization.
-
-    IMPORTANT: All cell values MUST be sanitized via sanitize_for_export()
-    to prevent formula injection attacks.
+    Fetches real data from the database for the requested grid, applies
+    column validation against a server-side allowlist, and sanitises every
+    cell value to prevent formula-injection attacks.
 
     Args:
         ctx: Application context with database access
         grid_name: Name of grid to export
         strategy_ids: Authorized strategy IDs for filtering
-        filter_params: AG Grid filter model
-        visible_columns: Columns to include
+        filter_params: AG Grid filter model (reserved for future use)
+        visible_columns: Columns to include (validated against allowlist)
         sort_model: AG Grid sort model
 
     Returns:
         Tuple of (excel_bytes, row_count)
 
     Raises:
-        NotImplementedError: If grid type not supported
+        NotImplementedError: If grid type not supported or openpyxl missing
     """
-    # Import openpyxl only when needed
     try:
         from openpyxl import Workbook  # type: ignore[import-untyped]
     except ImportError as e:
@@ -738,47 +980,45 @@ async def _generate_excel_content(
             "Excel export requires openpyxl: pip install openpyxl"
         ) from e
 
-    # Supported grids and their data fetchers
-    # TODO: Implement per-grid data fetchers with PII column filtering
-    supported_grids = {
-        "positions": "_fetch_positions_data",
-        "orders": "_fetch_orders_data",
-        "fills": "_fetch_fills_data",
-        "audit": "_fetch_audit_data",
-        "tca": "_fetch_tca_data",
-    }
-
-    if grid_name not in supported_grids:
+    if grid_name not in _GRID_FETCHERS:
         raise NotImplementedError(f"Excel export not implemented for grid: {grid_name}")
 
-    # For now, return a placeholder Excel file
-    # TODO: Implement actual data fetching and Excel generation
-    # NOTE: When implementing real data, MUST:
-    # 1. Sanitize ALL cell values via sanitize_for_export()
-    # 2. Enforce PII column filtering server-side based on user role
-    # 3. Validate visible_columns against allowed columns per grid
+    # Validate requested columns against server allowlist
+    columns = _validate_columns(grid_name, visible_columns)
+
+    # Fetch real data
+    fetcher = _GRID_FETCHERS[grid_name]
+    rows = fetcher(ctx, strategy_ids, columns, sort_model)
+
+    # Build workbook
     wb = Workbook()
     ws = wb.active
     ws.title = grid_name.title()
 
-    # Add header row (sanitize headers too)
-    headers = visible_columns or ["Column1", "Column2", "Column3"]
-    for col_idx, header in enumerate(headers, 1):
+    # Header row — sanitize headers
+    for col_idx, header in enumerate(columns, 1):
         ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Placeholder data - sanitize all values
-    ws.cell(row=2, column=1, value=sanitize_for_export("Excel export implementation pending"))
-    ws.cell(row=2, column=2, value=sanitize_for_export(f"Grid: {grid_name}"))
-    ws.cell(row=2, column=3, value=sanitize_for_export(f"Strategies: {len(strategy_ids)}"))
+    # Data rows — sanitize every value
+    for row_idx, row_data in enumerate(rows, 2):
+        for col_idx, col_name in enumerate(columns, 1):
+            raw_value = row_data.get(col_name)
+            # Convert complex types to string for Excel compatibility
+            if isinstance(raw_value, dict | list):
+                raw_value = json.dumps(raw_value)
+            ws.cell(
+                row=row_idx,
+                column=col_idx,
+                value=sanitize_for_export(
+                    str(raw_value) if raw_value is not None else ""
+                ),
+            )
 
-    # Save to bytes
     output = io.BytesIO()
     wb.save(output)
     output.seek(0)
 
-    # Row count (excluding header)
-    row_count = 1  # Placeholder row
-
+    row_count = len(rows)
     return output.getvalue(), row_count
 
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -888,24 +888,65 @@ def _build_filter_clauses(
         if not isinstance(spec, dict):
             continue
         qualified = f"{col_prefix}{col}" if col_prefix else col
-        filter_type = spec.get("filterType", spec.get("type", ""))
 
-        if filter_type == "text":
-            # Cast JSONB columns to text so ILIKE / = operators work.
-            text_col = f"{qualified}::text" if col in _jsonb else qualified
-            _apply_text_filter(text_col, spec, fragments, params)
-        elif filter_type == "number":
-            _apply_number_filter(qualified, spec, fragments, params)
-        elif filter_type == "date":
-            _apply_date_filter(qualified, spec, fragments, params)
-        elif filter_type == "set":
-            values = spec.get("values")
-            if isinstance(values, list) and values:
-                fragments.append(f"{qualified} = ANY(%s)")
-                params.append(values)
+        # AG Grid compound filters use a ``conditions`` array with an
+        # ``operator`` (AND/OR).  Flatten them into individual clauses.
+        conditions = spec.get("conditions")
+        if isinstance(conditions, list) and conditions:
+            operator = spec.get("operator", "AND").upper()
+            sql_op = "OR" if operator == "OR" else "AND"
+            sub_fragments: list[str] = []
+            sub_params: list[Any] = []
+            parent_type = spec.get("filterType", "")
+            for cond in conditions:
+                if not isinstance(cond, dict):
+                    continue
+                _apply_single_filter(
+                    col, cond, qualified, _jsonb, sub_fragments, sub_params,
+                    parent_filter_type=parent_type,
+                )
+            if sub_fragments:
+                combined = f" {sql_op} ".join(sub_fragments)
+                fragments.append(f"({combined})")
+                params.extend(sub_params)
+        else:
+            _apply_single_filter(col, spec, qualified, _jsonb, fragments, params)
 
     where = " ".join(f"AND {f}" for f in fragments)
     return where, params
+
+
+def _apply_single_filter(
+    col: str,
+    spec: dict[str, Any],
+    qualified: str,
+    jsonb_columns: set[str],
+    fragments: list[str],
+    params: list[Any],
+    *,
+    parent_filter_type: str = "",
+) -> None:
+    """Apply a single AG Grid filter condition to fragments/params.
+
+    *parent_filter_type* is used as a fallback when the condition
+    itself lacks a ``filterType`` key (common in compound filters
+    where the type lives on the outer spec).
+    """
+    filter_type = spec.get("filterType", spec.get("type", "")) or parent_filter_type
+
+    if filter_type in ("text", "contains", "equals", "startsWith", "endsWith"):
+        # Cast JSONB columns to text so ILIKE / = operators work.
+        text_col = f"{qualified}::text" if col in jsonb_columns else qualified
+        _apply_text_filter(text_col, spec, fragments, params)
+    elif filter_type in ("number", "greaterThan", "lessThan"):
+        _apply_number_filter(qualified, spec, fragments, params)
+    elif filter_type in ("date", "inRange"):
+        _apply_date_filter(qualified, spec, fragments, params)
+    elif filter_type == "set":
+        values = spec.get("values")
+        if isinstance(values, list) and values:
+            fragments.append(f"{qualified} = ANY(%s)")
+            params.append(values)
 
 
 def _apply_text_filter(
@@ -991,6 +1032,7 @@ def _fetch_positions_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
+    filterable_columns: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch positions data scoped to authorized strategies.
 
@@ -1008,6 +1050,7 @@ def _fetch_positions_data(
     adding ``strategy_id`` to the positions table will remove this
     limitation.
     """
+    filter_cols = filterable_columns or columns
     # Qualify sort columns with the "p." alias to avoid ambiguity when
     # joining positions with the symbol_strategy CTE.
     qualified_sort: list[dict[str, Any]] | None = None
@@ -1025,7 +1068,7 @@ def _fetch_positions_data(
     col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
-        columns,
+        filter_cols,
         col_prefix="p.",
     )
     with ctx.db.transaction() as conn:
@@ -1050,6 +1093,7 @@ def _fetch_orders_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
+    filterable_columns: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch orders scoped to authorized strategies.
 
@@ -1059,11 +1103,12 @@ def _fetch_orders_data(
     ``PENDING_STATUSES`` tuple defined in
     ``apps.execution_gateway.database``.
     """
+    filter_cols = filterable_columns or columns
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
     col_list = ", ".join(columns)
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
-        columns,
+        filter_cols,
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
@@ -1086,6 +1131,7 @@ def _fetch_fills_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
+    filterable_columns: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch fills (trades) scoped to authorized strategies.
 
@@ -1101,7 +1147,8 @@ def _fetch_fills_data(
     )
     # Exclude the synthetic 'status' column from filter processing
     # since it has no DB backing and cannot be filtered.
-    db_columns = [c for c in columns if c != "status"]
+    filter_cols = filterable_columns or columns
+    db_columns = [c for c in filter_cols if c != "status"]
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
         db_columns,
@@ -1128,6 +1175,7 @@ def _fetch_audit_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
+    filterable_columns: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch audit log entries scoped to authorized strategies.
 
@@ -1139,11 +1187,12 @@ def _fetch_audit_data(
     operations to users who may only be authorized for specific
     strategies.
     """
+    filter_cols = filterable_columns or columns
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
-        columns,
+        filter_cols,
         jsonb_columns=_JSONB_COLUMNS.get("audit"),
     )
     with ctx.db.transaction() as conn:
@@ -1166,6 +1215,7 @@ def _fetch_tca_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
+    filterable_columns: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch TCA trade data with order context, scoped to authorized strategies.
 
@@ -1176,6 +1226,7 @@ def _fetch_tca_data(
     resolved via ``_COLUMN_ALIASES["tca"]`` before reaching this
     fetcher, so mapped columns are included correctly.
     """
+    filter_cols = filterable_columns or columns
     # Map column names to their qualified table references
     tca_col_map: dict[str, str] = {
         "trade_id": "t.trade_id",
@@ -1220,10 +1271,10 @@ def _fetch_tca_data(
     if filter_params:
         tca_filter_params = {}
         for col, spec in filter_params.items():
-            if col in columns:
+            if col in filter_cols:
                 qualified = tca_col_map.get(col, f"t.{col}")
                 tca_filter_params[qualified] = spec
-    qualified_filter_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
+    qualified_filter_columns = [tca_col_map.get(c, f"t.{c}") for c in filter_cols]
     filter_clause, filter_params_list = _build_filter_clauses(
         tca_filter_params,
         qualified_filter_columns,
@@ -1245,9 +1296,17 @@ def _fetch_tca_data(
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
-# Type alias for grid data fetcher functions
+# Type alias for grid data fetcher functions.
+# Signature: (ctx, strategy_ids, columns, sort_model, filter_params, filterable_columns)
 _GridFetcher = Callable[
-    [AppContext, list[str], list[str], list[dict[str, Any]] | None, dict[str, Any] | None],
+    [
+        AppContext,
+        list[str],
+        list[str],
+        list[dict[str, Any]] | None,
+        dict[str, Any] | None,
+        list[str],
+    ],
     list[dict[str, Any]],
 ]
 
@@ -1322,7 +1381,10 @@ async def _generate_excel_content(
         ]
 
     # Offload synchronous DB fetch to a worker thread to avoid blocking
-    # the FastAPI event loop.
+    # the FastAPI event loop.  Pass the full grid allowlist so filters on
+    # hidden columns (columns not in the projected ``columns`` list) are
+    # still applied — AG Grid allows filtering on columns the user has
+    # subsequently hidden.
     fetcher = _GRID_FETCHERS[grid_name]
     rows = await asyncio.to_thread(
         fetcher,
@@ -1331,6 +1393,7 @@ async def _generate_excel_content(
         columns,
         resolved_sort,
         resolved_filters,
+        allowed,
     )
 
     # Build workbook (CPU-bound; done in worker thread below)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1319,7 +1319,9 @@ def _fetch_tca_data(
     order_clause = _build_order_clause(
         qualified_sort,
         qualified_tca_columns,
-        "t.executed_at DESC",
+        # Match the TCA API ordering (ASC) so visible-scope exports
+        # return the same rows the user sees in the dashboard grid.
+        "t.executed_at ASC",
     )
     # For TCA filters, qualify column names via tca_col_map so the
     # WHERE clause references the correct table alias (e.g. "o.qty"
@@ -1461,7 +1463,12 @@ async def _generate_excel_content(
 
     # When export_scope="visible", cap rows at the client-reported count
     # so the Excel file only includes what the user saw on screen.
-    if row_limit is not None and row_limit >= 0:
+    #
+    # NOTE: The TCA grid is excluded because it shows aggregated order-level
+    # rows in the dashboard while the export provides raw trade-level rows.
+    # Applying an order-based row_limit to trade rows would silently cut
+    # off fills for multi-fill orders.
+    if row_limit is not None and row_limit >= 0 and grid_name != "tca":
         rows = rows[:row_limit]
 
     # Build workbook (CPU-bound; done in worker thread below)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -830,8 +830,19 @@ def _fetch_positions_data(
     traded by multiple strategies are excluded to prevent cross-strategy
     data leakage.
     """
-    order_clause = _build_order_clause(sort_model, columns, "p.symbol ASC")
-    col_list = ", ".join(f"p.{c}" for c in columns)
+    # Qualify sort columns with the "p." alias to avoid ambiguity when
+    # joining positions with the symbol_strategy CTE.
+    qualified_sort: list[dict[str, Any]] | None = None
+    if sort_model:
+        qualified_sort = [
+            {**item, "colId": f"p.{item['colId']}"} if item.get("colId") in columns else item
+            for item in sort_model
+        ]
+    qualified_columns = [f"p.{c}" for c in columns]
+    order_clause = _build_order_clause(
+        qualified_sort, qualified_columns, "p.symbol ASC",
+    )
+    col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -969,7 +969,7 @@ def _apply_date_filter(
         fragments.append(f"{col}::date = %s::date")
         params.append(date_from)
     elif op == "greaterThan" and date_from:
-        fragments.append(f"{col} >= %s::timestamp")
+        fragments.append(f"{col} > %s::timestamp")
         params.append(date_from)
     elif op == "lessThan" and date_from:
         fragments.append(f"{col} < %s::timestamp")
@@ -1000,6 +1000,13 @@ def _fetch_positions_data(
     strategy only when exactly ONE strategy has ever traded it.  Symbols
     traded by multiple strategies are excluded to prevent cross-strategy
     data leakage.
+
+    This is the same scoping used by
+    ``apps.execution_gateway.database.get_positions_for_strategies``
+    and the ``/api/v1/positions`` endpoint, so the export rows match
+    exactly what the dashboard grid displays.  A future schema migration
+    adding ``strategy_id`` to the positions table will remove this
+    limitation.
     """
     # Qualify sort columns with the "p." alias to avoid ambiguity when
     # joining positions with the symbol_strategy CTE.

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -813,16 +813,26 @@ def _fetch_positions_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
-    """Fetch positions data scoped to authorized strategies."""
+    """Fetch positions data scoped to authorized strategies.
+
+    Positions are scoped by filtering to symbols that have at least one
+    order for the given *strategy_ids*.  The ``positions`` table does not
+    carry a ``strategy_id`` column itself, so a subquery against
+    ``orders`` is used.
+    """
     order_clause = _build_order_clause(sort_model, columns, "symbol ASC")
     col_list = ", ".join(columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM positions "  # noqa: S608
-                f"WHERE qty != 0 ORDER BY {order_clause} "
+                f"WHERE symbol IN ("
+                f"  SELECT DISTINCT symbol FROM orders "
+                f"  WHERE strategy_id = ANY(%s)"
+                f") AND qty != 0 "
+                f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (_EXPORT_ROW_LIMIT,),
+                (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
@@ -879,16 +889,25 @@ def _fetch_audit_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
-    """Fetch audit log entries."""
+    """Fetch audit log entries scoped to authorized strategies.
+
+    Audit entries are scoped by matching the ``strategy_id`` key inside
+    the ``details`` JSONB column against the authorized *strategy_ids*.
+    System-level entries (those without a ``strategy_id`` in their
+    details, e.g. kill-switch operations) are included as well so that
+    the full operational context is preserved.
+    """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM audit_log "  # noqa: S608
+                f"WHERE details->>'strategy_id' = ANY(%s) "
+                f"   OR details->>'strategy_id' IS NULL "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (_EXPORT_ROW_LIMIT,),
+                (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
@@ -999,19 +1018,31 @@ async def _generate_excel_content(
     for col_idx, header in enumerate(columns, 1):
         ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Data rows — sanitize every value
+    # Data rows — sanitize only string values to prevent formula injection
+    # while preserving native Excel types (numbers, dates) for proper
+    # formatting and calculations.
     for row_idx, row_data in enumerate(rows, 2):
         for col_idx, col_name in enumerate(columns, 1):
             raw_value = row_data.get(col_name)
-            # Convert complex types to string for Excel compatibility
             if isinstance(raw_value, dict | list):
-                raw_value = json.dumps(raw_value)
+                raw_value = json.dumps(raw_value, default=str)
+
+            # Only sanitize strings to prevent formula injection while
+            # preserving numeric/date types that openpyxl handles natively.
+            if isinstance(raw_value, str):
+                value_to_set: Any = sanitize_for_export(raw_value)
+            elif raw_value is None:
+                value_to_set = ""
+            elif isinstance(raw_value, datetime):
+                # openpyxl does not support timezone-aware datetimes
+                value_to_set = raw_value.replace(tzinfo=None)
+            else:
+                value_to_set = raw_value
+
             ws.cell(
                 row=row_idx,
                 column=col_idx,
-                value=sanitize_for_export(
-                    str(raw_value) if raw_value is not None else ""
-                ),
+                value=value_to_set,
             )
 
     output = io.BytesIO()

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -775,19 +775,38 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 _EXPORT_ROW_LIMIT = 10_000
 
 
+# ---------------------------------------------------------------------------
+# Frontend → DB column alias mapping.
+# The web console grids may use display-friendly field names (e.g. "time"
+# instead of "executed_at").  This mapping translates them before the
+# allowlist check so that valid columns are not silently dropped.
+# ---------------------------------------------------------------------------
+_COLUMN_ALIASES: dict[str, dict[str, str]] = {
+    "orders": {
+        "type": "order_type",
+    },
+    "fills": {
+        "time": "executed_at",
+    },
+}
+
+
 def _validate_columns(
     grid_name: str, visible_columns: list[str] | None
 ) -> list[str]:
     """Return the export column list, validated against the server allowlist.
 
-    If *visible_columns* is provided, only columns that exist in the
-    allowlist are kept (in the requested order).  Unknown columns are
-    silently dropped to prevent SQL injection or data leakage.
+    Frontend column aliases are resolved first (e.g. ``"time"`` →
+    ``"executed_at"``).  Only columns that exist in the allowlist are
+    kept (in the requested order).  Unknown columns are silently dropped
+    to prevent SQL injection or data leakage.
     """
     allowed = _GRID_COLUMNS[grid_name]
     if not visible_columns:
         return allowed
-    return [c for c in visible_columns if c in allowed] or allowed
+    aliases = _COLUMN_ALIASES.get(grid_name, {})
+    resolved = [aliases.get(c, c) for c in visible_columns]
+    return [c for c in resolved if c in allowed] or allowed
 
 
 def _build_order_clause(
@@ -958,7 +977,21 @@ def _fetch_tca_data(
     select_cols = ", ".join(
         f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns
     )
-    order_clause = _build_order_clause(sort_model, columns, "t.executed_at DESC")
+    # Qualify sort columns with table aliases via tca_col_map to
+    # avoid ambiguity when trades and orders share column names
+    # (e.g. symbol, qty, client_order_id).
+    qualified_sort: list[dict[str, Any]] | None = None
+    if sort_model:
+        qualified_sort = [
+            {**item, "colId": tca_col_map.get(item.get("colId", ""), f"t.{item.get('colId', '')}")}
+            if item.get("colId") in columns
+            else item
+            for item in sort_model
+        ]
+    qualified_tca_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
+    order_clause = _build_order_clause(
+        qualified_sort, qualified_tca_columns, "t.executed_at DESC",
+    )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -39,6 +39,7 @@ from apps.execution_gateway.app_context import AppContext
 from apps.execution_gateway.dependencies import get_context
 from apps.execution_gateway.services.auth_helpers import build_user_context
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
+from libs.core.common.constants import WORKING_ORDER_STATUSES
 from libs.data.sql.strategy_mapping_sql import SYMBOL_STRATEGY_CTE
 from libs.platform.security import sanitize_for_export
 from libs.platform.web_console_auth.permissions import Permission, get_authorized_strategies
@@ -783,22 +784,6 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 # Maximum rows per export to prevent excessive memory / query time
 _EXPORT_ROW_LIMIT = 10_000
 
-# Statuses shown in the dashboard's Working-orders grid.  Must match
-# ``WORKING_ORDER_STATUSES`` in
-# ``apps.web_console_ng.components.tabbed_panel`` to ensure export
-# parity with the on-screen grid.  ``PENDING_STATUSES`` from the
-# database module is broader (includes ``submitted`` and
-# ``submitted_unconfirmed``) and would return rows not visible in
-# the grid.
-_WORKING_ORDER_STATUSES: tuple[str, ...] = (
-    "new",
-    "pending_new",
-    "partially_filled",
-    "accepted",
-    "pending_cancel",
-    "pending_replace",
-)
-
 # Columns stored as JSONB in the database.  Text filters on these columns
 # must cast to ``::text`` to avoid PostgreSQL operator errors.
 _JSONB_COLUMNS: dict[str, set[str]] = {
@@ -1085,6 +1070,7 @@ def _fetch_positions_data(
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
     filterable_columns: list[str] | None = None,
+    row_limit: int = _EXPORT_ROW_LIMIT,
 ) -> list[dict[str, Any]]:
     """Fetch positions data scoped to authorized strategies.
 
@@ -1141,7 +1127,8 @@ def _fetch_positions_data(
                 filter=SQL(filter_clause),
                 order=SQL(order_clause),
             )
-            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
+            effective_limit = min(row_limit, _EXPORT_ROW_LIMIT)
+            cur.execute(query, (strategy_ids, *filter_params_list, effective_limit))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1153,12 +1140,13 @@ def _fetch_orders_data(
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
     filterable_columns: list[str] | None = None,
+    row_limit: int = _EXPORT_ROW_LIMIT,
 ) -> list[dict[str, Any]]:
     """Fetch orders scoped to authorized strategies.
 
     Only working/pending orders are returned to match the dashboard's
     Working-orders grid.  The status filter uses
-    ``_WORKING_ORDER_STATUSES`` which mirrors the client-side
+    ``WORKING_ORDER_STATUSES`` which mirrors the client-side
     ``WORKING_ORDER_STATUSES`` set from the web console, ensuring
     export parity with what the user sees on screen.
     """
@@ -1183,13 +1171,14 @@ def _fetch_orders_data(
                 filter=SQL(filter_clause),
                 order=SQL(order_clause),
             )
+            effective_limit = min(row_limit, _EXPORT_ROW_LIMIT)
             cur.execute(
                 query,
                 (
                     strategy_ids,
-                    list(_WORKING_ORDER_STATUSES),
+                    list(WORKING_ORDER_STATUSES),
                     *filter_params_list,
-                    _EXPORT_ROW_LIMIT,
+                    effective_limit,
                 ),
             )
             col_names = [desc[0] for desc in cur.description]
@@ -1203,6 +1192,7 @@ def _fetch_fills_data(
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
     filterable_columns: list[str] | None = None,
+    row_limit: int = _EXPORT_ROW_LIMIT,
 ) -> list[dict[str, Any]]:
     """Fetch fills (trades) scoped to authorized strategies.
 
@@ -1242,7 +1232,8 @@ def _fetch_fills_data(
                 filter=SQL(filter_clause),
                 order=SQL(order_clause),
             )
-            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
+            effective_limit = min(row_limit, _EXPORT_ROW_LIMIT)
+            cur.execute(query, (strategy_ids, *filter_params_list, effective_limit))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1254,6 +1245,7 @@ def _fetch_audit_data(
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
     filterable_columns: list[str] | None = None,
+    row_limit: int = _EXPORT_ROW_LIMIT,
 ) -> list[dict[str, Any]]:
     """Fetch audit log entries scoped to authorized strategies.
 
@@ -1264,6 +1256,18 @@ def _fetch_audit_data(
     strategy-related audit entries prevents leaking sensitive system
     operations to users who may only be authorized for specific
     strategies.
+
+    .. note::
+
+       For large audit_log tables, an expression index on
+       ``(details->>'strategy_id')`` is recommended to avoid full table
+       scans::
+
+           CREATE INDEX IF NOT EXISTS idx_audit_log_details_strategy_id
+               ON audit_log ((details->>'strategy_id'));
+
+       This should be added via an Alembic migration when the table
+       grows beyond ~100k rows.
     """
     filter_cols = filterable_columns or columns
     order_clause = _build_order_clause(sort_model, filter_cols, "timestamp DESC, id DESC")
@@ -1286,7 +1290,8 @@ def _fetch_audit_data(
                 filter=SQL(filter_clause),
                 order=SQL(order_clause),
             )
-            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
+            effective_limit = min(row_limit, _EXPORT_ROW_LIMIT)
+            cur.execute(query, (strategy_ids, *filter_params_list, effective_limit))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1298,6 +1303,7 @@ def _fetch_tca_data(
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
     filterable_columns: list[str] | None = None,
+    row_limit: int = _EXPORT_ROW_LIMIT,
 ) -> list[dict[str, Any]]:
     """Fetch TCA trade data with order context, scoped to authorized strategies.
 
@@ -1406,13 +1412,15 @@ def _fetch_tca_data(
                 filter=SQL(filter_clause),
                 order=SQL(order_clause),
             )
-            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
+            effective_limit = min(row_limit, _EXPORT_ROW_LIMIT)
+            cur.execute(query, (strategy_ids, *filter_params_list, effective_limit))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 # Type alias for grid data fetcher functions.
-# Signature: (ctx, strategy_ids, columns, sort_model, filter_params, filterable_columns)
+# Signature: (ctx, strategy_ids, columns, sort_model, filter_params,
+#              filterable_columns, row_limit)
 _GridFetcher = Callable[
     [
         AppContext,
@@ -1421,6 +1429,7 @@ _GridFetcher = Callable[
         list[dict[str, Any]] | None,
         dict[str, Any] | None,
         list[str],
+        int,
     ],
     list[dict[str, Any]],
 ]
@@ -1506,7 +1515,12 @@ async def _generate_excel_content(
     # hidden columns (columns not in the projected ``columns`` list) are
     # still applied — AG Grid allows filtering on columns the user has
     # subsequently hidden.
+    #
+    # When row_limit is set, push it down to the SQL LIMIT so the
+    # database only returns the rows actually needed instead of always
+    # fetching up to _EXPORT_ROW_LIMIT and truncating in Python.
     fetcher = _GRID_FETCHERS[grid_name]
+    sql_limit = row_limit if row_limit is not None and row_limit >= 0 else _EXPORT_ROW_LIMIT
     rows = await asyncio.to_thread(
         fetcher,
         ctx,
@@ -1515,6 +1529,7 @@ async def _generate_excel_content(
         resolved_sort,
         resolved_filters,
         allowed,
+        sql_limit,
     )
 
     # When export_scope="visible", cap rows at the client-reported count

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1200,7 +1200,13 @@ def _fetch_fills_data(
     because every record in the trades table represents a completed fill.
     """
     filter_cols = filterable_columns or columns
-    order_clause = _build_order_clause(sort_model, filter_cols, "executed_at DESC")
+    # Exclude the synthetic 'status' column from both sort and filter
+    # processing since it has no DB backing -- it's synthesized as a
+    # literal 'filled' in the SELECT list only.  Including it in the
+    # ORDER BY or WHERE would cause a PostgreSQL "column does not exist"
+    # error when the user hides the column but keeps a sort on it.
+    db_columns = [c for c in filter_cols if c != "status"]
+    order_clause = _build_order_clause(sort_model, db_columns, "executed_at DESC")
     # Synthesize 'status' as a literal since it doesn't exist in the
     # trades table -- all trade records are completed fills.
     col_parts: list[Composable] = []
@@ -1210,9 +1216,6 @@ def _fetch_fills_data(
         else:
             col_parts.append(SQL("t.{col}").format(col=Identifier(c)))
     col_list = SQL(", ").join(col_parts)
-    # Exclude the synthetic 'status' column from filter processing
-    # since it has no DB backing and cannot be filtered.
-    db_columns = [c for c in filter_cols if c != "status"]
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
         db_columns,

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1249,18 +1249,26 @@ async def _generate_excel_content(
     # Validate requested columns against server allowlist
     columns = _validate_columns(grid_name, visible_columns)
 
-    # Resolve filter column aliases so that frontend filter keys
-    # (e.g. "type" for orders, "time" for fills) map to the DB column
-    # names expected by the fetchers.
+    # Resolve column aliases in both filter_params and sort_model so
+    # that frontend field names (e.g. "type" for orders, "time" for
+    # fills) map to the DB column names expected by the fetchers.
+    aliases = _COLUMN_ALIASES.get(grid_name, {})
+    allowed = _GRID_COLUMNS[grid_name]
+
     resolved_filters: dict[str, Any] | None = None
     if filter_params:
-        aliases = _COLUMN_ALIASES.get(grid_name, {})
-        allowed = _GRID_COLUMNS[grid_name]
         resolved_filters = {}
         for key, spec in filter_params.items():
             resolved_key = aliases.get(key, key)
             if resolved_key in allowed:
                 resolved_filters[resolved_key] = spec
+
+    resolved_sort: list[dict[str, Any]] | None = None
+    if sort_model:
+        resolved_sort = [
+            {**item, "colId": aliases.get(item.get("colId", ""), item.get("colId", ""))}
+            for item in sort_model
+        ]
 
     # Offload synchronous DB fetch to a worker thread to avoid blocking
     # the FastAPI event loop.
@@ -1270,7 +1278,7 @@ async def _generate_excel_content(
         ctx,
         strategy_ids,
         columns,
-        sort_model,
+        resolved_sort,
         resolved_filters,
     )
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -946,8 +946,22 @@ def _apply_single_filter(
     *parent_filter_type* is used as a fallback when the condition
     itself lacks a ``filterType`` key (common in compound filters
     where the type lives on the outer spec).
+
+    Resolution order for ``filter_type``:
+      1. The child's own ``filterType`` (if present)
+      2. The *parent_filter_type* inherited from the compound wrapper
+      3. The child's ``type`` field (operation name like ``equals``)
+
+    Using ``parent_filter_type`` before ``type`` is important because
+    ``type`` stores the *operation* (e.g. ``"equals"``), which overlaps
+    with the text-filter check and would cause number/date ``equals``
+    conditions inside compound filters to be misrouted as text filters.
     """
-    filter_type = spec.get("filterType", spec.get("type", "")) or parent_filter_type
+    filter_type = (
+        spec.get("filterType")
+        or parent_filter_type
+        or spec.get("type", "")
+    )
 
     if filter_type in ("text", "contains", "equals", "startsWith", "endsWith"):
         # Cast JSONB columns to text so ILIKE / = operators work.

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -35,7 +35,6 @@ from pydantic import BaseModel, Field
 from apps.execution_gateway.api.dependencies import build_gateway_authenticator
 from apps.execution_gateway.api.utils import get_client_ip, get_user_agent
 from apps.execution_gateway.app_context import AppContext
-from apps.execution_gateway.database import PENDING_STATUSES
 from apps.execution_gateway.dependencies import get_context
 from apps.execution_gateway.services.auth_helpers import build_user_context
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
@@ -771,6 +770,22 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 # Maximum rows per export to prevent excessive memory / query time
 _EXPORT_ROW_LIMIT = 10_000
 
+# Statuses shown in the dashboard's Working-orders grid.  Must match
+# ``WORKING_ORDER_STATUSES`` in
+# ``apps.web_console_ng.components.tabbed_panel`` to ensure export
+# parity with the on-screen grid.  ``PENDING_STATUSES`` from the
+# database module is broader (includes ``submitted`` and
+# ``submitted_unconfirmed``) and would return rows not visible in
+# the grid.
+_WORKING_ORDER_STATUSES: tuple[str, ...] = (
+    "new",
+    "pending_new",
+    "partially_filled",
+    "accepted",
+    "pending_cancel",
+    "pending_replace",
+)
+
 # Columns stored as JSONB in the database.  Text filters on these columns
 # must cast to ``::text`` to avoid PostgreSQL operator errors.
 _JSONB_COLUMNS: dict[str, set[str]] = {
@@ -1098,10 +1113,10 @@ def _fetch_orders_data(
     """Fetch orders scoped to authorized strategies.
 
     Only working/pending orders are returned to match the dashboard's
-    Working-orders grid (which is populated from
-    ``/api/v1/orders/pending``).  The status filter uses the same
-    ``PENDING_STATUSES`` tuple defined in
-    ``apps.execution_gateway.database``.
+    Working-orders grid.  The status filter uses
+    ``_WORKING_ORDER_STATUSES`` which mirrors the client-side
+    ``WORKING_ORDER_STATUSES`` set from the web console, ensuring
+    export parity with what the user sees on screen.
     """
     filter_cols = filterable_columns or columns
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
@@ -1119,7 +1134,7 @@ def _fetch_orders_data(
                 f"{filter_clause} "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, list(PENDING_STATUSES), *filter_params_list, _EXPORT_ROW_LIMIT),
+                (strategy_ids, list(_WORKING_ORDER_STATUSES), *filter_params_list, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -1225,6 +1240,20 @@ def _fetch_tca_data(
     can compute their own analytics.  Frontend column aliases are
     resolved via ``_COLUMN_ALIASES["tca"]`` before reaching this
     fetcher, so mapped columns are included correctly.
+
+    .. note::
+
+       The Execution Quality page uses page-level date/strategy
+       selectors (``start_date``, ``end_date``, ``strategy_id``) that
+       are separate from the AG Grid filter model.  If the user
+       applies column-level date filters in the AG Grid they will be
+       carried through ``filter_params``, but the page-level selectors
+       require the frontend to inject them into the export payload.
+       When no matching AG Grid filters are present, the export
+       returns all strategy-scoped trades up to the row limit.  A
+       future enhancement should have the frontend toolbar merge
+       page-level constraints into ``filter_params`` before the
+       export request.
     """
     filter_cols = filterable_columns or columns
     # Map column names to their qualified table references

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -626,6 +626,17 @@ async def download_excel_export(
     visible_columns = audit_record["visible_columns"]
     sort_model = audit_record["sort_model"]
 
+    # Honour ``export_scope="visible"`` — when the grid displays a
+    # limited subset of rows (e.g. TCA page trims to 50), cap the
+    # server-side query so the Excel file does not contain rows that
+    # the user never saw.
+    row_limit: int | None = None
+    if (
+        audit_record.get("export_scope") == "visible"
+        and audit_record.get("estimated_row_count") is not None
+    ):
+        row_limit = audit_record["estimated_row_count"]
+
     # Generate Excel content with error handling
     try:
         excel_content, row_count = await _generate_excel_content(
@@ -635,6 +646,7 @@ async def download_excel_export(
             filter_params=filter_params,
             visible_columns=visible_columns,
             sort_model=sort_model,
+            row_limit=row_limit,
         )
     except NotImplementedError as e:
         # Mark as failed before raising
@@ -1372,6 +1384,8 @@ async def _generate_excel_content(
     filter_params: dict[str, Any] | None,
     visible_columns: list[str] | None,
     sort_model: list[dict[str, Any]] | None,
+    *,
+    row_limit: int | None = None,
 ) -> tuple[bytes, int]:
     """Generate Excel file content for a grid.
 
@@ -1386,6 +1400,10 @@ async def _generate_excel_content(
         filter_params: AG Grid filter model (translated to SQL WHERE clauses)
         visible_columns: Columns to include (validated against allowlist)
         sort_model: AG Grid sort model
+        row_limit: Optional cap on number of rows returned.  When
+            ``export_scope="visible"``, this is set to the client's
+            ``estimated_row_count`` so the Excel file only contains
+            the rows the user actually saw in the grid.
 
     Returns:
         Tuple of (excel_bytes, row_count)
@@ -1440,6 +1458,11 @@ async def _generate_excel_content(
         resolved_filters,
         allowed,
     )
+
+    # When export_scope="visible", cap rows at the client-reported count
+    # so the Excel file only includes what the user saw on screen.
+    if row_limit is not None and row_limit >= 0:
+        rows = rows[:row_limit]
 
     # Build workbook (CPU-bound; done in worker thread below)
     def _build_workbook() -> bytes:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1163,11 +1163,19 @@ def _fetch_tca_data(
         "t.executed_at DESC",
     )
     # For TCA filters, qualify column names via tca_col_map so the
-    # WHERE clause references the correct table alias.
+    # WHERE clause references the correct table alias (e.g. "o.qty"
+    # for order_qty, not "t.order_qty").
+    tca_filter_params: dict[str, Any] | None = None
+    if filter_params:
+        tca_filter_params = {}
+        for col, spec in filter_params.items():
+            if col in columns:
+                qualified = tca_col_map.get(col, f"t.{col}")
+                tca_filter_params[qualified] = spec
+    qualified_filter_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
     filter_clause, filter_params_list = _build_filter_clauses(
-        filter_params,
-        columns,
-        col_prefix="t.",
+        tca_filter_params,
+        qualified_filter_columns,
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1245,15 +1245,11 @@ def _fetch_tca_data(
 
        The Execution Quality page uses page-level date/strategy
        selectors (``start_date``, ``end_date``, ``strategy_id``) that
-       are separate from the AG Grid filter model.  If the user
-       applies column-level date filters in the AG Grid they will be
-       carried through ``filter_params``, but the page-level selectors
-       require the frontend to inject them into the export payload.
-       When no matching AG Grid filters are present, the export
-       returns all strategy-scoped trades up to the row limit.  A
-       future enhancement should have the frontend toolbar merge
-       page-level constraints into ``filter_params`` before the
-       export request.
+       are separate from the AG Grid filter model.  These constraints
+       are injected by the frontend toolbar via
+       ``GridExportToolbar.extra_filter_params`` so the server-side
+       export query is scoped to the same date range the user
+       selected.
     """
     filter_cols = filterable_columns or columns
     # Map column names to their qualified table references

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -729,6 +729,11 @@ _GRID_COLUMNS: dict[str, list[str]] = {
         "qty",
         "price",
         "executed_at",
+        # ``status`` is synthesized as a literal 'filled' in the query
+        # because all records in the trades table are completed fills.
+        # The dashboard grid exposes this as a column, so we include it
+        # in the allowlist to avoid silently dropping user-selected columns.
+        "status",
     ],
     "audit": [
         "id",
@@ -877,6 +882,10 @@ def _build_filter_clauses(
 
     for col, spec in filter_params.items():
         if col not in allowed_columns:
+            continue
+        # Guard against malformed filter entries (e.g. bare strings
+        # instead of dict specs) to avoid AttributeError on .get().
+        if not isinstance(spec, dict):
             continue
         qualified = f"{col_prefix}{col}" if col_prefix else col
         filter_type = spec.get("filterType", spec.get("type", ""))
@@ -1071,12 +1080,24 @@ def _fetch_fills_data(
     sort_model: list[dict[str, Any]] | None,
     filter_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch fills (trades) scoped to authorized strategies."""
+    """Fetch fills (trades) scoped to authorized strategies.
+
+    The ``status`` column is synthesized as the literal ``'filled'``
+    because every record in the trades table represents a completed fill.
+    """
     order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
-    col_list = ", ".join(f"t.{c}" for c in columns)
+    # Synthesize 'status' as a literal since it doesn't exist in the
+    # trades table -- all trade records are completed fills.
+    col_list = ", ".join(
+        "'filled' AS status" if c == "status" else f"t.{c}"
+        for c in columns
+    )
+    # Exclude the synthetic 'status' column from filter processing
+    # since it has no DB backing and cannot be filtered.
+    db_columns = [c for c in columns if c != "status"]
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
-        columns,
+        db_columns,
         col_prefix="t.",
     )
     with ctx.db.transaction() as conn:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -766,6 +766,12 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 # Maximum rows per export to prevent excessive memory / query time
 _EXPORT_ROW_LIMIT = 10_000
 
+# Columns stored as JSONB in the database.  Text filters on these columns
+# must cast to ``::text`` to avoid PostgreSQL operator errors.
+_JSONB_COLUMNS: dict[str, set[str]] = {
+    "audit": {"details"},
+}
+
 
 # ---------------------------------------------------------------------------
 # Frontend → DB column alias mapping.
@@ -815,11 +821,19 @@ def _build_order_clause(
     """Build a safe ORDER BY clause from an AG Grid sort model.
 
     Only column names that appear in *allowed_columns* are accepted.
+    Items are ordered by ``sortIndex`` (if present) so that multi-column
+    sorts honour the precedence chosen by the user in the grid.
     """
     if not sort_model:
         return default_order
+    # Sort by sortIndex when present to preserve AG Grid precedence.
+    # Items without sortIndex retain their original list position.
+    ordered = sorted(
+        sort_model,
+        key=lambda item: (item.get("sortIndex") is None, item.get("sortIndex", 0)),
+    )
     parts: list[str] = []
-    for item in sort_model:
+    for item in ordered:
         col = item.get("colId", "")
         direction = "DESC" if item.get("sort") == "desc" else "ASC"
         if col in allowed_columns:
@@ -832,6 +846,7 @@ def _build_filter_clauses(
     allowed_columns: list[str],
     *,
     col_prefix: str = "",
+    jsonb_columns: set[str] | None = None,
 ) -> tuple[str, list[Any]]:
     """Translate an AG Grid filter model into SQL WHERE fragments.
 
@@ -841,6 +856,10 @@ def _build_filter_clauses(
 
     Only columns present in *allowed_columns* are accepted; unknown
     columns are silently ignored to prevent SQL injection.
+
+    JSONB columns listed in *jsonb_columns* are automatically cast to
+    ``::text`` before text-type filters to avoid PostgreSQL operator
+    errors (JSONB does not support ``ILIKE`` directly).
 
     Supported AG Grid filter types:
 
@@ -854,6 +873,7 @@ def _build_filter_clauses(
 
     fragments: list[str] = []
     params: list[Any] = []
+    _jsonb = jsonb_columns or set()
 
     for col, spec in filter_params.items():
         if col not in allowed_columns:
@@ -862,7 +882,9 @@ def _build_filter_clauses(
         filter_type = spec.get("filterType", spec.get("type", ""))
 
         if filter_type == "text":
-            _apply_text_filter(qualified, spec, fragments, params)
+            # Cast JSONB columns to text so ILIKE / = operators work.
+            text_col = f"{qualified}::text" if col in _jsonb else qualified
+            _apply_text_filter(text_col, spec, fragments, params)
         elif filter_type == "number":
             _apply_number_filter(qualified, spec, fragments, params)
         elif filter_type == "date":
@@ -1094,6 +1116,7 @@ def _fetch_audit_data(
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
         columns,
+        jsonb_columns=_JSONB_COLUMNS.get("audit"),
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1104,8 +1104,13 @@ async def _generate_excel_content(
                     value_to_set = ""
                 elif isinstance(raw_value, datetime):
                     # openpyxl does not support timezone-aware datetimes.
-                    # Ensure UTC first, then strip for Excel compatibility.
-                    value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+                    # If tz-aware, convert to UTC then strip; if naive,
+                    # assume already UTC (per project coding standards)
+                    # and use as-is.
+                    if raw_value.tzinfo is not None:
+                        value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+                    else:
+                        value_to_set = raw_value
                 else:
                     value_to_set = raw_value
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -30,6 +30,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
+from psycopg.sql import SQL, Composable, Identifier
 from pydantic import BaseModel, Field
 
 from apps.execution_gateway.api.dependencies import build_gateway_authenticator
@@ -929,7 +930,12 @@ def _build_filter_clauses(
                 if not isinstance(cond, dict):
                     continue
                 _apply_single_filter(
-                    col, cond, qualified, _jsonb, sub_fragments, sub_params,
+                    col,
+                    cond,
+                    qualified,
+                    _jsonb,
+                    sub_fragments,
+                    sub_params,
                     parent_filter_type=parent_type,
                 )
             if sub_fragments:
@@ -969,11 +975,7 @@ def _apply_single_filter(
     with the text-filter check and would cause number/date ``equals``
     conditions inside compound filters to be misrouted as text filters.
     """
-    filter_type = (
-        spec.get("filterType")
-        or parent_filter_type
-        or spec.get("type", "")
-    )
+    filter_type = spec.get("filterType") or parent_filter_type or spec.get("type", "")
 
     if filter_type in ("text", "contains", "equals", "startsWith", "endsWith"):
         # Cast JSONB columns to text so ILIKE / = operators work.
@@ -1051,19 +1053,22 @@ def _apply_date_filter(
         fragments.append(f"{col}::date = %s::date")
         params.append(date_from)
     elif op == "greaterThan" and date_from:
-        fragments.append(f"{col} > %s::timestamp")
+        # AG Grid date filters are day-based: "greaterThan 2026-01-01"
+        # means "after that entire day", so we use >= dateFrom + 1 day
+        # to exclude all rows on the selected day.
+        fragments.append(f"{col} >= (%s::date + interval '1 day')")
         params.append(date_from)
     elif op == "lessThan" and date_from:
-        fragments.append(f"{col} < %s::timestamp")
+        # AG Grid "lessThan" is also day-based: exclude the selected day
+        # entirely by using < dateFrom (midnight of that day).
+        fragments.append(f"{col} < %s::date")
         params.append(date_from)
     elif op == "inRange" and date_from and date_to:
         # AG Grid sends dateTo as the selected calendar day (midnight).
         # Use ``dateTo::date + interval '1 day'`` so the entire end date
         # is included and single-day ranges (same dateFrom/dateTo) return
         # rows from that day.
-        fragments.append(
-            f"{col} >= %s::timestamp AND {col} < (%s::date + interval '1 day')"
-        )
+        fragments.append(f"{col} >= %s::timestamp AND {col} < (%s::date + interval '1 day')")
         params.append(date_from)
         params.append(date_to)
 
@@ -1099,20 +1104,22 @@ def _fetch_positions_data(
     """
     filter_cols = filterable_columns or columns
     # Qualify sort columns with the "p." alias to avoid ambiguity when
-    # joining positions with the symbol_strategy CTE.
+    # joining positions with the symbol_strategy CTE.  Use filter_cols
+    # (the full allowlist) rather than columns (projected) so sorts on
+    # hidden-but-allowed columns are still honoured.
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": f"p.{item['colId']}"} if item.get("colId") in columns else item
+            {**item, "colId": f"p.{item['colId']}"} if item.get("colId") in filter_cols else item
             for item in sort_model
         ]
-    qualified_columns = [f"p.{c}" for c in columns]
+    qualified_columns = [f"p.{c}" for c in filter_cols]
     order_clause = _build_order_clause(
         qualified_sort,
         qualified_columns,
         "p.symbol ASC",
     )
-    col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
+    col_list = SQL(", ").join(SQL("p.{col} AS {col}").format(col=Identifier(c)) for c in columns)
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
         filter_cols,
@@ -1120,16 +1127,21 @@ def _fetch_positions_data(
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"WITH {SYMBOL_STRATEGY_CTE} "  # noqa: S608
-                f"SELECT {col_list} FROM positions p "
-                f"JOIN symbol_strategy ss ON p.symbol = ss.symbol "
-                f"WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
-                f"{filter_clause} "
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
+            query = SQL(
+                "WITH {cte} "
+                "SELECT {cols} FROM positions p "
+                "JOIN symbol_strategy ss ON p.symbol = ss.symbol "
+                "WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
+                "{filter} "
+                "ORDER BY {order} "
+                "LIMIT %s"
+            ).format(
+                cte=SQL(SYMBOL_STRATEGY_CTE),
+                cols=col_list,
+                filter=SQL(filter_clause),
+                order=SQL(order_clause),
             )
+            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1151,22 +1163,34 @@ def _fetch_orders_data(
     export parity with what the user sees on screen.
     """
     filter_cols = filterable_columns or columns
-    order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
-    col_list = ", ".join(columns)
+    order_clause = _build_order_clause(sort_model, filter_cols, "created_at DESC")
+    col_list = SQL(", ").join(Identifier(c) for c in columns)
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
         filter_cols,
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
+            query = SQL(
+                "SELECT {cols} FROM orders "
+                "WHERE strategy_id = ANY(%s) "
+                "AND status = ANY(%s) "
+                "{filter} "
+                "ORDER BY {order} "
+                "LIMIT %s"
+            ).format(
+                cols=col_list,
+                filter=SQL(filter_clause),
+                order=SQL(order_clause),
+            )
             cur.execute(
-                f"SELECT {col_list} FROM orders "  # noqa: S608
-                f"WHERE strategy_id = ANY(%s) "
-                f"AND status = ANY(%s) "
-                f"{filter_clause} "
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                (strategy_ids, list(_WORKING_ORDER_STATUSES), *filter_params_list, _EXPORT_ROW_LIMIT),
+                query,
+                (
+                    strategy_ids,
+                    list(_WORKING_ORDER_STATUSES),
+                    *filter_params_list,
+                    _EXPORT_ROW_LIMIT,
+                ),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -1185,16 +1209,19 @@ def _fetch_fills_data(
     The ``status`` column is synthesized as the literal ``'filled'``
     because every record in the trades table represents a completed fill.
     """
-    order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
+    filter_cols = filterable_columns or columns
+    order_clause = _build_order_clause(sort_model, filter_cols, "executed_at DESC")
     # Synthesize 'status' as a literal since it doesn't exist in the
     # trades table -- all trade records are completed fills.
-    col_list = ", ".join(
-        "'filled' AS status" if c == "status" else f"t.{c}"
-        for c in columns
-    )
+    col_parts: list[Composable] = []
+    for c in columns:
+        if c == "status":
+            col_parts.append(SQL("'filled' AS status"))
+        else:
+            col_parts.append(SQL("t.{col}").format(col=Identifier(c)))
+    col_list = SQL(", ").join(col_parts)
     # Exclude the synthetic 'status' column from filter processing
     # since it has no DB backing and cannot be filtered.
-    filter_cols = filterable_columns or columns
     db_columns = [c for c in filter_cols if c != "status"]
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
@@ -1203,15 +1230,19 @@ def _fetch_fills_data(
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {col_list} FROM trades t "  # noqa: S608
-                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
-                f"AND t.strategy_id = ANY(%s) "
-                f"{filter_clause} "
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
+            query = SQL(
+                "SELECT {cols} FROM trades t "
+                "WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                "AND t.strategy_id = ANY(%s) "
+                "{filter} "
+                "ORDER BY {order} "
+                "LIMIT %s"
+            ).format(
+                cols=col_list,
+                filter=SQL(filter_clause),
+                order=SQL(order_clause),
             )
+            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1235,8 +1266,8 @@ def _fetch_audit_data(
     strategies.
     """
     filter_cols = filterable_columns or columns
-    order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
-    col_list = ", ".join(columns)
+    order_clause = _build_order_clause(sort_model, filter_cols, "timestamp DESC, id DESC")
+    col_list = SQL(", ").join(Identifier(c) for c in columns)
     filter_clause, filter_params_list = _build_filter_clauses(
         filter_params,
         filter_cols,
@@ -1244,14 +1275,18 @@ def _fetch_audit_data(
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {col_list} FROM audit_log "  # noqa: S608
-                f"WHERE details->>'strategy_id' = ANY(%s) "
-                f"{filter_clause} "
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
+            query = SQL(
+                "SELECT {cols} FROM audit_log "
+                "WHERE details->>'strategy_id' = ANY(%s) "
+                "{filter} "
+                "ORDER BY {order} "
+                "LIMIT %s"
+            ).format(
+                cols=col_list,
+                filter=SQL(filter_clause),
+                order=SQL(order_clause),
             )
+            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1298,7 +1333,17 @@ def _fetch_tca_data(
         "order_qty": "o.qty",
         "filled_avg_price": "o.filled_avg_price",
     }
-    select_cols = ", ".join(f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns)
+    # Build SELECT list using psycopg.sql -- column aliases from
+    # tca_col_map are pre-qualified table.column references that are
+    # safe because they come from a hardcoded mapping above, not user
+    # input.  The output alias uses Identifier for proper quoting.
+    select_cols = SQL(", ").join(
+        SQL("{ref} AS {alias}").format(
+            ref=SQL(tca_col_map.get(c, "t." + c)),
+            alias=Identifier(c),
+        )
+        for c in columns
+    )
     # Qualify sort columns with table aliases via tca_col_map to
     # avoid ambiguity when trades and orders share column names
     # (e.g. symbol, qty, client_order_id).
@@ -1310,12 +1355,12 @@ def _fetch_tca_data(
                     **item,
                     "colId": tca_col_map.get(item.get("colId", ""), f"t.{item.get('colId', '')}"),
                 }
-                if item.get("colId") in columns
+                if item.get("colId") in filter_cols
                 else item
             )
             for item in sort_model
         ]
-    qualified_tca_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
+    qualified_tca_columns = [tca_col_map.get(c, f"t.{c}") for c in filter_cols]
     order_clause = _build_order_clause(
         qualified_sort,
         qualified_tca_columns,
@@ -1323,9 +1368,16 @@ def _fetch_tca_data(
         # return the same rows the user sees in the dashboard grid.
         "t.executed_at ASC",
     )
-    # For TCA filters, qualify column names via tca_col_map so the
+    # For TCA filters, pre-qualify column names via tca_col_map so the
     # WHERE clause references the correct table alias (e.g. "o.qty"
     # for order_qty, not "t.order_qty").
+    #
+    # NOTE: Unlike the other single-table fetchers (which use the
+    # ``col_prefix`` parameter of ``_build_filter_clauses``), TCA
+    # requires per-column qualification because the JOIN spans two
+    # tables with different column owners.  Pre-qualifying here keeps
+    # ``_build_filter_clauses`` simple (single-prefix mode) while
+    # correctly routing each column to its owning table.
     tca_filter_params: dict[str, Any] | None = None
     if filter_params:
         tca_filter_params = {}
@@ -1340,17 +1392,21 @@ def _fetch_tca_data(
     )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {select_cols} "  # noqa: S608
-                f"FROM trades t "
-                f"LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
-                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
-                f"AND t.strategy_id = ANY(%s) "
-                f"{filter_clause} "
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT),
+            query = SQL(
+                "SELECT {cols} "
+                "FROM trades t "
+                "LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
+                "WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                "AND t.strategy_id = ANY(%s) "
+                "{filter} "
+                "ORDER BY {order} "
+                "LIMIT %s"
+            ).format(
+                cols=select_cols,
+                filter=SQL(filter_clause),
+                order=SQL(order_clause),
             )
+            cur.execute(query, (strategy_ids, *filter_params_list, _EXPORT_ROW_LIMIT))
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1475,6 +1531,7 @@ async def _generate_excel_content(
     def _build_workbook() -> bytes:
         wb = Workbook()
         ws = wb.active
+        assert ws is not None  # Workbook() always creates an active sheet
         ws.title = grid_name.title()
 
         # Header row -- sanitize headers

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -50,6 +50,7 @@ class GridExportToolbar:
         on_export_start: Callable[[str], None] | None = None,
         on_export_complete: Callable[[str, int], None] | None = None,
         api_base_url: str = "/api/v1",
+        extra_filter_params: dict[str, Any] | None = None,
     ) -> None:
         """Initialize export toolbar.
 
@@ -62,6 +63,11 @@ class GridExportToolbar:
             on_export_start: Callback when export starts
             on_export_complete: Callback when export completes (type, row_count)
             api_base_url: Base URL for export API endpoints
+            extra_filter_params: Additional AG-Grid-style filter params to merge
+                into the export payload.  Useful for page-level selectors
+                (e.g. date range, strategy) that are not part of the
+                grid's ``filterModel`` but must scope the server-side
+                export query.
         """
         self.grid_id = grid_id
         self.grid_name = grid_name
@@ -71,6 +77,7 @@ class GridExportToolbar:
         self.on_export_start = on_export_start
         self.on_export_complete = on_export_complete
         self.api_base_url = api_base_url
+        self.extra_filter_params = extra_filter_params or {}
 
         self._csv_button: ui.button | None = None
         self._excel_button: ui.button | None = None
@@ -162,6 +169,12 @@ class GridExportToolbar:
             import httpx
 
             headers = self._get_auth_headers()
+            # Merge page-level filters (e.g. TCA date selectors) with
+            # the AG Grid's own filterModel so the server-side export
+            # query is scoped to what the user actually sees.
+            filter_model = dict(grid_state.get("filterModel") or {})
+            if self.extra_filter_params:
+                filter_model.update(self.extra_filter_params)
             async with httpx.AsyncClient() as client:
                 response = await client.post(
                     f"{self.api_base_url}/export/audit",
@@ -169,7 +182,7 @@ class GridExportToolbar:
                     json={
                         "export_type": export_type,
                         "grid_name": self.grid_name,
-                        "filter_params": grid_state.get("filterModel"),
+                        "filter_params": filter_model or None,
                         "visible_columns": grid_state.get("columns"),
                         "sort_model": grid_state.get("sortModel"),
                         "export_scope": "visible",

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -250,8 +250,26 @@ def create_tabbed_panel(
     """
     state.active_tab = state.normalize_tab(state.active_tab)
 
+    def _sync_toolbar_symbol_filter(symbol: str | None) -> None:
+        """Inject the page-level symbol filter into all export toolbars.
+
+        The symbol picker lives outside AG Grid's filterModel, so the
+        server-side export query would miss it unless we pass it as an
+        extra filter param.
+        """
+        for toolbar in export_toolbars.values():
+            if symbol:
+                toolbar.extra_filter_params["symbol"] = {
+                    "filterType": "text",
+                    "type": "equals",
+                    "filter": symbol,
+                }
+            else:
+                toolbar.extra_filter_params.pop("symbol", None)
+
     def _on_filter_change(value: str | None) -> None:
         state.symbol_filter = value
+        _sync_toolbar_symbol_filter(value)
         if on_filter_change is not None:
             on_filter_change(value)
 
@@ -282,6 +300,9 @@ def create_tabbed_panel(
                     toolbar_container.set_visibility(is_active)
                     export_toolbars[tab_name] = toolbar
                     toolbar_containers[tab_name] = toolbar_container
+                # Initialise toolbars with the current symbol filter
+                # (may be non-null when restoring persisted state).
+                _sync_toolbar_symbol_filter(state.symbol_filter)
 
         with ui.tabs(value=state.active_tab).classes("w-full") as tabs:  # type: ignore[arg-type]
             tab_positions = ui.tab(name=TAB_POSITIONS, label=TAB_TITLES[TAB_POSITIONS])

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -25,6 +25,7 @@ from apps.web_console_ng.ui.trading_layout import (
     apply_compact_grid_classes,
     apply_compact_grid_options,
 )
+from libs.core.common.constants import WORKING_ORDER_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -44,19 +45,14 @@ TAB_TITLES = {
 
 # Grid ID and name mapping for export toolbar
 TAB_GRID_CONFIG = {
-    TAB_POSITIONS: {"grid_id": "_positionsGridApi", "grid_name": "positions", "prefix": "positions"},
+    TAB_POSITIONS: {
+        "grid_id": "_positionsGridApi",
+        "grid_name": "positions",
+        "prefix": "positions",
+    },
     TAB_WORKING: {"grid_id": "_ordersGridApi", "grid_name": "orders", "prefix": "orders"},
     TAB_FILLS: {"grid_id": "_fillsGridApi", "grid_name": "fills", "prefix": "fills"},
     TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "history", "prefix": "history"},
-}
-
-WORKING_ORDER_STATUSES = {
-    "new",
-    "pending_new",
-    "partially_filled",
-    "accepted",
-    "pending_cancel",
-    "pending_replace",
 }
 
 

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -480,10 +480,10 @@ async def _render_tca_dashboard(
                 with ui.row().classes("w-full justify-between items-center mb-2"):
                     ui.label("Order Details").classes("text-lg font-bold")
 
-                    # Export toolbar — inject page-level date selectors so the
-                    # server-side export query is scoped to the same date range
-                    # the user selected (these are not part of the AG Grid
-                    # filterModel by default).
+                    # Export toolbar — inject page-level selectors so the
+                    # server-side export query is scoped to exactly what the
+                    # user sees (date range, symbol, strategy).  These are
+                    # not part of the AG Grid filterModel by default.
                     tca_extra_filters: dict[str, Any] = {
                         "executed_at": {
                             "filterType": "date",
@@ -492,6 +492,18 @@ async def _render_tca_dashboard(
                             "dateTo": str(state["end_date"]),
                         },
                     }
+                    if state.get("symbol"):
+                        tca_extra_filters["symbol"] = {
+                            "filterType": "text",
+                            "type": "equals",
+                            "filter": state["symbol"],
+                        }
+                    if state.get("strategy_id"):
+                        tca_extra_filters["strategy_id"] = {
+                            "filterType": "text",
+                            "type": "equals",
+                            "filter": state["strategy_id"],
+                        }
                     export_toolbar = GridExportToolbar(
                         grid_id="tca-orders-grid",
                         grid_name="tca",

--- a/apps/web_console_ng/pages/execution_quality.py
+++ b/apps/web_console_ng/pages/execution_quality.py
@@ -480,11 +480,23 @@ async def _render_tca_dashboard(
                 with ui.row().classes("w-full justify-between items-center mb-2"):
                     ui.label("Order Details").classes("text-lg font-bold")
 
-                    # Export toolbar
+                    # Export toolbar — inject page-level date selectors so the
+                    # server-side export query is scoped to the same date range
+                    # the user selected (these are not part of the AG Grid
+                    # filterModel by default).
+                    tca_extra_filters: dict[str, Any] = {
+                        "executed_at": {
+                            "filterType": "date",
+                            "type": "inRange",
+                            "dateFrom": str(state["start_date"]),
+                            "dateTo": str(state["end_date"]),
+                        },
+                    }
                     export_toolbar = GridExportToolbar(
                         grid_id="tca-orders-grid",
                         grid_name="tca",
                         filename_prefix="tca_analysis",
+                        extra_filter_params=tca_extra_filters,
                     )
                     export_toolbar.create()
 

--- a/docs/ARCHITECTURE/system_map.config.json
+++ b/docs/ARCHITECTURE/system_map.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./system_map.schema.json",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Configuration for architecture visualization generation",
 
   "layers": [

--- a/docs/GETTING_STARTED/REPO_MAP.md
+++ b/docs/GETTING_STARTED/REPO_MAP.md
@@ -1,6 +1,6 @@
 # Repository Map
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-04-06
 
 This document provides a comprehensive map of the trading platform repository structure, explaining the purpose of each directory and key files.
 

--- a/libs/core/common/constants.py
+++ b/libs/core/common/constants.py
@@ -1,0 +1,28 @@
+"""Shared constants used across services.
+
+Keep constants here that must stay in sync between the execution gateway,
+web console, and other services.  A single source of truth prevents
+accidental drift when one file is updated but the other is forgotten.
+"""
+
+from __future__ import annotations
+
+# Order statuses shown in the dashboard's Working-orders grid.
+# This is a *strict subset* of ``PENDING_STATUSES`` from
+# ``apps.execution_gateway.database``; the broader set includes
+# ``submitted`` and ``submitted_unconfirmed`` which are not
+# rendered in the UI's working-orders tab.
+#
+# Used by:
+#   - ``apps.execution_gateway.routes.export``  (server-side SQL filter)
+#   - ``apps.web_console_ng.components.tabbed_panel``  (client-side filter)
+WORKING_ORDER_STATUSES: frozenset[str] = frozenset(
+    {
+        "new",
+        "pending_new",
+        "partially_filled",
+        "accepted",
+        "pending_cancel",
+        "pending_replace",
+    }
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ pre-commit = "^3.6.0"
 respx = "^0.22.0"
 types-PyYAML = "^6.0"  # Type stubs for PyYAML
 types-defusedxml = "^0.7.0"  # Type stubs for defusedxml
+types-openpyxl = "^3.1.5"  # Type stubs for openpyxl (Excel export)
 
 
 [tool.poetry.group.web-console-ng.dependencies]

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -167,6 +167,26 @@ class TestBuildFilterClauses:
         clause, params = _build_filter_clauses(filt, ["executed_at"])
         assert "2026-01-01" in params
         assert "2026-02-01" in params
+        # End date uses ``::date + interval '1 day'`` to include the
+        # entire end date (AG Grid sends midnight of the selected day).
+        assert "+ interval '1 day'" in clause
+
+    def test_date_in_range_single_day(self) -> None:
+        """Single-day range (same dateFrom/dateTo) should return rows."""
+        filt = {
+            "executed_at": {
+                "filterType": "date",
+                "type": "inRange",
+                "dateFrom": "2026-01-01",
+                "dateTo": "2026-01-01",
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["executed_at"])
+        # Both dates should be present
+        assert params.count("2026-01-01") == 2
+        # The upper bound uses ``::date + interval '1 day'`` so a
+        # single-day range can actually match rows on that date.
+        assert "+ interval '1 day'" in clause
 
     def test_date_greater_than_uses_strict_gt(self) -> None:
         """greaterThan date filter should use strict '>' not '>='."""

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -70,6 +70,24 @@ class TestBuildOrderClause:
         result = _build_order_clause(model, ["symbol"], "symbol ASC")
         assert result == "symbol ASC"
 
+    def test_sort_index_determines_precedence(self) -> None:
+        """Multi-column sorts should honour sortIndex from AG Grid."""
+        model = [
+            {"colId": "qty", "sort": "asc", "sortIndex": 1},
+            {"colId": "symbol", "sort": "desc", "sortIndex": 0},
+        ]
+        result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
+        assert result == "symbol DESC, qty ASC"
+
+    def test_sort_index_missing_falls_back_to_list_order(self) -> None:
+        """Items without sortIndex retain their original list position."""
+        model = [
+            {"colId": "qty", "sort": "asc"},
+            {"colId": "symbol", "sort": "desc"},
+        ]
+        result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
+        assert result == "qty ASC, symbol DESC"
+
 
 class TestBuildFilterClauses:
     def test_none_filter_returns_empty(self) -> None:
@@ -111,6 +129,24 @@ class TestBuildFilterClauses:
         filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
         clause, params = _build_filter_clauses(filt, ["symbol"], col_prefix="t.")
         assert "t.symbol" in clause
+
+    def test_jsonb_column_cast_to_text(self) -> None:
+        """JSONB columns should be cast to ::text for text filters."""
+        filt = {"details": {"filterType": "text", "type": "contains", "filter": "login"}}
+        clause, params = _build_filter_clauses(
+            filt, ["details"], jsonb_columns={"details"}
+        )
+        assert "details::text ILIKE" in clause
+        assert "%login%" in params
+
+    def test_non_jsonb_column_not_cast(self) -> None:
+        """Non-JSONB columns should not be cast even when jsonb_columns is provided."""
+        filt = {"action": {"filterType": "text", "type": "contains", "filter": "login"}}
+        clause, params = _build_filter_clauses(
+            filt, ["action"], jsonb_columns={"details"}
+        )
+        assert "action ILIKE" in clause
+        assert "::text" not in clause
 
     def test_date_in_range_filter(self) -> None:
         filt = {

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -719,3 +719,65 @@ class TestGenerateExcelContent:
         assert ws.cell(1, 2).value == "status"
         # Value should be the synthesized 'filled'
         assert ws.cell(2, 2).value == "filled"
+
+    async def test_row_limit_caps_visible_scope(self) -> None:
+        """row_limit truncates output to match visible-scope export."""
+        rows = [
+            (
+                "AAPL",
+                Decimal("10"),
+                Decimal("150.25"),
+                Decimal("152.00"),
+                Decimal("17.50"),
+                Decimal("0"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+            (
+                "MSFT",
+                Decimal("5"),
+                Decimal("400.00"),
+                Decimal("405.00"),
+                Decimal("25.00"),
+                Decimal("10"),
+                datetime(2026, 1, 2, tzinfo=UTC),
+            ),
+            (
+                "GOOGL",
+                Decimal("3"),
+                Decimal("170.00"),
+                Decimal("172.00"),
+                Decimal("6.00"),
+                Decimal("0"),
+                datetime(2026, 1, 3, tzinfo=UTC),
+            ),
+        ]
+        col_names = [
+            "symbol",
+            "qty",
+            "avg_entry_price",
+            "current_price",
+            "unrealized_pl",
+            "realized_pl",
+            "updated_at",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+            row_limit=2,
+        )
+
+        # Only 2 of 3 rows should be exported
+        assert row_count == 2
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        assert ws.cell(2, 1).value == "AAPL"
+        assert ws.cell(3, 1).value == "MSFT"
+        assert ws.cell(4, 1).value is None  # No third data row

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -133,18 +133,14 @@ class TestBuildFilterClauses:
     def test_jsonb_column_cast_to_text(self) -> None:
         """JSONB columns should be cast to ::text for text filters."""
         filt = {"details": {"filterType": "text", "type": "contains", "filter": "login"}}
-        clause, params = _build_filter_clauses(
-            filt, ["details"], jsonb_columns={"details"}
-        )
+        clause, params = _build_filter_clauses(filt, ["details"], jsonb_columns={"details"})
         assert "details::text ILIKE" in clause
         assert "%login%" in params
 
     def test_non_jsonb_column_not_cast(self) -> None:
         """Non-JSONB columns should not be cast even when jsonb_columns is provided."""
         filt = {"action": {"filterType": "text", "type": "contains", "filter": "login"}}
-        clause, params = _build_filter_clauses(
-            filt, ["action"], jsonb_columns={"details"}
-        )
+        clause, params = _build_filter_clauses(filt, ["action"], jsonb_columns={"details"})
         assert "action ILIKE" in clause
         assert "::text" not in clause
 
@@ -188,8 +184,8 @@ class TestBuildFilterClauses:
         # single-day range can actually match rows on that date.
         assert "+ interval '1 day'" in clause
 
-    def test_date_greater_than_uses_strict_gt(self) -> None:
-        """greaterThan date filter should use strict '>' not '>='."""
+    def test_date_greater_than_excludes_selected_day(self) -> None:
+        """greaterThan date filter uses dateFrom + 1 day (day-based semantics)."""
         filt = {
             "executed_at": {
                 "filterType": "date",
@@ -198,8 +194,23 @@ class TestBuildFilterClauses:
             }
         }
         clause, params = _build_filter_clauses(filt, ["executed_at"])
-        assert "> %s" in clause
-        assert ">=" not in clause
+        # Day-based: "greaterThan 2026-01-01" means >= 2026-01-02
+        assert ">= (%s::date + interval '1 day')" in clause
+        assert params == ["2026-01-01"]
+
+    def test_date_less_than_excludes_selected_day(self) -> None:
+        """lessThan date filter excludes the selected day entirely."""
+        filt = {
+            "executed_at": {
+                "filterType": "date",
+                "type": "lessThan",
+                "dateFrom": "2026-03-15",
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["executed_at"])
+        # Day-based: "lessThan 2026-03-15" means < midnight of that day
+        assert "< %s::date" in clause
+        assert params == ["2026-03-15"]
 
     def test_compound_and_filter(self) -> None:
         """AG Grid compound AND filter with conditions array."""
@@ -276,13 +287,9 @@ class TestBuildFilterClauses:
 
     def test_filter_on_hidden_column_applied(self) -> None:
         """Filters on columns not in the projected set should still apply."""
-        filt: dict[str, Any] = {
-            "status": {"filterType": "text", "type": "equals", "filter": "new"}
-        }
+        filt: dict[str, Any] = {"status": {"filterType": "text", "type": "equals", "filter": "new"}}
         # 'status' is not in projected columns, but is in filterable_columns
-        clause, params = _build_filter_clauses(
-            filt, ["symbol", "qty", "status"]
-        )
+        clause, params = _build_filter_clauses(filt, ["symbol", "qty", "status"])
         assert "status" in clause
         assert "new" in params
 
@@ -370,6 +377,7 @@ class TestGenerateExcelContent:
 
         wb = load_workbook(io.BytesIO(content))
         ws = wb.active
+        assert ws is not None
         assert ws.title == "Positions"
         # Header row
         assert ws.cell(1, 1).value == "symbol"
@@ -430,6 +438,7 @@ class TestGenerateExcelContent:
 
         wb = load_workbook(io.BytesIO(content))
         ws = wb.active
+        assert ws is not None
         # Only requested (valid) columns appear
         assert ws.cell(1, 1).value == "symbol"
         assert ws.cell(1, 2).value == "side"
@@ -508,6 +517,7 @@ class TestGenerateExcelContent:
 
         wb = load_workbook(io.BytesIO(content))
         ws = wb.active
+        assert ws is not None
         # The dangerous formula should be prefixed with '
         assert ws.cell(2, 1).value == "'=IMPORTDATA(url)"
 
@@ -548,6 +558,7 @@ class TestGenerateExcelContent:
 
         wb = load_workbook(io.BytesIO(content))
         ws = wb.active
+        assert ws is not None
         # String column stays string
         assert ws.cell(2, 1).value == "AAPL"
         # Numeric columns must NOT be stringified — openpyxl stores Decimal
@@ -646,11 +657,20 @@ class TestGenerateExcelContent:
             sort_model=None,
         )
 
-        # Verify the SQL was executed with pending status filter
+        # Verify the SQL was executed with pending status filter.
+        # The query is a psycopg.sql.Composed object; use as_string()
+        # with no argument (psycopg3 supports it for non-adaptive SQL).
         cursor_mock = ctx.db.transaction().__enter__().cursor().__enter__()
         call_args = cursor_mock.execute.call_args
-        sql = call_args[0][0]
-        assert "status = ANY" in sql
+        query_obj = call_args[0][0]
+        # psycopg.sql.Composed.as_string() can accept None for basic SQL
+        from psycopg.sql import Composable
+
+        if isinstance(query_obj, Composable):
+            sql_str = query_obj.as_string(None)
+        else:
+            sql_str = str(query_obj)
+        assert "status = ANY" in sql_str
 
     async def test_audit_row_count_matches_data(self) -> None:
         """Verify row_count reflects actual exported rows, not a placeholder."""
@@ -715,6 +735,7 @@ class TestGenerateExcelContent:
 
         wb = load_workbook(io.BytesIO(content))
         ws = wb.active
+        assert ws is not None
         # 'status' column should be present in the header
         assert ws.cell(1, 2).value == "status"
         # Value should be the synthesized 'filled'
@@ -778,6 +799,7 @@ class TestGenerateExcelContent:
 
         wb = load_workbook(io.BytesIO(content))
         ws = wb.active
+        assert ws is not None
         assert ws.cell(2, 1).value == "AAPL"
         assert ws.cell(3, 1).value == "MSFT"
         assert ws.cell(4, 1).value is None  # No third data row

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -1,0 +1,231 @@
+"""Tests for Excel export in apps/execution_gateway/routes/export.py.
+
+Verifies that _generate_excel_content returns real grid data (not placeholders)
+and that all cell values are sanitised against formula injection.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from apps.execution_gateway.app_factory import create_mock_context, create_test_config
+from apps.execution_gateway.dependencies import get_config, get_context
+from apps.execution_gateway.routes import export as export_module
+from apps.execution_gateway.routes.export import (
+    _GRID_COLUMNS,
+    _build_order_clause,
+    _validate_columns,
+)
+from libs.core.common.api_auth_dependency import AuthContext
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestValidateColumns:
+    def test_returns_allowlist_when_no_visible_columns(self) -> None:
+        result = _validate_columns("positions", None)
+        assert result == _GRID_COLUMNS["positions"]
+
+    def test_filters_unknown_columns(self) -> None:
+        result = _validate_columns("positions", ["symbol", "EVIL_COL", "qty"])
+        assert result == ["symbol", "qty"]
+
+    def test_preserves_requested_order(self) -> None:
+        result = _validate_columns("orders", ["status", "symbol", "side"])
+        assert result == ["status", "symbol", "side"]
+
+    def test_falls_back_to_default_when_all_invalid(self) -> None:
+        result = _validate_columns("fills", ["bad1", "bad2"])
+        assert result == _GRID_COLUMNS["fills"]
+
+
+class TestBuildOrderClause:
+    def test_default_order_when_no_sort_model(self) -> None:
+        assert _build_order_clause(None, ["symbol"], "symbol ASC") == "symbol ASC"
+
+    def test_valid_sort_model(self) -> None:
+        model = [{"colId": "symbol", "sort": "desc"}]
+        result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
+        assert result == "symbol DESC"
+
+    def test_ignores_unknown_columns(self) -> None:
+        model = [{"colId": "DROP TABLE", "sort": "asc"}]
+        result = _build_order_clause(model, ["symbol"], "symbol ASC")
+        assert result == "symbol ASC"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for _generate_excel_content
+# ---------------------------------------------------------------------------
+
+
+def _make_cursor_mock(rows: list[tuple[Any, ...]], col_names: list[str]) -> MagicMock:
+    """Create a mock cursor that returns the given rows."""
+    cursor = MagicMock()
+    cursor.description = [(name,) for name in col_names]
+    cursor.fetchall.return_value = rows
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    return cursor
+
+
+def _make_conn_mock(cursor: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+def _make_ctx_with_rows(
+    rows: list[tuple[Any, ...]], col_names: list[str]
+) -> MagicMock:
+    cursor = _make_cursor_mock(rows, col_names)
+    conn = _make_conn_mock(cursor)
+    ctx = create_mock_context()
+    ctx.db.transaction.return_value = conn
+    return ctx
+
+
+@pytest.mark.asyncio
+class TestGenerateExcelContent:
+    async def test_positions_returns_real_data(self) -> None:
+        rows = [
+            ("AAPL", Decimal("10"), Decimal("150.25"), Decimal("152.00"), Decimal("17.50"), Decimal("0"), datetime(2026, 1, 1, tzinfo=UTC)),
+            ("MSFT", Decimal("5"), Decimal("400.00"), Decimal("405.00"), Decimal("25.00"), Decimal("10"), datetime(2026, 1, 2, tzinfo=UTC)),
+        ]
+        col_names = ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        assert row_count == 2
+        assert isinstance(content, bytes)
+        assert len(content) > 0
+
+        # Verify it's a valid Excel file by reading it
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        assert ws.title == "Positions"
+        # Header row
+        assert ws.cell(1, 1).value == "symbol"
+        # Data — NOT placeholder text
+        assert ws.cell(2, 1).value == "AAPL"
+        assert ws.cell(3, 1).value == "MSFT"
+        assert "placeholder" not in str(ws.cell(2, 1).value).lower()
+        assert "pending" not in str(ws.cell(2, 1).value).lower()
+
+    async def test_orders_returns_real_data(self) -> None:
+        rows = [
+            ("ord-1", "alpha", "AAPL", "buy", 10, "market", None, None, "day", "filled", Decimal("10"), Decimal("150"), datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 1, 0, 1, tzinfo=UTC)),
+        ]
+        col_names = ["client_order_id", "strategy_id", "symbol", "side", "qty", "order_type", "limit_price", "stop_price", "time_in_force", "status", "filled_qty", "filled_avg_price", "created_at", "filled_at"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="orders",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=["symbol", "side", "qty", "status"],
+            sort_model=None,
+        )
+
+        assert row_count == 1
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # Only requested (valid) columns appear
+        assert ws.cell(1, 1).value == "symbol"
+        assert ws.cell(1, 2).value == "side"
+
+    async def test_unsupported_grid_raises(self) -> None:
+        ctx = create_mock_context()
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            await export_module._generate_excel_content(
+                ctx=ctx,
+                grid_name="unknown_grid",
+                strategy_ids=["alpha"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+
+    async def test_empty_result_returns_zero_row_count(self) -> None:
+        ctx = _make_ctx_with_rows([], ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"])
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        assert row_count == 0
+
+    async def test_formula_injection_sanitised(self) -> None:
+        """Values starting with = are prefixed with ' to prevent formula injection."""
+        rows = [("=IMPORTDATA(url)", Decimal("1"), Decimal("1"), Decimal("1"), Decimal("0"), Decimal("0"), datetime(2026, 1, 1, tzinfo=UTC))]
+        col_names = ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, _ = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # The dangerous formula should be prefixed with '
+        assert ws.cell(2, 1).value == "'=IMPORTDATA(url)"
+
+    async def test_audit_row_count_matches_data(self) -> None:
+        """Verify row_count reflects actual exported rows, not a placeholder."""
+        rows = [
+            (1, datetime(2026, 1, 1, tzinfo=UTC), "admin", "login", "{}", None),
+            (2, datetime(2026, 1, 2, tzinfo=UTC), "admin", "export", "{}", "test"),
+            (3, datetime(2026, 1, 3, tzinfo=UTC), "admin", "logout", "{}", None),
+        ]
+        col_names = ["id", "timestamp", "user_id", "action", "details", "reason"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        _, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="audit",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        assert row_count == 3

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -168,6 +168,19 @@ class TestBuildFilterClauses:
         assert "2026-01-01" in params
         assert "2026-02-01" in params
 
+    def test_date_greater_than_uses_strict_gt(self) -> None:
+        """greaterThan date filter should use strict '>' not '>='."""
+        filt = {
+            "executed_at": {
+                "filterType": "date",
+                "type": "greaterThan",
+                "dateFrom": "2026-01-01",
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["executed_at"])
+        assert "> %s" in clause
+        assert ">=" not in clause
+
 
 # ---------------------------------------------------------------------------
 # Integration tests for _generate_excel_content

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -235,6 +235,45 @@ class TestBuildFilterClauses:
         assert "AAPL" in params
         assert "MSFT" in params
 
+    def test_compound_number_equals_not_misrouted_as_text(self) -> None:
+        """Compound number filter with 'equals' children must use number path."""
+        filt: dict[str, Any] = {
+            "qty": {
+                "filterType": "number",
+                "operator": "AND",
+                "conditions": [
+                    {"type": "greaterThan", "filter": 5},
+                    {"type": "equals", "filter": 10},
+                ],
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["qty"])
+        # Both conditions should use numeric operators
+        assert "> %s" in clause
+        assert "= %s" in clause
+        assert 5 in params
+        assert 10 in params
+        # Must NOT use ILIKE (text path) for the equals condition
+        assert "ILIKE" not in clause
+
+    def test_compound_date_equals_not_misrouted_as_text(self) -> None:
+        """Compound date filter with 'equals' child must use date path."""
+        filt: dict[str, Any] = {
+            "executed_at": {
+                "filterType": "date",
+                "operator": "AND",
+                "conditions": [
+                    {"type": "equals", "dateFrom": "2026-01-15"},
+                    {"type": "greaterThan", "dateFrom": "2026-01-01"},
+                ],
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["executed_at"])
+        # The equals condition should use the date path (::date cast)
+        assert "::date = %s::date" in clause
+        assert "2026-01-15" in params
+        assert "2026-01-01" in params
+
     def test_filter_on_hidden_column_applied(self) -> None:
         """Filters on columns not in the projected set should still apply."""
         filt: dict[str, Any] = {

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -18,6 +18,7 @@ from apps.execution_gateway.app_factory import create_mock_context
 from apps.execution_gateway.routes import export as export_module
 from apps.execution_gateway.routes.export import (
     _GRID_COLUMNS,
+    _build_filter_clauses,
     _build_order_clause,
     _validate_columns,
 )
@@ -70,6 +71,61 @@ class TestBuildOrderClause:
         assert result == "symbol ASC"
 
 
+class TestBuildFilterClauses:
+    def test_none_filter_returns_empty(self) -> None:
+        clause, params = _build_filter_clauses(None, ["symbol"])
+        assert clause == ""
+        assert params == []
+
+    def test_text_contains_filter(self) -> None:
+        filt = {"symbol": {"filterType": "text", "type": "contains", "filter": "AA"}}
+        clause, params = _build_filter_clauses(filt, ["symbol"])
+        assert "ILIKE" in clause
+        assert "%AA%" in params
+
+    def test_text_equals_filter(self) -> None:
+        filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
+        clause, params = _build_filter_clauses(filt, ["symbol"])
+        assert "= %s" in clause
+        assert "AAPL" in params
+
+    def test_number_filter(self) -> None:
+        filt = {"qty": {"filterType": "number", "type": "greaterThan", "filter": 100}}
+        clause, params = _build_filter_clauses(filt, ["qty"])
+        assert "> %s" in clause
+        assert 100 in params
+
+    def test_set_filter(self) -> None:
+        filt = {"status": {"filterType": "set", "values": ["new", "filled"]}}
+        clause, params = _build_filter_clauses(filt, ["status"])
+        assert "ANY" in clause
+        assert ["new", "filled"] in params
+
+    def test_unknown_column_ignored(self) -> None:
+        filt = {"evil_col": {"filterType": "text", "type": "equals", "filter": "x"}}
+        clause, params = _build_filter_clauses(filt, ["symbol"])
+        assert clause == ""
+        assert params == []
+
+    def test_col_prefix_applied(self) -> None:
+        filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
+        clause, params = _build_filter_clauses(filt, ["symbol"], col_prefix="t.")
+        assert "t.symbol" in clause
+
+    def test_date_in_range_filter(self) -> None:
+        filt = {
+            "executed_at": {
+                "filterType": "date",
+                "type": "inRange",
+                "dateFrom": "2026-01-01",
+                "dateTo": "2026-02-01",
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["executed_at"])
+        assert "2026-01-01" in params
+        assert "2026-02-01" in params
+
+
 # ---------------------------------------------------------------------------
 # Integration tests for _generate_excel_content
 # ---------------------------------------------------------------------------
@@ -93,9 +149,7 @@ def _make_conn_mock(cursor: MagicMock) -> MagicMock:
     return conn
 
 
-def _make_ctx_with_rows(
-    rows: list[tuple[Any, ...]], col_names: list[str]
-) -> MagicMock:
+def _make_ctx_with_rows(rows: list[tuple[Any, ...]], col_names: list[str]) -> MagicMock:
     cursor = _make_cursor_mock(rows, col_names)
     conn = _make_conn_mock(cursor)
     ctx = create_mock_context()
@@ -107,10 +161,34 @@ def _make_ctx_with_rows(
 class TestGenerateExcelContent:
     async def test_positions_returns_real_data(self) -> None:
         rows = [
-            ("AAPL", Decimal("10"), Decimal("150.25"), Decimal("152.00"), Decimal("17.50"), Decimal("0"), datetime(2026, 1, 1, tzinfo=UTC)),
-            ("MSFT", Decimal("5"), Decimal("400.00"), Decimal("405.00"), Decimal("25.00"), Decimal("10"), datetime(2026, 1, 2, tzinfo=UTC)),
+            (
+                "AAPL",
+                Decimal("10"),
+                Decimal("150.25"),
+                Decimal("152.00"),
+                Decimal("17.50"),
+                Decimal("0"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+            (
+                "MSFT",
+                Decimal("5"),
+                Decimal("400.00"),
+                Decimal("405.00"),
+                Decimal("25.00"),
+                Decimal("10"),
+                datetime(2026, 1, 2, tzinfo=UTC),
+            ),
         ]
-        col_names = ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"]
+        col_names = [
+            "symbol",
+            "qty",
+            "avg_entry_price",
+            "current_price",
+            "unrealized_pl",
+            "realized_pl",
+            "updated_at",
+        ]
         ctx = _make_ctx_with_rows(rows, col_names)
 
         content, row_count = await export_module._generate_excel_content(
@@ -142,9 +220,39 @@ class TestGenerateExcelContent:
 
     async def test_orders_returns_real_data(self) -> None:
         rows = [
-            ("ord-1", "alpha", "AAPL", "buy", 10, "market", None, None, "day", "filled", Decimal("10"), Decimal("150"), datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 1, 0, 1, tzinfo=UTC)),
+            (
+                "ord-1",
+                "alpha",
+                "AAPL",
+                "buy",
+                10,
+                "market",
+                None,
+                None,
+                "day",
+                "filled",
+                Decimal("10"),
+                Decimal("150"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+                datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+            ),
         ]
-        col_names = ["client_order_id", "strategy_id", "symbol", "side", "qty", "order_type", "limit_price", "stop_price", "time_in_force", "status", "filled_qty", "filled_avg_price", "created_at", "filled_at"]
+        col_names = [
+            "client_order_id",
+            "strategy_id",
+            "symbol",
+            "side",
+            "qty",
+            "order_type",
+            "limit_price",
+            "stop_price",
+            "time_in_force",
+            "status",
+            "filled_qty",
+            "filled_avg_price",
+            "created_at",
+            "filled_at",
+        ]
         ctx = _make_ctx_with_rows(rows, col_names)
 
         content, row_count = await export_module._generate_excel_content(
@@ -178,7 +286,18 @@ class TestGenerateExcelContent:
             )
 
     async def test_empty_result_returns_zero_row_count(self) -> None:
-        ctx = _make_ctx_with_rows([], ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"])
+        ctx = _make_ctx_with_rows(
+            [],
+            [
+                "symbol",
+                "qty",
+                "avg_entry_price",
+                "current_price",
+                "unrealized_pl",
+                "realized_pl",
+                "updated_at",
+            ],
+        )
 
         content, row_count = await export_module._generate_excel_content(
             ctx=ctx,
@@ -193,8 +312,26 @@ class TestGenerateExcelContent:
 
     async def test_formula_injection_sanitised(self) -> None:
         """Values starting with = are prefixed with ' to prevent formula injection."""
-        rows = [("=IMPORTDATA(url)", Decimal("1"), Decimal("1"), Decimal("1"), Decimal("0"), Decimal("0"), datetime(2026, 1, 1, tzinfo=UTC))]
-        col_names = ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"]
+        rows = [
+            (
+                "=IMPORTDATA(url)",
+                Decimal("1"),
+                Decimal("1"),
+                Decimal("1"),
+                Decimal("0"),
+                Decimal("0"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        ]
+        col_names = [
+            "symbol",
+            "qty",
+            "avg_entry_price",
+            "current_price",
+            "unrealized_pl",
+            "realized_pl",
+            "updated_at",
+        ]
         ctx = _make_ctx_with_rows(rows, col_names)
 
         content, _ = await export_module._generate_excel_content(
@@ -227,8 +364,13 @@ class TestGenerateExcelContent:
             ),
         ]
         col_names = [
-            "symbol", "qty", "avg_entry_price", "current_price",
-            "unrealized_pl", "realized_pl", "updated_at",
+            "symbol",
+            "qty",
+            "avg_entry_price",
+            "current_price",
+            "unrealized_pl",
+            "realized_pl",
+            "updated_at",
         ]
         ctx = _make_ctx_with_rows(rows, col_names)
 
@@ -253,9 +395,101 @@ class TestGenerateExcelContent:
         assert not isinstance(qty_val, str), f"qty should be numeric, got str: {qty_val!r}"
         # datetime should be preserved as a datetime
         updated_val = ws.cell(2, 7).value
-        assert not isinstance(updated_val, str), (
-            f"updated_at should be datetime, got str: {updated_val!r}"
+        assert not isinstance(
+            updated_val, str
+        ), f"updated_at should be datetime, got str: {updated_val!r}"
+
+    async def test_filter_params_passed_to_fetcher(self) -> None:
+        """Verify filter_params are resolved and forwarded to the fetcher."""
+        rows = [
+            (
+                "AAPL",
+                Decimal("10"),
+                Decimal("150.25"),
+                Decimal("152.00"),
+                Decimal("17.50"),
+                Decimal("0"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ]
+        col_names = [
+            "symbol",
+            "qty",
+            "avg_entry_price",
+            "current_price",
+            "unrealized_pl",
+            "realized_pl",
+            "updated_at",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        # Provide a text filter on symbol
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params={"symbol": {"filterType": "text", "type": "contains", "filter": "AA"}},
+            visible_columns=None,
+            sort_model=None,
         )
+
+        # The SQL query should have been executed with the filter params
+        # We verify that the call succeeded and returned data
+        assert row_count == 1
+        assert isinstance(content, bytes)
+
+    async def test_orders_export_filters_pending_statuses(self) -> None:
+        """Verify that orders export includes the pending-status filter."""
+        rows = [
+            (
+                "ord-1",
+                "alpha",
+                "AAPL",
+                "buy",
+                10,
+                "market",
+                None,
+                None,
+                "day",
+                "new",
+                Decimal("0"),
+                None,
+                datetime(2026, 1, 1, tzinfo=UTC),
+                None,
+            ),
+        ]
+        col_names = [
+            "client_order_id",
+            "strategy_id",
+            "symbol",
+            "side",
+            "qty",
+            "order_type",
+            "limit_price",
+            "stop_price",
+            "time_in_force",
+            "status",
+            "filled_qty",
+            "filled_avg_price",
+            "created_at",
+            "filled_at",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="orders",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        # Verify the SQL was executed with pending status filter
+        cursor_mock = ctx.db.transaction().__enter__().cursor().__enter__()
+        call_args = cursor_mock.execute.call_args
+        sql = call_args[0][0]
+        assert "status = ANY" in sql
 
     async def test_audit_row_count_matches_data(self) -> None:
         """Verify row_count reflects actual exported rows, not a placeholder."""

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -44,6 +44,16 @@ class TestValidateColumns:
         result = _validate_columns("fills", ["bad1", "bad2"])
         assert result == _GRID_COLUMNS["fills"]
 
+    def test_resolves_frontend_column_aliases(self) -> None:
+        """Frontend alias "time" is resolved to "executed_at" for fills."""
+        result = _validate_columns("fills", ["time", "symbol", "qty"])
+        assert result == ["executed_at", "symbol", "qty"]
+
+    def test_resolves_orders_type_alias(self) -> None:
+        """Frontend alias "type" is resolved to "order_type" for orders."""
+        result = _validate_columns("orders", ["symbol", "type", "status"])
+        assert result == ["symbol", "order_type", "status"]
+
 
 class TestBuildOrderClause:
     def test_default_order_when_no_sort_model(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -181,6 +181,52 @@ class TestBuildFilterClauses:
         assert "> %s" in clause
         assert ">=" not in clause
 
+    def test_compound_and_filter(self) -> None:
+        """AG Grid compound AND filter with conditions array."""
+        filt: dict[str, Any] = {
+            "symbol": {
+                "filterType": "text",
+                "operator": "AND",
+                "conditions": [
+                    {"type": "contains", "filter": "A"},
+                    {"type": "startsWith", "filter": "AA"},
+                ],
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["symbol"])
+        assert "AND" in clause
+        assert "%A%" in params
+        assert "AA%" in params
+
+    def test_compound_or_filter(self) -> None:
+        """AG Grid compound OR filter with conditions array."""
+        filt: dict[str, Any] = {
+            "symbol": {
+                "filterType": "text",
+                "operator": "OR",
+                "conditions": [
+                    {"type": "equals", "filter": "AAPL"},
+                    {"type": "equals", "filter": "MSFT"},
+                ],
+            }
+        }
+        clause, params = _build_filter_clauses(filt, ["symbol"])
+        assert "OR" in clause
+        assert "AAPL" in params
+        assert "MSFT" in params
+
+    def test_filter_on_hidden_column_applied(self) -> None:
+        """Filters on columns not in the projected set should still apply."""
+        filt: dict[str, Any] = {
+            "status": {"filterType": "text", "type": "equals", "filter": "new"}
+        }
+        # 'status' is not in projected columns, but is in filterable_columns
+        clause, params = _build_filter_clauses(
+            filt, ["symbol", "qty", "status"]
+        )
+        assert "status" in clause
+        assert "new" in params
+
 
 # ---------------------------------------------------------------------------
 # Integration tests for _generate_excel_content

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -7,26 +7,20 @@ and that all cell values are sanitised against formula injection.
 from __future__ import annotations
 
 import io
-import json
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI, Request
-from fastapi.testclient import TestClient
 
-from apps.execution_gateway.app_factory import create_mock_context, create_test_config
-from apps.execution_gateway.dependencies import get_config, get_context
+from apps.execution_gateway.app_factory import create_mock_context
 from apps.execution_gateway.routes import export as export_module
 from apps.execution_gateway.routes.export import (
     _GRID_COLUMNS,
     _build_order_clause,
     _validate_columns,
 )
-from libs.core.common.api_auth_dependency import AuthContext
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for helper functions
@@ -99,7 +93,7 @@ def _make_ctx_with_rows(
     return ctx
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestGenerateExcelContent:
     async def test_positions_returns_real_data(self) -> None:
         rows = [
@@ -208,6 +202,50 @@ class TestGenerateExcelContent:
         ws = wb.active
         # The dangerous formula should be prefixed with '
         assert ws.cell(2, 1).value == "'=IMPORTDATA(url)"
+
+    async def test_numeric_types_preserved_in_excel(self) -> None:
+        """Numeric and datetime values are stored as native types, not strings."""
+        rows = [
+            (
+                "AAPL",
+                Decimal("10"),
+                Decimal("150.25"),
+                Decimal("152.00"),
+                Decimal("17.50"),
+                Decimal("0"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ]
+        col_names = [
+            "symbol", "qty", "avg_entry_price", "current_price",
+            "unrealized_pl", "realized_pl", "updated_at",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, _ = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # String column stays string
+        assert ws.cell(2, 1).value == "AAPL"
+        # Numeric columns must NOT be stringified — openpyxl stores Decimal
+        # as a number, so the cell value should be numeric (not a string).
+        qty_val = ws.cell(2, 2).value
+        assert not isinstance(qty_val, str), f"qty should be numeric, got str: {qty_val!r}"
+        # datetime should be preserved as a datetime
+        updated_val = ws.cell(2, 7).value
+        assert not isinstance(updated_val, str), (
+            f"updated_at should be datetime, got str: {updated_val!r}"
+        )
 
     async def test_audit_row_count_matches_data(self) -> None:
         """Verify row_count reflects actual exported rows, not a placeholder."""

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -148,6 +148,13 @@ class TestBuildFilterClauses:
         assert "action ILIKE" in clause
         assert "::text" not in clause
 
+    def test_malformed_filter_spec_ignored(self) -> None:
+        """Non-dict filter specs should be silently skipped, not raise."""
+        filt: dict[str, Any] = {"symbol": "AAPL"}  # bare string, not a dict spec
+        clause, params = _build_filter_clauses(filt, ["symbol"])
+        assert clause == ""
+        assert params == []
+
     def test_date_in_range_filter(self) -> None:
         filt = {
             "executed_at": {
@@ -547,3 +554,50 @@ class TestGenerateExcelContent:
         )
 
         assert row_count == 3
+
+    async def test_fills_status_column_synthesized(self) -> None:
+        """Fills export should synthesize 'status' as 'filled' since all trades are fills."""
+        rows = [
+            (
+                "fill-1",
+                "ord-1",
+                "alpha",
+                "AAPL",
+                "buy",
+                Decimal("10"),
+                Decimal("150.25"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+                "filled",
+            ),
+        ]
+        col_names = [
+            "trade_id",
+            "client_order_id",
+            "strategy_id",
+            "symbol",
+            "side",
+            "qty",
+            "price",
+            "executed_at",
+            "status",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="fills",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=["symbol", "status", "qty"],
+            sort_model=None,
+        )
+
+        assert row_count == 1
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # 'status' column should be present in the header
+        assert ws.cell(1, 2).value == "status"
+        # Value should be the synthesized 'filled'
+        assert ws.cell(2, 2).value == "filled"


### PR DESCRIPTION
## Summary
- Implements per-grid data fetchers (`positions`, `orders`, `fills`, `audit`, `tca`) in `_generate_excel_content()` so the Excel export endpoint returns actual database rows instead of placeholder content
- Adds server-side column allowlists per grid to prevent data leakage — only approved columns can be exported
- Validates and sanitises all cell values via `sanitize_for_export()` to prevent formula injection
- Adds sort-model support for AG Grid ordering and a 10k row export cap
- Fixes `actual_row_count` in audit records to reflect real exported rows, not a hardcoded `1`

Closes #151

## Test plan
- [x] 13 new unit tests covering column validation, sort-model building, real data export for positions/orders/audit, empty results, formula injection sanitisation, and row count accuracy
- [x] All 332 existing route tests pass (no regressions)
- [x] Ruff lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)