### PR TITLE
Fix #163: route severity=page alerts to PagerDuty

### DIFF
--- a/docs/GETTING_STARTED/REPO_MAP.md
+++ b/docs/GETTING_STARTED/REPO_MAP.md
@@ -894,5 +894,5 @@ make kill-switch # Emergency stop
 ---
 
 **Document Version:** 2.3 (AI Context Optimization — cross-platform skills & context)
-**Last Updated:** 2026-03-02
+**Last Updated:** 2026-04-06
 **Maintained By:** Development Team

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -1,7 +1,8 @@
 # Alertmanager Configuration for Trading Platform
 #
 # Routes alerts from Prometheus to notification channels:
-# - Critical alerts -> PagerDuty
+# - Page alerts -> PagerDuty (mapped to critical) + Slack
+# - Critical alerts -> PagerDuty + Slack
 # - Warning alerts -> Slack #alerts-ops
 #
 # Environment variables required:
@@ -42,13 +43,13 @@ route:
     - match:
         severity: page
       receiver: 'pagerduty-platform'
-      continue: true  # Also send to default (Slack)
+      continue: true  # Continue to catch-all Slack route below
 
     # Critical alerts -> PagerDuty + Slack
     - match:
         severity: critical
       receiver: 'pagerduty-platform'
-      continue: true  # Also send to default (Slack)
+      continue: true  # Continue to catch-all Slack route below
 
     # Track 7 SLA alerts
     - match:
@@ -63,6 +64,9 @@ route:
         - match:
             severity: warning
           receiver: 'slack-ops'
+
+    # Catch-all: ensures alerts with continue=true also reach Slack
+    - receiver: 'slack-ops'
 
 # Notification receivers
 receivers:

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -47,11 +47,11 @@ route:
       group_wait: 15s
       group_interval: 1m
       routes:
-        - match:
-            severity: critical
+        - match_re:
+            severity: ^(critical|page)$
           receiver: 'pagerduty-platform'
-          continue: true  # Also send critical to Slack below
-        - receiver: 'slack-ops'  # Catches page/critical (via continue) and warning
+          continue: true  # Also send critical/page to Slack below
+        - receiver: 'slack-ops'  # Catches critical/page (via continue) and warning
 
     # Page alerts -> PagerDuty + Slack
     - match:

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -38,6 +38,12 @@ route:
 
   # Child routes for severity-based routing
   routes:
+    # Page alerts -> PagerDuty + Slack
+    - match:
+        severity: page
+      receiver: 'pagerduty-platform'
+      continue: true  # Also send to default (Slack)
+
     # Critical alerts -> PagerDuty + Slack
     - match:
         severity: critical
@@ -87,7 +93,7 @@ receivers:
     pagerduty_configs:
       - service_key: '${PAGERDUTY_SERVICE_KEY}'
         send_resolved: true
-        severity: '{{ .CommonLabels.severity }}'
+        severity: '{{ if eq .CommonLabels.severity "page" }}critical{{ else }}{{ .CommonLabels.severity }}{{ end }}'
         description: '{{ .CommonAnnotations.summary }}'
         details:
           firing: '{{ template "pagerduty.default.instances" .Alerts.Firing }}'

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -51,12 +51,15 @@ route:
       receiver: 'pagerduty-platform'
       continue: true  # Continue to catch-all Slack route below
 
-    # Track 7 SLA alerts
+    # Track 7 SLA alerts (continue to catch-all for Slack delivery)
+    # Note: critical track7 alerts may also match the severity=critical
+    # route above; PagerDuty deduplicates via dedup_key so this is safe.
     - match:
         sla: track7
       group_by: ['alertname']
       group_wait: 15s
       group_interval: 1m
+      continue: true  # Continue to catch-all Slack route below
       routes:
         - match:
             severity: critical

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -52,7 +52,7 @@ route:
       continue: true  # Continue to catch-all Slack route below
 
     # Track 7 SLA alerts — handled entirely within sub-routes
