### PR TITLE
fix: return real grid data from Excel export endpoint

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,16 +2,16 @@
 
 [agents.codebase_navigator]
 description = "Fast, low-cost read-only explorer for files, symbols, call sites, and data flows."
-config_file = ".codex/agents/codebase_navigator.toml"
+config_file = "agents/codebase_navigator.toml"
 
 [agents.security_reviewer]
 description = "Trading-focused security reviewer for credentials, injection risks, idempotency bypasses, and race conditions."
-config_file = ".codex/agents/security_reviewer.toml"
+config_file = "agents/security_reviewer.toml"
 
 [agents.test_writer]
 description = "Pytest TDD test author for trading safety invariants and regression coverage."
-config_file = ".codex/agents/test_writer.toml"
+config_file = "agents/test_writer.toml"
 
 [agents.reconciler_debugger]
 description = "Diagnoses DB vs Alpaca position mismatches by tracing orders, fills, breaker state, and reconciliation evidence."
-config_file = ".codex/agents/reconciler_debugger.toml"
+config_file = "agents/reconciler_debugger.toml"

--- a/.github/workflows/atlas-notify.yml
+++ b/.github/workflows/atlas-notify.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   notify:
     runs-on: self-hosted
+    timeout-minutes: 5
     steps:
       - name: Notify Jarvis on PR opened
         if: github.event_name == 'pull_request' && github.event.action == 'opened'

--- a/.github/workflows/ci-tests-parallel.yml
+++ b/.github/workflows/ci-tests-parallel.yml
@@ -573,10 +573,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if [ "${{ needs.integration-tests.result }}" != "success" ]; then
-            echo "integration-tests failed"
+          result="${{ needs.integration-tests.result }}"
+          if [ "$result" == "failure" ] || [ "$result" == "cancelled" ]; then
+            echo "integration-tests $result"
             exit 1
           fi
+          echo "integration-tests $result"
 
   ci-coverage-report:
     name: coverage-report

--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,6 @@ repomix*.xml
 
 # locks
 .ci-local.lock