-    # (no continue: child routes already deliver to PagerDuty and Slack)
+    # (no continue on parent: avoids duplicate Slack for warnings)
     - match:
         sla: track7
       group_by: ['alertname']
@@ -62,9 +62,8 @@ route:
         - match:
             severity: critical
           receiver: 'pagerduty-platform'
-        - match:
-            severity: warning
-          receiver: 'slack-ops'
+          continue: true  # Also send critical to Slack below
+        - receiver: 'slack-ops'  # Catches critical (via continue) and warning
 
     # Catch-all: ensures alerts with continue=true also reach Slack
     - receiver: 'slack-ops'

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -37,8 +37,22 @@ route:
   # Group alerts by these labels
   group_by: ['alertname', 'severity', 'team']
 
-  # Child routes for severity-based routing
+  # Child routes for alert routing
   routes:
+    # Track 7 SLA alerts — matched first to avoid duplicate PagerDuty
+    # when alerts carry both sla=track7 and severity=critical/page.
+    - match:
+        sla: track7
+      group_by: ['alertname']
+      group_wait: 15s
+      group_interval: 1m
+      routes:
+        - match:
+            severity: critical
+          receiver: 'pagerduty-platform'
+          continue: true  # Also send critical to Slack below
+        - receiver: 'slack-ops'  # Catches page/critical (via continue) and warning
+
     # Page alerts -> PagerDuty + Slack
     - match:
         severity: page
@@ -50,20 +64,6 @@ route:
         severity: critical
       receiver: 'pagerduty-platform'
       continue: true  # Continue to catch-all Slack route below
-
-    # Track 7 SLA alerts — handled entirely within sub-routes
-    # (no continue on parent: avoids duplicate Slack for warnings)
-    - match:
-        sla: track7
-      group_by: ['alertname']
-      group_wait: 15s
-      group_interval: 1m
-      routes:
-        - match:
-            severity: critical
-          receiver: 'pagerduty-platform'
-          continue: true  # Also send critical to Slack below
-        - receiver: 'slack-ops'  # Catches critical (via continue) and warning
 
     # Catch-all: ensures alerts with continue=true also reach Slack
     - receiver: 'slack-ops'

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -91,7 +91,7 @@ receivers:
     pagerduty_configs:
       - service_key: '${PAGERDUTY_SERVICE_KEY}'
         send_resolved: true
-        severity: '{{ if eq .CommonLabels.severity "page" }}critical{{ else }}{{ .CommonLabels.severity }}{{ end }}'
+        severity: '{{ if eq (index .Alerts 0).Labels.severity "page" }}critical{{ else }}{{ (index .Alerts 0).Labels.severity }}{{ end }}'
         description: '{{ .CommonAnnotations.summary }}'
         details:
           firing: '{{ template "pagerduty.default.instances" .Alerts.Firing }}'

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -51,15 +51,13 @@ route:
       receiver: 'pagerduty-platform'
       continue: true  # Continue to catch-all Slack route below
 
-    # Track 7 SLA alerts (continue to catch-all for Slack delivery)
-    # Note: critical track7 alerts may also match the severity=critical
-    # route above; PagerDuty deduplicates via dedup_key so this is safe.
+    # Track 7 SLA alerts — handled entirely within sub-routes
+    # (no continue: child routes already deliver to PagerDuty and Slack)
     - match:
         sla: track7
       group_by: ['alertname']
       group_wait: 15s
       group_interval: 1m
-      continue: true  # Continue to catch-all Slack route below
       routes:
         - match:
             severity: critical

--- a/infra/alertmanager/config.yml
+++ b/infra/alertmanager/config.yml
@@ -53,15 +53,9 @@ route:
           continue: true  # Also send critical/page to Slack below
         - receiver: 'slack-ops'  # Catches critical/page (via continue) and warning
 
-    # Page alerts -> PagerDuty + Slack
-    - match:
-        severity: page
-      receiver: 'pagerduty-platform'
-      continue: true  # Continue to catch-all Slack route below
-
-    # Critical alerts -> PagerDuty + Slack
-    - match:
-        severity: critical
+    # Page and critical alerts -> PagerDuty + Slack
+    - match_re:
+        severity: ^(critical|page)$
       receiver: 'pagerduty-platform'
       continue: true  # Continue to catch-all Slack route below
 

--- a/infra/prometheus/alerts/track7_sla.yml
+++ b/infra/prometheus/alerts/track7_sla.yml
@@ -69,11 +69,12 @@ groups:
           runbook: "https://docs.trading-platform.local/RUNBOOKS/ops.md"
 
       # Poison Queue Size (SLA: 0, Alert > 10)
+      # Synchronized with alert_delivery.yml — both use severity: page, for: 1m
       - alert: AlertPoisonQueueHigh
         expr: alert_poison_queue_size > 10
-        for: 5m
+        for: 1m
         labels:
-          severity: critical
+          severity: page
           team: platform
           sla: track7
         annotations:

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -225,8 +225,8 @@ class TestAlertmanagerConfig:
         pagerduty_config = pagerduty_receiver["pagerduty_configs"][0]
         severity_template = pagerduty_config["severity"]
         expected_template = (
-            '{{ if eq .CommonLabels.severity "page" }}critical'
-            "{{ else }}{{ .CommonLabels.severity }}{{ end }}"
+            '{{ if eq (index .Alerts 0).Labels.severity "page" }}critical'
+            "{{ else }}{{ (index .Alerts 0).Labels.severity }}{{ end }}"
         )
         assert severity_template == expected_template
 

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -181,7 +181,7 @@ class TestAlertmanagerConfig:
 
         assert track7_route is not None, "track7 SLA route not found"
 
-    def test_page_routing_exists(self, alertmanager_config):
+    def test_page_routing_exists(self, alertmanager_config: dict) -> None:
         """Verify severity=page alerts route to PagerDuty and reach Slack."""
         routes = alertmanager_config["route"].get("routes", [])
         page_route = next(
@@ -205,7 +205,7 @@ class TestAlertmanagerConfig:
             slack_catchall is not None
         ), "catch-all slack-ops route must follow page route for dual-delivery"
 
-    def test_pagerduty_maps_page_to_critical(self, alertmanager_config):
+    def test_pagerduty_maps_page_to_critical(self, alertmanager_config: dict) -> None:
         """Verify PagerDuty severity normalizes page alerts to critical."""
         pagerduty_receiver = next(
             (r for r in alertmanager_config["receivers"] if r.get("name") == "pagerduty-platform"),

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -182,32 +182,44 @@ class TestAlertmanagerConfig:
         assert track7_route is not None, "track7 SLA route not found"
 
     def test_page_routing_exists(self, alertmanager_config):
-        """Verify severity=page alerts route to PagerDuty."""
+        """Verify severity=page alerts route to PagerDuty and reach Slack."""
         routes = alertmanager_config["route"].get("routes", [])
-        page_route = None
-        for route in routes:
-            match = route.get("match", {})
-            if match.get("severity") == "page":
-                page_route = route
-                break
+        page_route = next(
+            (r for r in routes if r.get("match", {}).get("severity") == "page"),
+            None,
+        )
 
         assert page_route is not None, "severity=page route not found"
         assert page_route.get("receiver") == "pagerduty-platform"
         assert page_route.get("continue") is True
 
+        # Verify a catch-all Slack route exists after the page route so
+        # alerts with continue=true are also delivered to Slack.
+        page_idx = routes.index(page_route)
+        remaining = routes[page_idx + 1 :]
+        slack_catchall = next(
+            (r for r in remaining if r.get("receiver") == "slack-ops" and "match" not in r),
+            None,
+        )
+        assert (
+            slack_catchall is not None
+        ), "catch-all slack-ops route must follow page route for dual-delivery"
+
     def test_pagerduty_maps_page_to_critical(self, alertmanager_config):
         """Verify PagerDuty severity normalizes page alerts to critical."""
-        pagerduty_receiver = None
-        for receiver in alertmanager_config["receivers"]:
-            if receiver.get("name") == "pagerduty-platform":
-                pagerduty_receiver = receiver
-                break
+        pagerduty_receiver = next(
+            (r for r in alertmanager_config["receivers"] if r.get("name") == "pagerduty-platform"),
+            None,
+        )
 
         assert pagerduty_receiver is not None
         pagerduty_config = pagerduty_receiver["pagerduty_configs"][0]
         severity_template = pagerduty_config["severity"]
-        assert 'if eq .CommonLabels.severity "page"' in severity_template
-        assert 'critical' in severity_template
+        expected_template = (
+            '{{ if eq .CommonLabels.severity "page" }}critical'
+            "{{ else }}{{ .CommonLabels.severity }}{{ end }}"
+        )
+        assert severity_template == expected_template
 
     def test_inhibit_rules_defined(self, alertmanager_config):
         """Verify inhibit rules are defined."""

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -214,6 +214,39 @@ class TestAlertmanagerConfig:
             slack_catchall is not None
         ), "catch-all slack-ops route must follow page route for dual-delivery"
 