-*.lock
 
 # backtest and test result data
 data/backtest_results/*

--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ repomix*.xml
 
 # locks
 .ci-local.lock
+*.lock
 
 # backtest and test result data
 data/backtest_results/*
@@ -174,3 +175,4 @@ qlib/
 
 # local json
 response.json
+

--- a/apps/execution_gateway/app_context.py
+++ b/apps/execution_gateway/app_context.py
@@ -153,7 +153,11 @@ class DatabaseClientProtocol(Protocol):
         ...
 
     def get_orders_for_export(
-        self, *, strategy_ids: list[str], limit: int = 50_000
+        self,
+        *,
+        strategy_ids: list[str],
+        statuses: list[str] | None = None,
+        limit: int = 50_000,
     ) -> list[dict[str, Any]]:
         """Fetch orders for Excel export with generous limit."""
         ...

--- a/apps/execution_gateway/app_context.py
+++ b/apps/execution_gateway/app_context.py
@@ -163,9 +163,9 @@ class DatabaseClientProtocol(Protocol):
         ...
 
     def get_fills_for_export(
-        self, *, strategy_ids: list[str], limit: int = 10_000, lookback_hours: int = 2160
+        self, *, strategy_ids: list[str], limit: int = 10_000
     ) -> list[dict[str, Any]]:
-        """Fetch fills for Excel export with generous limits."""
+        """Fetch fills for Excel export from trades table."""
         ...
 
     def get_strategy_status(self, strategy_id: str) -> dict[str, Any] | None:

--- a/apps/execution_gateway/app_context.py
+++ b/apps/execution_gateway/app_context.py
@@ -152,6 +152,18 @@ class DatabaseClientProtocol(Protocol):
         """Fetch status metadata for multiple strategies."""
         ...
 
+    def get_orders_for_export(
+        self, *, strategy_ids: list[str], limit: int = 50_000
+    ) -> list[dict[str, Any]]:
+        """Fetch orders for Excel export with generous limit."""
+        ...
+
+    def get_fills_for_export(
+        self, *, strategy_ids: list[str], limit: int = 10_000, lookback_hours: int = 2160
+    ) -> list[dict[str, Any]]:
+        """Fetch fills for Excel export with generous limits."""
+        ...
+
     def get_strategy_status(self, strategy_id: str) -> dict[str, Any] | None:
         """Fetch status metadata for a strategy."""
         ...

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2071,6 +2071,133 @@ class DatabaseClient:
                 return _execute()
             raise
 
+    def get_orders_for_export(
+        self,
+        *,
+        strategy_ids: list[str],
+        limit: int = 50_000,
+    ) -> list[dict[str, Any]]:
+        """Fetch orders for Excel export with generous limit.
+
+        Unlike the activity-feed queries, export needs access to the full
+        order history (within reason).  The caller must already have
+        validated strategy-level authorization.
+
+        Args:
+            strategy_ids: Strategy IDs the user is authorized for.
+            limit: Maximum rows (capped at 50 000 to bound memory).
+
+        Returns:
+            List of dicts with order columns suitable for export grids.
+        """
+        if not strategy_ids:
+            return []
+        limit = max(1, min(int(limit), 50_000))
+
+        def _execute() -> list[dict[str, Any]]:
+            with self._connection() as conn:
+                with conn.cursor(row_factory=dict_row) as cur:
+                    cur.execute(
+                        """
+                        SELECT client_order_id, strategy_id, symbol, side, qty,
+                               order_type, status, filled_qty, filled_avg_price,
+                               created_at, submitted_at, filled_at
+                        FROM orders
+                        WHERE strategy_id = ANY(%s)
+                        ORDER BY created_at DESC
+                        LIMIT %s
+                        """,
+                        (strategy_ids, limit),
+                    )
+                    return cur.fetchall()
+
+        try:
+            return _execute()
+        except (OperationalError, DatabaseError) as exc:
+            logger.error(
+                "Database error fetching orders for export",
+                extra={"strategies": strategy_ids, "limit": limit, "error": str(exc)},
+            )
+            if "AdminShutdown" in type(exc).__name__ or "terminating connection" in str(exc):
+                self._recreate_pool()
+                return _execute()
+            raise
+
+    def get_fills_for_export(
+        self,
+        *,
+        strategy_ids: list[str],
+        limit: int = 10_000,
+        lookback_hours: int = 2160,
+    ) -> list[dict[str, Any]]:
+        """Fetch fills for Excel export with generous limits.
+
+        Unlike ``get_recent_fills`` (activity-feed, capped at 200/7d),
+        this method allows larger result sets suitable for spreadsheet
+        export (up to 10 000 rows, 90-day lookback).
+
+        Args:
+            strategy_ids: Strategy IDs the user is authorized for.
+            limit: Maximum rows (capped at 10 000).
+            lookback_hours: Time window (capped at 2160 = 90 days).
+
+        Returns:
+            List of dicts with fill columns suitable for export grids.
+        """
+        if not strategy_ids:
+            return []
+        limit = max(1, min(int(limit), 10_000))
+        lookback_hours = max(1, min(int(lookback_hours), 2160))
+
+        def _execute() -> list[dict[str, Any]]:
+            with self._connection() as conn:
+                with conn.cursor(row_factory=dict_row) as cur:
+                    cur.execute(
+                        """
+                        SELECT
+                            o.client_order_id,
+                            o.symbol,
+                            o.side,
+                            o.status,
+                            COALESCE(NULLIF(fill->>'fill_qty', '')::NUMERIC, 0) AS qty,
+                            COALESCE(NULLIF(fill->>'fill_price', '')::NUMERIC, 0) AS price,
+                            COALESCE(NULLIF(fill->>'realized_pl', '')::NUMERIC, 0) AS realized_pl,
+                            COALESCE(
+                                NULLIF(fill->>'timestamp', '')::timestamptz,
+                                o.updated_at
+                            ) AS fill_timestamp
+                        FROM orders o
+                        CROSS JOIN jsonb_array_elements(o.metadata->'fills') AS fill
+                        WHERE o.status IN ('filled', 'partially_filled')
+                          AND o.metadata ? 'fills'
+                          AND jsonb_array_length(o.metadata->'fills') > 0
+                          AND o.updated_at >= NOW() - make_interval(hours => %s)
+                          AND o.strategy_id = ANY(%s)
+                          AND COALESCE(
+                                  NULLIF(fill->>'timestamp', '')::timestamptz,
+                                  o.updated_at
+                              ) >= NOW() - make_interval(hours => %s)
+                          AND NOT COALESCE((fill->>'superseded')::boolean, FALSE)
+                        ORDER BY fill_timestamp DESC
+                        LIMIT %s
+                        """,
+                        (lookback_hours, strategy_ids, lookback_hours, limit),
+                    )
+                    rows = cur.fetchall()
+            return [{**row, "timestamp": row.pop("fill_timestamp")} for row in rows]
+
+        try:
+            return _execute()
+        except (OperationalError, DatabaseError) as exc:
+            logger.error(
+                "Database error fetching fills for export",
+                extra={"strategies": strategy_ids, "limit": limit, "error": str(exc)},
+            )
+            if "AdminShutdown" in type(exc).__name__ or "terminating connection" in str(exc):
+                self._recreate_pool()
+                return _execute()
+            raise
+
     def update_order_status(
         self,
         client_order_id: str,

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2195,6 +2195,7 @@ class DatabaseClient:
                         WHERE o.status IN ('filled', 'partially_filled')
                           AND o.metadata ? 'fills'
                           AND jsonb_array_length(o.metadata->'fills') > 0
+                          AND o.updated_at >= NOW() - make_interval(hours => %s)
                           AND o.strategy_id = ANY(%s)
                           AND COALESCE(
                                   NULLIF(fill->>'timestamp', '')::timestamptz,
@@ -2204,7 +2205,7 @@ class DatabaseClient:
                         ORDER BY fill_timestamp DESC
                         LIMIT %s
                         """,
-                        (strategy_ids, lookback_hours, limit),
+                        (lookback_hours, strategy_ids, lookback_hours, limit),
                     )
                     rows = cur.fetchall()
             return [{**row, "timestamp": row.pop("fill_timestamp")} for row in rows]

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2170,13 +2170,12 @@ class DatabaseClient:
                             t.client_order_id,
                             t.symbol,
                             t.side,
-                            COALESCE(o.status, 'filled') AS status,
+                            'filled' AS status,
                             t.qty,
                             t.price,
                             t.realized_pnl AS realized_pl,
                             t.executed_at AS "timestamp"
                         FROM trades t
-                        LEFT JOIN orders o ON t.client_order_id = o.client_order_id
                         WHERE t.strategy_id = ANY(%s)
                           AND COALESCE(t.superseded, FALSE) = FALSE
                         ORDER BY t.executed_at DESC

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2170,12 +2170,13 @@ class DatabaseClient:
                             t.client_order_id,
                             t.symbol,
                             t.side,
-                            'filled' AS status,
+                            COALESCE(o.status, 'filled') AS status,
                             t.qty,
                             t.price,
                             t.realized_pnl AS realized_pl,
                             t.executed_at AS "timestamp"
                         FROM trades t
+                        LEFT JOIN orders o ON t.client_order_id = o.client_order_id
                         WHERE t.strategy_id = ANY(%s)
                           AND COALESCE(t.superseded, FALSE) = FALSE
                         ORDER BY t.executed_at DESC

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2104,35 +2104,25 @@ class DatabaseClient:
                 return []
             with self._connection() as conn:
                 with conn.cursor(row_factory=dict_row) as cur:
+                    where = "WHERE strategy_id = ANY(%s)"
+                    params: list[Any] = [strategy_ids]
                     if statuses is not None:
-                        cur.execute(
-                            """
-                            SELECT client_order_id, strategy_id, symbol, side, qty,
-                                   order_type, status, filled_qty, filled_avg_price,
-                                   limit_price, stop_price,
-                                   created_at, submitted_at, filled_at
-                            FROM orders
-                            WHERE strategy_id = ANY(%s)
-                              AND status = ANY(%s)
-                            ORDER BY created_at DESC
-                            LIMIT %s
-                            """,
-                            (strategy_ids, statuses, limit),
-                        )
-                    else:
-                        cur.execute(
-                            """
-                            SELECT client_order_id, strategy_id, symbol, side, qty,
-                                   order_type, status, filled_qty, filled_avg_price,
-                                   limit_price, stop_price,
-                                   created_at, submitted_at, filled_at
-                            FROM orders
-                            WHERE strategy_id = ANY(%s)
-                            ORDER BY created_at DESC
-                            LIMIT %s
-                            """,
-                            (strategy_ids, limit),
-                        )
+                        where += " AND status = ANY(%s)"
+                        params.append(statuses)
+                    params.append(limit)
+                    cur.execute(
+                        f"""
+                        SELECT client_order_id, strategy_id, symbol, side, qty,
+                               order_type, status, filled_qty, filled_avg_price,
+                               limit_price, stop_price,
+                               created_at, submitted_at, filled_at
+                        FROM orders
+                        {where}
+                        ORDER BY created_at DESC
+                        LIMIT %s
+                        """,
+                        params,
+                    )
                     return cur.fetchall()
 
         try:
@@ -2189,7 +2179,7 @@ class DatabaseClient:
                             COALESCE(
                                 NULLIF(fill->>'timestamp', '')::timestamptz,
                                 o.updated_at
-                            ) AS fill_timestamp
+                            ) AS "timestamp"
                         FROM orders o
                         CROSS JOIN LATERAL jsonb_array_elements(o.metadata->'fills') AS fill
                         WHERE o.status IN ('filled', 'partially_filled')
@@ -2202,13 +2192,12 @@ class DatabaseClient:
                                   o.updated_at
                               ) >= NOW() - make_interval(hours => %s)
                           AND NOT COALESCE((fill->>'superseded')::boolean, FALSE)
-                        ORDER BY fill_timestamp DESC
+                        ORDER BY "timestamp" DESC
                         LIMIT %s
                         """,
                         (lookback_hours, strategy_ids, lookback_hours, limit),
                     )
-                    rows = cur.fetchall()
-            return [{**row, "timestamp": row.pop("fill_timestamp")} for row in rows]
+                    return cur.fetchall()
 
         try:
             return _execute()

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2144,11 +2144,11 @@ class DatabaseClient:
         limit: int = 10_000,
         lookback_hours: int = 2160,
     ) -> list[dict[str, Any]]:
-        """Fetch fills for Excel export with generous limits.
+        """Fetch fills for Excel export from the trades table.
 
-        Unlike ``get_recent_fills`` (activity-feed, capped at 200/7d),
-        this method allows larger result sets suitable for spreadsheet
-        export (up to 10 000 rows, 90-day lookback).
+        Queries the ``trades`` table (same source as the dashboard fills
+        grid) to ensure export-what-you-see parity.  Superseded trades
+        are excluded, matching the dashboard filter.
 
         Args:
             strategy_ids: Strategy IDs the user is authorized for.
@@ -2169,33 +2169,22 @@ class DatabaseClient:
                     cur.execute(
                         """
                         SELECT
-                            o.client_order_id,
-                            o.symbol,
-                            o.side,
-                            o.status,
-                            COALESCE(NULLIF(fill->>'fill_qty', '')::NUMERIC, 0) AS qty,
-                            COALESCE(NULLIF(fill->>'fill_price', '')::NUMERIC, 0) AS price,
-                            COALESCE(NULLIF(fill->>'realized_pl', '')::NUMERIC, 0) AS realized_pl,
-                            COALESCE(
-                                NULLIF(fill->>'timestamp', '')::timestamptz,
-                                o.updated_at
-                            ) AS "timestamp"
-                        FROM orders o
-                        CROSS JOIN LATERAL jsonb_array_elements(o.metadata->'fills') AS fill
-                        WHERE o.status IN ('filled', 'partially_filled')
-                          AND o.metadata ? 'fills'
-                          AND jsonb_array_length(o.metadata->'fills') > 0
-                          AND o.updated_at >= NOW() - make_interval(hours => %s)
-                          AND o.strategy_id = ANY(%s)
-                          AND COALESCE(
-                                  NULLIF(fill->>'timestamp', '')::timestamptz,
-                                  o.updated_at
-                              ) >= NOW() - make_interval(hours => %s)
-                          AND NOT COALESCE((fill->>'superseded')::boolean, FALSE)
-                        ORDER BY "timestamp" DESC
+                            t.client_order_id,
+                            t.symbol,
+                            t.side,
+                            'filled' AS status,
+                            t.qty,
+                            t.price,
+                            t.realized_pnl AS realized_pl,
+                            t.executed_at AS "timestamp"
+                        FROM trades t
+                        WHERE t.strategy_id = ANY(%s)
+                          AND t.executed_at >= NOW() - make_interval(hours => %s)
+                          AND COALESCE(t.superseded, FALSE) = FALSE
+                        ORDER BY t.executed_at DESC
                         LIMIT %s
                         """,
-                        (lookback_hours, strategy_ids, lookback_hours, limit),
+                        (strategy_ids, lookback_hours, limit),
                     )
                     return cur.fetchall()
 

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2075,6 +2075,7 @@ class DatabaseClient:
         self,
         *,
         strategy_ids: list[str],
+        statuses: list[str] | None = None,
         limit: int = 50_000,
     ) -> list[dict[str, Any]]:
         """Fetch orders for Excel export with generous limit.
@@ -2085,6 +2086,9 @@ class DatabaseClient:
 
         Args:
             strategy_ids: Strategy IDs the user is authorized for.
+            statuses: Optional list of order statuses to filter by.
+                When provided, only orders with matching status are returned
+                (e.g. working-tab exports pass active statuses only).
             limit: Maximum rows (capped at 50 000 to bound memory).
 
         Returns:
@@ -2097,18 +2101,33 @@ class DatabaseClient:
         def _execute() -> list[dict[str, Any]]:
             with self._connection() as conn:
                 with conn.cursor(row_factory=dict_row) as cur:
-                    cur.execute(
-                        """
-                        SELECT client_order_id, strategy_id, symbol, side, qty,
-                               order_type, status, filled_qty, filled_avg_price,
-                               created_at, submitted_at, filled_at
-                        FROM orders
-                        WHERE strategy_id = ANY(%s)
-                        ORDER BY created_at DESC
-                        LIMIT %s
-                        """,
-                        (strategy_ids, limit),
-                    )
+                    if statuses:
+                        cur.execute(
+                            """
+                            SELECT client_order_id, strategy_id, symbol, side, qty,
+                                   order_type, status, filled_qty, filled_avg_price,
+                                   created_at, submitted_at, filled_at
+                            FROM orders
+                            WHERE strategy_id = ANY(%s)
+                              AND status = ANY(%s)
+                            ORDER BY created_at DESC
+                            LIMIT %s
+                            """,
+                            (strategy_ids, statuses, limit),
+                        )
+                    else:
+                        cur.execute(
+                            """
+                            SELECT client_order_id, strategy_id, symbol, side, qty,
+                                   order_type, status, filled_qty, filled_avg_price,
+                                   created_at, submitted_at, filled_at
+                            FROM orders
+                            WHERE strategy_id = ANY(%s)
+                            ORDER BY created_at DESC
+                            LIMIT %s
+                            """,
+                            (strategy_ids, limit),
+                        )
                     return cur.fetchall()
 
         try:
@@ -2171,7 +2190,6 @@ class DatabaseClient:
                         WHERE o.status IN ('filled', 'partially_filled')
                           AND o.metadata ? 'fills'
                           AND jsonb_array_length(o.metadata->'fills') > 0
-                          AND o.updated_at >= NOW() - make_interval(hours => %s)
                           AND o.strategy_id = ANY(%s)
                           AND COALESCE(
                                   NULLIF(fill->>'timestamp', '')::timestamptz,
@@ -2181,7 +2199,7 @@ class DatabaseClient:
                         ORDER BY fill_timestamp DESC
                         LIMIT %s
                         """,
-                        (lookback_hours, strategy_ids, lookback_hours, limit),
+                        (strategy_ids, lookback_hours, limit),
                     )
                     rows = cur.fetchall()
             return [{**row, "timestamp": row.pop("fill_timestamp")} for row in rows]

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2191,7 +2191,7 @@ class DatabaseClient:
                                 o.updated_at
                             ) AS fill_timestamp
                         FROM orders o
-                        CROSS JOIN jsonb_array_elements(o.metadata->'fills') AS fill
+                        CROSS JOIN LATERAL jsonb_array_elements(o.metadata->'fills') AS fill
                         WHERE o.status IN ('filled', 'partially_filled')
                           AND o.metadata ? 'fills'
                           AND jsonb_array_length(o.metadata->'fills') > 0

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2142,18 +2142,17 @@ class DatabaseClient:
         *,
         strategy_ids: list[str],
         limit: int = 10_000,
-        lookback_hours: int = 2160,
     ) -> list[dict[str, Any]]:
         """Fetch fills for Excel export from the trades table.
 
         Queries the ``trades`` table (same source as the dashboard fills
-        grid) to ensure export-what-you-see parity.  Superseded trades
-        are excluded, matching the dashboard filter.
+        grid) to ensure export-what-you-see parity.  No date cutoff is
+        applied (matching ``StrategyScopedDataAccess.get_trades``);
+        only superseded trades are excluded.
 
         Args:
             strategy_ids: Strategy IDs the user is authorized for.
             limit: Maximum rows (capped at 10 000).
-            lookback_hours: Time window (capped at 2160 = 90 days).
 
         Returns:
             List of dicts with fill columns suitable for export grids.
@@ -2161,7 +2160,6 @@ class DatabaseClient:
         if not strategy_ids:
             return []
         limit = max(1, min(int(limit), 10_000))
-        lookback_hours = max(1, min(int(lookback_hours), 2160))
 
         def _execute() -> list[dict[str, Any]]:
             with self._connection() as conn:
@@ -2179,12 +2177,11 @@ class DatabaseClient:
                             t.executed_at AS "timestamp"
                         FROM trades t
                         WHERE t.strategy_id = ANY(%s)
-                          AND t.executed_at >= NOW() - make_interval(hours => %s)
                           AND COALESCE(t.superseded, FALSE) = FALSE
                         ORDER BY t.executed_at DESC
                         LIMIT %s
                         """,
-                        (strategy_ids, lookback_hours, limit),
+                        (strategy_ids, limit),
                     )
                     return cur.fetchall()
 

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2099,13 +2099,17 @@ class DatabaseClient:
         limit = max(1, min(int(limit), 50_000))
 
         def _execute() -> list[dict[str, Any]]:
+            # Explicit empty list means "no statuses selected" → zero rows
+            if statuses is not None and len(statuses) == 0:
+                return []
             with self._connection() as conn:
                 with conn.cursor(row_factory=dict_row) as cur:
-                    if statuses:
+                    if statuses is not None:
                         cur.execute(
                             """
                             SELECT client_order_id, strategy_id, symbol, side, qty,
                                    order_type, status, filled_qty, filled_avg_price,
+                                   limit_price, stop_price,
                                    created_at, submitted_at, filled_at
                             FROM orders
                             WHERE strategy_id = ANY(%s)
@@ -2120,6 +2124,7 @@ class DatabaseClient:
                             """
                             SELECT client_order_id, strategy_id, symbol, side, qty,
                                    order_type, status, filled_qty, filled_avg_price,
+                                   limit_price, stop_price,
                                    created_at, submitted_at, filled_at
                             FROM orders
                             WHERE strategy_id = ANY(%s)

--- a/apps/execution_gateway/database.py
+++ b/apps/execution_gateway/database.py
@@ -2100,7 +2100,7 @@ class DatabaseClient:
 
         def _execute() -> list[dict[str, Any]]:
             # Explicit empty list means "no statuses selected" → zero rows
-            if statuses is not None and len(statuses) == 0:
+            if statuses is not None and not statuses:
                 return []
             with self._connection() as conn:
                 with conn.cursor(row_factory=dict_row) as cur:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1100,8 +1100,8 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         if operator == "inRange":
             if dt_to is not None:
                 return dt_from.date() <= dt_val.date() <= dt_to.date()
-            # Missing dateTo — apply one-sided bound (greaterThanOrEqual)
-            return dt_val.date() >= dt_from.date()
+            # Missing dateTo — can't apply range, keep row (consistent with numeric)
+            return True
         return True
 
     # Unsupported filter type — keep the row
@@ -1145,7 +1145,11 @@ def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
     if operator and isinstance(condition1, dict):
         # Legacy condition1/condition2 format — recurse for nested compounds
         result1 = _match_compound_filter(value, condition1)
-        result2 = _match_compound_filter(value, condition2) if isinstance(condition2, dict) else True
+        # Missing condition2: AND defaults to True (identity), OR to False (identity)
+        if isinstance(condition2, dict):
+            result2 = _match_compound_filter(value, condition2)
+        else:
+            result2 = operator != "OR"
         if operator == "AND":
             return result1 and result2
         if operator == "OR":

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import io
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from collections.abc import Callable
 from typing import Any, Literal
 from uuid import UUID
 
@@ -700,6 +702,385 @@ async def download_excel_export(
 # This ensures a single source of truth for formula injection protection.
 
 
+def _coerce_cell_value(value: Any) -> Any:
+    """Coerce a database value to an Excel-safe type.
+
+    Decimals are converted to float so openpyxl writes them as numbers.
+    Datetimes are kept as-is (openpyxl handles them natively).
+    Everything else is stringified and sanitized.
+    """
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime):
+        # openpyxl requires timezone-naive datetimes
+        return value.replace(tzinfo=None) if value.tzinfo else value
+    if isinstance(value, date):
+        return value
+    if isinstance(value, bool | int | float):
+        return value
+    # Dict/list → JSON string; all strings sanitized for formula injection
+    if isinstance(value, dict | list):
+        return sanitize_for_export(json.dumps(value, default=str))
+    return sanitize_for_export(str(value))
+
+
+# =============================================================================
+# Per-Grid Data Fetchers
+# =============================================================================
+
+
+def _fetch_positions_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    _filter_params: dict[str, Any] | None,
+) -> tuple[list[str], list[list[Any]]]:
+    """Fetch positions grid data scoped to authorized strategies."""
+    columns = [
+        "symbol", "qty", "avg_entry_price", "current_price",
+        "unrealized_pl", "realized_pl", "updated_at", "last_trade_at",
+    ]
+    positions = ctx.db.get_positions_for_strategies(strategy_ids)
+    rows = [
+        [getattr(pos, col, None) for col in columns]
+        for pos in positions
+    ]
+    return columns, rows
+
+
+def _fetch_orders_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    _filter_params: dict[str, Any] | None,
+) -> tuple[list[str], list[list[Any]]]:
+    """Fetch orders grid data scoped to authorized strategies."""
+    columns = [
+        "client_order_id", "strategy_id", "symbol", "side", "qty",
+        "order_type", "status", "filled_qty", "filled_avg_price",
+        "created_at", "submitted_at", "filled_at",
+    ]
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT client_order_id, strategy_id, symbol, side, qty,
+                       order_type, status, filled_qty, filled_avg_price,
+                       created_at, submitted_at, filled_at
+                FROM orders
+                WHERE strategy_id = ANY(%s)
+                ORDER BY created_at DESC
+                LIMIT 5000
+                """,
+                (strategy_ids,),
+            )
+            db_rows = cur.fetchall()
+    rows = [list(row) for row in db_rows]
+    return columns, rows
+
+
+def _fetch_fills_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    _filter_params: dict[str, Any] | None,
+) -> tuple[list[str], list[list[Any]]]:
+    """Fetch recent fills scoped to authorized strategies."""
+    columns = [
+        "client_order_id", "symbol", "side", "status",
+        "qty", "price", "realized_pl", "timestamp",
+    ]
+    fills = ctx.db.get_recent_fills(
+        strategy_ids=strategy_ids,
+        limit=200,
+        lookback_hours=168,  # 7 days max
+    )
+    rows = [
+        [fill.get(col) for col in columns]
+        for fill in fills
+    ]
+    return columns, rows
+
+
+def _fetch_audit_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    _filter_params: dict[str, Any] | None,
+) -> tuple[list[str], list[list[Any]]]:
+    """Fetch audit log entries scoped to authorized strategies.
+
+    The audit_log table has no direct strategy_id column, so we join through
+    the orders table for order-related entries to enforce strategy scoping.
+    Non-order audit entries (e.g., login events) are included if they belong
+    to the current user's session — but since we don't have user_id context
+    here, we restrict to order-scoped entries only for safety.
+
+    Raises:
+        NotImplementedError: Audit export is disabled until full strategy
+            scoping can be implemented without data leakage.
+    """
+    raise NotImplementedError(
+        "Audit grid export is disabled: audit_log has no strategy_id column "
+        "and cannot be reliably scoped to authorized strategies. "
+        "Use the web console audit view which applies client-side filtering."
+    )
+
+
+def _fetch_tca_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    _filter_params: dict[str, Any] | None,
+) -> tuple[list[str], list[list[Any]]]:
+    """Fetch TCA data scoped to authorized strategies.
+
+    Raises:
+        NotImplementedError: TCA export is disabled because the UI grid uses
+            computed columns (execution_date, fill_rate_pct, is_bps, vwap_bps,
+            impact_bps, notional) derived from the TCA analysis pipeline. The
+            server-side fetcher only has raw trade columns and cannot reproduce
+            the UI's computed metrics. Filters/sorts on UI column names would
+            silently fail.
+    """
+    raise NotImplementedError(
+        "TCA grid export is disabled: the UI grid uses computed columns "
+        "(execution_date, fill_rate_pct, is_bps, vwap_bps, impact_bps, notional) "
+        "that require the TCA analysis pipeline. The server-side exporter cannot "
+        "reproduce these metrics. Use CSV export from the browser instead."
+    )
+
+
+# Map grid names to their fetchers
+_GridFetcher = Callable[
+    [AppContext, list[str], dict[str, Any] | None],
+    tuple[list[str], list[list[Any]]],
+]
+
+_GRID_FETCHERS: dict[str, _GridFetcher] = {
+    "positions": _fetch_positions_data,
+    "orders": _fetch_orders_data,
+    "fills": _fetch_fills_data,
+    "audit": _fetch_audit_data,
+    "tca": _fetch_tca_data,
+}
+
+
+def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
+    """Check if a single cell value matches an AG Grid filter definition.
+
+    Supports text, number, and date filter types with common operators.
+    Returns True if the value passes the filter (should be kept).
+    """
+    filter_type = filter_def.get("filterType", "text")
+    operator = filter_def.get("type", "")
+    filter_value = filter_def.get("filter")
+
+    if value is None:
+        # Null values only match "blank" filters
+        return operator == "blank"
+
+    if filter_type == "text":
+        text_val = str(value).lower()
+        filter_str = str(filter_value).lower() if filter_value is not None else ""
+        if operator == "contains":
+            return filter_str in text_val
+        if operator == "notContains":
+            return filter_str not in text_val
+        if operator == "equals":
+            return text_val == filter_str
+        if operator == "notEqual":
+            return text_val != filter_str
+        if operator == "startsWith":
+            return text_val.startswith(filter_str)
+        if operator == "endsWith":
+            return text_val.endswith(filter_str)
+        if operator == "blank":
+            return text_val.strip() == ""
+        if operator == "notBlank":
+            return text_val.strip() != ""
+        return True  # Unknown text operator — don't filter out
+
+    if filter_type == "number":
+        try:
+            num_val = float(Decimal(str(value))) if isinstance(value, Decimal) else float(value)
+            num_filter = float(filter_value) if filter_value is not None else 0.0
+        except (ValueError, TypeError):
+            return True  # Can't compare — keep the row
+        if operator == "equals":
+            return num_val == num_filter
+        if operator == "notEqual":
+            return num_val != num_filter
+        if operator == "greaterThan":
+            return num_val > num_filter
+        if operator == "greaterThanOrEqual":
+            return num_val >= num_filter
+        if operator == "lessThan":
+            return num_val < num_filter
+        if operator == "lessThanOrEqual":
+            return num_val <= num_filter
+        filter_to = filter_def.get("filterTo")
+        if operator == "inRange" and filter_to is not None:
+            return num_filter <= num_val <= float(filter_to)
+        return True
+
+    if filter_type == "date":
+        # AG Grid sends dateFrom/dateTo as ISO-ish strings, e.g. "2026-03-28 00:00:00"
+        date_from_str = filter_def.get("dateFrom")
+        date_to_str = filter_def.get("dateTo")
+
+        # Coerce cell value to a comparable datetime
+        if isinstance(value, datetime):
+            dt_val = value.replace(tzinfo=None) if value.tzinfo else value
+        elif isinstance(value, date):
+            dt_val = datetime(value.year, value.month, value.day)
+        elif isinstance(value, str):
+            try:
+                dt_val = datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+            except ValueError:
+                return True  # Unparseable — keep the row
+        else:
+            return True  # Non-date value — keep the row
+
+        def _parse_ag_date(s: str | None) -> datetime | None:
+            if not s:
+                return None
+            try:
+                return datetime.fromisoformat(s.replace("Z", "+00:00")).replace(tzinfo=None)
+            except ValueError:
+                return None
+
+        dt_from = _parse_ag_date(date_from_str)
+        dt_to = _parse_ag_date(date_to_str)
+
+        if operator == "blank":
+            return False  # value is not None (checked above)
+        if operator == "notBlank":
+            return True
+        if dt_from is None:
+            return True  # No filter value — can't compare, keep row
+
+        if operator == "equals":
+            return dt_val.date() == dt_from.date()
+        if operator == "notEqual":
+            return dt_val.date() != dt_from.date()
+        if operator == "greaterThan":
+            return dt_val.date() > dt_from.date()
+        if operator == "lessThan":
+            return dt_val.date() < dt_from.date()
+        if operator == "inRange" and dt_to is not None:
+            return dt_from.date() <= dt_val.date() <= dt_to.date()
+        return True
+
+    # Unsupported filter type — keep the row
+    return True
+
+
+def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
+    """Handle AG Grid compound filters (operator + condition1/condition2).
+
+    If the filter_def contains an 'operator' key with 'condition1' and 'condition2',
+    it's a compound filter. Otherwise delegate to _match_filter for simple filters.
+    """
+    operator = filter_def.get("operator")
+    condition1 = filter_def.get("condition1")
+    condition2 = filter_def.get("condition2")
+
+    if operator and isinstance(condition1, dict):
+        result1 = _match_filter(value, condition1)
+        result2 = _match_filter(value, condition2) if isinstance(condition2, dict) else True
+        if operator == "AND":
+            return result1 and result2
+        if operator == "OR":
+            return result1 or result2
+        return result1  # Unknown operator — fall back to condition1 only
+
+    # Simple (non-compound) filter
+    return _match_filter(value, filter_def)
+
+
+def _apply_filters(
+    columns: list[str],
+    rows: list[list[Any]],
+    filter_params: dict[str, Any],
+) -> list[list[Any]]:
+    """Apply AG Grid filter model to rows (Python-side).
+
+    Args:
+        columns: Column names matching row indices.
+        filter_params: AG Grid filter model, e.g.
+            {"symbol": {"filterType": "text", "type": "contains", "filter": "AAPL"}}
+
+    Returns:
+        Filtered rows.
+    """
+    col_index = {c: i for i, c in enumerate(columns)}
+
+    # Build list of (column_index, filter_def) for active filters
+    active_filters: list[tuple[int, dict[str, Any]]] = []
+    for col_name, filter_def in filter_params.items():
+        if col_name in col_index and isinstance(filter_def, dict):
+            active_filters.append((col_index[col_name], filter_def))
+
+    if not active_filters:
+        return rows
+
+    def _row_matches(row: list[Any]) -> bool:
+        for idx, fdef in active_filters:
+            if not _match_compound_filter(row[idx], fdef):
+                return False
+        return True
+
+    return [row for row in rows if _row_matches(row)]
+
+
+def _apply_sort(
+    columns: list[str],
+    rows: list[list[Any]],
+    sort_model: list[dict[str, Any]],
+) -> list[list[Any]]:
+    """Apply AG Grid sort model to rows (Python-side).
+
+    Uses ``sortIndex`` (if present) to determine multi-sort precedence,
+    matching AG Grid behaviour.  When ``sortIndex`` is absent the array
+    position is used as a fallback so that simple sort models still work.
+
+    Args:
+        columns: Column names matching row indices.
+        sort_model: AG Grid sort model, e.g.
+            [{"colId": "symbol", "sort": "asc", "sortIndex": 0},
+             {"colId": "qty", "sort": "desc", "sortIndex": 1}]
+
+    Returns:
+        Sorted rows (new list).
+    """
+    col_index = {c: i for i, c in enumerate(columns)}
+
+    # Normalise sort order: honour sortIndex when present, fall back to
+    # array position.  Higher sortIndex = lower priority (applied first in
+    # the reversed iteration below).
+    indexed_model = [
+        (spec.get("sortIndex", pos), spec)
+        for pos, spec in enumerate(sort_model)
+    ]
+    indexed_model.sort(key=lambda t: t[0])
+    ordered_specs = [spec for _, spec in indexed_model]
+
+    # Build sort keys in reverse priority order (last = primary in multi-sort)
+    sorted_rows = list(rows)
+    for sort_spec in reversed(ordered_specs):
+        col_id = sort_spec.get("colId", "")
+        if col_id not in col_index:
+            continue
+        idx = col_index[col_id]
+        descending = sort_spec.get("sort", "asc") == "desc"
+
+        # Partition nulls out so they always end up last regardless of direction
+        null_rows = [r for r in sorted_rows if r[idx] is None]
+        non_null_rows = [r for r in sorted_rows if r[idx] is not None]
+        non_null_rows.sort(key=lambda row, _idx=idx: row[_idx], reverse=descending)
+        sorted_rows = non_null_rows + null_rows
+
+    return sorted_rows
+
+
 async def _generate_excel_content(
     ctx: AppContext,
     grid_name: str,
@@ -710,27 +1091,23 @@ async def _generate_excel_content(
 ) -> tuple[bytes, int]:
     """Generate Excel file content for a grid.
 
-    This is a placeholder that will be implemented for each grid type.
-    Uses openpyxl for Excel generation with formula sanitization.
-
-    IMPORTANT: All cell values MUST be sanitized via sanitize_for_export()
-    to prevent formula injection attacks.
+    Fetches real data from the database via per-grid fetchers and writes
+    it to an openpyxl Workbook with formula-injection sanitization.
 
     Args:
         ctx: Application context with database access
         grid_name: Name of grid to export
         strategy_ids: Authorized strategy IDs for filtering
         filter_params: AG Grid filter model
-        visible_columns: Columns to include
-        sort_model: AG Grid sort model
+        visible_columns: Columns to include (if None, all columns)
+        sort_model: AG Grid sort model for row ordering
 
     Returns:
         Tuple of (excel_bytes, row_count)
 
     Raises:
-        NotImplementedError: If grid type not supported
+        NotImplementedError: If grid type not supported or openpyxl missing
     """
-    # Import openpyxl only when needed
     try:
         from openpyxl import Workbook  # type: ignore[import-untyped]
     except ImportError as e:
@@ -738,47 +1115,53 @@ async def _generate_excel_content(
             "Excel export requires openpyxl: pip install openpyxl"
         ) from e
 
-    # Supported grids and their data fetchers
-    # TODO: Implement per-grid data fetchers with PII column filtering
-    supported_grids = {
-        "positions": "_fetch_positions_data",
-        "orders": "_fetch_orders_data",
-        "fills": "_fetch_fills_data",
-        "audit": "_fetch_audit_data",
-        "tca": "_fetch_tca_data",
-    }
-
-    if grid_name not in supported_grids:
+    fetcher = _GRID_FETCHERS.get(grid_name)
+    if fetcher is None:
         raise NotImplementedError(f"Excel export not implemented for grid: {grid_name}")
 
-    # For now, return a placeholder Excel file
-    # TODO: Implement actual data fetching and Excel generation
-    # NOTE: When implementing real data, MUST:
-    # 1. Sanitize ALL cell values via sanitize_for_export()
-    # 2. Enforce PII column filtering server-side based on user role
-    # 3. Validate visible_columns against allowed columns per grid
+    # Fetch real data
+    all_columns, data_rows = fetcher(ctx, strategy_ids, filter_params)
+
+    # Apply filter_params (Python-side filtering for AG Grid filter model)
+    if filter_params:
+        data_rows = _apply_filters(all_columns, data_rows, filter_params)
+
+    # Apply sort_model (Python-side sorting for AG Grid sort model)
+    if sort_model:
+        data_rows = _apply_sort(all_columns, data_rows, sort_model)
+
+    # Filter to visible columns if specified, preserving CLIENT column order
+    if visible_columns:
+        col_index_map = {c: i for i, c in enumerate(all_columns)}
+        # Iterate visible_columns (client order), skip any not in server columns
+        ordered_indices = [
+            col_index_map[c] for c in visible_columns if c in col_index_map
+        ]
+        headers = [all_columns[i] for i in ordered_indices]
+        rows = [[row[i] for i in ordered_indices] for row in data_rows]
+    else:
+        headers = all_columns
+        rows = data_rows
+
+    # Build workbook
     wb = Workbook()
     ws = wb.active
     ws.title = grid_name.title()
 
-    # Add header row (sanitize headers too)
-    headers = visible_columns or ["Column1", "Column2", "Column3"]
+    # Header row (sanitized)
     for col_idx, header in enumerate(headers, 1):
         ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Placeholder data - sanitize all values
-    ws.cell(row=2, column=1, value=sanitize_for_export("Excel export implementation pending"))
-    ws.cell(row=2, column=2, value=sanitize_for_export(f"Grid: {grid_name}"))
-    ws.cell(row=2, column=3, value=sanitize_for_export(f"Strategies: {len(strategy_ids)}"))
+    # Data rows (sanitized + type-coerced)
+    for row_idx, row in enumerate(rows, 2):
+        for col_idx, value in enumerate(row, 1):
+            ws.cell(row=row_idx, column=col_idx, value=_coerce_cell_value(value))
 
-    # Save to bytes
     output = io.BytesIO()
     wb.save(output)
     output.seek(0)
 
-    # Row count (excluding header)
-    row_count = 1  # Placeholder row
-
+    row_count = len(rows)
     return output.getvalue(), row_count
 
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1027,7 +1027,10 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return num_val <= num_filter
         filter_to = filter_def.get("filterTo")
         if operator == "inRange" and filter_to is not None:
-            return num_filter <= num_val <= Decimal(str(filter_to))
+            try:
+                return num_filter <= num_val <= Decimal(str(filter_to))
+            except (InvalidOperation, ValueError, TypeError):
+                return True  # Bad upper bound — can't compare, keep row
         return True
 
     if filter_type == "date":
@@ -1044,9 +1047,9 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             try:
                 dt_val = datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
             except ValueError:
-                return True  # Unparseable — keep the row
+                return False  # Unparseable — exclude (fail-closed, consistent with numeric)
         else:
-            return True  # Non-date value — keep the row
+            return False  # Non-date value — exclude (fail-closed, consistent with numeric)
 
         def _parse_ag_date(s: str | None) -> datetime | None:
             if not s:
@@ -1083,16 +1086,32 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
 
 
 def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
-    """Handle AG Grid compound filters (operator + condition1/condition2).
+    """Handle AG Grid compound filters.
 
-    If the filter_def contains an 'operator' key with 'condition1' and 'condition2',
-    it's a compound filter. Otherwise delegate to _match_filter for simple filters.
+    AG Grid emits two compound formats:
+    1. ``operator`` + ``condition1`` / ``condition2`` (legacy)
+    2. ``operator`` + ``conditions: [...]`` (simple combined filters)
+
+    If neither compound format is detected, delegate to _match_filter.
     """
     operator = filter_def.get("operator")
     condition1 = filter_def.get("condition1")
     condition2 = filter_def.get("condition2")
+    conditions = filter_def.get("conditions")
+
+    if operator and isinstance(conditions, list) and len(conditions) > 0:
+        # AG Grid conditions array format
+        results = [_match_filter(value, c) for c in conditions if isinstance(c, dict)]
+        if not results:
+            return True  # No valid conditions — keep the row
+        if operator == "AND":
+            return all(results)
+        if operator == "OR":
+            return any(results)
+        return results[0]
 
     if operator and isinstance(condition1, dict):
+        # Legacy condition1/condition2 format
         result1 = _match_filter(value, condition1)
         result2 = _match_filter(value, condition2) if isinstance(condition2, dict) else True
         if operator == "AND":

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1195,8 +1195,8 @@ def _apply_sort(
     # Normalise sort order: honour sortIndex when present, fall back to
     # array position.  Higher sortIndex = lower priority (applied first in
     # the reversed iteration below).
-    indexed_model = [
-        (spec.get("sortIndex", pos), spec)
+    indexed_model: list[tuple[int, dict[str, Any]]] = [
+        (int(spec["sortIndex"]) if spec.get("sortIndex") is not None else pos, spec)
         for pos, spec in enumerate(sort_model)
     ]
     indexed_model.sort(key=lambda t: t[0])
@@ -1294,10 +1294,9 @@ def _build_excel_sync(
         headers = all_columns
         rows = data_rows
 
-    # Build workbook
-    wb = Workbook()
-    ws = wb.active
-    ws.title = grid_name.title()
+    # Build workbook (write-only mode for memory efficiency on large exports)
+    wb = Workbook(write_only=True)
+    ws = wb.create_sheet(title=grid_name.title())
 
     # Header row (sanitized)
     ws.append([sanitize_for_export(h) for h in headers])

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1160,6 +1160,7 @@ def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return all(results)
         if operator == "OR":
             return any(results)
+        logger.warning("Unknown compound filter operator: %s", operator)
         return results[0]
 
     if operator and isinstance(condition1, dict):
@@ -1174,6 +1175,7 @@ def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return result1 and result2
         if operator == "OR":
             return result1 or result2
+        logger.warning("Unknown compound filter operator: %s", operator)
         return result1  # Unknown operator — fall back to condition1 only
 
     # Simple (non-compound) filter

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -898,16 +898,18 @@ def _fetch_working_orders_data(
 ) -> tuple[list[str], list[list[Any]]]:
     """Fetch working (active) orders for export.
 
-    Delegates to ``_fetch_orders_data`` with ``working_only=True`` and
-    appends a computed ``progress`` column (filled_qty / qty) matching
-    the Working Orders grid's visible progress field.
+    Delegates to ``_fetch_orders_data`` with ``working_only=True`` so
+    the SQL query is restricted to active statuses, matching the
+    Working Orders tab scope.
+
+    Note: The UI's ``progress`` column is omitted because it's only
+    populated for synthetic parent rows in the hierarchical TWAP view
+    (via ``compute_parent_aggregates``).  A flat export cannot reproduce
+    this hierarchy, so the column is excluded to avoid parity mismatch.
     """
-    columns, rows = _fetch_orders_data(
+    return _fetch_orders_data(
         ctx, strategy_ids, filter_params, working_only=True,
     )
-    # Append computed progress column
-    enriched_rows = [row + [_compute_progress(row, columns)] for row in rows]
-    return columns + ["progress"], enriched_rows
 
 
 def _fetch_fills_data(
@@ -1095,7 +1097,7 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         if isinstance(value, datetime):
             dt_val = _to_naive_utc(value)
         elif isinstance(value, date):
-            dt_val = datetime(value.year, value.month, value.day)
+            dt_val = datetime.combine(value, datetime.min.time())
         elif isinstance(value, str):
             try:
                 dt_val = _to_naive_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
@@ -1289,7 +1291,7 @@ def _apply_sort(
                 return (1, v.astimezone(UTC).replace(tzinfo=None))
             return (1, v)
         if isinstance(v, date):
-            return (1, datetime(v.year, v.month, v.day))
+            return (1, datetime.combine(v, datetime.min.time()))
         return (2, str(v))
 
     # Build sort keys in reverse priority order (last = primary in multi-sort)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -646,7 +646,7 @@ async def download_excel_export(
     max_rows: int | None = None
     if export_scope == "visible":
         estimated = audit_record.get("estimated_row_count")
-        if isinstance(estimated, int) and estimated > 0:
+        if isinstance(estimated, int) and estimated >= 0:
             max_rows = estimated
 
     # Generate Excel content with error handling
@@ -1052,14 +1052,20 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         date_from_str = filter_def.get("dateFrom")
         date_to_str = filter_def.get("dateTo")
 
+        def _to_naive_utc(dt: datetime) -> datetime:
+            """Convert to UTC then strip tzinfo for consistent comparison."""
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(UTC).replace(tzinfo=None)
+            return dt
+
         # Coerce cell value to a comparable datetime
         if isinstance(value, datetime):
-            dt_val = value.replace(tzinfo=None) if value.tzinfo else value
+            dt_val = _to_naive_utc(value)
         elif isinstance(value, date):
             dt_val = datetime(value.year, value.month, value.day)
         elif isinstance(value, str):
             try:
-                dt_val = datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+                dt_val = _to_naive_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
             except ValueError:
                 return False  # Unparseable — exclude (fail-closed, consistent with numeric)
         else:
@@ -1069,7 +1075,7 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             if not s:
                 return None
             try:
-                return datetime.fromisoformat(s.replace("Z", "+00:00")).replace(tzinfo=None)
+                return _to_naive_utc(datetime.fromisoformat(s.replace("Z", "+00:00")))
             except ValueError:
                 return None
 
@@ -1126,7 +1132,8 @@ def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
                     enriched.append({**c, "filterType": parent_filter_type})
                 else:
                     enriched.append(c)
-        results = [_match_filter(value, c) for c in enriched]
+        # Recurse via _match_compound_filter to handle nested compounds
+        results = [_match_compound_filter(value, c) for c in enriched]
         if not results:
             return True  # No valid conditions — keep the row
         if operator == "AND":
@@ -1136,9 +1143,9 @@ def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         return results[0]
 
     if operator and isinstance(condition1, dict):
-        # Legacy condition1/condition2 format
-        result1 = _match_filter(value, condition1)
-        result2 = _match_filter(value, condition2) if isinstance(condition2, dict) else True
+        # Legacy condition1/condition2 format — recurse for nested compounds
+        result1 = _match_compound_filter(value, condition1)
+        result2 = _match_compound_filter(value, condition2) if isinstance(condition2, dict) else True
         if operator == "AND":
             return result1 and result2
         if operator == "OR":
@@ -1240,8 +1247,8 @@ def _apply_sort(
         if isinstance(v, int | float):
             return (0, Decimal(str(v)))
         if isinstance(v, datetime):
-            # Compare datetimes natively (strip tz for consistent ordering)
-            return (1, v.replace(tzinfo=None) if v.tzinfo else v)
+            # Convert to UTC then strip tz for consistent ordering
+            return (1, v.astimezone(UTC).replace(tzinfo=None) if v.tzinfo else v)
         if isinstance(v, date):
             return (1, datetime(v.year, v.month, v.day))
         return (2, str(v))

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -757,7 +757,9 @@ def _compute_unrealized_plpc(pos: Any) -> Decimal | None:
         return None
     if avg_entry == 0 or qty == 0:
         return None
-    return Decimal(str(unrealized_pl)) / (Decimal(str(avg_entry)) * abs(Decimal(str(qty))))
+    # Position fields are already Decimal from schemas.Position
+    result: Decimal = unrealized_pl / (avg_entry * abs(qty))
+    return result
 
 
 def _fetch_positions_data(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1354,9 +1354,16 @@ def _build_excel_sync(
     # Use `is not None` so an explicit empty list [] produces an empty export
     if visible_columns is not None:
         col_index_map = {c: i for i, c in enumerate(all_columns)}
-        # Iterate visible_columns (client order), skip any not in server columns
+        # Ensure essential identifier columns are always included (auto-group
+        # grids like working_orders omit symbol from visible_columns)
+        essential = {"symbol", "client_order_id"}
+        augmented = list(visible_columns)
+        for col in essential:
+            if col not in augmented and col in col_index_map:
+                augmented.append(col)
+        # Iterate augmented columns (client order + essentials), skip any not in server
         ordered_indices = [
-            col_index_map[c] for c in visible_columns if c in col_index_map
+            col_index_map[c] for c in augmented if c in col_index_map
         ]
         headers = [all_columns[i] for i in ordered_indices]
         rows = [[row[i] for i in ordered_indices] for row in data_rows]

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1077,8 +1077,11 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return dt_val.date() > dt_from.date()
         if operator == "lessThan":
             return dt_val.date() < dt_from.date()
-        if operator == "inRange" and dt_to is not None:
-            return dt_from.date() <= dt_val.date() <= dt_to.date()
+        if operator == "inRange":
+            if dt_to is not None:
+                return dt_from.date() <= dt_val.date() <= dt_to.date()
+            # Missing dateTo — apply one-sided bound (greaterThanOrEqual)
+            return dt_val.date() >= dt_from.date()
         return True
 
     # Unsupported filter type — keep the row
@@ -1100,8 +1103,16 @@ def _match_compound_filter(value: Any, filter_def: dict[str, Any]) -> bool:
     conditions = filter_def.get("conditions")
 
     if operator and isinstance(conditions, list) and len(conditions) > 0:
-        # AG Grid conditions array format
-        results = [_match_filter(value, c) for c in conditions if isinstance(c, dict)]
+        # AG Grid conditions array format — children inherit filterType from parent
+        parent_filter_type = filter_def.get("filterType")
+        enriched: list[dict[str, Any]] = []
+        for c in conditions:
+            if isinstance(c, dict):
+                if "filterType" not in c and parent_filter_type:
+                    enriched.append({**c, "filterType": parent_filter_type})
+                else:
+                    enriched.append(c)
+        results = [_match_filter(value, c) for c in enriched]
         if not results:
             return True  # No valid conditions — keep the row
         if operator == "AND":

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -973,6 +973,7 @@ _GRID_FETCHERS: dict[str, _GridFetcher] = {
     "orders": _fetch_orders_data,
     "working_orders": _fetch_working_orders_data,
     "fills": _fetch_fills_data,
+    "history": _fetch_fills_data,  # History grid uses same trades source as fills
     "audit": _fetch_audit_data,
     "tca": _fetch_tca_data,
 }
@@ -1338,7 +1339,8 @@ def _build_excel_sync(
         data_rows = data_rows[:max_rows]
 
     # Filter to visible columns if specified, preserving CLIENT column order
-    if visible_columns:
+    # Use `is not None` so an explicit empty list [] produces an empty export
+    if visible_columns is not None:
         col_index_map = {c: i for i, c in enumerate(all_columns)}
         # Iterate visible_columns (client order), skip any not in server columns
         ordered_indices = [

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1340,13 +1340,15 @@ def _build_excel_sync(
     if filter_params:
         data_rows = _apply_filters(all_columns, data_rows, filter_params)
 
-    # Truncate to visible-scope row count BEFORE sorting so we export
-    # the same rows the dashboard displays (not different rows from a
-    # larger server-side dataset that happen to sort to the top).
+    # Visible-scope truncation: applied AFTER filtering, BEFORE sorting.
+    # Order: filter → truncate → sort.
+    # - After filter: so we cap the same filtered subset the grid shows
+    # - Before sort: so sorting operates on the capped set (matching grid
+    #   behavior where AG Grid sorts its local data, not the full DB)
     if max_rows is not None and len(data_rows) > max_rows:
         data_rows = data_rows[:max_rows]
 
-    # Apply sort_model (Python-side sorting for AG Grid sort model)
+    # Apply sort_model (Python-side sorting for the capped row set)
     if sort_model:
         data_rows = _apply_sort(all_columns, data_rows, sort_model)
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -749,18 +749,49 @@ def _fetch_positions_data(
     return columns, rows
 
 
+def _extract_status_values(filter_params: dict[str, Any] | None) -> list[str] | None:
+    """Extract status filter values from AG Grid filter model for SQL push-down.
+
+    Returns a list of status strings if a status filter is present,
+    or None to fetch all statuses.
+    """
+    if not filter_params or "status" not in filter_params:
+        return None
+    status_filter = filter_params["status"]
+    if not isinstance(status_filter, dict):
+        return None
+    filter_val = status_filter.get("filter")
+    op = status_filter.get("type", "")
+    if op == "equals" and isinstance(filter_val, str):
+        return [filter_val]
+    # For set/in filters, collect all values
+    values = status_filter.get("values")
+    if isinstance(values, list):
+        return [str(v) for v in values if v is not None]
+    return None
+
+
 def _fetch_orders_data(
     ctx: AppContext,
     strategy_ids: list[str],
-    _filter_params: dict[str, Any] | None,
+    filter_params: dict[str, Any] | None,
 ) -> tuple[list[str], list[list[Any]]]:
-    """Fetch orders grid data scoped to authorized strategies."""
+    """Fetch orders grid data scoped to authorized strategies.
+
+    Pushes status filtering to SQL when a status filter is present
+    in filter_params, ensuring correct row-count limits regardless
+    of working/all-orders tab context.
+    """
     columns = [
         "client_order_id", "strategy_id", "symbol", "side", "qty",
         "order_type", "status", "filled_qty", "filled_avg_price",
         "created_at", "submitted_at", "filled_at",
     ]
-    order_dicts = ctx.db.get_orders_for_export(strategy_ids=strategy_ids)
+    statuses = _extract_status_values(filter_params)
+    order_dicts = ctx.db.get_orders_for_export(
+        strategy_ids=strategy_ids,
+        statuses=statuses,
+    )
     rows = [[d.get(col) for col in columns] for d in order_dicts]
     return columns, rows
 
@@ -770,19 +801,30 @@ def _fetch_fills_data(
     strategy_ids: list[str],
     _filter_params: dict[str, Any] | None,
 ) -> tuple[list[str], list[list[Any]]]:
-    """Fetch fills for export scoped to authorized strategies."""
-    columns = [
+    """Fetch fills for export scoped to authorized strategies.
+
+    The UI grid uses field name ``time`` for the fill timestamp, so we
+    expose the column as ``time`` here (the DB method returns it as
+    ``timestamp``).  This ensures visible_columns, filter, and sort
+    models from the client match correctly.
+    """
+    # DB returns "timestamp"; UI grid field is "time"
+    db_columns = [
         "client_order_id", "symbol", "side", "status",
         "qty", "price", "realized_pl", "timestamp",
+    ]
+    export_columns = [
+        "client_order_id", "symbol", "side", "status",
+        "qty", "price", "realized_pl", "time",
     ]
     fills = ctx.db.get_fills_for_export(
         strategy_ids=strategy_ids,
     )
     rows = [
-        [fill.get(col) for col in columns]
+        [fill.get(col) for col in db_columns]
         for fill in fills
     ]
-    return columns, rows
+    return export_columns, rows
 
 
 def _fetch_audit_data(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -760,22 +760,8 @@ def _fetch_orders_data(
         "order_type", "status", "filled_qty", "filled_avg_price",
         "created_at", "submitted_at", "filled_at",
     ]
-    with ctx.db.transaction() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT client_order_id, strategy_id, symbol, side, qty,
-                       order_type, status, filled_qty, filled_avg_price,
-                       created_at, submitted_at, filled_at
-                FROM orders
-                WHERE strategy_id = ANY(%s)
-                ORDER BY created_at DESC
-                LIMIT 5000
-                """,
-                (strategy_ids,),
-            )
-            db_rows = cur.fetchall()
-    rows = [list(row) for row in db_rows]
+    order_dicts = ctx.db.get_orders_for_export(strategy_ids=strategy_ids)
+    rows = [[d.get(col) for col in columns] for d in order_dicts]
     return columns, rows
 
 
@@ -784,15 +770,13 @@ def _fetch_fills_data(
     strategy_ids: list[str],
     _filter_params: dict[str, Any] | None,
 ) -> tuple[list[str], list[list[Any]]]:
-    """Fetch recent fills scoped to authorized strategies."""
+    """Fetch fills for export scoped to authorized strategies."""
     columns = [
         "client_order_id", "symbol", "side", "status",
         "qty", "price", "realized_pl", "timestamp",
     ]
-    fills = ctx.db.get_recent_fills(
+    fills = ctx.db.get_fills_for_export(
         strategy_ids=strategy_ids,
-        limit=200,
-        lookback_hours=168,  # 7 days max
     )
     rows = [
         [fill.get(col) for col in columns]
@@ -900,7 +884,7 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
 
     if filter_type == "number":
         try:
-            num_val = float(Decimal(str(value))) if isinstance(value, Decimal) else float(value)
+            num_val = float(value)
             num_filter = float(filter_value) if filter_value is not None else 0.0
         except (ValueError, TypeError):
             return True  # Can't compare — keep the row
@@ -1075,7 +1059,20 @@ def _apply_sort(
         # Partition nulls out so they always end up last regardless of direction
         null_rows = [r for r in sorted_rows if r[idx] is None]
         non_null_rows = [r for r in sorted_rows if r[idx] is not None]
-        non_null_rows.sort(key=lambda row, _idx=idx: row[_idx], reverse=descending)
+
+        def _sort_key(row: list[Any], _idx: int = idx) -> tuple[int, Any]:
+            """Return a comparable sort key safe for mixed-type columns.
+
+            Numeric types (int/float/Decimal) are coerced to float so they
+            compare correctly with each other.  Non-numeric values are
+            stringified and placed in a separate bucket to avoid TypeError.
+            """
+            v = row[_idx]
+            if isinstance(v, int | float | Decimal):
+                return (0, float(v))
+            return (1, str(v))
+
+        non_null_rows.sort(key=_sort_key, reverse=descending)
         sorted_rows = non_null_rows + null_rows
 
     return sorted_rows

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -963,6 +963,14 @@ _GRID_FETCHERS: dict[str, _GridFetcher] = {
 }
 
 
+def _to_decimal(v: Any) -> Decimal | None:
+    """Convert a value to Decimal, returning None on failure."""
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
 def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
     """Check if a single cell value matches an AG Grid filter definition.
 
@@ -1003,15 +1011,13 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return False  # value is not None (checked above), so not blank
         if operator == "notBlank":
             return True  # value is not None, so it's not blank
-        try:
-            num_val = Decimal(str(value))
-        except (InvalidOperation, ValueError, TypeError):
+        num_val = _to_decimal(value)
+        if num_val is None:
             return False  # Non-numeric value fails numeric filter
         if filter_value is None:
             return True  # No filter value provided — can't compare, keep row
-        try:
-            num_filter = Decimal(str(filter_value))
-        except (InvalidOperation, ValueError, TypeError):
+        num_filter = _to_decimal(filter_value)
+        if num_filter is None:
             return True  # Bad filter value — can't compare, keep row
         if operator == "equals":
             return num_val == num_filter
@@ -1025,12 +1031,11 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return num_val < num_filter
         if operator == "lessThanOrEqual":
             return num_val <= num_filter
-        filter_to = filter_def.get("filterTo")
-        if operator == "inRange" and filter_to is not None:
-            try:
-                return num_filter <= num_val <= Decimal(str(filter_to))
-            except (InvalidOperation, ValueError, TypeError):
-                return True  # Bad upper bound — can't compare, keep row
+        if operator == "inRange":
+            num_to = _to_decimal(filter_def.get("filterTo"))
+            if num_to is None:
+                return True  # Bad/missing upper bound — can't compare, keep row
+            return num_filter <= num_val <= num_to
         return True
 
     if filter_type == "date":

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1047,7 +1047,7 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return True  # No filter value provided — can't compare, keep row
         num_filter = _to_decimal(filter_value)
         if num_filter is None:
-            return True  # Bad filter value — can't compare, keep row
+            return False  # Bad filter value — exclude row (fail-closed)
         if operator == "equals":
             return num_val == num_filter
         if operator == "notEqual":
@@ -1120,8 +1120,8 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         if operator == "inRange":
             if dt_to is not None:
                 return dt_from.date() <= dt_val.date() <= dt_to.date()
-            # Missing dateTo — can't apply range, keep row (consistent with numeric)
-            return True
+            # Missing dateTo — incomplete range filter, exclude row (fail-closed)
+            return False
         return True
 
     # Unsupported filter type — keep the row
@@ -1302,7 +1302,8 @@ def _apply_sort(
             return _key
 
         non_null_rows.sort(key=_make_key(idx), reverse=descending)
-        sorted_rows = non_null_rows + null_rows
+        # Nulls first when descending (see missing data at top), nulls last when ascending
+        sorted_rows = (null_rows + non_null_rows) if descending else (non_null_rows + null_rows)
 
     return sorted_rows
 
@@ -1351,9 +1352,7 @@ def _build_excel_sync(
 
     # Visible-scope truncation: applied AFTER filter+sort so the exported
     # slice matches the user's sorted view (top N rows of sorted result).
-    # Skip for working_orders: estimated_row_count includes synthetic
-    # hierarchy rows but we export flat leaf orders.
-    if max_rows is not None and grid_name != "working_orders" and len(data_rows) > max_rows:
+    if max_rows is not None and len(data_rows) > max_rows:
         data_rows = data_rows[:max_rows]
 
     # Filter to visible columns if specified, preserving CLIENT column order

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -801,11 +801,11 @@ def _extract_status_values(filter_params: dict[str, Any] | None) -> list[str] | 
     filter_val = status_filter.get("filter")
     op = status_filter.get("type", "")
     if op == "equals" and isinstance(filter_val, str):
-        return [filter_val]
-    # For set/in filters, collect all values
+        return [filter_val.lower()]
+    # For set/in filters, collect all values (normalize to lowercase for SQL)
     values = status_filter.get("values")
     if isinstance(values, list):
-        return [str(v) for v in values if v is not None]
+        return [str(v).lower() for v in values if v is not None]
     return None
 
 
@@ -1387,8 +1387,7 @@ def _build_excel_sync(
         ws.append([_coerce_cell_value(v) for v in row])
 
     output = io.BytesIO()
-    wb.save(output)
-    wb.close()  # Required for write_only mode to finalize temp files
+    wb.save(output)  # save() handles cleanup for write_only workbooks
     output.seek(0)
 
     row_count = len(rows)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -641,6 +641,14 @@ async def download_excel_export(
     visible_columns = audit_record["visible_columns"]
     sort_model = audit_record["sort_model"]
 
+    # For visible-scope exports, cap rows to what the user sees
+    export_scope = audit_record.get("export_scope", "visible")
+    max_rows: int | None = None
+    if export_scope == "visible":
+        estimated = audit_record.get("estimated_row_count")
+        if isinstance(estimated, int) and estimated > 0:
+            max_rows = estimated
+
     # Generate Excel content with error handling
     try:
         excel_content, row_count = await _generate_excel_content(
@@ -650,6 +658,7 @@ async def download_excel_export(
             filter_params=filter_params,
             visible_columns=visible_columns,
             sort_model=sort_model,
+            max_rows=max_rows,
         )
     except NotImplementedError as e:
         # Mark as failed before raising
@@ -1200,8 +1209,17 @@ def _apply_sort(
     # Normalise sort order: honour sortIndex when present, fall back to
     # array position.  Higher sortIndex = lower priority (applied first in
     # the reversed iteration below).
+    def _safe_sort_index(spec: dict[str, Any], fallback: int) -> int:
+        raw = spec.get("sortIndex")
+        if raw is None:
+            return fallback
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return fallback
+
     indexed_model: list[tuple[int, dict[str, Any]]] = [
-        (int(spec["sortIndex"]) if spec.get("sortIndex") is not None else pos, spec)
+        (_safe_sort_index(spec, pos), spec)
         for pos, spec in enumerate(sort_model)
     ]
     indexed_model.sort(key=lambda t: t[0])
@@ -1261,12 +1279,18 @@ def _build_excel_sync(
     filter_params: dict[str, Any] | None,
     visible_columns: list[str] | None,
     sort_model: list[dict[str, Any]] | None,
+    max_rows: int | None = None,
 ) -> tuple[bytes, int]:
     """Synchronous helper that does the heavy lifting for Excel export.
 
     Separated from the async wrapper so it can be offloaded to a worker
     thread via ``asyncio.to_thread``, preventing event-loop blocking on
     large datasets (up to 50 000 rows).
+
+    Args:
+        max_rows: When provided, truncate output to this many rows after
+            filtering/sorting.  Used for visible-scope exports to match
+            the number of rows the user sees in the grid.
     """
     try:
         from openpyxl import Workbook  # type: ignore[import-untyped]
@@ -1289,6 +1313,10 @@ def _build_excel_sync(
     # Apply sort_model (Python-side sorting for AG Grid sort model)
     if sort_model:
         data_rows = _apply_sort(all_columns, data_rows, sort_model)
+
+    # Truncate to visible-scope row count if requested
+    if max_rows is not None and len(data_rows) > max_rows:
+        data_rows = data_rows[:max_rows]
 
     # Filter to visible columns if specified, preserving CLIENT column order
     if visible_columns:
@@ -1316,6 +1344,7 @@ def _build_excel_sync(
 
     output = io.BytesIO()
     wb.save(output)
+    wb.close()  # Required for write_only mode to finalize temp files
     output.seek(0)
 
     row_count = len(rows)
@@ -1329,6 +1358,7 @@ async def _generate_excel_content(
     filter_params: dict[str, Any] | None,
     visible_columns: list[str] | None,
     sort_model: list[dict[str, Any]] | None,
+    max_rows: int | None = None,
 ) -> tuple[bytes, int]:
     """Generate Excel file content for a grid.
 
@@ -1342,6 +1372,7 @@ async def _generate_excel_content(
         _build_excel_sync,
         ctx, grid_name, strategy_ids,
         filter_params, visible_columns, sort_model,
+        max_rows,
     )
 
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -765,13 +765,18 @@ def _fetch_positions_data(
     strategy_ids: list[str],
     _filter_params: dict[str, Any] | None,
 ) -> tuple[list[str], list[list[Any]]]:
-    """Fetch positions grid data scoped to authorized strategies."""
+    """Fetch positions grid data matching the dashboard positions view.
+
+    Uses ``get_all_positions()`` (same source as the /api/v1/positions
+    endpoint and the positions grid) to avoid the fail-closed exclusion
+    of multi-strategy symbols in ``get_positions_for_strategies``.
+    """
     db_columns = [
         "symbol", "qty", "avg_entry_price", "current_price",
         "unrealized_pl", "realized_pl", "updated_at", "last_trade_at",
     ]
     export_columns = db_columns + ["unrealized_plpc"]
-    positions = ctx.db.get_positions_for_strategies(strategy_ids)
+    positions = ctx.db.get_all_positions()
     rows = [
         [getattr(pos, col, None) for col in db_columns] + [_compute_unrealized_plpc(pos)]
         for pos in positions
@@ -1251,8 +1256,10 @@ def _apply_sort(
         if isinstance(v, int | float):
             return (0, Decimal(str(v)))
         if isinstance(v, datetime):
-            # Convert to UTC then strip tz for consistent ordering
-            return (1, v.astimezone(UTC).replace(tzinfo=None) if v.tzinfo else v)
+            # Aware → convert to UTC then strip tz; naive → assumed UTC per project standard
+            if v.tzinfo is not None:
+                return (1, v.astimezone(UTC).replace(tzinfo=None))
+            return (1, v)
         if isinstance(v, date):
             return (1, datetime(v.year, v.month, v.day))
         return (2, str(v))

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -733,9 +733,12 @@ def _coerce_cell_value(value: Any) -> Any:
         return value
     if isinstance(value, bool | int | float):
         return value
-    # Dict/list → JSON string; all strings sanitized for formula injection
+    # Dict/list → JSON string; truncate to prevent oversized cells
     if isinstance(value, dict | list):
-        return sanitize_for_export(json.dumps(value, default=str))
+        serialized = json.dumps(value, default=str)
+        if len(serialized) > 32_000:  # Excel cell limit ~32K chars
+            serialized = serialized[:32_000] + "…[truncated]"
+        return sanitize_for_export(serialized)
     return sanitize_for_export(str(value))
 
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1202,6 +1202,27 @@ def _apply_sort(
     indexed_model.sort(key=lambda t: t[0])
     ordered_specs = [spec for _, spec in indexed_model]
 
+    def _sort_value(v: Any) -> tuple[int, Any]:
+        """Return a comparable sort key safe for mixed-type columns.
+
+        Numeric types (int/float/Decimal) are coerced to Decimal so they
+        compare correctly with each other without precision loss.
+        Non-numeric values are stringified and placed in a separate
+        bucket to avoid TypeError.
+        """
+        if isinstance(v, bool):
+            return (2, str(v))  # bool is subclass of int; sort as string
+        if isinstance(v, Decimal):
+            return (0, v)
+        if isinstance(v, int | float):
+            return (0, Decimal(str(v)))
+        if isinstance(v, datetime):
+            # Compare datetimes natively (strip tz for consistent ordering)
+            return (1, v.replace(tzinfo=None) if v.tzinfo else v)
+        if isinstance(v, date):
+            return (1, datetime(v.year, v.month, v.day))
+        return (2, str(v))
+
     # Build sort keys in reverse priority order (last = primary in multi-sort)
     sorted_rows = list(rows)
     for sort_spec in reversed(ordered_specs):
@@ -1217,29 +1238,12 @@ def _apply_sort(
         for r in sorted_rows:
             (null_rows if r[idx] is None else non_null_rows).append(r)
 
-        def _sort_key(row: list[Any], _idx: int = idx) -> tuple[int, Any]:
-            """Return a comparable sort key safe for mixed-type columns.
+        def _make_key(col_idx: int) -> Callable[[list[Any]], tuple[int, Any]]:
+            def _key(row: list[Any]) -> tuple[int, Any]:
+                return _sort_value(row[col_idx])
+            return _key
 
-            Numeric types (int/float/Decimal) are coerced to Decimal so they
-            compare correctly with each other without precision loss.
-            Non-numeric values are stringified and placed in a separate
-            bucket to avoid TypeError.
-            """
-            v = row[_idx]
-            if isinstance(v, bool):
-                return (2, str(v))  # bool is subclass of int; sort as string
-            if isinstance(v, Decimal):
-                return (0, v)
-            if isinstance(v, int | float):
-                return (0, Decimal(str(v)))
-            if isinstance(v, datetime):
-                # Compare datetimes natively (strip tz for consistent ordering)
-                return (1, v.replace(tzinfo=None) if v.tzinfo else v)
-            if isinstance(v, date):
-                return (1, datetime(v.year, v.month, v.day))
-            return (2, str(v))
-
-        non_null_rows.sort(key=_sort_key, reverse=descending)
+        non_null_rows.sort(key=_make_key(idx), reverse=descending)
         sorted_rows = non_null_rows + null_rows
 
     return sorted_rows

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 import io
 import json
 import logging
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from collections.abc import Callable
 from typing import Any, Literal
 from uuid import UUID
 
@@ -705,14 +705,14 @@ async def download_excel_export(
 def _coerce_cell_value(value: Any) -> Any:
     """Coerce a database value to an Excel-safe type.
 
-    Decimals are converted to float so openpyxl writes them as numbers.
+    Decimals are kept as-is (openpyxl handles them natively, preserving precision).
     Datetimes are kept as-is (openpyxl handles them natively).
     Everything else is stringified and sanitized.
     """
     if value is None:
         return None
     if isinstance(value, Decimal):
-        return float(value)
+        return value  # openpyxl supports Decimal natively; preserve precision
     if isinstance(value, datetime):
         # openpyxl requires timezone-naive datetimes
         return value.replace(tzinfo=None) if value.tzinfo else value
@@ -859,7 +859,7 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
 
     if value is None:
         # Null values only match "blank" filters
-        return operator == "blank"
+        return bool(operator == "blank")
 
     if filter_type == "text":
         text_val = str(value).lower()
@@ -883,11 +883,20 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         return True  # Unknown text operator — don't filter out
 
     if filter_type == "number":
+        if operator == "blank":
+            return False  # value is not None (checked above), so not blank
+        if operator == "notBlank":
+            return True  # value is not None, so it's not blank
         try:
             num_val = float(value)
-            num_filter = float(filter_value) if filter_value is not None else 0.0
         except (ValueError, TypeError):
-            return True  # Can't compare — keep the row
+            return False  # Non-numeric value fails numeric filter
+        if filter_value is None:
+            return True  # No filter value provided — can't compare, keep row
+        try:
+            num_filter = float(filter_value)
+        except (ValueError, TypeError):
+            return True  # Bad filter value — can't compare, keep row
         if operator == "equals":
             return num_val == num_filter
         if operator == "notEqual":
@@ -1057,8 +1066,10 @@ def _apply_sort(
         descending = sort_spec.get("sort", "asc") == "desc"
 
         # Partition nulls out so they always end up last regardless of direction
-        null_rows = [r for r in sorted_rows if r[idx] is None]
-        non_null_rows = [r for r in sorted_rows if r[idx] is not None]
+        null_rows: list[list[Any]] = []
+        non_null_rows: list[list[Any]] = []
+        for r in sorted_rows:
+            (null_rows if r[idx] is None else non_null_rows).append(r)
 
         def _sort_key(row: list[Any], _idx: int = idx) -> tuple[int, Any]:
             """Return a comparable sort key safe for mixed-type columns.
@@ -1146,13 +1157,11 @@ async def _generate_excel_content(
     ws.title = grid_name.title()
 
     # Header row (sanitized)
-    for col_idx, header in enumerate(headers, 1):
-        ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
+    ws.append([sanitize_for_export(h) for h in headers])
 
     # Data rows (sanitized + type-coerced)
-    for row_idx, row in enumerate(rows, 2):
-        for col_idx, value in enumerate(row, 1):
-            ws.cell(row=row_idx, column=col_idx, value=_coerce_cell_value(value))
+    for row in rows:
+        ws.append([_coerce_cell_value(v) for v in row])
 
     output = io.BytesIO()
     wb.save(output)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -716,8 +716,10 @@ def _coerce_cell_value(value: Any) -> Any:
     if isinstance(value, Decimal):
         return value  # openpyxl supports Decimal natively; preserve precision
     if isinstance(value, datetime):
-        # openpyxl requires timezone-naive datetimes
-        return value.replace(tzinfo=None) if value.tzinfo else value
+        # openpyxl requires timezone-naive datetimes; convert to UTC first
+        if value.tzinfo is not None:
+            value = value.astimezone(UTC).replace(tzinfo=None)
+        return value
     if isinstance(value, date):
         return value
     if isinstance(value, bool | int | float):
@@ -818,8 +820,13 @@ def _fetch_orders_data(
     ]
 
     statuses = _extract_status_values(filter_params)
-    if statuses is None and working_only:
-        statuses = WORKING_ORDER_STATUSES
+    if working_only:
+        # Always enforce working statuses; intersect with client filter if present
+        allowed = set(WORKING_ORDER_STATUSES)
+        if statuses is not None:
+            statuses = [s for s in statuses if s in allowed]
+        else:
+            statuses = WORKING_ORDER_STATUSES
 
     order_dicts = ctx.db.get_orders_for_export(
         strategy_ids=strategy_ids,
@@ -1173,12 +1180,17 @@ def _apply_sort(
             """
             v = row[_idx]
             if isinstance(v, bool):
-                return (1, str(v))  # bool is subclass of int; sort as string
+                return (2, str(v))  # bool is subclass of int; sort as string
             if isinstance(v, Decimal):
                 return (0, v)
             if isinstance(v, int | float):
                 return (0, Decimal(str(v)))
-            return (1, str(v))
+            if isinstance(v, datetime):
+                # Compare datetimes natively (strip tz for consistent ordering)
+                return (1, v.replace(tzinfo=None) if v.tzinfo else v)
+            if isinstance(v, date):
+                return (1, datetime(v.year, v.month, v.day))
+            return (2, str(v))
 
         non_null_rows.sort(key=_sort_key, reverse=descending)
         sorted_rows = non_null_rows + null_rows
@@ -1186,7 +1198,7 @@ def _apply_sort(
     return sorted_rows
 
 
-async def _generate_excel_content(
+def _build_excel_sync(
     ctx: AppContext,
     grid_name: str,
     strategy_ids: list[str],
@@ -1194,24 +1206,11 @@ async def _generate_excel_content(
     visible_columns: list[str] | None,
     sort_model: list[dict[str, Any]] | None,
 ) -> tuple[bytes, int]:
-    """Generate Excel file content for a grid.
+    """Synchronous helper that does the heavy lifting for Excel export.
 
-    Fetches real data from the database via per-grid fetchers and writes
-    it to an openpyxl Workbook with formula-injection sanitization.
-
-    Args:
-        ctx: Application context with database access
-        grid_name: Name of grid to export
-        strategy_ids: Authorized strategy IDs for filtering
-        filter_params: AG Grid filter model
-        visible_columns: Columns to include (if None, all columns)
-        sort_model: AG Grid sort model for row ordering
-
-    Returns:
-        Tuple of (excel_bytes, row_count)
-
-    Raises:
-        NotImplementedError: If grid type not supported or openpyxl missing
+    Separated from the async wrapper so it can be offloaded to a worker
+    thread via ``asyncio.to_thread``, preventing event-loop blocking on
+    large datasets (up to 50 000 rows).
     """
     try:
         from openpyxl import Workbook  # type: ignore[import-untyped]
@@ -1266,6 +1265,29 @@ async def _generate_excel_content(
 
     row_count = len(rows)
     return output.getvalue(), row_count
+
+
+async def _generate_excel_content(
+    ctx: AppContext,
+    grid_name: str,
+    strategy_ids: list[str],
+    filter_params: dict[str, Any] | None,
+    visible_columns: list[str] | None,
+    sort_model: list[dict[str, Any]] | None,
+) -> tuple[bytes, int]:
+    """Generate Excel file content for a grid.
+
+    Offloads the blocking work (DB fetch, filtering, sorting, openpyxl
+    workbook generation) to a worker thread so the FastAPI event loop
+    is not blocked on large exports.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(
+        _build_excel_sync,
+        ctx, grid_name, strategy_ids,
+        filter_params, visible_columns, sort_model,
+    )
 
 
 @router.get(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -735,22 +735,39 @@ def _coerce_cell_value(value: Any) -> Any:
 # =============================================================================
 
 
+def _compute_unrealized_plpc(pos: Any) -> Decimal | None:
+    """Compute unrealized P&L percentage for a position.
+
+    Mirrors the UI computation in positions_grid.py so the exported
+    ``unrealized_plpc`` column matches what the user sees.
+    """
+    unrealized_pl = getattr(pos, "unrealized_pl", None)
+    avg_entry = getattr(pos, "avg_entry_price", None)
+    qty = getattr(pos, "qty", None)
+    if unrealized_pl is None or avg_entry is None or qty is None:
+        return None
+    if avg_entry == 0 or qty == 0:
+        return None
+    return Decimal(str(unrealized_pl)) / (Decimal(str(avg_entry)) * abs(Decimal(str(qty))))
+
+
 def _fetch_positions_data(
     ctx: AppContext,
     strategy_ids: list[str],
     _filter_params: dict[str, Any] | None,
 ) -> tuple[list[str], list[list[Any]]]:
     """Fetch positions grid data scoped to authorized strategies."""
-    columns = [
+    db_columns = [
         "symbol", "qty", "avg_entry_price", "current_price",
         "unrealized_pl", "realized_pl", "updated_at", "last_trade_at",
     ]
+    export_columns = db_columns + ["unrealized_plpc"]
     positions = ctx.db.get_positions_for_strategies(strategy_ids)
     rows = [
-        [getattr(pos, col, None) for col in columns]
+        [getattr(pos, col, None) for col in db_columns] + [_compute_unrealized_plpc(pos)]
         for pos in positions
     ]
-    return columns, rows
+    return export_columns, rows
 
 
 def _extract_status_values(filter_params: dict[str, Any] | None) -> list[str] | None:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -24,7 +24,7 @@ import json
 import logging
 from collections.abc import Callable
 from datetime import UTC, date, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal
 from uuid import UUID
 
@@ -888,14 +888,14 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
         if operator == "notBlank":
             return True  # value is not None, so it's not blank
         try:
-            num_val = float(value)
-        except (ValueError, TypeError):
+            num_val = Decimal(str(value))
+        except (InvalidOperation, ValueError, TypeError):
             return False  # Non-numeric value fails numeric filter
         if filter_value is None:
             return True  # No filter value provided — can't compare, keep row
         try:
-            num_filter = float(filter_value)
-        except (ValueError, TypeError):
+            num_filter = Decimal(str(filter_value))
+        except (InvalidOperation, ValueError, TypeError):
             return True  # Bad filter value — can't compare, keep row
         if operator == "equals":
             return num_val == num_filter
@@ -911,7 +911,7 @@ def _match_filter(value: Any, filter_def: dict[str, Any]) -> bool:
             return num_val <= num_filter
         filter_to = filter_def.get("filterTo")
         if operator == "inRange" and filter_to is not None:
-            return num_filter <= num_val <= float(filter_to)
+            return num_filter <= num_val <= Decimal(str(filter_to))
         return True
 
     if filter_type == "date":
@@ -1074,13 +1074,16 @@ def _apply_sort(
         def _sort_key(row: list[Any], _idx: int = idx) -> tuple[int, Any]:
             """Return a comparable sort key safe for mixed-type columns.
 
-            Numeric types (int/float/Decimal) are coerced to float so they
-            compare correctly with each other.  Non-numeric values are
-            stringified and placed in a separate bucket to avoid TypeError.
+            Numeric types (int/float/Decimal) are coerced to Decimal so they
+            compare correctly with each other without precision loss.
+            Non-numeric values are stringified and placed in a separate
+            bucket to avoid TypeError.
             """
             v = row[_idx]
-            if isinstance(v, int | float | Decimal):
-                return (0, float(v))
+            if isinstance(v, Decimal):
+                return (0, v)
+            if isinstance(v, int | float):
+                return (0, Decimal(str(v)))
             return (1, str(v))
 
         non_null_rows.sort(key=_sort_key, reverse=descending)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -68,7 +68,9 @@ class ExportAuditCreateRequest(BaseModel):
         ..., description="Type of export"
     )
     grid_name: str = Field(
-        ..., description="Name of grid being exported (positions, orders, fills, audit, tca)"
+        ...,
+        description="Name of grid being exported "
+        "(positions, orders, working_orders, fills, audit, tca)",
     )
     filter_params: dict[str, Any] | None = Field(
         default=None, description="AG Grid filter model at time of export"
@@ -771,29 +773,76 @@ def _extract_status_values(filter_params: dict[str, Any] | None) -> list[str] | 
     return None
 
 
+# DB column → UI field aliases for orders grid.
+# The UI grid uses field ids like "type" (not "order_type"), so exported
+# columns must match the client's visible_columns / filter / sort model.
+_ORDERS_DB_TO_UI: dict[str, str] = {
+    "order_type": "type",
+}
+
+# Active order statuses that define the "Working" tab scope.
+# Must stay in sync with WORKING_ORDER_STATUSES in tabbed_panel.py.
+WORKING_ORDER_STATUSES: list[str] = [
+    "new", "pending_new", "accepted", "partially_filled",
+    "pending_cancel", "pending_replace",
+]
+
+
 def _fetch_orders_data(
     ctx: AppContext,
     strategy_ids: list[str],
     filter_params: dict[str, Any] | None,
+    *,
+    working_only: bool = False,
 ) -> tuple[list[str], list[list[Any]]]:
     """Fetch orders grid data scoped to authorized strategies.
 
     Pushes status filtering to SQL when a status filter is present
     in filter_params, ensuring correct row-count limits regardless
     of working/all-orders tab context.
+
+    Args:
+        working_only: When True, restricts to active order statuses
+            even if filter_params has no explicit status filter.
+            Used by the ``working_orders`` grid alias.
     """
-    columns = [
+    db_columns = [
         "client_order_id", "strategy_id", "symbol", "side", "qty",
         "order_type", "status", "filled_qty", "filled_avg_price",
+        "limit_price", "stop_price",
         "created_at", "submitted_at", "filled_at",
     ]
+    # Columns exposed to the client (with UI-friendly names)
+    export_columns = [
+        _ORDERS_DB_TO_UI.get(c, c) for c in db_columns
+    ]
+
     statuses = _extract_status_values(filter_params)
+    if statuses is None and working_only:
+        statuses = WORKING_ORDER_STATUSES
+
     order_dicts = ctx.db.get_orders_for_export(
         strategy_ids=strategy_ids,
         statuses=statuses,
     )
-    rows = [[d.get(col) for col in columns] for d in order_dicts]
-    return columns, rows
+    rows = [[d.get(col) for col in db_columns] for d in order_dicts]
+    return export_columns, rows
+
+
+def _fetch_working_orders_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    filter_params: dict[str, Any] | None,
+) -> tuple[list[str], list[list[Any]]]:
+    """Fetch working (active) orders for export.
+
+    Delegates to ``_fetch_orders_data`` with ``working_only=True`` so
+    the SQL query is restricted to active statuses, matching the
+    Working Orders tab scope.
+    """
+    return _fetch_orders_data(
+        ctx, strategy_ids, filter_params, working_only=True,
+    )
 
 
 def _fetch_fills_data(
@@ -883,6 +932,7 @@ _GridFetcher = Callable[
 _GRID_FETCHERS: dict[str, _GridFetcher] = {
     "positions": _fetch_positions_data,
     "orders": _fetch_orders_data,
+    "working_orders": _fetch_working_orders_data,
     "fills": _fetch_fills_data,
     "audit": _fetch_audit_data,
     "tca": _fetch_tca_data,
@@ -1122,6 +1172,8 @@ def _apply_sort(
             bucket to avoid TypeError.
             """
             v = row[_idx]
+            if isinstance(v, bool):
+                return (1, str(v))  # bool is subclass of int; sort as string
             if isinstance(v, Decimal):
                 return (0, v)
             if isinstance(v, int | float):

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -873,24 +873,6 @@ def _fetch_orders_data(
     return export_columns, rows
 
 
-def _compute_progress(row: list[Any], columns: list[str]) -> Decimal | None:
-    """Compute fill progress (filled_qty / qty) for working orders.
-
-    Mirrors the UI's progress column shown for parent TWAP rows.
-    Returns None if qty is zero or values are missing.
-    """
-    try:
-        qty_idx = columns.index("qty")
-        filled_idx = columns.index("filled_qty")
-        qty = row[qty_idx]
-        filled = row[filled_idx]
-        if qty is None or filled is None or qty == 0:
-            return None
-        return Decimal(str(filled)) / Decimal(str(qty))
-    except (ValueError, InvalidOperation):
-        return None
-
-
 def _fetch_working_orders_data(
     ctx: AppContext,
     strategy_ids: list[str],
@@ -1358,13 +1340,15 @@ def _build_excel_sync(
     if filter_params:
         data_rows = _apply_filters(all_columns, data_rows, filter_params)
 
+    # Truncate to visible-scope row count BEFORE sorting so we export
+    # the same rows the dashboard displays (not different rows from a
+    # larger server-side dataset that happen to sort to the top).
+    if max_rows is not None and len(data_rows) > max_rows:
+        data_rows = data_rows[:max_rows]
+
     # Apply sort_model (Python-side sorting for AG Grid sort model)
     if sort_model:
         data_rows = _apply_sort(all_columns, data_rows, sort_model)
-
-    # Truncate to visible-scope row count if requested
-    if max_rows is not None and len(data_rows) > max_rows:
-        data_rows = data_rows[:max_rows]
 
     # Filter to visible columns if specified, preserving CLIENT column order
     # Use `is not None` so an explicit empty list [] produces an empty export

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -758,8 +758,10 @@ def _compute_unrealized_plpc(pos: Any) -> Decimal | None:
     qty = getattr(pos, "qty", None)
     if unrealized_pl is None or avg_entry is None or qty is None:
         return None
-    if avg_entry == 0 or qty == 0:
-        return None
+    if qty == 0:
+        return Decimal(0)  # Closed position — no unrealized P&L %
+    if avg_entry == 0:
+        return None  # Data anomaly — can't compute percentage
     # Position fields are already Decimal from schemas.Position
     result: Decimal = unrealized_pl / (avg_entry * abs(qty))
     return result
@@ -983,7 +985,8 @@ _GRID_FETCHERS: dict[str, _GridFetcher] = {
     "orders": _fetch_orders_data,
     "working_orders": _fetch_working_orders_data,
     "fills": _fetch_fills_data,
-    "history": _fetch_fills_data,  # History grid uses same trades source as fills
+    # "history" intentionally omitted — history_snapshot is a separate
+    # client-side dataset not backed by a server-side fetcher yet.
     "audit": _fetch_audit_data,
     "tca": _fetch_tca_data,
 }
@@ -1340,30 +1343,26 @@ def _build_excel_sync(
     if filter_params:
         data_rows = _apply_filters(all_columns, data_rows, filter_params)
 
-    # Visible-scope truncation: applied AFTER filtering, BEFORE sorting.
-    # Order: filter → truncate → sort.
-    # - After filter: so we cap the same filtered subset the grid shows
-    # - Before sort: so sorting operates on the capped set (matching grid
-    #   behavior where AG Grid sorts its local data, not the full DB)
-    if max_rows is not None and len(data_rows) > max_rows:
-        data_rows = data_rows[:max_rows]
-
-    # Apply sort_model (Python-side sorting for the capped row set)
+    # Apply sort_model (Python-side sorting for AG Grid sort model)
     if sort_model:
         data_rows = _apply_sort(all_columns, data_rows, sort_model)
+
+    # Visible-scope truncation: applied AFTER filter+sort so the exported
+    # slice matches the user's sorted view (top N rows of sorted result).
+    if max_rows is not None and len(data_rows) > max_rows:
+        data_rows = data_rows[:max_rows]
 
     # Filter to visible columns if specified, preserving CLIENT column order
     # Use `is not None` so an explicit empty list [] produces an empty export
     if visible_columns is not None:
         col_index_map = {c: i for i, c in enumerate(all_columns)}
-        # Ensure essential identifier columns are always included (auto-group
-        # grids like working_orders omit symbol from visible_columns)
-        essential = {"symbol", "client_order_id"}
         augmented = list(visible_columns)
-        for col in essential:
-            if col not in augmented and col in col_index_map:
-                augmented.append(col)
-        # Iterate augmented columns (client order + essentials), skip any not in server
+        # Only inject essential identifier columns for auto-group grids
+        # (working_orders omits symbol from visible_columns via auto-group)
+        if grid_name == "working_orders":
+            for col in ("symbol", "client_order_id"):
+                if col not in augmented and col in col_index_map:
+                    augmented.append(col)
         ordered_indices = [
             col_index_map[c] for c in augmented if c in col_index_map
         ]

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -870,6 +870,24 @@ def _fetch_orders_data(
     return export_columns, rows
 
 
+def _compute_progress(row: list[Any], columns: list[str]) -> Decimal | None:
+    """Compute fill progress (filled_qty / qty) for working orders.
+
+    Mirrors the UI's progress column shown for parent TWAP rows.
+    Returns None if qty is zero or values are missing.
+    """
+    try:
+        qty_idx = columns.index("qty")
+        filled_idx = columns.index("filled_qty")
+        qty = row[qty_idx]
+        filled = row[filled_idx]
+        if qty is None or filled is None or qty == 0:
+            return None
+        return Decimal(str(filled)) / Decimal(str(qty))
+    except (ValueError, InvalidOperation):
+        return None
+
+
 def _fetch_working_orders_data(
     ctx: AppContext,
     strategy_ids: list[str],
@@ -877,13 +895,16 @@ def _fetch_working_orders_data(
 ) -> tuple[list[str], list[list[Any]]]:
     """Fetch working (active) orders for export.
 
-    Delegates to ``_fetch_orders_data`` with ``working_only=True`` so
-    the SQL query is restricted to active statuses, matching the
-    Working Orders tab scope.
+    Delegates to ``_fetch_orders_data`` with ``working_only=True`` and
+    appends a computed ``progress`` column (filled_qty / qty) matching
+    the Working Orders grid's visible progress field.
     """
-    return _fetch_orders_data(
+    columns, rows = _fetch_orders_data(
         ctx, strategy_ids, filter_params, working_only=True,
     )
+    # Append computed progress column
+    enriched_rows = [row + [_compute_progress(row, columns)] for row in rows]
+    return columns + ["progress"], enriched_rows
 
 
 def _fetch_fills_data(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1349,7 +1349,9 @@ def _build_excel_sync(
 
     # Visible-scope truncation: applied AFTER filter+sort so the exported
     # slice matches the user's sorted view (top N rows of sorted result).
-    if max_rows is not None and len(data_rows) > max_rows:
+    # Skip for working_orders: estimated_row_count includes synthetic
+    # hierarchy rows but we export flat leaf orders.
+    if max_rows is not None and grid_name != "working_orders" and len(data_rows) > max_rows:
         data_rows = data_rows[:max_rows]
 
     # Filter to visible columns if specified, preserving CLIENT column order

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -765,18 +765,19 @@ def _fetch_positions_data(
     strategy_ids: list[str],
     _filter_params: dict[str, Any] | None,
 ) -> tuple[list[str], list[list[Any]]]:
-    """Fetch positions grid data matching the dashboard positions view.
+    """Fetch positions grid data scoped to authorized strategies.
 
-    Uses ``get_all_positions()`` (same source as the /api/v1/positions
-    endpoint and the positions grid) to avoid the fail-closed exclusion
-    of multi-strategy symbols in ``get_positions_for_strategies``.
+    Uses ``get_positions_for_strategies`` to enforce strategy-level
+    authorization.  Symbols traded by multiple strategies are excluded
+    (fail-closed) to prevent cross-strategy data leakage — this is a
+    known limitation until the positions table gains a strategy_id column.
     """
     db_columns = [
         "symbol", "qty", "avg_entry_price", "current_price",
         "unrealized_pl", "realized_pl", "updated_at", "last_trade_at",
     ]
     export_columns = db_columns + ["unrealized_plpc"]
-    positions = ctx.db.get_all_positions()
+    positions = ctx.db.get_positions_for_strategies(strategy_ids)
     rows = [
         [getattr(pos, col, None) for col in db_columns] + [_compute_unrealized_plpc(pos)]
         for pos in positions

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -83,8 +83,9 @@ class GridExportToolbar:
     def _merge_filters(self, filter_model: dict[str, Any] | None) -> dict[str, Any] | None:
         """Merge AG Grid filter model with extra_filters (e.g., symbol dropdown).
 
-        Extra filters are only added for keys not already in the AG Grid model,
-        so explicit grid filters always take precedence.
+        When both the grid and extra_filters define the same column, they are
+        combined as an AND compound filter so visible rows = intersection of both
+        (matching dashboard behavior where the dropdown is applied before AG Grid).
         """
         base = dict(filter_model) if filter_model else {}
         if self.extra_filters:
@@ -93,6 +94,13 @@ class GridExportToolbar:
                 for key, val in extra.items():
                     if key not in base:
                         base[key] = val
+                    elif isinstance(val, dict) and isinstance(base[key], dict):
+                        # Both define the same column — combine as AND
+                        base[key] = {
+                            "filterType": val.get("filterType", base[key].get("filterType", "text")),
+                            "operator": "AND",
+                            "conditions": [base[key], val],
+                        }
             except Exception:
                 logger.warning("extra_filters callback failed", exc_info=True)
         return base or None

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -102,7 +102,7 @@ class GridExportToolbar:
                             existing.get("operator") == "AND"
                             and isinstance(existing.get("conditions"), list)
                         ):
-                            existing["conditions"].append(val)
+                            existing["conditions"] = list(existing.get("conditions", [])) + [val]
                         else:
                             # Wrap both in a new AND compound
                             base[key] = {

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -95,12 +95,20 @@ class GridExportToolbar:
                     if key not in base:
                         base[key] = val
                     elif isinstance(val, dict) and isinstance(base[key], dict):
-                        # Both define the same column — combine as AND
-                        base[key] = {
-                            "filterType": val.get("filterType", base[key].get("filterType", "text")),
-                            "operator": "AND",
-                            "conditions": [base[key], val],
-                        }
+                        existing = base[key]
+                        # If existing is already an AND compound, append to its conditions
+                        if (
+                            existing.get("operator") == "AND"
+                            and isinstance(existing.get("conditions"), list)
+                        ):
+                            existing["conditions"].append(val)
+                        else:
+                            # Wrap both in a new AND compound
+                            base[key] = {
+                                "filterType": val.get("filterType", existing.get("filterType", "text")),
+                                "operator": "AND",
+                                "conditions": [existing, val],
+                            }
             except (TypeError, ValueError, KeyError, AttributeError):
                 logger.warning("extra_filters callback failed", exc_info=True)
         return base or None

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -101,7 +101,7 @@ class GridExportToolbar:
                             "operator": "AND",
                             "conditions": [base[key], val],
                         }
-            except Exception:
+            except (TypeError, ValueError, KeyError, AttributeError):
                 logger.warning("extra_filters callback failed", exc_info=True)
         return base or None
 

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -50,6 +50,7 @@ class GridExportToolbar:
         on_export_start: Callable[[str], None] | None = None,
         on_export_complete: Callable[[str, int], None] | None = None,
         api_base_url: str = "/api/v1",
+        extra_filters: Callable[[], dict[str, Any]] | None = None,
     ) -> None:
         """Initialize export toolbar.
 
@@ -62,6 +63,8 @@ class GridExportToolbar:
             on_export_start: Callback when export starts
             on_export_complete: Callback when export completes (type, row_count)
             api_base_url: Base URL for export API endpoints
+            extra_filters: Optional callable returning additional filter_params
+                to merge (e.g., active symbol dropdown filter not in AG Grid model)
         """
         self.grid_id = grid_id
         self.grid_name = grid_name
@@ -71,10 +74,28 @@ class GridExportToolbar:
         self.on_export_start = on_export_start
         self.on_export_complete = on_export_complete
         self.api_base_url = api_base_url
+        self.extra_filters = extra_filters
 
         self._csv_button: ui.button | None = None
         self._excel_button: ui.button | None = None
         self._clipboard_button: ui.button | None = None
+
+    def _merge_filters(self, filter_model: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Merge AG Grid filter model with extra_filters (e.g., symbol dropdown).
+
+        Extra filters are only added for keys not already in the AG Grid model,
+        so explicit grid filters always take precedence.
+        """
+        base = dict(filter_model) if filter_model else {}
+        if self.extra_filters:
+            try:
+                extra = self.extra_filters()
+                for key, val in extra.items():
+                    if key not in base:
+                        base[key] = val
+            except Exception:
+                pass  # Don't block export if extra_filters callback fails
+        return base or None
 
     def _get_filename(self) -> str:
         """Generate filename with timestamp."""
@@ -169,7 +190,7 @@ class GridExportToolbar:
                     json={
                         "export_type": export_type,
                         "grid_name": self.grid_name,
-                        "filter_params": grid_state.get("filterModel"),
+                        "filter_params": self._merge_filters(grid_state.get("filterModel")),
                         "visible_columns": grid_state.get("columns"),
                         "sort_model": grid_state.get("sortModel"),
                         "export_scope": "visible",

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -9,6 +9,7 @@ Provides CSV, Excel, and Clipboard export functionality with:
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -87,7 +88,7 @@ class GridExportToolbar:
         combined as an AND compound filter so visible rows = intersection of both
         (matching dashboard behavior where the dropdown is applied before AG Grid).
         """
-        base = dict(filter_model) if filter_model else {}
+        base: dict[str, Any] = copy.deepcopy(filter_model) if filter_model else {}
         if self.extra_filters:
             try:
                 extra = self.extra_filters()

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -94,7 +94,7 @@ class GridExportToolbar:
                     if key not in base:
                         base[key] = val
             except Exception:
-                pass  # Don't block export if extra_filters callback fails
+                logger.warning("extra_filters callback failed", exc_info=True)
         return base or None
 
     def _get_filename(self) -> str:

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -270,11 +270,25 @@ def create_tabbed_panel(
                 for tab_name in (TAB_POSITIONS, TAB_WORKING, TAB_FILLS, TAB_HISTORY):
                     config = TAB_GRID_CONFIG.get(tab_name, {})
                     with ui.element("div").classes("") as toolbar_container:
+
+                        def _make_symbol_filter(s: TabbedPanelState) -> Callable[[], dict[str, Any]]:
+                            """Create a closure that returns the active symbol filter."""
+                            def _get() -> dict[str, Any]:
+                                if s.symbol_filter:
+                                    return {"symbol": {
+                                        "filterType": "text",
+                                        "type": "equals",
+                                        "filter": s.symbol_filter,
+                                    }}
+                                return {}
+                            return _get
+
                         toolbar = GridExportToolbar(
                             grid_id=config.get("grid_id", ""),
                             grid_name=config.get("grid_name", tab_name),
                             filename_prefix=config.get("prefix", tab_name),
                             api_base_url=api_base_url,
+                            extra_filters=_make_symbol_filter(state),
                         )
                         toolbar.create()
                     # Only show toolbar for active tab

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -45,7 +45,7 @@ TAB_TITLES = {
 # Grid ID and name mapping for export toolbar
 TAB_GRID_CONFIG = {
     TAB_POSITIONS: {"grid_id": "_positionsGridApi", "grid_name": "positions", "prefix": "positions"},
-    TAB_WORKING: {"grid_id": "_ordersGridApi", "grid_name": "orders", "prefix": "orders"},
+    TAB_WORKING: {"grid_id": "_ordersGridApi", "grid_name": "working_orders", "prefix": "orders"},
     TAB_FILLS: {"grid_id": "_fillsGridApi", "grid_name": "fills", "prefix": "fills"},
     TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "history", "prefix": "history"},
 }

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -47,7 +47,7 @@ TAB_GRID_CONFIG = {
     TAB_POSITIONS: {"grid_id": "_positionsGridApi", "grid_name": "positions", "prefix": "positions"},
     TAB_WORKING: {"grid_id": "_ordersGridApi", "grid_name": "working_orders", "prefix": "orders"},
     TAB_FILLS: {"grid_id": "_fillsGridApi", "grid_name": "fills", "prefix": "fills"},
-    TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "history", "prefix": "history"},
+    TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "orders", "prefix": "history"},
 }
 
 WORKING_ORDER_STATUSES = {

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -267,7 +267,9 @@ def create_tabbed_panel(
 
             # Create export toolbars (one per tab, show/hide based on active)
             if enable_export:
-                for tab_name in (TAB_POSITIONS, TAB_WORKING, TAB_FILLS, TAB_HISTORY):
+                # History tab excluded — history_snapshot is client-side only,
+                # no server-side fetcher available for Excel export.
+                for tab_name in (TAB_POSITIONS, TAB_WORKING, TAB_FILLS):
                     config = TAB_GRID_CONFIG.get(tab_name, {})
                     with ui.element("div").classes("") as toolbar_container:
 

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -47,7 +47,7 @@ TAB_GRID_CONFIG = {
     TAB_POSITIONS: {"grid_id": "_positionsGridApi", "grid_name": "positions", "prefix": "positions"},
     TAB_WORKING: {"grid_id": "_ordersGridApi", "grid_name": "working_orders", "prefix": "orders"},
     TAB_FILLS: {"grid_id": "_fillsGridApi", "grid_name": "fills", "prefix": "fills"},
-    TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "orders", "prefix": "history"},
+    TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "history", "prefix": "history"},
 }
 
 WORKING_ORDER_STATUSES = {

--- a/docs/ARCHITECTURE/system_map.config.json
+++ b/docs/ARCHITECTURE/system_map.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./system_map.schema.json",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Configuration for architecture visualization generation",
 
   "layers": [

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -23,6 +23,7 @@ from apps.execution_gateway.routes.export import (
     _apply_filters,
     _apply_sort,
     _coerce_cell_value,
+    _extract_status_values,
     _fetch_audit_data,
     _fetch_fills_data,
     _fetch_orders_data,
@@ -581,6 +582,26 @@ class TestFetchOrdersData:
         assert rows[0][0] == "ord-123"
 
 
+class TestExtractStatusValues:
+    def test_none_filter_params(self) -> None:
+        assert _extract_status_values(None) is None
+
+    def test_no_status_key(self) -> None:
+        assert _extract_status_values({"symbol": {"filterType": "text"}}) is None
+
+    def test_equals_operator(self) -> None:
+        fp = {"status": {"filterType": "text", "type": "equals", "filter": "pending"}}
+        assert _extract_status_values(fp) == ["pending"]
+
+    def test_set_values(self) -> None:
+        fp = {"status": {"filterType": "set", "values": ["pending", "new", "accepted"]}}
+        result = _extract_status_values(fp)
+        assert result == ["pending", "new", "accepted"]
+
+    def test_non_dict_status(self) -> None:
+        assert _extract_status_values({"status": "pending"}) is None
+
+
 class TestFetchFillsData:
     def test_returns_real_fills(self) -> None:
         fill = {
@@ -598,6 +619,26 @@ class TestFetchFillsData:
 
         assert len(rows) == 1
         assert rows[0][columns.index("symbol")] == "GOOG"
+
+    def test_column_name_is_time_not_timestamp(self) -> None:
+        """UI grid uses field 'time', not 'timestamp'."""
+        fill = {
+            "client_order_id": "ord-789",
+            "symbol": "AAPL",
+            "side": "buy",
+            "status": "filled",
+            "qty": Decimal("10"),
+            "price": Decimal("150.00"),
+            "realized_pl": Decimal("0"),
+            "timestamp": datetime(2026, 3, 28, tzinfo=UTC),
+        }
+        ctx = _make_ctx(fills=[fill])
+        columns, rows = _fetch_fills_data(ctx, ["strat1"], None)
+
+        assert "time" in columns
+        assert "timestamp" not in columns
+        time_idx = columns.index("time")
+        assert rows[0][time_idx] == datetime(2026, 3, 28, tzinfo=UTC)
 
 
 class TestFetchAuditData:

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -86,7 +86,7 @@ def _make_ctx(
 ) -> MagicMock:
     """Build a mock AppContext with db methods."""
     ctx = MagicMock()
-    ctx.db.get_all_positions.return_value = positions or []
+    ctx.db.get_positions_for_strategies.return_value = positions or []
     ctx.db.get_fills_for_export.return_value = fills or []
     ctx.db.get_trades_for_tca.return_value = tca_trades or []
     ctx.db.get_orders_for_export.return_value = order_rows or []

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -29,6 +29,7 @@ from apps.execution_gateway.routes.export import (
     _fetch_orders_data,
     _fetch_positions_data,
     _fetch_tca_data,
+    _fetch_working_orders_data,
     _generate_excel_content,
     _match_compound_filter,
     _match_filter,
@@ -66,6 +67,7 @@ def _make_position(**overrides: Any) -> _FakePosition:
 _ORDER_COLUMNS = [
     "client_order_id", "strategy_id", "symbol", "side", "qty",
     "order_type", "status", "filled_qty", "filled_avg_price",
+    "limit_price", "stop_price",
     "created_at", "submitted_at", "filled_at",
 ]
 
@@ -540,6 +542,15 @@ class TestApplySort:
         assert result[2] == ["sell", 30]
         assert result[3] == ["sell", 10]
 
+    def test_sort_boolean_column_no_crash(self) -> None:
+        """bool is a subclass of int; sorting must not crash on Decimal(str(True))."""
+        columns = ["name", "active"]
+        rows = [["A", True], ["B", False], ["C", True]]
+        sort_model = [{"colId": "active", "sort": "asc"}]
+        result = _apply_sort(columns, rows, sort_model)
+        # Should not crash; False sorts before True lexicographically
+        assert len(result) == 3
+
 
 # ---------------------------------------------------------------------------
 # Per-grid fetcher tests
@@ -570,6 +581,7 @@ class TestFetchOrdersData:
         order_row = _order_dict(
             "ord-123", "strat1", "MSFT", "buy", 100,
             "limit", "filled", Decimal("100"), Decimal("310.50"),
+            Decimal("310.00"), None,
             datetime(2026, 3, 28, tzinfo=UTC),
             datetime(2026, 3, 28, tzinfo=UTC),
             datetime(2026, 3, 28, tzinfo=UTC),
@@ -580,6 +592,46 @@ class TestFetchOrdersData:
         assert "client_order_id" in columns
         assert len(rows) == 1
         assert rows[0][0] == "ord-123"
+
+    def test_column_order_type_aliased_to_type(self) -> None:
+        """UI grid field is 'type', not 'order_type'."""
+        order_row = _order_dict(
+            "ord-1", "s1", "AAPL", "buy", 10,
+            "limit", "new", Decimal("0"), Decimal("0"),
+            None, None,
+            datetime(2026, 3, 28, tzinfo=UTC),
+            None, None,
+        )
+        ctx = _make_ctx(order_rows=[order_row])
+        columns, _ = _fetch_orders_data(ctx, ["s1"], None)
+        assert "type" in columns
+        assert "order_type" not in columns
+
+    def test_includes_limit_and_stop_price(self) -> None:
+        order_row = _order_dict(
+            "ord-1", "s1", "AAPL", "buy", 10,
+            "limit", "new", Decimal("0"), Decimal("0"),
+            None, None,
+            datetime(2026, 3, 28, tzinfo=UTC),
+            None, None,
+        )
+        ctx = _make_ctx(order_rows=[order_row])
+        columns, _ = _fetch_orders_data(ctx, ["s1"], None)
+        assert "limit_price" in columns
+        assert "stop_price" in columns
+
+
+class TestFetchWorkingOrdersData:
+    def test_passes_working_statuses(self) -> None:
+        """working_orders grid should restrict to active statuses."""
+        ctx = _make_ctx(order_rows=[])
+        _fetch_working_orders_data(ctx, ["strat1"], None)
+        # Verify statuses were passed to DB call
+        call_kwargs = ctx.db.get_orders_for_export.call_args
+        statuses = call_kwargs.kwargs.get("statuses") or call_kwargs[1].get("statuses")
+        assert statuses is not None
+        assert "new" in statuses
+        assert "partially_filled" in statuses
 
 
 class TestExtractStatusValues:
@@ -694,6 +746,7 @@ class TestGenerateExcelContent:
         order_row = _order_dict(
             "ord-abc", "strat1", "AAPL", "buy", 10,
             "market", "filled", Decimal("10"), Decimal("150.00"),
+            None, None,
             datetime(2026, 3, 28, tzinfo=UTC), None, None,
         )
         ctx = _make_ctx(order_rows=[order_row])
@@ -917,16 +970,19 @@ class TestGenerateExcelContent:
             _order_dict(
                 "ord-1", "strat1", "AAPL", "buy", 10,
                 "market", "filled", Decimal("10"), Decimal("150.00"),
+                None, None,
                 datetime(2026, 3, 25, 10, 0, tzinfo=UTC), None, None,
             ),
             _order_dict(
                 "ord-2", "strat1", "MSFT", "buy", 20,
                 "market", "filled", Decimal("20"), Decimal("300.00"),
+                None, None,
                 datetime(2026, 3, 28, 14, 0, tzinfo=UTC), None, None,
             ),
             _order_dict(
                 "ord-3", "strat1", "GOOG", "sell", 5,
                 "market", "filled", Decimal("5"), Decimal("170.00"),
+                None, None,
                 datetime(2026, 3, 30, 8, 0, tzinfo=UTC), None, None,
             ),
         ]

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -484,16 +484,16 @@ class TestApplySort:
         assert result[1] == ["MSFT"]
         assert result[2] == [None]
 
-    def test_sort_nulls_last_descending(self) -> None:
-        """Nulls must sort last even with descending sort order."""
+    def test_sort_nulls_first_descending(self) -> None:
+        """Nulls sort first when descending (surface missing data at top)."""
         columns = ["symbol"]
         rows = [["AAPL"], [None], ["MSFT"]]
         sort_model = [{"colId": "symbol", "sort": "desc"}]
         result = _apply_sort(columns, rows, sort_model)
-        # Descending: MSFT, AAPL, then None last
-        assert result[0] == ["MSFT"]
-        assert result[1] == ["AAPL"]
-        assert result[2] == [None]
+        # Descending: None first, then MSFT, AAPL
+        assert result[0] == [None]
+        assert result[1] == ["MSFT"]
+        assert result[2] == ["AAPL"]
 
     def test_unknown_column_ignored(self) -> None:
         columns = ["symbol"]

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -67,30 +67,31 @@ def _make_position(**overrides: Any) -> _FakePosition:
     return _FakePosition(**overrides)
 
 
+_ORDER_COLUMNS = [
+    "client_order_id", "strategy_id", "symbol", "side", "qty",
+    "order_type", "status", "filled_qty", "filled_avg_price",
+    "created_at", "submitted_at", "filled_at",
+]
+
+
+def _order_dict(*values: Any) -> dict[str, Any]:
+    """Build an order dict from positional values matching export column order."""
+    return dict(zip(_ORDER_COLUMNS, values, strict=False))
+
+
 def _make_ctx(
     *,
     positions: list | None = None,
     fills: list[dict] | None = None,
     tca_trades: list[dict] | None = None,
-    order_rows: list[tuple] | None = None,
+    order_rows: list[dict] | None = None,
 ) -> MagicMock:
     """Build a mock AppContext with db methods."""
     ctx = MagicMock()
     ctx.db.get_positions_for_strategies.return_value = positions or []
-    ctx.db.get_recent_fills.return_value = fills or []
+    ctx.db.get_fills_for_export.return_value = fills or []
     ctx.db.get_trades_for_tca.return_value = tca_trades or []
-
-    cursor = MagicMock()
-    cursor.fetchall.return_value = order_rows or []
-    cursor.__enter__ = MagicMock(return_value=cursor)
-    cursor.__exit__ = MagicMock(return_value=False)
-
-    conn = MagicMock()
-    conn.cursor.return_value = cursor
-    conn.__enter__ = MagicMock(return_value=conn)
-    conn.__exit__ = MagicMock(return_value=False)
-
-    ctx.db.transaction.return_value = conn
+    ctx.db.get_orders_for_export.return_value = order_rows or []
     return ctx
 
 
@@ -548,7 +549,7 @@ class TestFetchPositionsData:
 
 class TestFetchOrdersData:
     def test_returns_real_rows(self) -> None:
-        order_row = (
+        order_row = _order_dict(
             "ord-123", "strat1", "MSFT", "buy", 100,
             "limit", "filled", Decimal("100"), Decimal("310.50"),
             datetime(2026, 3, 28, tzinfo=UTC),
@@ -632,7 +633,7 @@ class TestGenerateExcelContent:
         assert ws.cell(row=2, column=symbol_col).value == "NVDA"
 
     def test_orders_grid_real_data(self) -> None:
-        order_row = (
+        order_row = _order_dict(
             "ord-abc", "strat1", "AAPL", "buy", 10,
             "market", "filled", Decimal("10"), Decimal("150.00"),
             datetime(2026, 3, 28, tzinfo=UTC), None, None,
@@ -855,17 +856,17 @@ class TestGenerateExcelContent:
     def test_date_filter_on_orders_grid(self) -> None:
         """Date filter on created_at must correctly filter order rows."""
         order_rows = [
-            (
+            _order_dict(
                 "ord-1", "strat1", "AAPL", "buy", 10,
                 "market", "filled", Decimal("10"), Decimal("150.00"),
                 datetime(2026, 3, 25, 10, 0, tzinfo=UTC), None, None,
             ),
-            (
+            _order_dict(
                 "ord-2", "strat1", "MSFT", "buy", 20,
                 "market", "filled", Decimal("20"), Decimal("300.00"),
                 datetime(2026, 3, 28, 14, 0, tzinfo=UTC), None, None,
             ),
-            (
+            _order_dict(
                 "ord-3", "strat1", "GOOG", "sell", 5,
                 "market", "filled", Decimal("5"), Decimal("170.00"),
                 datetime(2026, 3, 30, 8, 0, tzinfo=UTC), None, None,

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import io
-import json
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -21,7 +20,6 @@ from uuid import UUID, uuid4
 import pytest
 
 from apps.execution_gateway.routes.export import (
-    ExportAuditCreateRequest,
     _apply_filters,
     _apply_sort,
     _coerce_cell_value,
@@ -34,10 +32,7 @@ from apps.execution_gateway.routes.export import (
     _match_compound_filter,
     _match_filter,
     download_excel_export,
-    router,
 )
-from libs.platform.security import sanitize_for_export
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -115,8 +110,10 @@ class TestCoerceCellValue:
     def test_none(self) -> None:
         assert _coerce_cell_value(None) is None
 
-    def test_decimal_to_float(self) -> None:
-        assert _coerce_cell_value(Decimal("3.14")) == pytest.approx(3.14)
+    def test_decimal_preserved(self) -> None:
+        result = _coerce_cell_value(Decimal("3.14"))
+        assert isinstance(result, Decimal)
+        assert result == Decimal("3.14")
 
     def test_datetime_strips_tzinfo(self) -> None:
         dt = datetime(2026, 1, 1, tzinfo=UTC)
@@ -179,6 +176,26 @@ class TestMatchFilter:
         f = {"filterType": "number", "type": "equals", "filter": 42}
         assert _match_filter(42, f) is True
         assert _match_filter(43, f) is False
+
+    def test_number_blank_and_not_blank(self) -> None:
+        f_blank = {"filterType": "number", "type": "blank"}
+        assert _match_filter(None, f_blank) is True
+        assert _match_filter(42, f_blank) is False
+
+        f_not_blank = {"filterType": "number", "type": "notBlank"}
+        assert _match_filter(42, f_not_blank) is True
+        assert _match_filter(None, f_not_blank) is False
+
+    def test_number_filter_none_filter_value(self) -> None:
+        """When filter_value is None, keep all rows (can't compare)."""
+        f = {"filterType": "number", "type": "greaterThan", "filter": None}
+        assert _match_filter(42, f) is True
+        assert _match_filter(0, f) is True
+
+    def test_number_non_numeric_value_excluded(self) -> None:
+        """Non-numeric cell values should be excluded by numeric filters."""
+        f = {"filterType": "number", "type": "greaterThan", "filter": 10}
+        assert _match_filter("not_a_number", f) is False
 
     def test_none_value_matches_blank(self) -> None:
         f = {"filterType": "text", "type": "blank"}
@@ -709,7 +726,7 @@ class TestGenerateExcelContent:
         headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
         assert headers == ["qty", "symbol"]
         # Verify data follows same order
-        assert ws.cell(row=2, column=1).value == pytest.approx(100.0)  # qty (Decimal→float)
+        assert ws.cell(row=2, column=1).value == Decimal("100")  # qty (Decimal preserved)
         assert ws.cell(row=2, column=2).value == "META"  # symbol
 
     def test_visible_columns_subset(self) -> None:
@@ -1082,7 +1099,7 @@ class TestDownloadExcelExportRoute:
             "completed_at": None,
         }
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_successful_download_returns_excel(self) -> None:
         """Happy path: returns StreamingResponse with Excel content."""
         audit_id = uuid4()
@@ -1120,7 +1137,7 @@ class TestDownloadExcelExportRoute:
         call_kwargs = mock_complete.call_args
         assert call_kwargs[1]["actual_row_count"] == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_audit_grid_returns_501(self) -> None:
         """Audit grid export must return 501 (disabled for safety)."""
         from fastapi import HTTPException
@@ -1158,7 +1175,7 @@ class TestDownloadExcelExportRoute:
             assert exc_info.value.status_code == 501
             assert "strategy" in str(exc_info.value.detail).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_wrong_user_returns_403(self) -> None:
         from fastapi import HTTPException
 
@@ -1183,7 +1200,7 @@ class TestDownloadExcelExportRoute:
                 )
             assert exc_info.value.status_code == 403
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_already_used_returns_410(self) -> None:
         from fastapi import HTTPException
 
@@ -1208,7 +1225,7 @@ class TestDownloadExcelExportRoute:
                 )
             assert exc_info.value.status_code == 410
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_filter_and_sort_respected_in_route(self) -> None:
         """Route must pass filter/sort from audit record to Excel generator."""
         audit_id = uuid4()

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -1,0 +1,1265 @@
+"""Tests for Excel export with real grid data (issue #151).
+
+Validates that _generate_excel_content returns real data (not placeholders)
+for all supported grids, applies filters/sort, respects column order,
+and that the audit grid is disabled for safety.
+
+Also includes route-level tests for the download_excel_export endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from apps.execution_gateway.routes.export import (
+    ExportAuditCreateRequest,
+    _apply_filters,
+    _apply_sort,
+    _coerce_cell_value,
+    _fetch_audit_data,
+    _fetch_fills_data,
+    _fetch_orders_data,
+    _fetch_positions_data,
+    _fetch_tca_data,
+    _generate_excel_content,
+    _match_compound_filter,
+    _match_filter,
+    download_excel_export,
+    router,
+)
+from libs.platform.security import sanitize_for_export
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakePosition:
+    """Lightweight fake Position for testing."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        defaults = {
+            "symbol": "AAPL",
+            "qty": Decimal("10"),
+            "avg_entry_price": Decimal("150.25"),
+            "current_price": Decimal("155.00"),
+            "unrealized_pl": Decimal("47.50"),
+            "realized_pl": Decimal("0"),
+            "updated_at": datetime(2026, 3, 28, 16, 0, tzinfo=UTC),
+            "last_trade_at": datetime(2026, 3, 28, 15, 30, tzinfo=UTC),
+        }
+        defaults.update(kwargs)
+        for k, v in defaults.items():
+            setattr(self, k, v)
+
+
+def _make_position(**overrides: Any) -> _FakePosition:
+    return _FakePosition(**overrides)
+
+
+def _make_ctx(
+    *,
+    positions: list | None = None,
+    fills: list[dict] | None = None,
+    tca_trades: list[dict] | None = None,
+    order_rows: list[tuple] | None = None,
+) -> MagicMock:
+    """Build a mock AppContext with db methods."""
+    ctx = MagicMock()
+    ctx.db.get_positions_for_strategies.return_value = positions or []
+    ctx.db.get_recent_fills.return_value = fills or []
+    ctx.db.get_trades_for_tca.return_value = tca_trades or []
+
+    cursor = MagicMock()
+    cursor.fetchall.return_value = order_rows or []
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+
+    ctx.db.transaction.return_value = conn
+    return ctx
+
+
+def _load_workbook(excel_bytes: bytes):
+    from openpyxl import load_workbook
+
+    return load_workbook(io.BytesIO(excel_bytes))
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_cell_value tests
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceCellValue:
+    def test_none(self) -> None:
+        assert _coerce_cell_value(None) is None
+
+    def test_decimal_to_float(self) -> None:
+        assert _coerce_cell_value(Decimal("3.14")) == pytest.approx(3.14)
+
+    def test_datetime_strips_tzinfo(self) -> None:
+        dt = datetime(2026, 1, 1, tzinfo=UTC)
+        result = _coerce_cell_value(dt)
+        assert isinstance(result, datetime)
+        assert result.tzinfo is None
+
+    def test_int_passthrough(self) -> None:
+        assert _coerce_cell_value(42) == 42
+
+    def test_string_sanitized(self) -> None:
+        assert _coerce_cell_value("=SUM(A1)") == "'=SUM(A1)"
+
+    def test_dict_json_sanitized(self) -> None:
+        result = _coerce_cell_value({"key": "value"})
+        assert '"key"' in result
+        assert '"value"' in result
+
+
+# ---------------------------------------------------------------------------
+# _match_filter tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatchFilter:
+    def test_text_contains(self) -> None:
+        f = {"filterType": "text", "type": "contains", "filter": "AA"}
+        assert _match_filter("AAPL", f) is True
+        assert _match_filter("MSFT", f) is False
+
+    def test_text_equals(self) -> None:
+        f = {"filterType": "text", "type": "equals", "filter": "AAPL"}
+        assert _match_filter("AAPL", f) is True
+        assert _match_filter("aapl", f) is True  # case-insensitive
+        assert _match_filter("AAPLX", f) is False
+
+    def test_text_starts_with(self) -> None:
+        f = {"filterType": "text", "type": "startsWith", "filter": "MS"}
+        assert _match_filter("MSFT", f) is True
+        assert _match_filter("AAPL", f) is False
+
+    def test_text_not_contains(self) -> None:
+        f = {"filterType": "text", "type": "notContains", "filter": "X"}
+        assert _match_filter("AAPL", f) is True
+        assert _match_filter("XOM", f) is False
+
+    def test_number_greater_than(self) -> None:
+        f = {"filterType": "number", "type": "greaterThan", "filter": 50}
+        assert _match_filter(100, f) is True
+        assert _match_filter(Decimal("100"), f) is True
+        assert _match_filter(30, f) is False
+
+    def test_number_in_range(self) -> None:
+        f = {"filterType": "number", "type": "inRange", "filter": 10, "filterTo": 50}
+        assert _match_filter(25, f) is True
+        assert _match_filter(5, f) is False
+        assert _match_filter(60, f) is False
+
+    def test_number_equals(self) -> None:
+        f = {"filterType": "number", "type": "equals", "filter": 42}
+        assert _match_filter(42, f) is True
+        assert _match_filter(43, f) is False
+
+    def test_none_value_matches_blank(self) -> None:
+        f = {"filterType": "text", "type": "blank"}
+        assert _match_filter(None, f) is True
+
+    def test_none_value_rejects_non_blank(self) -> None:
+        f = {"filterType": "text", "type": "contains", "filter": "X"}
+        assert _match_filter(None, f) is False
+
+    def test_date_equals(self) -> None:
+        f = {"filterType": "date", "type": "equals", "dateFrom": "2026-03-28 00:00:00"}
+        assert _match_filter(datetime(2026, 3, 28, 14, 30, tzinfo=UTC), f) is True
+        assert _match_filter(datetime(2026, 3, 27, 23, 59, tzinfo=UTC), f) is False
+
+    def test_date_not_equal(self) -> None:
+        f = {"filterType": "date", "type": "notEqual", "dateFrom": "2026-03-28 00:00:00"}
+        assert _match_filter(datetime(2026, 3, 28, 10, 0, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 27, 10, 0, tzinfo=UTC), f) is True
+
+    def test_date_greater_than(self) -> None:
+        f = {"filterType": "date", "type": "greaterThan", "dateFrom": "2026-03-28 00:00:00"}
+        assert _match_filter(datetime(2026, 3, 29, tzinfo=UTC), f) is True
+        assert _match_filter(datetime(2026, 3, 27, tzinfo=UTC), f) is False
+
+    def test_date_greater_than_same_day(self) -> None:
+        """Same-day values must NOT pass greaterThan — AG Grid uses day granularity."""
+        f = {"filterType": "date", "type": "greaterThan", "dateFrom": "2026-03-28 00:00:00"}
+        # Same day at various times — all should be excluded
+        assert _match_filter(datetime(2026, 3, 28, 0, 0, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 28, 10, 30, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 28, 23, 59, 59, tzinfo=UTC), f) is False
+        # Next day — should pass
+        assert _match_filter(datetime(2026, 3, 29, 0, 0, tzinfo=UTC), f) is True
+
+    def test_date_less_than(self) -> None:
+        f = {"filterType": "date", "type": "lessThan", "dateFrom": "2026-03-28 00:00:00"}
+        assert _match_filter(datetime(2026, 3, 27, tzinfo=UTC), f) is True
+        assert _match_filter(datetime(2026, 3, 29, tzinfo=UTC), f) is False
+
+    def test_date_less_than_same_day(self) -> None:
+        """Same-day values must NOT pass lessThan — AG Grid uses day granularity."""
+        f = {"filterType": "date", "type": "lessThan", "dateFrom": "2026-03-28 00:00:00"}
+        # Same day at various times — all should be excluded
+        assert _match_filter(datetime(2026, 3, 28, 0, 0, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 28, 10, 30, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 28, 23, 59, 59, tzinfo=UTC), f) is False
+        # Previous day — should pass
+        assert _match_filter(datetime(2026, 3, 27, 23, 59, 59, tzinfo=UTC), f) is True
+
+    def test_date_in_range(self) -> None:
+        f = {
+            "filterType": "date",
+            "type": "inRange",
+            "dateFrom": "2026-03-25 00:00:00",
+            "dateTo": "2026-03-28 23:59:59",
+        }
+        assert _match_filter(datetime(2026, 3, 26, tzinfo=UTC), f) is True
+        assert _match_filter(datetime(2026, 3, 24, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 30, tzinfo=UTC), f) is False
+
+    def test_date_in_range_boundary_days(self) -> None:
+        """Boundary days of inRange must be included regardless of time-of-day."""
+        f = {
+            "filterType": "date",
+            "type": "inRange",
+            "dateFrom": "2026-03-25 00:00:00",
+            "dateTo": "2026-03-28 00:00:00",
+        }
+        # Start boundary day at any time
+        assert _match_filter(datetime(2026, 3, 25, 0, 0, tzinfo=UTC), f) is True
+        assert _match_filter(datetime(2026, 3, 25, 23, 59, tzinfo=UTC), f) is True
+        # End boundary day at any time
+        assert _match_filter(datetime(2026, 3, 28, 0, 0, tzinfo=UTC), f) is True
+        assert _match_filter(datetime(2026, 3, 28, 23, 59, tzinfo=UTC), f) is True
+        # Outside range
+        assert _match_filter(datetime(2026, 3, 24, 23, 59, tzinfo=UTC), f) is False
+        assert _match_filter(datetime(2026, 3, 29, 0, 0, tzinfo=UTC), f) is False
+
+    def test_date_blank_and_not_blank(self) -> None:
+        f_blank = {"filterType": "date", "type": "blank"}
+        assert _match_filter(None, f_blank) is True
+        assert _match_filter(datetime(2026, 3, 28, tzinfo=UTC), f_blank) is False
+
+        f_not_blank = {"filterType": "date", "type": "notBlank"}
+        assert _match_filter(datetime(2026, 3, 28, tzinfo=UTC), f_not_blank) is True
+        assert _match_filter(None, f_not_blank) is False
+
+    def test_date_with_date_object(self) -> None:
+        """date (not datetime) cell values must also match."""
+        from datetime import date as date_type
+        f = {"filterType": "date", "type": "equals", "dateFrom": "2026-03-28 00:00:00"}
+        assert _match_filter(date_type(2026, 3, 28), f) is True
+        assert _match_filter(date_type(2026, 3, 27), f) is False
+
+    def test_date_with_iso_string_value(self) -> None:
+        """String cell values that are ISO dates should be parsed and filtered."""
+        f = {"filterType": "date", "type": "greaterThan", "dateFrom": "2026-03-28 00:00:00"}
+        assert _match_filter("2026-03-29T10:00:00", f) is True
+        assert _match_filter("2026-03-27T10:00:00", f) is False
+        # Same-day ISO string must NOT pass greaterThan
+        assert _match_filter("2026-03-28T15:00:00", f) is False
+
+    def test_date_missing_date_from_keeps_row(self) -> None:
+        """If dateFrom is missing, filter can't apply — keep the row."""
+        f = {"filterType": "date", "type": "equals"}
+        assert _match_filter(datetime(2026, 3, 28, tzinfo=UTC), f) is True
+
+    def test_unknown_filter_type_keeps_row(self) -> None:
+        f = {"filterType": "custom", "type": "magic", "filter": "x"}
+        assert _match_filter("anything", f) is True
+
+
+# ---------------------------------------------------------------------------
+# _match_compound_filter tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCompoundFilter:
+    def test_and_compound_both_true(self) -> None:
+        f = {
+            "filterType": "number",
+            "operator": "AND",
+            "condition1": {"filterType": "number", "type": "greaterThan", "filter": 10},
+            "condition2": {"filterType": "number", "type": "lessThan", "filter": 50},
+        }
+        assert _match_compound_filter(25, f) is True
+
+    def test_and_compound_one_false(self) -> None:
+        f = {
+            "filterType": "number",
+            "operator": "AND",
+            "condition1": {"filterType": "number", "type": "greaterThan", "filter": 10},
+            "condition2": {"filterType": "number", "type": "lessThan", "filter": 50},
+        }
+        assert _match_compound_filter(5, f) is False
+        assert _match_compound_filter(60, f) is False
+
+    def test_or_compound(self) -> None:
+        f = {
+            "filterType": "text",
+            "operator": "OR",
+            "condition1": {"filterType": "text", "type": "equals", "filter": "AAPL"},
+            "condition2": {"filterType": "text", "type": "equals", "filter": "MSFT"},
+        }
+        assert _match_compound_filter("AAPL", f) is True
+        assert _match_compound_filter("MSFT", f) is True
+        assert _match_compound_filter("GOOG", f) is False
+
+    def test_simple_filter_passthrough(self) -> None:
+        """Non-compound filters delegate to _match_filter."""
+        f = {"filterType": "text", "type": "contains", "filter": "AA"}
+        assert _match_compound_filter("AAPL", f) is True
+        assert _match_compound_filter("MSFT", f) is False
+
+
+# ---------------------------------------------------------------------------
+# _apply_filters tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFilters:
+    def test_text_filter_reduces_rows(self) -> None:
+        columns = ["symbol", "qty"]
+        rows = [["AAPL", 10], ["MSFT", 20], ["AMZN", 30]]
+        filters = {"symbol": {"filterType": "text", "type": "contains", "filter": "A"}}
+        result = _apply_filters(columns, rows, filters)
+        assert len(result) == 2
+        assert result[0][0] == "AAPL"
+        assert result[1][0] == "AMZN"
+
+    def test_number_filter(self) -> None:
+        columns = ["symbol", "qty"]
+        rows = [["AAPL", 10], ["MSFT", 20], ["AMZN", 30]]
+        filters = {"qty": {"filterType": "number", "type": "greaterThan", "filter": 15}}
+        result = _apply_filters(columns, rows, filters)
+        assert len(result) == 2
+        symbols = [r[0] for r in result]
+        assert "AAPL" not in symbols
+
+    def test_multiple_filters_combined(self) -> None:
+        columns = ["symbol", "qty"]
+        rows = [["AAPL", 10], ["AMZN", 30], ["AMAT", 5]]
+        filters = {
+            "symbol": {"filterType": "text", "type": "startsWith", "filter": "A"},
+            "qty": {"filterType": "number", "type": "greaterThan", "filter": 8},
+        }
+        result = _apply_filters(columns, rows, filters)
+        # All start with A, but only AAPL(10) and AMZN(30) have qty > 8
+        assert len(result) == 2
+
+    def test_unknown_column_ignored(self) -> None:
+        columns = ["symbol"]
+        rows = [["AAPL"], ["MSFT"]]
+        filters = {"nonexistent": {"filterType": "text", "type": "equals", "filter": "X"}}
+        result = _apply_filters(columns, rows, filters)
+        assert len(result) == 2  # No filtering applied
+
+    def test_empty_filter_params(self) -> None:
+        columns = ["symbol"]
+        rows = [["AAPL"]]
+        result = _apply_filters(columns, rows, {})
+        assert len(result) == 1
+
+    def test_compound_and_filter(self) -> None:
+        """AG Grid compound filter with AND operator must filter correctly."""
+        columns = ["symbol", "qty"]
+        rows = [["AAPL", 5], ["MSFT", 20], ["AMZN", 30], ["GOOG", 50]]
+        filters = {
+            "qty": {
+                "filterType": "number",
+                "operator": "AND",
+                "condition1": {"filterType": "number", "type": "greaterThan", "filter": 10},
+                "condition2": {"filterType": "number", "type": "lessThan", "filter": 40},
+            }
+        }
+        result = _apply_filters(columns, rows, filters)
+        # Only MSFT(20) and AMZN(30) are in range (10, 40)
+        assert len(result) == 2
+        assert result[0][0] == "MSFT"
+        assert result[1][0] == "AMZN"
+
+    def test_compound_or_filter(self) -> None:
+        """AG Grid compound filter with OR operator."""
+        columns = ["symbol", "qty"]
+        rows = [["AAPL", 5], ["MSFT", 20], ["AMZN", 30]]
+        filters = {
+            "symbol": {
+                "filterType": "text",
+                "operator": "OR",
+                "condition1": {"filterType": "text", "type": "equals", "filter": "AAPL"},
+                "condition2": {"filterType": "text", "type": "equals", "filter": "AMZN"},
+            }
+        }
+        result = _apply_filters(columns, rows, filters)
+        assert len(result) == 2
+        symbols = [r[0] for r in result]
+        assert "AAPL" in symbols
+        assert "AMZN" in symbols
+        assert "MSFT" not in symbols
+
+
+# ---------------------------------------------------------------------------
+# _apply_sort tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplySort:
+    def test_sort_ascending(self) -> None:
+        columns = ["symbol", "qty"]
+        rows = [["MSFT", 20], ["AAPL", 10], ["AMZN", 30]]
+        sort_model = [{"colId": "symbol", "sort": "asc"}]
+        result = _apply_sort(columns, rows, sort_model)
+        assert [r[0] for r in result] == ["AAPL", "AMZN", "MSFT"]
+
+    def test_sort_descending(self) -> None:
+        columns = ["symbol", "qty"]
+        rows = [["MSFT", 20], ["AAPL", 10], ["AMZN", 30]]
+        sort_model = [{"colId": "qty", "sort": "desc"}]
+        result = _apply_sort(columns, rows, sort_model)
+        assert [r[1] for r in result] == [30, 20, 10]
+
+    def test_multi_sort(self) -> None:
+        columns = ["side", "qty"]
+        rows = [["buy", 20], ["sell", 10], ["buy", 5], ["sell", 30]]
+        sort_model = [
+            {"colId": "side", "sort": "asc"},
+            {"colId": "qty", "sort": "desc"},
+        ]
+        result = _apply_sort(columns, rows, sort_model)
+        # Primary: side asc (buy, buy, sell, sell)
+        # Secondary: qty desc within each group
+        assert result[0] == ["buy", 20]
+        assert result[1] == ["buy", 5]
+        assert result[2] == ["sell", 30]
+        assert result[3] == ["sell", 10]
+
+    def test_sort_nulls_last(self) -> None:
+        columns = ["symbol"]
+        rows = [["AAPL"], [None], ["MSFT"]]
+        sort_model = [{"colId": "symbol", "sort": "asc"}]
+        result = _apply_sort(columns, rows, sort_model)
+        assert result[0] == ["AAPL"]
+        assert result[1] == ["MSFT"]
+        assert result[2] == [None]
+
+    def test_sort_nulls_last_descending(self) -> None:
+        """Nulls must sort last even with descending sort order."""
+        columns = ["symbol"]
+        rows = [["AAPL"], [None], ["MSFT"]]
+        sort_model = [{"colId": "symbol", "sort": "desc"}]
+        result = _apply_sort(columns, rows, sort_model)
+        # Descending: MSFT, AAPL, then None last
+        assert result[0] == ["MSFT"]
+        assert result[1] == ["AAPL"]
+        assert result[2] == [None]
+
+    def test_unknown_column_ignored(self) -> None:
+        columns = ["symbol"]
+        rows = [["MSFT"], ["AAPL"]]
+        sort_model = [{"colId": "nonexistent", "sort": "asc"}]
+        result = _apply_sort(columns, rows, sort_model)
+        # Order unchanged
+        assert result[0] == ["MSFT"]
+
+    def test_sort_index_overrides_array_order(self) -> None:
+        """sortIndex must determine multi-sort precedence, not array position.
+
+        Regression test: AG Grid serializes sortIndex in getColumnState().
+        If the array order differs from sortIndex, the export must follow
+        sortIndex (lower = higher priority).
+        """
+        columns = ["side", "qty"]
+        rows = [["buy", 20], ["sell", 10], ["buy", 5], ["sell", 30]]
+
+        # Array order: qty first, side second — but sortIndex says
+        # side is primary (0) and qty is secondary (1).
+        sort_model = [
+            {"colId": "qty", "sort": "desc", "sortIndex": 1},
+            {"colId": "side", "sort": "asc", "sortIndex": 0},
+        ]
+        result = _apply_sort(columns, rows, sort_model)
+        # Primary: side asc (buy, buy, sell, sell)
+        # Secondary: qty desc within each group
+        assert result[0] == ["buy", 20]
+        assert result[1] == ["buy", 5]
+        assert result[2] == ["sell", 30]
+        assert result[3] == ["sell", 10]
+
+    def test_sort_index_missing_falls_back_to_array_order(self) -> None:
+        """When sortIndex is absent, array position is used as fallback."""
+        columns = ["side", "qty"]
+        rows = [["buy", 20], ["sell", 10], ["buy", 5], ["sell", 30]]
+        sort_model = [
+            {"colId": "side", "sort": "asc"},
+            {"colId": "qty", "sort": "desc"},
+        ]
+        result = _apply_sort(columns, rows, sort_model)
+        # Same as test_multi_sort: side primary, qty secondary
+        assert result[0] == ["buy", 20]
+        assert result[1] == ["buy", 5]
+        assert result[2] == ["sell", 30]
+        assert result[3] == ["sell", 10]
+
+
+# ---------------------------------------------------------------------------
+# Per-grid fetcher tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPositionsData:
+    def test_returns_real_columns_and_rows(self) -> None:
+        pos = _make_position()
+        ctx = _make_ctx(positions=[pos])
+        columns, rows = _fetch_positions_data(ctx, ["strat1"], None)
+
+        assert "symbol" in columns
+        assert "qty" in columns
+        assert len(rows) == 1
+        assert rows[0][columns.index("symbol")] == "AAPL"
+        assert rows[0][columns.index("qty")] == Decimal("10")
+
+    def test_empty_positions(self) -> None:
+        ctx = _make_ctx(positions=[])
+        columns, rows = _fetch_positions_data(ctx, ["strat1"], None)
+        assert len(rows) == 0
+        assert len(columns) > 0
+
+
+class TestFetchOrdersData:
+    def test_returns_real_rows(self) -> None:
+        order_row = (
+            "ord-123", "strat1", "MSFT", "buy", 100,
+            "limit", "filled", Decimal("100"), Decimal("310.50"),
+            datetime(2026, 3, 28, tzinfo=UTC),
+            datetime(2026, 3, 28, tzinfo=UTC),
+            datetime(2026, 3, 28, tzinfo=UTC),
+        )
+        ctx = _make_ctx(order_rows=[order_row])
+        columns, rows = _fetch_orders_data(ctx, ["strat1"], None)
+
+        assert "client_order_id" in columns
+        assert len(rows) == 1
+        assert rows[0][0] == "ord-123"
+
+
+class TestFetchFillsData:
+    def test_returns_real_fills(self) -> None:
+        fill = {
+            "client_order_id": "ord-456",
+            "symbol": "GOOG",
+            "side": "sell",
+            "status": "filled",
+            "qty": Decimal("5"),
+            "price": Decimal("170.00"),
+            "realized_pl": Decimal("25.00"),
+            "timestamp": datetime(2026, 3, 28, tzinfo=UTC),
+        }
+        ctx = _make_ctx(fills=[fill])
+        columns, rows = _fetch_fills_data(ctx, ["strat1"], None)
+
+        assert len(rows) == 1
+        assert rows[0][columns.index("symbol")] == "GOOG"
+
+
+class TestFetchAuditData:
+    def test_raises_not_implemented(self) -> None:
+        """Audit export must be disabled — no strategy_id column for scoping."""
+        ctx = _make_ctx()
+        with pytest.raises(NotImplementedError, match="strategy"):
+            _fetch_audit_data(ctx, ["strat1"], None)
+
+
+class TestFetchTcaData:
+    def test_raises_not_implemented(self) -> None:
+        """TCA export must be disabled — UI uses computed columns the server can't reproduce."""
+        ctx = _make_ctx()
+        with pytest.raises(NotImplementedError, match="computed columns"):
+            _fetch_tca_data(ctx, ["strat1"], None)
+
+
+# ---------------------------------------------------------------------------
+# Integration: _generate_excel_content end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateExcelContent:
+    """Verify that _generate_excel_content produces real data workbooks."""
+
+    def test_positions_grid_real_data(self) -> None:
+        pos = _make_position(symbol="NVDA", qty=Decimal("50"))
+        ctx = _make_ctx(positions=[pos])
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 1
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        assert ws.title == "Positions"
+
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        assert "symbol" in headers
+        symbol_col = headers.index("symbol") + 1
+        assert ws.cell(row=2, column=symbol_col).value == "NVDA"
+
+    def test_orders_grid_real_data(self) -> None:
+        order_row = (
+            "ord-abc", "strat1", "AAPL", "buy", 10,
+            "market", "filled", Decimal("10"), Decimal("150.00"),
+            datetime(2026, 3, 28, tzinfo=UTC), None, None,
+        )
+        ctx = _make_ctx(order_rows=[order_row])
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="orders",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 1
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        assert ws.cell(row=2, column=1).value == "ord-abc"
+
+    def test_fills_grid_real_data(self) -> None:
+        fill = {
+            "client_order_id": "ord-fill",
+            "symbol": "TSLA",
+            "side": "sell",
+            "status": "filled",
+            "qty": Decimal("3"),
+            "price": Decimal("250.00"),
+            "realized_pl": Decimal("15.00"),
+            "timestamp": datetime(2026, 3, 28, tzinfo=UTC),
+        }
+        ctx = _make_ctx(fills=[fill])
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="fills",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 1
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        symbol_col = headers.index("symbol") + 1
+        assert ws.cell(row=2, column=symbol_col).value == "TSLA"
+
+    def test_visible_columns_preserves_client_order(self) -> None:
+        """Visible columns must appear in the order the client sent them."""
+        pos = _make_position(symbol="META", qty=Decimal("100"))
+        ctx = _make_ctx(positions=[pos])
+
+        # Client sends columns in reversed order: qty first, then symbol
+        excel_bytes, _ = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=["qty", "symbol"],
+                sort_model=None,
+            )
+        )
+
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        assert headers == ["qty", "symbol"]
+        # Verify data follows same order
+        assert ws.cell(row=2, column=1).value == pytest.approx(100.0)  # qty (Decimal→float)
+        assert ws.cell(row=2, column=2).value == "META"  # symbol
+
+    def test_visible_columns_subset(self) -> None:
+        pos = _make_position(symbol="META")
+        ctx = _make_ctx(positions=[pos])
+
+        excel_bytes, _ = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=["symbol", "qty"],
+                sort_model=None,
+            )
+        )
+
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        assert headers == ["symbol", "qty"]
+        assert ws.max_column == 2
+
+    def test_filter_params_applied(self) -> None:
+        """Filter params must reduce exported rows."""
+        positions = [
+            _make_position(symbol="AAPL", qty=Decimal("10")),
+            _make_position(symbol="MSFT", qty=Decimal("20")),
+            _make_position(symbol="AMZN", qty=Decimal("30")),
+        ]
+        ctx = _make_ctx(positions=positions)
+
+        filter_params = {
+            "symbol": {"filterType": "text", "type": "contains", "filter": "A"},
+        }
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=filter_params,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        # AAPL and AMZN contain "A", MSFT does not
+        assert row_count == 2
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        sym_col = headers.index("symbol") + 1
+        exported_symbols = [
+            ws.cell(row=r, column=sym_col).value
+            for r in range(2, 2 + row_count)
+        ]
+        assert "AAPL" in exported_symbols
+        assert "AMZN" in exported_symbols
+        assert "MSFT" not in exported_symbols
+
+    def test_sort_model_applied(self) -> None:
+        """Sort model must reorder exported rows."""
+        positions = [
+            _make_position(symbol="MSFT", qty=Decimal("20")),
+            _make_position(symbol="AAPL", qty=Decimal("10")),
+            _make_position(symbol="AMZN", qty=Decimal("30")),
+        ]
+        ctx = _make_ctx(positions=positions)
+
+        sort_model = [{"colId": "symbol", "sort": "asc"}]
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=sort_model,
+            )
+        )
+
+        assert row_count == 3
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        sym_col = headers.index("symbol") + 1
+        exported_symbols = [
+            ws.cell(row=r, column=sym_col).value
+            for r in range(2, 2 + row_count)
+        ]
+        assert exported_symbols == ["AAPL", "AMZN", "MSFT"]
+
+    def test_filter_and_sort_combined(self) -> None:
+        """Filter + sort applied together."""
+        positions = [
+            _make_position(symbol="MSFT", qty=Decimal("20")),
+            _make_position(symbol="AAPL", qty=Decimal("10")),
+            _make_position(symbol="AMZN", qty=Decimal("30")),
+            _make_position(symbol="GOOG", qty=Decimal("15")),
+        ]
+        ctx = _make_ctx(positions=positions)
+
+        # Filter: qty > 12 → MSFT(20), AMZN(30), GOOG(15)
+        # Sort: qty desc → AMZN(30), MSFT(20), GOOG(15)
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params={"qty": {"filterType": "number", "type": "greaterThan", "filter": 12}},
+                visible_columns=["symbol", "qty"],
+                sort_model=[{"colId": "qty", "sort": "desc"}],
+            )
+        )
+
+        assert row_count == 3
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        assert headers == ["symbol", "qty"]
+        symbols = [ws.cell(row=r, column=1).value for r in range(2, 5)]
+        assert symbols == ["AMZN", "MSFT", "GOOG"]
+
+    def test_row_count_reflects_filtered_data(self) -> None:
+        """Row count must reflect post-filter count, not pre-filter."""
+        positions = [_make_position(symbol=f"SYM{i}") for i in range(5)]
+        ctx = _make_ctx(positions=positions)
+
+        # Filter that matches none
+        _, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params={"symbol": {"filterType": "text", "type": "equals", "filter": "NOMATCH"}},
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+        assert row_count == 0
+
+    def test_date_filter_on_orders_grid(self) -> None:
+        """Date filter on created_at must correctly filter order rows."""
+        order_rows = [
+            (
+                "ord-1", "strat1", "AAPL", "buy", 10,
+                "market", "filled", Decimal("10"), Decimal("150.00"),
+                datetime(2026, 3, 25, 10, 0, tzinfo=UTC), None, None,
+            ),
+            (
+                "ord-2", "strat1", "MSFT", "buy", 20,
+                "market", "filled", Decimal("20"), Decimal("300.00"),
+                datetime(2026, 3, 28, 14, 0, tzinfo=UTC), None, None,
+            ),
+            (
+                "ord-3", "strat1", "GOOG", "sell", 5,
+                "market", "filled", Decimal("5"), Decimal("170.00"),
+                datetime(2026, 3, 30, 8, 0, tzinfo=UTC), None, None,
+            ),
+        ]
+        ctx = _make_ctx(order_rows=order_rows)
+
+        # Filter: created_at > 2026-03-27 → should keep ord-2 and ord-3
+        filter_params = {
+            "created_at": {
+                "filterType": "date",
+                "type": "greaterThan",
+                "dateFrom": "2026-03-27 00:00:00",
+            }
+        }
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="orders",
+                strategy_ids=["strat1"],
+                filter_params=filter_params,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 2
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        oid_col = headers.index("client_order_id") + 1
+        exported_ids = [ws.cell(row=r, column=oid_col).value for r in range(2, 2 + row_count)]
+        assert "ord-1" not in exported_ids
+        assert "ord-2" in exported_ids
+        assert "ord-3" in exported_ids
+
+    def test_date_in_range_filter_on_positions(self) -> None:
+        """Date inRange filter on updated_at must correctly scope positions."""
+        positions = [
+            _make_position(symbol="OLD", updated_at=datetime(2026, 3, 20, tzinfo=UTC)),
+            _make_position(symbol="MID", updated_at=datetime(2026, 3, 26, tzinfo=UTC)),
+            _make_position(symbol="NEW", updated_at=datetime(2026, 3, 30, tzinfo=UTC)),
+        ]
+        ctx = _make_ctx(positions=positions)
+
+        filter_params = {
+            "updated_at": {
+                "filterType": "date",
+                "type": "inRange",
+                "dateFrom": "2026-03-24 00:00:00",
+                "dateTo": "2026-03-28 23:59:59",
+            }
+        }
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=filter_params,
+                visible_columns=["symbol", "updated_at"],
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 1
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        assert ws.cell(row=2, column=1).value == "MID"
+
+    def test_audit_grid_raises_not_implemented(self) -> None:
+        """Audit grid export must be disabled for safety (no strategy scoping)."""
+        ctx = _make_ctx()
+        with pytest.raises(NotImplementedError, match="strategy"):
+            _run(
+                _generate_excel_content(
+                    ctx=ctx,
+                    grid_name="audit",
+                    strategy_ids=["strat1"],
+                    filter_params=None,
+                    visible_columns=None,
+                    sort_model=None,
+                )
+            )
+
+    def test_tca_grid_raises_not_implemented(self) -> None:
+        """TCA grid export must be disabled — UI uses computed columns."""
+        ctx = _make_ctx()
+        with pytest.raises(NotImplementedError, match="computed columns"):
+            _run(
+                _generate_excel_content(
+                    ctx=ctx,
+                    grid_name="tca",
+                    strategy_ids=["strat1"],
+                    filter_params=None,
+                    visible_columns=None,
+                    sort_model=None,
+                )
+            )
+
+    def test_unsupported_grid_raises(self) -> None:
+        ctx = _make_ctx()
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            _run(
+                _generate_excel_content(
+                    ctx=ctx,
+                    grid_name="unknown_grid",
+                    strategy_ids=["s1"],
+                    filter_params=None,
+                    visible_columns=None,
+                    sort_model=None,
+                )
+            )
+
+    def test_empty_data_returns_headers_only(self) -> None:
+        ctx = _make_ctx(positions=[])
+
+        excel_bytes, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 0
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        assert ws.cell(row=1, column=1).value is not None
+        assert ws.cell(row=2, column=1).value is None
+
+    def test_formula_injection_sanitized(self) -> None:
+        pos = _make_position(symbol="=CMD()")
+        ctx = _make_ctx(positions=[pos])
+
+        excel_bytes, _ = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=["symbol"],
+                sort_model=None,
+            )
+        )
+
+        wb = _load_workbook(excel_bytes)
+        ws = wb.active
+        assert ws.cell(row=2, column=1).value == "'=CMD()"
+
+    def test_row_count_reflects_real_data(self) -> None:
+        positions = [_make_position(symbol=f"SYM{i}") for i in range(5)]
+        ctx = _make_ctx(positions=positions)
+
+        _, row_count = _run(
+            _generate_excel_content(
+                ctx=ctx,
+                grid_name="positions",
+                strategy_ids=["strat1"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+        )
+
+        assert row_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests: download_excel_export
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadExcelExportRoute:
+    """Route-level tests for GET /api/v1/export/excel/{audit_id}."""
+
+    def _make_audit_record(
+        self,
+        *,
+        audit_id: UUID | None = None,
+        user_id: str = "admin",
+        grid_name: str = "positions",
+        export_type: str = "excel",
+        status: str = "pending",
+        strategy_ids: list[str] | None = None,
+        filter_params: dict | None = None,
+        visible_columns: list[str] | None = None,
+        sort_model: list[dict] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "audit_id": audit_id or uuid4(),
+            "user_id": user_id,
+            "export_type": export_type,
+            "grid_name": grid_name,
+            "filter_params": filter_params,
+            "visible_columns": visible_columns,
+            "sort_model": sort_model,
+            "strategy_ids": strategy_ids or ["strat1"],
+            "export_scope": "visible",
+            "estimated_row_count": None,
+            "actual_row_count": None,
+            "reported_by": None,
+            "status": status,
+            "error_message": None,
+            "ip_address": "127.0.0.1",
+            "session_id": "sess-1",
+            "user_agent": "test",
+            "created_at": datetime(2026, 3, 28, tzinfo=UTC),
+            "completed_at": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_successful_download_returns_excel(self) -> None:
+        """Happy path: returns StreamingResponse with Excel content."""
+        audit_id = uuid4()
+        audit_record = self._make_audit_record(audit_id=audit_id)
+        pos = _make_position(symbol="TEST")
+        ctx = _make_ctx(positions=[pos])
+        user = {"user_id": "admin", "user": MagicMock(), "session_id": "sess-1"}
+
+        with (
+            patch(
+                "apps.execution_gateway.routes.export._get_export_audit",
+                new_callable=AsyncMock,
+                return_value=audit_record,
+            ),
+            patch(
+                "apps.execution_gateway.routes.export._claim_export_audit",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "apps.execution_gateway.routes.export._complete_and_expire_export_audit",
+                new_callable=AsyncMock,
+            ) as mock_complete,
+        ):
+            response = await download_excel_export(
+                audit_id=audit_id,
+                ctx=ctx,
+                user=user,
+                _auth_context=MagicMock(),
+            )
+
+        assert response.media_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        # Verify audit was completed with correct row count
+        mock_complete.assert_called_once()
+        call_kwargs = mock_complete.call_args
+        assert call_kwargs[1]["actual_row_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_audit_grid_returns_501(self) -> None:
+        """Audit grid export must return 501 (disabled for safety)."""
+        from fastapi import HTTPException
+
+        audit_id = uuid4()
+        audit_record = self._make_audit_record(
+            audit_id=audit_id, grid_name="audit"
+        )
+        ctx = _make_ctx()
+        user = {"user_id": "admin", "user": MagicMock(), "session_id": "sess-1"}
+
+        with (
+            patch(
+                "apps.execution_gateway.routes.export._get_export_audit",
+                new_callable=AsyncMock,
+                return_value=audit_record,
+            ),
+            patch(
+                "apps.execution_gateway.routes.export._claim_export_audit",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "apps.execution_gateway.routes.export._fail_export_audit",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await download_excel_export(
+                    audit_id=audit_id,
+                    ctx=ctx,
+                    user=user,
+                    _auth_context=MagicMock(),
+                )
+            assert exc_info.value.status_code == 501
+            assert "strategy" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_wrong_user_returns_403(self) -> None:
+        from fastapi import HTTPException
+
+        audit_id = uuid4()
+        audit_record = self._make_audit_record(
+            audit_id=audit_id, user_id="other_user"
+        )
+        ctx = _make_ctx()
+        user = {"user_id": "admin", "user": MagicMock(), "session_id": "sess-1"}
+
+        with patch(
+            "apps.execution_gateway.routes.export._get_export_audit",
+            new_callable=AsyncMock,
+            return_value=audit_record,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await download_excel_export(
+                    audit_id=audit_id,
+                    ctx=ctx,
+                    user=user,
+                    _auth_context=MagicMock(),
+                )
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_already_used_returns_410(self) -> None:
+        from fastapi import HTTPException
+
+        audit_id = uuid4()
+        audit_record = self._make_audit_record(
+            audit_id=audit_id, status="expired"
+        )
+        ctx = _make_ctx()
+        user = {"user_id": "admin", "user": MagicMock(), "session_id": "sess-1"}
+
+        with patch(
+            "apps.execution_gateway.routes.export._get_export_audit",
+            new_callable=AsyncMock,
+            return_value=audit_record,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await download_excel_export(
+                    audit_id=audit_id,
+                    ctx=ctx,
+                    user=user,
+                    _auth_context=MagicMock(),
+                )
+            assert exc_info.value.status_code == 410
+
+    @pytest.mark.asyncio
+    async def test_filter_and_sort_respected_in_route(self) -> None:
+        """Route must pass filter/sort from audit record to Excel generator."""
+        audit_id = uuid4()
+        positions = [
+            _make_position(symbol="AAPL", qty=Decimal("10")),
+            _make_position(symbol="MSFT", qty=Decimal("20")),
+            _make_position(symbol="AMZN", qty=Decimal("30")),
+        ]
+        audit_record = self._make_audit_record(
+            audit_id=audit_id,
+            filter_params={"symbol": {"filterType": "text", "type": "contains", "filter": "A"}},
+            sort_model=[{"colId": "qty", "sort": "desc"}],
+            visible_columns=["qty", "symbol"],
+        )
+        ctx = _make_ctx(positions=positions)
+        user = {"user_id": "admin", "user": MagicMock(), "session_id": "sess-1"}
+
+        with (
+            patch(
+                "apps.execution_gateway.routes.export._get_export_audit",
+                new_callable=AsyncMock,
+                return_value=audit_record,
+            ),
+            patch(
+                "apps.execution_gateway.routes.export._claim_export_audit",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "apps.execution_gateway.routes.export._complete_and_expire_export_audit",
+                new_callable=AsyncMock,
+            ) as mock_complete,
+        ):
+            response = await download_excel_export(
+                audit_id=audit_id,
+                ctx=ctx,
+                user=user,
+                _auth_context=MagicMock(),
+            )
+
+        # Read the response body
+        body = b""
+        async for chunk in response.body_iterator:
+            body += chunk if isinstance(chunk, bytes) else chunk.encode()
+
+        wb = _load_workbook(body)
+        ws = wb.active
+        headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+        # Client column order: qty, symbol
+        assert headers == ["qty", "symbol"]
+
+        # Filter: AAPL and AMZN (contain "A"), sort: qty desc → AMZN(30), AAPL(10)
+        assert mock_complete.call_args[1]["actual_row_count"] == 2
+        assert ws.cell(row=2, column=2).value == "AMZN"  # symbol col = 2
+        assert ws.cell(row=3, column=2).value == "AAPL"

--- a/tests/apps/execution_gateway/test_excel_export.py
+++ b/tests/apps/execution_gateway/test_excel_export.py
@@ -86,7 +86,7 @@ def _make_ctx(
 ) -> MagicMock:
     """Build a mock AppContext with db methods."""
     ctx = MagicMock()
-    ctx.db.get_positions_for_strategies.return_value = positions or []
+    ctx.db.get_all_positions.return_value = positions or []
     ctx.db.get_fills_for_export.return_value = fills or []
     ctx.db.get_trades_for_tca.return_value = tca_trades or []
     ctx.db.get_orders_for_export.return_value = order_rows or []


### PR DESCRIPTION
## Summary
- Replace Excel export placeholders with real data fetchers for positions, orders, fills
- AG Grid-compliant server-side filtering (text, number, date, compound, conditions array)
- AG Grid-compliant multi-column sorting with Decimal precision and null handling
- Working orders grid with status enforcement and symbol filter propagation
- Trades table as fills data source (matching dashboard parity)
- Formula injection sanitization, write-only workbook, asyncio.to_thread
- Comprehensive test suite (88 tests)

## Test plan
- [x] `make ci-local` passes (ruff, mypy --strict, 88 export tests, doc freshness)
- [ ] Manual: export positions/orders/fills from dashboard, verify data matches grid
- [ ] Manual: export with symbol filter active, verify scoped correctly
- [ ] Manual: export working orders tab, verify only active statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)