+    def test_track7_routes_page_to_pagerduty(self, alertmanager_config: dict) -> None:
+        """Verify track7 sub-routes send page alerts to PagerDuty and Slack."""
+        routes = alertmanager_config["route"].get("routes", [])
+        track7_route = next(
+            (r for r in routes if r.get("match", {}).get("sla") == "track7"),
+            None,
+        )
+        assert track7_route is not None, "track7 SLA route not found"
+
+        child_routes = track7_route.get("routes", [])
+        # First child should match critical|page and route to PagerDuty
+        pagerduty_child = next(
+            (
+                r
+                for r in child_routes
+                if r.get("receiver") == "pagerduty-platform"
+                and "page" in r.get("match_re", {}).get("severity", "")
+            ),
+            None,
+        )
+        assert pagerduty_child is not None, "track7 must route page alerts to pagerduty-platform"
+        assert (
+            pagerduty_child.get("continue") is True
+        ), "track7 PagerDuty child must continue to Slack catch-all"
+
+        # A catch-all Slack child must follow for dual-delivery
+        pd_idx = child_routes.index(pagerduty_child)
+        slack_child = next(
+            (r for r in child_routes[pd_idx + 1 :] if r.get("receiver") == "slack-ops"),
+            None,
+        )
+        assert slack_child is not None, "track7 must have a Slack catch-all child after PagerDuty"
+
     def test_pagerduty_maps_page_to_critical(self, alertmanager_config: dict) -> None:
         """Verify PagerDuty severity normalizes page alerts to critical."""
         pagerduty_receiver = next(

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -144,32 +144,32 @@ class TestAlertmanagerConfig:
         with open(config_path) as f:
             return yaml.safe_load(f)
 
-    def test_alertmanager_config_valid_yaml(self, alertmanager_config):
+    def test_alertmanager_config_valid_yaml(self, alertmanager_config: dict) -> None:
         """Verify config.yml is valid YAML."""
         assert alertmanager_config is not None
         assert isinstance(alertmanager_config, dict)
 
-    def test_route_defined(self, alertmanager_config):
+    def test_route_defined(self, alertmanager_config: dict) -> None:
         """Verify routing tree is defined."""
         assert "route" in alertmanager_config
         assert "receiver" in alertmanager_config["route"]
 
-    def test_receivers_defined(self, alertmanager_config):
+    def test_receivers_defined(self, alertmanager_config: dict) -> None:
         """Verify receivers are defined."""
         assert "receivers" in alertmanager_config
         assert len(alertmanager_config["receivers"]) > 0
 
-    def test_slack_receiver_exists(self, alertmanager_config):
+    def test_slack_receiver_exists(self, alertmanager_config: dict) -> None:
         """Verify Slack receiver is configured."""
         receiver_names = [r["name"] for r in alertmanager_config["receivers"]]
         assert "slack-ops" in receiver_names, "slack-ops receiver not found"
 
-    def test_pagerduty_receiver_exists(self, alertmanager_config):
+    def test_pagerduty_receiver_exists(self, alertmanager_config: dict) -> None:
         """Verify PagerDuty receiver is configured."""
         receiver_names = [r["name"] for r in alertmanager_config["receivers"]]
         assert "pagerduty-platform" in receiver_names, "pagerduty-platform receiver not found"
 
-    def test_track7_routing_exists(self, alertmanager_config):
+    def test_track7_routing_exists(self, alertmanager_config: dict) -> None:
         """Verify Track 7 SLA routing is configured."""
         routes = alertmanager_config["route"].get("routes", [])
         track7_route = None
@@ -263,7 +263,7 @@ class TestAlertmanagerConfig:
         )
         assert severity_template == expected_template
 
-    def test_inhibit_rules_defined(self, alertmanager_config):
+    def test_inhibit_rules_defined(self, alertmanager_config: dict) -> None:
         """Verify inhibit rules are defined."""
         assert "inhibit_rules" in alertmanager_config
         assert len(alertmanager_config["inhibit_rules"]) > 0

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -138,38 +139,38 @@ class TestAlertmanagerConfig:
     """Validate Alertmanager configuration."""
 
     @pytest.fixture()
-    def alertmanager_config(self) -> dict:
+    def alertmanager_config(self) -> dict[str, Any]:
         """Load alertmanager config.yml."""
         config_path = Path(__file__).parent.parent.parent / "infra/alertmanager/config.yml"
         with open(config_path) as f:
             return yaml.safe_load(f)
 
-    def test_alertmanager_config_valid_yaml(self, alertmanager_config: dict) -> None:
+    def test_alertmanager_config_valid_yaml(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify config.yml is valid YAML."""
         assert alertmanager_config is not None
         assert isinstance(alertmanager_config, dict)
 
-    def test_route_defined(self, alertmanager_config: dict) -> None:
+    def test_route_defined(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify routing tree is defined."""
         assert "route" in alertmanager_config
         assert "receiver" in alertmanager_config["route"]
 
-    def test_receivers_defined(self, alertmanager_config: dict) -> None:
+    def test_receivers_defined(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify receivers are defined."""
         assert "receivers" in alertmanager_config
         assert len(alertmanager_config["receivers"]) > 0
 
-    def test_slack_receiver_exists(self, alertmanager_config: dict) -> None:
+    def test_slack_receiver_exists(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify Slack receiver is configured."""
         receiver_names = [r["name"] for r in alertmanager_config["receivers"]]
         assert "slack-ops" in receiver_names, "slack-ops receiver not found"
 
-    def test_pagerduty_receiver_exists(self, alertmanager_config: dict) -> None:
+    def test_pagerduty_receiver_exists(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify PagerDuty receiver is configured."""
         receiver_names = [r["name"] for r in alertmanager_config["receivers"]]
         assert "pagerduty-platform" in receiver_names, "pagerduty-platform receiver not found"
 
-    def test_track7_routing_exists(self, alertmanager_config: dict) -> None:
+    def test_track7_routing_exists(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify Track 7 SLA routing is configured."""
         routes = alertmanager_config["route"].get("routes", [])
         track7_route = None
@@ -181,7 +182,7 @@ class TestAlertmanagerConfig:
 
         assert track7_route is not None, "track7 SLA route not found"
 
-    def test_page_routing_exists(self, alertmanager_config: dict) -> None:
+    def test_page_routing_exists(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify severity=page alerts route to PagerDuty and reach Slack."""
         routes = alertmanager_config["route"].get("routes", [])
         page_route = next(
@@ -214,7 +215,7 @@ class TestAlertmanagerConfig:
             slack_catchall is not None
         ), "catch-all slack-ops route must follow page route for dual-delivery"
 
-    def test_track7_routes_page_to_pagerduty(self, alertmanager_config: dict) -> None:
+    def test_track7_routes_page_to_pagerduty(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify track7 sub-routes send page alerts to PagerDuty and Slack."""
         routes = alertmanager_config["route"].get("routes", [])
         track7_route = next(
@@ -247,7 +248,7 @@ class TestAlertmanagerConfig:
         )
         assert slack_child is not None, "track7 must have a Slack catch-all child after PagerDuty"
 
-    def test_pagerduty_maps_page_to_critical(self, alertmanager_config: dict) -> None:
+    def test_pagerduty_maps_page_to_critical(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify PagerDuty severity normalizes page alerts to critical."""
         pagerduty_receiver = next(
             (r for r in alertmanager_config["receivers"] if r.get("name") == "pagerduty-platform"),
@@ -263,7 +264,7 @@ class TestAlertmanagerConfig:
         )
         assert severity_template == expected_template
 
-    def test_inhibit_rules_defined(self, alertmanager_config: dict) -> None:
+    def test_inhibit_rules_defined(self, alertmanager_config: dict[str, Any]) -> None:
         """Verify inhibit rules are defined."""
         assert "inhibit_rules" in alertmanager_config
         assert len(alertmanager_config["inhibit_rules"]) > 0

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -181,6 +181,34 @@ class TestAlertmanagerConfig:
 
         assert track7_route is not None, "track7 SLA route not found"
 
+    def test_page_routing_exists(self, alertmanager_config):
+        """Verify severity=page alerts route to PagerDuty."""
+        routes = alertmanager_config["route"].get("routes", [])
+        page_route = None
+        for route in routes:
+            match = route.get("match", {})
+            if match.get("severity") == "page":
+                page_route = route
+                break
+
+        assert page_route is not None, "severity=page route not found"
+        assert page_route.get("receiver") == "pagerduty-platform"
+        assert page_route.get("continue") is True
+
+    def test_pagerduty_maps_page_to_critical(self, alertmanager_config):
+        """Verify PagerDuty severity normalizes page alerts to critical."""
+        pagerduty_receiver = None
+        for receiver in alertmanager_config["receivers"]:
+            if receiver.get("name") == "pagerduty-platform":
+                pagerduty_receiver = receiver
+                break
+
+        assert pagerduty_receiver is not None
+        pagerduty_config = pagerduty_receiver["pagerduty_configs"][0]
+        severity_template = pagerduty_config["severity"]
+        assert 'if eq .CommonLabels.severity "page"' in severity_template
+        assert 'critical' in severity_template
+
     def test_inhibit_rules_defined(self, alertmanager_config):
         """Verify inhibit rules are defined."""
         assert "inhibit_rules" in alertmanager_config

--- a/tests/infra/test_sla_config.py
+++ b/tests/infra/test_sla_config.py
@@ -185,7 +185,12 @@ class TestAlertmanagerConfig:
         """Verify severity=page alerts route to PagerDuty and reach Slack."""
         routes = alertmanager_config["route"].get("routes", [])
         page_route = next(
-            (r for r in routes if r.get("match", {}).get("severity") == "page"),
+            (
+                r
+                for r in routes
+                if r.get("match", {}).get("severity") == "page"
+                or "page" in r.get("match_re", {}).get("severity", "")
+            ),
             None,
         )
 
@@ -198,7 +203,11 @@ class TestAlertmanagerConfig:
         page_idx = routes.index(page_route)
         remaining = routes[page_idx + 1 :]
         slack_catchall = next(
-            (r for r in remaining if r.get("receiver") == "slack-ops" and "match" not in r),
+            (
+                r
+                for r in remaining
+                if r.get("receiver") == "slack-ops" and "match" not in r and "match_re" not in r
+            ),
             None,
         )
         assert (


### PR DESCRIPTION
## Summary\n- add an Alertmanager route for  alerts to PagerDuty while continuing to Slack\n- normalize PagerDuty event severity from  to  so the delivered event uses a valid PagerDuty severity\n- add infra tests covering the new route and severity mapping\n\nFixes #163