### PR TITLE
fix(web-console): stabilize startup, routing, and disconnect handling

### DIFF
--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -17,14 +17,7 @@ from psycopg_pool import AsyncConnectionPool, ConnectionPool
 from redis import Redis
 from rq import Queue, Worker
 
-from libs.core.common.exceptions import ConfigurationError
-from libs.platform.alerts.channels import (
-    BaseChannel,
-    EmailChannel,
-    PagerDutyChannel,
-    SlackChannel,
-    SMSChannel,
-)
+from libs.platform.alerts.channels import BaseChannel, build_channel_handlers
 from libs.platform.alerts.delivery_service import DeliveryExecutor, QueueDepthManager
 from libs.platform.alerts.models import ChannelType, DeliveryResult
 from libs.platform.alerts.poison_queue import PoisonQueue
@@ -116,48 +109,12 @@ async def _close_async_resources(resources: AsyncResources) -> None:
 def _get_channels() -> dict[ChannelType, BaseChannel]:
     """Build channel handlers, lazily skipping unconfigured channels.
 
-    Email requires aiosmtplib (optional). SMS requires Twilio credentials.
-    If either dependency is missing or unconfigured, the channel is skipped
-    and a warning is logged. Slack and PagerDuty are always enabled.
+    Delegates to the shared ``build_channel_handlers`` factory so that
+    channel initialization logic is not duplicated across services.
     """
     global _CHANNELS
     if _CHANNELS is None:
-        _CHANNELS = {
-            ChannelType.SLACK: SlackChannel(),
-        }
-        # Email requires aiosmtplib - skip if dependency is missing
-        if EmailChannel is None:
-            logger.warning(
-                "email_channel_disabled",
-                extra={
-                    "reason": "email dependencies unavailable",
-                    "hint": "Install aiosmtplib to enable SMTP email notifications",
-                },
-            )
-        else:
-            _CHANNELS[ChannelType.EMAIL] = EmailChannel()
-        # SMS requires Twilio credentials - skip if dependency missing or not configured
-        if SMSChannel is None:
-            logger.warning(
-                "sms_channel_disabled",
-                extra={
-                    "reason": "SMS dependencies unavailable",
-                    "hint": "Install twilio to enable SMS notifications",
-                },
-            )
-        else:
-            try:
-                _CHANNELS[ChannelType.SMS] = SMSChannel()
-            except ConfigurationError as exc:
-                logger.warning(
-                    "sms_channel_disabled",
-                    extra={
-                        "reason": str(exc),
-                        "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
-                    },
-                )
-        # PagerDuty uses routing key per-recipient, no global credentials needed
-        _CHANNELS[ChannelType.PAGERDUTY] = PagerDutyChannel()
+        _CHANNELS = build_channel_handlers(logger=logger)
     return _CHANNELS
 
 

--- a/apps/alert_worker/entrypoint.py
+++ b/apps/alert_worker/entrypoint.py
@@ -116,26 +116,46 @@ async def _close_async_resources(resources: AsyncResources) -> None:
 def _get_channels() -> dict[ChannelType, BaseChannel]:
     """Build channel handlers, lazily skipping unconfigured channels.
 
-    SMS channel requires Twilio credentials. If not configured, SMS is
-    skipped and a warning is logged. Email, Slack, and PagerDuty are always enabled.
+    Email requires aiosmtplib (optional). SMS requires Twilio credentials.
+    If either dependency is missing or unconfigured, the channel is skipped
+    and a warning is logged. Slack and PagerDuty are always enabled.
     """
     global _CHANNELS
     if _CHANNELS is None:
         _CHANNELS = {
-            ChannelType.EMAIL: EmailChannel(),
             ChannelType.SLACK: SlackChannel(),
         }
-        # SMS requires Twilio credentials - skip if not configured
-        try:
-            _CHANNELS[ChannelType.SMS] = SMSChannel()
-        except ConfigurationError as exc:
+        # Email requires aiosmtplib - skip if dependency is missing
+        if EmailChannel is None:
+            logger.warning(
+                "email_channel_disabled",
+                extra={
+                    "reason": "email dependencies unavailable",
+                    "hint": "Install aiosmtplib to enable SMTP email notifications",
+                },
+            )
+        else:
+            _CHANNELS[ChannelType.EMAIL] = EmailChannel()
+        # SMS requires Twilio credentials - skip if dependency missing or not configured
+        if SMSChannel is None:
             logger.warning(
                 "sms_channel_disabled",
                 extra={
-                    "reason": str(exc),
-                    "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+                    "reason": "SMS dependencies unavailable",
+                    "hint": "Install twilio to enable SMS notifications",
                 },
             )
+        else:
+            try:
+                _CHANNELS[ChannelType.SMS] = SMSChannel()
+            except ConfigurationError as exc:
+                logger.warning(
+                    "sms_channel_disabled",
+                    extra={
+                        "reason": str(exc),
+                        "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+                    },
+                )
         # PagerDuty uses routing key per-recipient, no global credentials needed
         _CHANNELS[ChannelType.PAGERDUTY] = PagerDutyChannel()
     return _CHANNELS

--- a/apps/web_console_ng/Dockerfile
+++ b/apps/web_console_ng/Dockerfile
@@ -15,10 +15,12 @@ RUN groupadd -r appuser && useradd --no-create-home -r -g appuser appuser
 
 # Create .nicegui directory for NiceGUI persistence (user storage, etc.)
 RUN mkdir -p /app/.nicegui && chown appuser:appuser /app/.nicegui
+RUN mkdir -p /app/data/universes && chown -R appuser:appuser /app/data
 
 COPY --chown=appuser:appuser apps/web_console_ng /app/apps/web_console_ng
 COPY --chown=appuser:appuser libs /app/libs
 COPY --chown=appuser:appuser config /app/config
+COPY --chown=appuser:appuser strategies /app/strategies
 
 ENV PYTHONPATH=/app
 

--- a/apps/web_console_ng/Dockerfile
+++ b/apps/web_console_ng/Dockerfile
@@ -18,6 +18,7 @@ RUN mkdir -p /app/.nicegui && chown appuser:appuser /app/.nicegui
 
 COPY --chown=appuser:appuser apps/web_console_ng /app/apps/web_console_ng
 COPY --chown=appuser:appuser libs /app/libs
+COPY --chown=appuser:appuser config /app/config
 
 ENV PYTHONPATH=/app
 

--- a/apps/web_console_ng/api/workspace.py
+++ b/apps/web_console_ng/api/workspace.py
@@ -13,6 +13,7 @@ from apps.web_console_ng.auth.csrf import verify_csrf_token
 from apps.web_console_ng.core.workspace_persistence import (
     MAX_STATE_SIZE,
     DatabaseUnavailableError,
+    WorkspaceSchemaUnavailableError,
     get_workspace_service,
 )
 
@@ -151,6 +152,11 @@ async def save_grid_state(
             grid_id=grid_id,
             state=state.model_dump(exclude_none=True),
         )
+    except WorkspaceSchemaUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Workspace schema unavailable",
+        ) from None
     except DatabaseUnavailableError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -177,6 +183,11 @@ async def load_grid_state(
     service = get_workspace_service()
     try:
         return await service.load_grid_state(user_id=user["user_id"], grid_id=grid_id)
+    except WorkspaceSchemaUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Workspace schema unavailable",
+        ) from None
     except DatabaseUnavailableError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -200,6 +211,11 @@ async def reset_grid_state(
     service = get_workspace_service()
     try:
         await service.reset_workspace(user["user_id"], f"grid.{grid_id}")
+    except WorkspaceSchemaUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Workspace schema unavailable",
+        ) from None
     except DatabaseUnavailableError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/apps/web_console_ng/auth/middleware.py
+++ b/apps/web_console_ng/auth/middleware.py
@@ -24,6 +24,29 @@ from apps.web_console_ng.auth.session_store import (
 logger = logging.getLogger(__name__)
 
 
+async def _call_next_with_disconnect_guard(
+    request: Request, call_next: Callable[[Request], Any]
+) -> Response:
+    """Call downstream middleware/route and handle disconnect race safely.
+
+    Starlette can raise RuntimeError("No response returned.") when a client disconnects
+    mid-request before downstream has emitted a response. Treat that case as benign
+    only when the request is confirmed disconnected.
+    """
+    try:
+        return cast(Response, await call_next(request))
+    except RuntimeError as exc:
+        if str(exc) != "No response returned.":
+            raise
+        if not await request.is_disconnected():
+            raise
+        logger.debug(
+            "suppressing_no_response_returned_for_disconnected_client",
+            extra={"path": request.url.path},
+        )
+        return Response(status_code=204)
+
+
 def _get_request_from_storage() -> Request:
     """Return current request from NiceGUI context or a minimal fallback for tests.
 
@@ -205,7 +228,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable[[Request], Any]) -> Response:
         # Skip static files, health checks, and auth entrypoints
         if request.url.path.startswith(self._EXEMPT_PATH_PREFIXES):
-            return cast(Response, await call_next(request))
+            return await _call_next_with_disconnect_guard(request, call_next)
 
         # 1. mTLS Auto-Login (if enabled)
         # We check this at middleware level to allow bypass of login form
@@ -297,7 +320,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return response
             return Response(status_code=401)
 
-        return cast(Response, await call_next(request))
+        return await _call_next_with_disconnect_guard(request, call_next)
 
     # P6T19: _override_role_from_db, _apply_role_override, _update_session_payload
     # removed — single-admin model hardcodes role="admin" in dispatch above.
@@ -369,7 +392,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                     )
                 # For HTML requests, proceed without user - decorators will handle error UI
 
-        return cast(Response, await call_next(request))
+        return await _call_next_with_disconnect_guard(request, call_next)
 
 
 async def _validate_and_get_user_for_decorator(

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -7,6 +7,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from psycopg.errors import UndefinedColumn, UndefinedObject, UndefinedTable
+
 from apps.web_console_ng.core.database import get_db_pool
 
 logger = logging.getLogger(__name__)
@@ -28,8 +30,7 @@ class DatabaseUnavailableError(Exception):
 
 def _is_workspace_schema_missing_error(exc: Exception) -> bool:
     """Return True for workspace_state schema drift/missing-table errors."""
-    exc_type = type(exc).__name__
-    if exc_type not in {"UndefinedTable", "UndefinedColumn", "UndefinedObject"}:
+    if not isinstance(exc, (UndefinedTable, UndefinedColumn, UndefinedObject)):
         return False
     return "workspace_state" in str(exc).lower()
 

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -26,6 +26,14 @@ class DatabaseUnavailableError(Exception):
     pass
 
 
+def _is_workspace_schema_missing_error(exc: Exception) -> bool:
+    """Return True for workspace_state schema drift/missing-table errors."""
+    exc_type = type(exc).__name__
+    if exc_type not in {"UndefinedTable", "UndefinedColumn", "UndefinedObject"}:
+        return False
+    return "workspace_state" in str(exc).lower()
+
+
 @dataclass
 class WorkspaceState:
     """Workspace state container."""
@@ -94,19 +102,29 @@ class WorkspacePersistenceService:
             return False
 
         pool = _require_db_pool()
-        # Use async context managers for AsyncConnectionPool
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    """
-                    INSERT INTO workspace_state (user_id, workspace_key, state_json, schema_version)
-                    VALUES (%s, %s, %s, %s)
-                    ON CONFLICT (user_id, workspace_key)
-                    DO UPDATE SET state_json = EXCLUDED.state_json, schema_version = EXCLUDED.schema_version
-                    """,
-                    (user_id, workspace_key, state_json, SCHEMA_VERSIONS["grid"]),
+        try:
+            # Use async context managers for AsyncConnectionPool
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        """
+                        INSERT INTO workspace_state (user_id, workspace_key, state_json, schema_version)
+                        VALUES (%s, %s, %s, %s)
+                        ON CONFLICT (user_id, workspace_key)
+                        DO UPDATE SET state_json = EXCLUDED.state_json, schema_version = EXCLUDED.schema_version
+                        """,
+                        (user_id, workspace_key, state_json, SCHEMA_VERSIONS["grid"]),
+                    )
+                await conn.commit()
+        except Exception as exc:
+            if _is_workspace_schema_missing_error(exc):
+                logger.warning(
+                    "workspace_state_schema_unavailable: operation=save_grid_state key=%s error=%s",
+                    workspace_key,
+                    type(exc).__name__,
                 )
-            await conn.commit()
+                return False
+            raise
 
         logger.info(
             "workspace_state_saved",
@@ -133,18 +151,28 @@ class WorkspacePersistenceService:
         workspace_key = f"grid.{grid_id}"
 
         pool = _require_db_pool()
-        # Use async context managers for AsyncConnectionPool
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    """
-                    SELECT state_json, schema_version
-                    FROM workspace_state
-                    WHERE user_id = %s AND workspace_key = %s
-                    """,
-                    (user_id, workspace_key),
+        try:
+            # Use async context managers for AsyncConnectionPool
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        """
+                        SELECT state_json, schema_version
+                        FROM workspace_state
+                        WHERE user_id = %s AND workspace_key = %s
+                        """,
+                        (user_id, workspace_key),
+                    )
+                    row = await cur.fetchone()
+        except Exception as exc:
+            if _is_workspace_schema_missing_error(exc):
+                logger.warning(
+                    "workspace_state_schema_unavailable: operation=load_grid_state key=%s error=%s",
+                    workspace_key,
+                    type(exc).__name__,
                 )
-                row = await cur.fetchone()
+                return None
+            raise
 
         if not row:
             return None
@@ -240,18 +268,28 @@ class WorkspacePersistenceService:
             return False
 
         pool = _require_db_pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    """
-                    INSERT INTO workspace_state (user_id, workspace_key, state_json, schema_version)
-                    VALUES (%s, %s, %s, %s)
-                    ON CONFLICT (user_id, workspace_key)
-                    DO UPDATE SET state_json = EXCLUDED.state_json, schema_version = EXCLUDED.schema_version
-                    """,
-                    (user_id, workspace_key, state_json, SCHEMA_VERSIONS["panel"]),
+        try:
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        """
+                        INSERT INTO workspace_state (user_id, workspace_key, state_json, schema_version)
+                        VALUES (%s, %s, %s, %s)
+                        ON CONFLICT (user_id, workspace_key)
+                        DO UPDATE SET state_json = EXCLUDED.state_json, schema_version = EXCLUDED.schema_version
+                        """,
+                        (user_id, workspace_key, state_json, SCHEMA_VERSIONS["panel"]),
+                    )
+                await conn.commit()
+        except Exception as exc:
+            if _is_workspace_schema_missing_error(exc):
+                logger.warning(
+                    "workspace_state_schema_unavailable: operation=save_panel_state key=%s error=%s",
+                    workspace_key,
+                    type(exc).__name__,
                 )
-            await conn.commit()
+                return False
+            raise
 
         logger.info(
             "workspace_state_saved",
@@ -278,17 +316,27 @@ class WorkspacePersistenceService:
         workspace_key = f"panel.{panel_id}"
 
         pool = _require_db_pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    """
-                    SELECT state_json, schema_version
-                    FROM workspace_state
-                    WHERE user_id = %s AND workspace_key = %s
-                    """,
-                    (user_id, workspace_key),
+        try:
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        """
+                        SELECT state_json, schema_version
+                        FROM workspace_state
+                        WHERE user_id = %s AND workspace_key = %s
+                        """,
+                        (user_id, workspace_key),
+                    )
+                    row = await cur.fetchone()
+        except Exception as exc:
+            if _is_workspace_schema_missing_error(exc):
+                logger.warning(
+                    "workspace_state_schema_unavailable: operation=load_panel_state key=%s error=%s",
+                    workspace_key,
+                    type(exc).__name__,
                 )
-                row = await cur.fetchone()
+                return None
+            raise
 
         if not row:
             return None
@@ -356,20 +404,30 @@ class WorkspacePersistenceService:
             DatabaseUnavailableError: If database pool is not configured
         """
         pool = _require_db_pool()
-        # Use async context managers for AsyncConnectionPool
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                if workspace_key:
-                    await cur.execute(
-                        "DELETE FROM workspace_state WHERE user_id = %s AND workspace_key = %s",
-                        (user_id, workspace_key),
-                    )
-                else:
-                    await cur.execute(
-                        "DELETE FROM workspace_state WHERE user_id = %s",
-                        (user_id,),
-                    )
-            await conn.commit()
+        try:
+            # Use async context managers for AsyncConnectionPool
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    if workspace_key:
+                        await cur.execute(
+                            "DELETE FROM workspace_state WHERE user_id = %s AND workspace_key = %s",
+                            (user_id, workspace_key),
+                        )
+                    else:
+                        await cur.execute(
+                            "DELETE FROM workspace_state WHERE user_id = %s",
+                            (user_id,),
+                        )
+                await conn.commit()
+        except Exception as exc:
+            if _is_workspace_schema_missing_error(exc):
+                logger.warning(
+                    "workspace_state_schema_unavailable: operation=reset_workspace key=%s error=%s",
+                    workspace_key or "all",
+                    type(exc).__name__,
+                )
+                return
+            raise
 
         logger.info(
             "workspace_state_reset",

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NoReturn
 
 from psycopg.errors import UndefinedColumn, UndefinedObject, UndefinedTable
 
@@ -28,11 +28,53 @@ class DatabaseUnavailableError(Exception):
     pass
 
 
+class WorkspaceSchemaUnavailableError(DatabaseUnavailableError):
+    """Raised when workspace_state schema elements are missing."""
+
+    def __init__(
+        self,
+        operation: str,
+        workspace_key: str,
+        *,
+        cause: Exception | None = None,
+    ) -> None:
+        message = (
+            f"workspace_state schema unavailable during {operation} for key={workspace_key}"
+        )
+        if cause is not None:
+            message = f"{message} ({type(cause).__name__})"
+        super().__init__(message)
+        self.operation = operation
+        self.workspace_key = workspace_key
+
+
 def _is_workspace_schema_missing_error(exc: Exception) -> bool:
     """Return True for workspace_state schema drift/missing-table errors."""
     if not isinstance(exc, UndefinedTable | UndefinedColumn | UndefinedObject):
         return False
     return "workspace_state" in str(exc).lower()
+
+
+def _raise_workspace_schema_unavailable(
+    exc: Exception,
+    *,
+    operation: str,
+    workspace_key: str,
+) -> NoReturn:
+    """Log and re-raise schema drift errors as a typed workspace exception."""
+    logger.warning(
+        "workspace_state_schema_unavailable",
+        extra={
+            "operation": operation,
+            "workspace_key": workspace_key,
+            "error": type(exc).__name__,
+        },
+    )
+    raise WorkspaceSchemaUnavailableError(
+        operation,
+        workspace_key,
+        cause=exc,
+    ) from exc
 
 
 @dataclass
@@ -119,12 +161,11 @@ class WorkspacePersistenceService:
                 await conn.commit()
         except Exception as exc:
             if _is_workspace_schema_missing_error(exc):
-                logger.warning(
-                    "workspace_state_schema_unavailable: operation=save_grid_state key=%s error=%s",
-                    workspace_key,
-                    type(exc).__name__,
+                _raise_workspace_schema_unavailable(
+                    exc,
+                    operation="save_grid_state",
+                    workspace_key=workspace_key,
                 )
-                return False
             raise
 
         logger.info(
@@ -167,12 +208,11 @@ class WorkspacePersistenceService:
                     row = await cur.fetchone()
         except Exception as exc:
             if _is_workspace_schema_missing_error(exc):
-                logger.warning(
-                    "workspace_state_schema_unavailable: operation=load_grid_state key=%s error=%s",
-                    workspace_key,
-                    type(exc).__name__,
+                _raise_workspace_schema_unavailable(
+                    exc,
+                    operation="load_grid_state",
+                    workspace_key=workspace_key,
                 )
-                return None
             raise
 
         if not row:
@@ -284,12 +324,11 @@ class WorkspacePersistenceService:
                 await conn.commit()
         except Exception as exc:
             if _is_workspace_schema_missing_error(exc):
-                logger.warning(
-                    "workspace_state_schema_unavailable: operation=save_panel_state key=%s error=%s",
-                    workspace_key,
-                    type(exc).__name__,
+                _raise_workspace_schema_unavailable(
+                    exc,
+                    operation="save_panel_state",
+                    workspace_key=workspace_key,
                 )
-                return False
             raise
 
         logger.info(
@@ -331,12 +370,11 @@ class WorkspacePersistenceService:
                     row = await cur.fetchone()
         except Exception as exc:
             if _is_workspace_schema_missing_error(exc):
-                logger.warning(
-                    "workspace_state_schema_unavailable: operation=load_panel_state key=%s error=%s",
-                    workspace_key,
-                    type(exc).__name__,
+                _raise_workspace_schema_unavailable(
+                    exc,
+                    operation="load_panel_state",
+                    workspace_key=workspace_key,
                 )
-                return None
             raise
 
         if not row:
@@ -422,12 +460,11 @@ class WorkspacePersistenceService:
                 await conn.commit()
         except Exception as exc:
             if _is_workspace_schema_missing_error(exc):
-                logger.warning(
-                    "workspace_state_schema_unavailable: operation=reset_workspace key=%s error=%s",
-                    workspace_key or "all",
-                    type(exc).__name__,
+                _raise_workspace_schema_unavailable(
+                    exc,
+                    operation="reset_workspace",
+                    workspace_key=workspace_key or "all",
                 )
-                return
             raise
 
         logger.info(
@@ -452,6 +489,7 @@ __all__ = [
     "WorkspaceState",
     "WorkspacePersistenceService",
     "DatabaseUnavailableError",
+    "WorkspaceSchemaUnavailableError",
     "get_workspace_service",
     "SCHEMA_VERSIONS",
 ]

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -51,10 +51,17 @@ class WorkspaceSchemaUnavailableError(DatabaseUnavailableError):
 
 
 def _is_workspace_schema_missing_error(exc: Exception) -> bool:
-    """Return True for workspace_state schema drift/missing-table errors."""
-    if not isinstance(exc, UndefinedTable | UndefinedColumn | UndefinedObject):
-        return False
-    return "workspace_state" in str(exc).lower()
+    """Return True for workspace_state schema drift/missing-table errors.
+
+    All ``UndefinedTable``, ``UndefinedColumn``, and ``UndefinedObject``
+    exceptions that arise within workspace operations are treated as schema
+    unavailability.  Postgres ``UndefinedColumn`` messages do not always
+    include the table name (e.g. ``column "schema_version" does not exist``),
+    so a string-only check is insufficient.  Because the ``_workspace_schema_guard``
+    context manager is scoped to workspace operations, any such error is
+    inherently workspace-related.
+    """
+    return isinstance(exc, UndefinedTable | UndefinedColumn | UndefinedObject)
 
 
 def _raise_workspace_schema_unavailable(

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
@@ -77,6 +79,25 @@ def _raise_workspace_schema_unavailable(
     ) from exc
 
 
+@asynccontextmanager
+async def _workspace_schema_guard(
+    *,
+    operation: str,
+    workspace_key: str,
+) -> AsyncIterator[None]:
+    """Normalize schema-missing DB errors into a typed workspace exception."""
+    try:
+        yield
+    except Exception as exc:
+        if _is_workspace_schema_missing_error(exc):
+            _raise_workspace_schema_unavailable(
+                exc,
+                operation=operation,
+                workspace_key=workspace_key,
+            )
+        raise
+
+
 @dataclass
 class WorkspaceState:
     """Workspace state container."""
@@ -145,7 +166,10 @@ class WorkspacePersistenceService:
             return False
 
         pool = _require_db_pool()
-        try:
+        async with _workspace_schema_guard(
+            operation="save_grid_state",
+            workspace_key=workspace_key,
+        ):
             # Use async context managers for AsyncConnectionPool
             async with pool.connection() as conn:
                 async with conn.cursor() as cur:
@@ -158,15 +182,6 @@ class WorkspacePersistenceService:
                         """,
                         (user_id, workspace_key, state_json, SCHEMA_VERSIONS["grid"]),
                     )
-                await conn.commit()
-        except Exception as exc:
-            if _is_workspace_schema_missing_error(exc):
-                _raise_workspace_schema_unavailable(
-                    exc,
-                    operation="save_grid_state",
-                    workspace_key=workspace_key,
-                )
-            raise
 
         logger.info(
             "workspace_state_saved",
@@ -193,7 +208,11 @@ class WorkspacePersistenceService:
         workspace_key = f"grid.{grid_id}"
 
         pool = _require_db_pool()
-        try:
+        row: Any | None = None
+        async with _workspace_schema_guard(
+            operation="load_grid_state",
+            workspace_key=workspace_key,
+        ):
             # Use async context managers for AsyncConnectionPool
             async with pool.connection() as conn:
                 async with conn.cursor() as cur:
@@ -206,14 +225,6 @@ class WorkspacePersistenceService:
                         (user_id, workspace_key),
                     )
                     row = await cur.fetchone()
-        except Exception as exc:
-            if _is_workspace_schema_missing_error(exc):
-                _raise_workspace_schema_unavailable(
-                    exc,
-                    operation="load_grid_state",
-                    workspace_key=workspace_key,
-                )
-            raise
 
         if not row:
             return None
@@ -309,7 +320,10 @@ class WorkspacePersistenceService:
             return False
 
         pool = _require_db_pool()
-        try:
+        async with _workspace_schema_guard(
+            operation="save_panel_state",
+            workspace_key=workspace_key,
+        ):
             async with pool.connection() as conn:
                 async with conn.cursor() as cur:
                     await cur.execute(
@@ -321,15 +335,6 @@ class WorkspacePersistenceService:
                         """,
                         (user_id, workspace_key, state_json, SCHEMA_VERSIONS["panel"]),
                     )
-                await conn.commit()
-        except Exception as exc:
-            if _is_workspace_schema_missing_error(exc):
-                _raise_workspace_schema_unavailable(
-                    exc,
-                    operation="save_panel_state",
-                    workspace_key=workspace_key,
-                )
-            raise
 
         logger.info(
             "workspace_state_saved",
@@ -356,7 +361,11 @@ class WorkspacePersistenceService:
         workspace_key = f"panel.{panel_id}"
 
         pool = _require_db_pool()
-        try:
+        row: Any | None = None
+        async with _workspace_schema_guard(
+            operation="load_panel_state",
+            workspace_key=workspace_key,
+        ):
             async with pool.connection() as conn:
                 async with conn.cursor() as cur:
                     await cur.execute(
@@ -368,14 +377,6 @@ class WorkspacePersistenceService:
                         (user_id, workspace_key),
                     )
                     row = await cur.fetchone()
-        except Exception as exc:
-            if _is_workspace_schema_missing_error(exc):
-                _raise_workspace_schema_unavailable(
-                    exc,
-                    operation="load_panel_state",
-                    workspace_key=workspace_key,
-                )
-            raise
 
         if not row:
             return None
@@ -443,7 +444,10 @@ class WorkspacePersistenceService:
             DatabaseUnavailableError: If database pool is not configured
         """
         pool = _require_db_pool()
-        try:
+        async with _workspace_schema_guard(
+            operation="reset_workspace",
+            workspace_key=workspace_key or "all",
+        ):
             # Use async context managers for AsyncConnectionPool
             async with pool.connection() as conn:
                 async with conn.cursor() as cur:
@@ -457,15 +461,6 @@ class WorkspacePersistenceService:
                             "DELETE FROM workspace_state WHERE user_id = %s",
                             (user_id,),
                         )
-                await conn.commit()
-        except Exception as exc:
-            if _is_workspace_schema_missing_error(exc):
-                _raise_workspace_schema_unavailable(
-                    exc,
-                    operation="reset_workspace",
-                    workspace_key=workspace_key or "all",
-                )
-            raise
 
         logger.info(
             "workspace_state_reset",

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -30,7 +30,7 @@ class DatabaseUnavailableError(Exception):
 
 def _is_workspace_schema_missing_error(exc: Exception) -> bool:
     """Return True for workspace_state schema drift/missing-table errors."""
-    if not isinstance(exc, (UndefinedTable, UndefinedColumn, UndefinedObject)):
+    if not isinstance(exc, UndefinedTable | UndefinedColumn | UndefinedObject):
         return False
     return "workspace_state" in str(exc).lower()
 

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -50,7 +50,7 @@ class WorkspaceSchemaUnavailableError(DatabaseUnavailableError):
 
 def _is_workspace_schema_missing_error(exc: Exception) -> bool:
     """Return True for workspace_state schema drift/missing-table errors."""
-    if not isinstance(exc, UndefinedTable | UndefinedColumn | UndefinedObject):
+    if not isinstance(exc, (UndefinedTable, UndefinedColumn, UndefinedObject)):
         return False
     return "workspace_state" in str(exc).lower()
 

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -189,6 +189,7 @@ class WorkspacePersistenceService:
                         """,
                         (user_id, workspace_key, state_json, SCHEMA_VERSIONS["grid"]),
                     )
+                await conn.commit()
 
         logger.info(
             "workspace_state_saved",
@@ -342,6 +343,7 @@ class WorkspacePersistenceService:
                         """,
                         (user_id, workspace_key, state_json, SCHEMA_VERSIONS["panel"]),
                     )
+                await conn.commit()
 
         logger.info(
             "workspace_state_saved",
@@ -468,6 +470,7 @@ class WorkspacePersistenceService:
                             "DELETE FROM workspace_state WHERE user_id = %s",
                             (user_id,),
                         )
+                await conn.commit()
 
         logger.info(
             "workspace_state_reset",

--- a/apps/web_console_ng/core/workspace_persistence.py
+++ b/apps/web_console_ng/core/workspace_persistence.py
@@ -50,7 +50,7 @@ class WorkspaceSchemaUnavailableError(DatabaseUnavailableError):
 
 def _is_workspace_schema_missing_error(exc: Exception) -> bool:
     """Return True for workspace_state schema drift/missing-table errors."""
-    if not isinstance(exc, (UndefinedTable, UndefinedColumn, UndefinedObject)):
+    if not isinstance(exc, UndefinedTable | UndefinedColumn | UndefinedObject):
         return False
     return "workspace_state" in str(exc).lower()
 

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -82,7 +82,7 @@ def _patch_nicegui_request_tracking_middleware() -> None:
             raise
 
     _dispatch_with_no_response_guard._no_response_patch_applied = True  # type: ignore[attr-defined]
-    middleware_cls.dispatch = _dispatch_with_no_response_guard  # type: ignore[method-assign]
+    middleware_cls.dispatch = _dispatch_with_no_response_guard
 
 
 class SuppressNoResponseReturnedMiddleware:

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -166,16 +166,6 @@ app.add_middleware(SuppressNoResponseReturnedMiddleware)
 @app.exception_handler(Exception)
 async def log_unhandled_exception(request: Request, exc: Exception) -> PlainTextResponse:
     """Log unhandled exceptions with full traceback for debug."""
-    if (
-        isinstance(exc, RuntimeError)
-        and str(exc) == "No response returned."
-        and await request.is_disconnected()
-    ):
-        # Starlette emits this sentinel RuntimeError when the client disconnects
-        # before any downstream response can be produced.
-        logger.debug("suppressing_no_response_returned_runtime_error")
-        return PlainTextResponse("", status_code=204)
-
     logger.error(
         "unhandled_exception path=%s type=%s message=%s",
         str(request.url.path),

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 import traceback
+from collections.abc import Awaitable, Callable
 
 from nicegui import app, ui
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from apps.web_console_ng import config
 
@@ -34,7 +36,61 @@ from apps.web_console_ng.ui.disconnect_overlay import inject_disconnect_overlay
 logger = logging.getLogger(__name__)
 
 
+def _patch_nicegui_request_tracking_middleware() -> None:
+    """Patch NiceGUI request tracking middleware to ignore disconnect sentinel."""
+    try:
+        from nicegui import storage as nicegui_storage
+    except (ImportError, AttributeError):
+        return
+
+    dispatch = nicegui_storage.RequestTrackingMiddleware.dispatch
+    if getattr(dispatch, "_no_response_patch_applied", False):
+        return
+
+    async def _dispatch_with_no_response_guard(
+        self: object, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        try:
+            return await dispatch(self, request, call_next)
+        except RuntimeError as exc:
+            if str(exc) == "No response returned.":
+                logger.debug("suppressing_no_response_returned_in_nicegui_storage")
+                return Response(status_code=204)
+            raise
+
+    setattr(_dispatch_with_no_response_guard, "_no_response_patch_applied", True)
+    nicegui_storage.RequestTrackingMiddleware.dispatch = _dispatch_with_no_response_guard
+
+
+class SuppressNoResponseReturnedMiddleware:
+    """Swallow Starlette disconnect sentinel RuntimeError for HTTP requests."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    @staticmethod
+    def _is_no_response_returned(exc: BaseException) -> bool:
+        if isinstance(exc, RuntimeError):
+            return str(exc) == "No response returned."
+        if isinstance(exc, BaseExceptionGroup):
+            return all(
+                SuppressNoResponseReturnedMiddleware._is_no_response_returned(sub_exc)
+                for sub_exc in exc.exceptions
+            )
+        return False
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        try:
+            await self.app(scope, receive, send)
+        except Exception as exc:
+            if scope.get("type") == "http" and self._is_no_response_returned(exc):
+                logger.debug("suppressing_no_response_returned_runtime_error_at_asgi")
+                return
+            raise
+
+
 # Initialize async DB pool via core.database (centralizes pool config and provides get_db_pool())
+_patch_nicegui_request_tracking_middleware()
 db_pool = init_db_pool()
 
 audit_logger = AuthAuditLogger.get(
@@ -69,11 +125,18 @@ app.add_middleware(
 )
 app.add_middleware(AdmissionControlMiddleware)
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=config.ALLOWED_HOSTS)
+app.add_middleware(SuppressNoResponseReturnedMiddleware)
 
 
 @app.exception_handler(Exception)
 async def log_unhandled_exception(request: Request, exc: Exception) -> PlainTextResponse:
     """Log unhandled exceptions with full traceback for debug."""
+    if isinstance(exc, RuntimeError) and str(exc) == "No response returned.":
+        # Starlette emits this sentinel RuntimeError when the client disconnects
+        # before any downstream response can be produced.
+        logger.debug("suppressing_no_response_returned_runtime_error")
+        return PlainTextResponse("", status_code=204)
+
     logger.error(
         "unhandled_exception path=%s type=%s message=%s",
         str(request.url.path),

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -63,12 +63,8 @@ def _patch_nicegui_request_tracking_middleware() -> None:
                     return Response(status_code=204)
             raise
 
-    setattr(_dispatch_with_no_response_guard, "_no_response_patch_applied", True)
-    setattr(
-        nicegui_storage.RequestTrackingMiddleware,
-        "dispatch",
-        _dispatch_with_no_response_guard,
-    )
+    _dispatch_with_no_response_guard._no_response_patch_applied = True  # type: ignore[attr-defined]
+    nicegui_storage.RequestTrackingMiddleware.dispatch = _dispatch_with_no_response_guard  # type: ignore[method-assign]
 
 
 class SuppressNoResponseReturnedMiddleware:

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import traceback
 from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from nicegui import app, ui
 from starlette.middleware.trustedhost import TrustedHostMiddleware
@@ -43,23 +44,31 @@ def _patch_nicegui_request_tracking_middleware() -> None:
     except (ImportError, AttributeError):
         return
 
-    dispatch = nicegui_storage.RequestTrackingMiddleware.dispatch
+    dispatch = cast(
+        Callable[[Any, Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]],
+        nicegui_storage.RequestTrackingMiddleware.dispatch,
+    )
     if getattr(dispatch, "_no_response_patch_applied", False):
         return
 
     async def _dispatch_with_no_response_guard(
-        self: object, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+        self: Any, request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
         try:
             return await dispatch(self, request, call_next)
         except RuntimeError as exc:
             if str(exc) == "No response returned.":
-                logger.debug("suppressing_no_response_returned_in_nicegui_storage")
-                return Response(status_code=204)
+                if await request.is_disconnected():
+                    logger.debug("suppressing_no_response_returned_in_nicegui_storage")
+                    return Response(status_code=204)
             raise
 
     setattr(_dispatch_with_no_response_guard, "_no_response_patch_applied", True)
-    nicegui_storage.RequestTrackingMiddleware.dispatch = _dispatch_with_no_response_guard
+    setattr(
+        nicegui_storage.RequestTrackingMiddleware,
+        "dispatch",
+        _dispatch_with_no_response_guard,
+    )
 
 
 class SuppressNoResponseReturnedMiddleware:
@@ -79,11 +88,20 @@ class SuppressNoResponseReturnedMiddleware:
             )
         return False
 
+    @staticmethod
+    async def _is_client_disconnected(scope: Scope, receive: Receive) -> bool:
+        if scope.get("type") != "http":
+            return False
+        request = Request(scope, receive)
+        return await request.is_disconnected()
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         try:
             await self.app(scope, receive, send)
         except Exception as exc:
-            if scope.get("type") == "http" and self._is_no_response_returned(exc):
+            if self._is_no_response_returned(exc) and await self._is_client_disconnected(
+                scope, receive
+            ):
                 logger.debug("suppressing_no_response_returned_runtime_error_at_asgi")
                 return
             raise
@@ -131,7 +149,11 @@ app.add_middleware(SuppressNoResponseReturnedMiddleware)
 @app.exception_handler(Exception)
 async def log_unhandled_exception(request: Request, exc: Exception) -> PlainTextResponse:
     """Log unhandled exceptions with full traceback for debug."""
-    if isinstance(exc, RuntimeError) and str(exc) == "No response returned.":
+    if (
+        isinstance(exc, RuntimeError)
+        and str(exc) == "No response returned."
+        and await request.is_disconnected()
+    ):
         # Starlette emits this sentinel RuntimeError when the client disconnects
         # before any downstream response can be produced.
         logger.debug("suppressing_no_response_returned_runtime_error")

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -128,7 +128,10 @@ app.include_router(workspace_router)
 # Import pages to trigger @ui.page decorator registration (including /login, /dashboard, etc.)
 from apps.web_console_ng import pages  # noqa: E402,F401
 
-# Middleware added in LIFO order: TrustedHost -> Admission -> Session -> Auth.
+# Middleware added in LIFO order (outermost first):
+# SuppressNoResponse -> TrustedHost -> Admission -> Session -> Auth.
+# SuppressNoResponseReturnedMiddleware wraps the entire stack to catch
+# Starlette disconnect sentinels at the ASGI level.
 # AdmissionControlMiddleware MUST run before Session/Auth to enforce capacity limits
 # at the ASGI level before WebSocket upgrade completes.
 app.add_middleware(AuthMiddleware)

--- a/apps/web_console_ng/main.py
+++ b/apps/web_console_ng/main.py
@@ -38,18 +38,36 @@ logger = logging.getLogger(__name__)
 
 
 def _patch_nicegui_request_tracking_middleware() -> None:
-    """Patch NiceGUI request tracking middleware to ignore disconnect sentinel."""
+    """Patch NiceGUI request tracking middleware to ignore disconnect sentinel.
+
+    This patches a NiceGUI internal (``RequestTrackingMiddleware.dispatch``).
+    If the internal changes across NiceGUI versions, we fall through
+    gracefully: the ASGI-level ``SuppressNoResponseReturnedMiddleware``
+    provides a second line of defence for the same class of error.
+    """
     try:
         from nicegui import storage as nicegui_storage
     except (ImportError, AttributeError):
         return
 
-    dispatch = cast(
-        Callable[[Any, Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]],
-        nicegui_storage.RequestTrackingMiddleware.dispatch,
-    )
+    # Guard: ensure the internal class and attribute still exist.
+    middleware_cls = getattr(nicegui_storage, "RequestTrackingMiddleware", None)
+    if middleware_cls is None:
+        logger.debug("nicegui_patch_skipped: RequestTrackingMiddleware not found")
+        return
+
+    dispatch = getattr(middleware_cls, "dispatch", None)
+    if dispatch is None or not callable(dispatch):
+        logger.debug("nicegui_patch_skipped: dispatch attribute missing or not callable")
+        return
+
     if getattr(dispatch, "_no_response_patch_applied", False):
         return
+
+    dispatch = cast(
+        Callable[[Any, Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]],
+        dispatch,
+    )
 
     async def _dispatch_with_no_response_guard(
         self: Any, request: Request, call_next: Callable[[Request], Awaitable[Response]]
@@ -64,7 +82,7 @@ def _patch_nicegui_request_tracking_middleware() -> None:
             raise
 
     _dispatch_with_no_response_guard._no_response_patch_applied = True  # type: ignore[attr-defined]
-    nicegui_storage.RequestTrackingMiddleware.dispatch = _dispatch_with_no_response_guard  # type: ignore[method-assign]
+    middleware_cls.dispatch = _dispatch_with_no_response_guard  # type: ignore[method-assign]
 
 
 class SuppressNoResponseReturnedMiddleware:

--- a/apps/web_console_ng/pages/__init__.py
+++ b/apps/web_console_ng/pages/__init__.py
@@ -6,44 +6,56 @@ module names needed for testing. Import directly from submodules:
     from apps.web_console_ng.pages.manual_order import manual_order_page
 
 ⚠️ CRITICAL (P5T7): Import page modules here to trigger @ui.page decorator registration.
-Add imports as pages are implemented:
+Add imports as pages are implemented.
 """
 
-# P5T4-T5 pages (already implemented)
-# P5T6 pages
-# P5T7 pages (add as implemented):
-from apps.web_console_ng.pages import (
-    admin,  # noqa: F401
-    # P6T19: admin_users removed (single-admin model)
-    alerts,  # noqa: F401
-    alpha_explorer,  # noqa: F401 - P5T8
-    attribution,  # noqa: F401 - P6T10
-    backtest,  # noqa: F401
-    circuit_breaker,  # noqa: F401
-    compare,  # noqa: F401 - P5T8
-    dashboard,  # noqa: F401
-    data_coverage,  # noqa: F401 - P6T13
-    data_inspector,  # noqa: F401 - P6T13
-    data_management,  # noqa: F401
-    data_source_status,  # noqa: F401 - P6T14
-    execution_quality,  # noqa: F401 - P6T8
-    exposure,  # noqa: F401 - P6T15
-    feature_browser,  # noqa: F401 - P6T14
-    forgot_password,  # noqa: F401 - Auth page
-    health,  # noqa: F401
-    journal,  # noqa: F401 - P5T8
-    login,  # noqa: F401 - Auth page
-    manual_order,  # noqa: F401
-    mfa_verify,  # noqa: F401 - Auth page
-    models,  # noqa: F401 - P6T17
-    notebook_launcher,  # noqa: F401 - P5T8
-    performance,  # noqa: F401 - P5T8
-    position_management,  # noqa: F401
-    risk,  # noqa: F401
-    scheduled_reports,  # noqa: F401 - P5T8
-    shadow_results,  # noqa: F401 - P6T14
-    sql_explorer,  # noqa: F401 - P6T14
-    strategies,  # noqa: F401 - P6T17
-    tax_lots,  # noqa: F401 - P6T16
-    universes,  # noqa: F401 - P6T15
+from __future__ import annotations
+
+import importlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PAGE_MODULES = (
+    "apps.web_console_ng.pages.admin",
+    "apps.web_console_ng.pages.alerts",
+    "apps.web_console_ng.pages.alpha_explorer",
+    "apps.web_console_ng.pages.attribution",
+    "apps.web_console_ng.pages.backtest",
+    "apps.web_console_ng.pages.circuit_breaker",
+    "apps.web_console_ng.pages.compare",
+    "apps.web_console_ng.pages.dashboard",
+    "apps.web_console_ng.pages.data_coverage",
+    "apps.web_console_ng.pages.data_inspector",
+    "apps.web_console_ng.pages.data_management",
+    "apps.web_console_ng.pages.data_source_status",
+    "apps.web_console_ng.pages.execution_quality",
+    "apps.web_console_ng.pages.exposure",
+    "apps.web_console_ng.pages.feature_browser",
+    "apps.web_console_ng.pages.forgot_password",
+    "apps.web_console_ng.pages.health",
+    "apps.web_console_ng.pages.journal",
+    "apps.web_console_ng.pages.login",
+    "apps.web_console_ng.pages.manual_order",
+    "apps.web_console_ng.pages.mfa_verify",
+    "apps.web_console_ng.pages.models",
+    "apps.web_console_ng.pages.notebook_launcher",
+    "apps.web_console_ng.pages.performance",
+    "apps.web_console_ng.pages.position_management",
+    "apps.web_console_ng.pages.risk",
+    "apps.web_console_ng.pages.scheduled_reports",
+    "apps.web_console_ng.pages.shadow_results",
+    "apps.web_console_ng.pages.sql_explorer",
+    "apps.web_console_ng.pages.strategies",
+    "apps.web_console_ng.pages.tax_lots",
+    "apps.web_console_ng.pages.universes",
 )
+
+for module_name in _PAGE_MODULES:
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        logger.warning(
+            "page_module_skipped_missing_dependency",
+            extra={"page_module": module_name, "error": str(exc)},
+        )

--- a/apps/web_console_ng/pages/__init__.py
+++ b/apps/web_console_ng/pages/__init__.py
@@ -51,12 +51,32 @@ _PAGE_MODULES = (
     "apps.web_console_ng.pages.universes",
 )
 
+# Known optional third-party packages that individual page modules may depend on.
+# If these are absent we skip the page gracefully; any other missing module is a
+# genuine regression and must fail fast.
+_OPTIONAL_PACKAGES = frozenset({
+    "rq",           # backtest job queue
+    "plotly",       # charting in some pages
+    "pandas",       # data frames
+    "polars",       # data frames
+    "strategies",   # strategy helpers (not present in web-console image)
+})
+
 for module_name in _PAGE_MODULES:
     try:
         importlib.import_module(module_name)
     except ModuleNotFoundError as exc:
-        logger.warning(
-            "page_module_skipped_missing_dependency: module=%s error=%s",
-            module_name,
-            exc,
-        )
+        # Only tolerate missing *optional* third-party packages.  If the page
+        # module itself or one of its project-level transitive deps is missing,
+        # that is a real regression and should fail fast.
+        if exc.name is not None and any(
+            exc.name == pkg or exc.name.startswith(f"{pkg}.")
+            for pkg in _OPTIONAL_PACKAGES
+        ):
+            logger.warning(
+                "page_module_skipped_missing_optional_dependency: module=%s missing_package=%s",
+                module_name,
+                exc.name,
+            )
+        else:
+            raise

--- a/apps/web_console_ng/pages/__init__.py
+++ b/apps/web_console_ng/pages/__init__.py
@@ -56,6 +56,7 @@ for module_name in _PAGE_MODULES:
         importlib.import_module(module_name)
     except ModuleNotFoundError as exc:
         logger.warning(
-            "page_module_skipped_missing_dependency",
-            extra={"page_module": module_name, "error": str(exc)},
+            "page_module_skipped_missing_dependency: module=%s error=%s",
+            module_name,
+            exc,
         )

--- a/apps/web_console_ng/pages/__init__.py
+++ b/apps/web_console_ng/pages/__init__.py
@@ -62,6 +62,10 @@ _OPTIONAL_PACKAGES = frozenset({
     "strategies",   # strategy helpers (not present in web-console image)
 })
 
+# Tracks which modules were skipped due to missing optional deps.
+# Exposed for health/readiness diagnostics (see ``get_skipped_page_modules``).
+_SKIPPED_MODULES: list[tuple[str, str]] = []
+
 for module_name in _PAGE_MODULES:
     try:
         importlib.import_module(module_name)
@@ -73,6 +77,7 @@ for module_name in _PAGE_MODULES:
             exc.name == pkg or exc.name.startswith(f"{pkg}.")
             for pkg in _OPTIONAL_PACKAGES
         ):
+            _SKIPPED_MODULES.append((module_name, exc.name))
             logger.warning(
                 "page_module_skipped_missing_optional_dependency: module=%s missing_package=%s",
                 module_name,
@@ -80,3 +85,12 @@ for module_name in _PAGE_MODULES:
             )
         else:
             raise
+
+
+def get_skipped_page_modules() -> list[tuple[str, str]]:
+    """Return list of (module_name, missing_package) for skipped page modules.
+
+    Useful for health/readiness diagnostics to surface which pages
+    are unavailable due to missing optional dependencies.
+    """
+    return list(_SKIPPED_MODULES)

--- a/apps/web_console_ng/pages/backtest.py
+++ b/apps/web_console_ng/pages/backtest.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import plotly.graph_objects as go
 import polars as pl
 from nicegui import run, ui
+from psycopg.errors import UndefinedColumn
 
 from apps.web_console_ng import config
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
@@ -96,10 +97,7 @@ def _get_rq_redis_client() -> Redis:
 
 def _is_missing_column_error(exc: Exception, column_name: str) -> bool:
     """Return True when a DB error indicates a missing column."""
-    return (
-        type(exc).__name__ == "UndefinedColumn"
-        and f'column "{column_name}"' in str(exc).lower()
-    )
+    return isinstance(exc, UndefinedColumn) and f'column "{column_name}"' in str(exc).lower()
 
 
 def _get_user_id(user: dict[str, Any]) -> str:

--- a/apps/web_console_ng/pages/backtest.py
+++ b/apps/web_console_ng/pages/backtest.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 import plotly.graph_objects as go
 import polars as pl
 from nicegui import run, ui
-from psycopg.errors import UndefinedColumn
+from psycopg.errors import UndefinedColumn, UndefinedTable
 
 from apps.web_console_ng import config
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
@@ -165,6 +165,12 @@ def _get_user_jobs_sync(
         try:
             cur.execute(sql_with_cost_summary, (created_by, status, BACKTEST_JOB_QUERY_LIMIT))
         except Exception as exc:
+            if isinstance(exc, UndefinedTable):
+                logger.warning(
+                    "backtest_jobs_table_missing",
+                    extra={"created_by": created_by, "error": str(exc)},
+                )
+                return []
             if not _is_missing_column_error(exc, "cost_summary"):
                 raise
             logger.warning(

--- a/apps/web_console_ng/pages/backtest.py
+++ b/apps/web_console_ng/pages/backtest.py
@@ -94,6 +94,14 @@ def _get_rq_redis_client() -> Redis:
     return _rq_redis_client
 
 
+def _is_missing_column_error(exc: Exception, column_name: str) -> bool:
+    """Return True when a DB error indicates a missing column."""
+    return (
+        type(exc).__name__ == "UndefinedColumn"
+        and f'column "{column_name}"' in str(exc).lower()
+    )
+
+
 def _get_user_id(user: dict[str, Any]) -> str:
     """Get user identifier with fail-closed behavior.
 
@@ -135,7 +143,7 @@ def _get_user_jobs_sync(
     if invalid:
         raise ValueError(f"Invalid statuses: {invalid}. Valid: {VALID_STATUSES}")
 
-    sql = """
+    sql_with_cost_summary = """
         SELECT job_id, alpha_name, start_date, end_date, status, created_at,
                error_message, mean_ic, icir, hit_rate, coverage, average_turnover,
                result_path, cost_summary,
@@ -145,8 +153,27 @@ def _get_user_jobs_sync(
         ORDER BY created_at DESC
         LIMIT %s
     """
+    sql_without_cost_summary = """
+        SELECT job_id, alpha_name, start_date, end_date, status, created_at,
+               error_message, mean_ic, icir, hit_rate, coverage, average_turnover,
+               result_path, NULL AS cost_summary,
+               COALESCE(config_json->>'provider', 'crsp') AS provider
+        FROM backtest_jobs
+        WHERE created_by = %s AND status = ANY(%s)
+        ORDER BY created_at DESC
+        LIMIT %s
+    """
     with db_pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, (created_by, status, BACKTEST_JOB_QUERY_LIMIT))
+        try:
+            cur.execute(sql_with_cost_summary, (created_by, status, BACKTEST_JOB_QUERY_LIMIT))
+        except Exception as exc:
+            if not _is_missing_column_error(exc, "cost_summary"):
+                raise
+            logger.warning(
+                "backtest_jobs_cost_summary_column_missing: falling back without cost_summary"
+            )
+            conn.rollback()
+            cur.execute(sql_without_cost_summary, (created_by, status, BACKTEST_JOB_QUERY_LIMIT))
         jobs = cur.fetchall()
 
     if not jobs:

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -116,6 +116,7 @@ def _get_user_id_safe(user: Any) -> str | None:
     return str(val) if val is not None else None
 
 
+@ui.page("/data/management")
 @ui.page("/data")
 @requires_auth
 @main_layout

--- a/apps/web_console_ng/pages/data_source_status.py
+++ b/apps/web_console_ng/pages/data_source_status.py
@@ -104,6 +104,7 @@ def _render_status_plot(sources: list[DataSourceStatusDTO], container: ui.column
         ui.plotly(fig).classes("w-full")
 
 
+@ui.page("/data/source-status")
 @ui.page("/data/sources")
 @requires_auth
 @main_layout

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 _CLEANUP_OWNER_KEY = "exposure_timers"
 
 
+@ui.page("/exposure")
 @ui.page("/risk/exposure")
 @requires_auth
 @main_layout

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -27,6 +27,18 @@ from libs.platform.web_console_auth.permissions import Permission, has_permissio
 
 logger = logging.getLogger(__name__)
 
+_ALPHA158_IMPORT_ERROR: str | None
+try:
+    from strategies.alpha_baseline.features import (
+        get_alpha158_features as _imported_alpha158_features,
+    )
+except ModuleNotFoundError as exc:
+    _get_alpha158_features: Any | None = None
+    _ALPHA158_IMPORT_ERROR = str(exc)
+else:
+    _get_alpha158_features = _imported_alpha158_features
+    _ALPHA158_IMPORT_ERROR = None
+
 _MAX_CACHE_DAYS = 30
 _MAX_CACHE_SYMBOLS = 5
 _MAX_LOOKBACK_DAYS = 60
@@ -169,12 +181,12 @@ async def feature_browser_page() -> None:
 
         loading_state["feature_data_loading"] = True
         try:
-            try:
-                from strategies.alpha_baseline.features import get_alpha158_features
-            except ModuleNotFoundError as exc:
+            if _get_alpha158_features is None:
                 logger.warning(
-                    "feature_browser_dependency_missing: %s",
-                    exc,
+                    "feature_browser_dependency_missing",
+                    extra={
+                        "reason": _ALPHA158_IMPORT_ERROR or "feature dependencies unavailable",
+                    },
                 )
                 ui.notify(
                     "Feature engine dependencies are not available in this runtime.",
@@ -186,7 +198,7 @@ async def feature_browser_page() -> None:
             start_dt = end_dt - timedelta(days=_MAX_CACHE_DAYS + _MAX_LOOKBACK_DAYS)
             symbols = _DEFAULT_SYMBOLS[:_MAX_CACHE_SYMBOLS]
             features_df = await asyncio.to_thread(
-                get_alpha158_features,
+                _get_alpha158_features,
                 symbols=symbols,
                 start_date=start_dt.isoformat(),
                 end_date=end_dt.isoformat(),

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -24,7 +24,6 @@ from libs.data.feature_metadata import (
     get_sample_values,
 )
 from libs.platform.web_console_auth.permissions import Permission, has_permission
-from strategies.alpha_baseline.features import get_alpha158_features
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +169,19 @@ async def feature_browser_page() -> None:
 
         loading_state["feature_data_loading"] = True
         try:
+            try:
+                from strategies.alpha_baseline.features import get_alpha158_features
+            except ModuleNotFoundError as exc:
+                logger.warning(
+                    "feature_browser_dependency_missing: %s",
+                    exc,
+                )
+                ui.notify(
+                    "Feature engine dependencies are not available in this runtime.",
+                    type="warning",
+                )
+                return None
+
             end_dt = date.today()
             start_dt = end_dt - timedelta(days=_MAX_CACHE_DAYS + _MAX_LOOKBACK_DAYS)
             symbols = _DEFAULT_SYMBOLS[:_MAX_CACHE_SYMBOLS]

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -33,8 +33,16 @@ try:
         get_alpha158_features as _imported_alpha158_features,
     )
 except ModuleNotFoundError as exc:
-    _get_alpha158_features: Any | None = None
-    _ALPHA158_IMPORT_ERROR = str(exc)
+    # Only tolerate the ``strategies`` package itself being absent (it is
+    # not shipped in the web-console Docker image).  Any other missing
+    # module (e.g. a renamed internal import) is a real regression.
+    if exc.name is not None and (
+        exc.name == "strategies" or exc.name.startswith("strategies.")
+    ):
+        _get_alpha158_features: Any | None = None
+        _ALPHA158_IMPORT_ERROR = str(exc)
+    else:
+        raise
 else:
     _get_alpha158_features = _imported_alpha158_features
     _ALPHA158_IMPORT_ERROR = None

--- a/apps/web_console_ng/pages/position_management.py
+++ b/apps/web_console_ng/pages/position_management.py
@@ -189,7 +189,7 @@ async def position_management_page(client: Client) -> None:
                 ],
                 "rowData": [],
                 "domLayout": "autoHeight",
-                "getRowId": "params => params.data.symbol",
+                "getRowId": "params => params?.data?.symbol ?? ('row-' + String(params?.rowIndex ?? ''))",
                 "rowSelection": "single",
             }
         ).classes("w-full mb-4")

--- a/apps/web_console_ng/pages/position_management.py
+++ b/apps/web_console_ng/pages/position_management.py
@@ -202,7 +202,7 @@ async def position_management_page(client: Client) -> None:
                 ],
                 "rowData": [],
                 "domLayout": "autoHeight",
-                "getRowId": "params => params?.data?.symbol ?? ('row-' + String(params?.rowIndex ?? ''))",
+                ":getRowId": "params => params?.data?.symbol ?? ('row-' + String(params?.rowIndex ?? ''))",
                 "rowSelection": "single",
             }
         ).classes("w-full mb-4")

--- a/apps/web_console_ng/pages/position_management.py
+++ b/apps/web_console_ng/pages/position_management.py
@@ -93,11 +93,16 @@ async def check_kill_switch_safety(
 
 
 def _coerce_numeric(value: Any) -> float:
-    """Convert API payload values to float for safe summary calculations."""
+    """Convert API payload values to float for safe summary calculations.
+
+    Handles None, bool, int, float, and string inputs. Returns 0.0 for
+    values that cannot be converted, logging a warning for unexpected types
+    per the project's "never swallow exceptions" standard.
+    """
     if value is None:
         return 0.0
     if isinstance(value, bool):
-        return 0.0
+        return 1.0 if value else 0.0
     if isinstance(value, int | float):
         return float(value)
     if isinstance(value, str):
@@ -107,10 +112,18 @@ def _coerce_numeric(value: Any) -> float:
         try:
             return float(normalized)
         except ValueError:
+            logger.warning(
+                "coerce_numeric_failed",
+                extra={"value_type": "str", "value_repr": repr(value[:50])},
+            )
             return 0.0
     try:
         return float(value)
     except (TypeError, ValueError):
+        logger.warning(
+            "coerce_numeric_failed",
+            extra={"value_type": type(value).__name__},
+        )
         return 0.0
 
 

--- a/apps/web_console_ng/pages/position_management.py
+++ b/apps/web_console_ng/pages/position_management.py
@@ -189,7 +189,7 @@ async def position_management_page(client: Client) -> None:
                 ],
                 "rowData": [],
                 "domLayout": "autoHeight",
-                ":getRowId": "params => params.data.symbol",
+                "getRowId": "params => params.data.symbol",
                 "rowSelection": "single",
             }
         ).classes("w-full mb-4")

--- a/apps/web_console_ng/pages/position_management.py
+++ b/apps/web_console_ng/pages/position_management.py
@@ -92,6 +92,28 @@ async def check_kill_switch_safety(
         )
 
 
+def _coerce_numeric(value: Any) -> float:
+    """Convert API payload values to float for safe summary calculations."""
+    if value is None:
+        return 0.0
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        normalized = value.strip().replace(",", "")
+        if not normalized:
+            return 0.0
+        try:
+            return float(normalized)
+        except ValueError:
+            return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 @ui.page("/position-management")
 @requires_auth
 @main_layout
@@ -167,7 +189,7 @@ async def position_management_page(client: Client) -> None:
                 ],
                 "rowData": [],
                 "domLayout": "autoHeight",
-                "getRowId": "data => data.symbol",
+                ":getRowId": "params => params.data.symbol",
                 "rowSelection": "single",
             }
         ).classes("w-full mb-4")
@@ -192,9 +214,9 @@ async def position_management_page(client: Client) -> None:
 
     def update_summary() -> None:
         position_count_label.set_text(f"Positions: {len(positions_data)}")
-        total_value = sum(p.get("market_value", 0) or 0 for p in positions_data)
+        total_value = sum(_coerce_numeric(p.get("market_value")) for p in positions_data)
         total_value_label.set_text(f"Total Value: ${total_value:,.2f}")
-        unrealized = sum(p.get("unrealized_pl", 0) or 0 for p in positions_data)
+        unrealized = sum(_coerce_numeric(p.get("unrealized_pl")) for p in positions_data)
         color = "text-green-600" if unrealized >= 0 else "text-red-600"
         unrealized_pnl_label.classes(remove="text-green-600 text-red-600", add=color)
         unrealized_pnl_label.set_text(f"Unrealized P&L: ${unrealized:,.2f}")

--- a/apps/web_console_ng/pages/position_management.py
+++ b/apps/web_console_ng/pages/position_management.py
@@ -98,7 +98,7 @@ def _coerce_numeric(value: Any) -> float:
         return 0.0
     if isinstance(value, bool):
         return 0.0
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return float(value)
     if isinstance(value, str):
         normalized = value.strip().replace(",", "")

--- a/apps/web_console_ng/pages/scheduled_reports.py
+++ b/apps/web_console_ng/pages/scheduled_reports.py
@@ -64,6 +64,7 @@ def _get_service(db_pool: Any, user: dict[str, Any]) -> Any:
     )
 
 
+@ui.page("/reports/scheduled")
 @ui.page("/reports")
 @requires_auth
 @main_layout

--- a/apps/web_console_ng/pages/shadow_results.py
+++ b/apps/web_console_ng/pages/shadow_results.py
@@ -157,6 +157,7 @@ def _format_metric(value: Any, precision: int = 4) -> str:
     return "-"
 
 
+@ui.page("/shadow-results")
 @ui.page("/data/shadow")
 @requires_auth
 @main_layout

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -52,6 +52,7 @@ async def _get_validated_paths() -> tuple[dict[str, set[str]], list[str]]:
         return result
 
 
+@ui.page("/sql-explorer")
 @ui.page("/data/sql-explorer")
 @requires_auth
 @main_layout

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -247,8 +247,6 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
         # Header
         status_bar = StatusBar()
-        log_drawer = LogDrawer(notification_router)
-        log_drawer.create()
 
         with ui.header().classes(
             "bg-slate-900 items-center text-white px-4 h-14 flex-nowrap overflow-x-auto"
@@ -258,6 +256,8 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
             # Header metrics (NLV, Leverage, Day Change) - P6T2
             header_metrics = HeaderMetrics()
+            log_drawer = LogDrawer(notification_router)
+            log_drawer.create()
 
             latency_monitor = LatencyMonitor()
             latency_badge = (

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -247,6 +247,8 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
         # Header
         status_bar = StatusBar()
+        log_drawer = LogDrawer(notification_router)
+        log_drawer.create()
 
         with ui.header().classes(
             "bg-slate-900 items-center text-white px-4 h-14 flex-nowrap overflow-x-auto"
@@ -336,9 +338,6 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     )
                     .props("id=connection-badge")
                 )
-
-                log_drawer = LogDrawer(notification_router)
-                log_drawer.create()
 
                 with ui.row().classes("items-center gap-2"):
                     ui.label(user_name).classes("text-sm")

--- a/docs/ARCHITECTURE/system_map.canvas
+++ b/docs/ARCHITECTURE/system_map.canvas
@@ -174,14 +174,14 @@
       "toSide": "bottom"
     },
     {
-      "fromNode": "svc_alert_worker",
+      "fromNode": "svc_auth_service",
       "fromSide": "bottom",
       "id": "edge_21",
       "toNode": "lib_core",
       "toSide": "top"
     },
     {
-      "fromNode": "svc_auth_service",
+      "fromNode": "svc_execution_gateway",
       "fromSide": "bottom",
       "id": "edge_22",
       "toNode": "lib_core",
@@ -191,39 +191,39 @@
       "fromNode": "svc_execution_gateway",
       "fromSide": "bottom",
       "id": "edge_23",
-      "toNode": "lib_core",
+      "toNode": "lib_data",
       "toSide": "top"
     },
     {
-      "fromNode": "svc_execution_gateway",
+      "fromNode": "svc_market_data_service",
       "fromSide": "bottom",
       "id": "edge_24",
-      "toNode": "lib_data",
+      "toNode": "lib_core",
       "toSide": "top"
     },
     {
       "fromNode": "svc_market_data_service",
       "fromSide": "bottom",
       "id": "edge_25",
-      "toNode": "lib_core",
-      "toSide": "top"
-    },
-    {
-      "fromNode": "svc_market_data_service",
-      "fromSide": "bottom",
-      "id": "edge_26",
       "toNode": "lib_data",
       "toSide": "top"
     },
     {
       "fromNode": "svc_model_registry",
       "fromSide": "bottom",
-      "id": "edge_27",
+      "id": "edge_26",
       "toNode": "lib_models",
       "toSide": "top"
     },
     {
       "fromNode": "svc_orchestrator",
+      "fromSide": "bottom",
+      "id": "edge_27",
+      "toNode": "lib_core",
+      "toSide": "top"
+    },
+    {
+      "fromNode": "svc_signal_service",
       "fromSide": "bottom",
       "id": "edge_28",
       "toNode": "lib_core",
@@ -233,69 +233,62 @@
       "fromNode": "svc_signal_service",
       "fromSide": "bottom",
       "id": "edge_29",
-      "toNode": "lib_core",
-      "toSide": "top"
-    },
-    {
-      "fromNode": "svc_signal_service",
-      "fromSide": "bottom",
-      "id": "edge_30",
       "toNode": "strat_alpha_baseline",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_31",
+      "id": "edge_30",
       "toNode": "lib_analytics",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_32",
+      "id": "edge_31",
       "toNode": "lib_common",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_33",
+      "id": "edge_32",
       "toNode": "lib_core",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_34",
+      "id": "edge_33",
       "toNode": "lib_data",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_35",
+      "id": "edge_34",
       "toNode": "lib_models",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_36",
+      "id": "edge_35",
       "toNode": "lib_web_console_data",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_37",
+      "id": "edge_36",
       "toNode": "lib_web_console_services",
       "toSide": "top"
     },
     {
       "fromNode": "svc_web_console_ng",
       "fromSide": "bottom",
-      "id": "edge_38",
+      "id": "edge_37",
       "toNode": "strat_alpha_baseline",
       "toSide": "top"
     }

--- a/docs/ARCHITECTURE/system_map_deps.md
+++ b/docs/ARCHITECTURE/system_map_deps.md
@@ -53,7 +53,6 @@ flowchart TB
   lib_web_console_services -.-> lib_platform
   lib_web_console_services -.-> lib_trading
   lib_web_console_services -.-> lib_web_console_data
-  svc_alert_worker -.-> lib_core
   svc_alert_worker -.-> lib_platform
   svc_auth_service -.-> lib_core
   svc_auth_service -.-> lib_platform

--- a/libs/data/data_providers/__init__.py
+++ b/libs/data/data_providers/__init__.py
@@ -51,7 +51,6 @@ from libs.data.data_providers.protocols import (
     ProviderUnavailableError,
     YFinanceDataProviderAdapter,
 )
-from libs.data.data_providers.sync_manager import SyncManager, SyncProgress
 from libs.data.data_providers.unified_fetcher import (
     FetcherConfig,
     ProviderType,
@@ -62,13 +61,24 @@ from libs.data.data_providers.universe import (
     ForwardReturnsProvider,
     UniverseProvider,
 )
-from libs.data.data_providers.wrds_client import WRDSClient, WRDSConfig
 from libs.data.data_providers.yfinance_provider import (
     DriftDetectedError,
     ProductionGateError,
     YFinanceError,
     YFinanceProvider,
 )
+
+try:
+    from libs.data.data_providers.sync_manager import SyncManager, SyncProgress
+except ModuleNotFoundError:
+    SyncManager = None  # type: ignore[assignment]
+    SyncProgress = None  # type: ignore[assignment]
+
+try:
+    from libs.data.data_providers.wrds_client import WRDSClient, WRDSConfig
+except ModuleNotFoundError:
+    WRDSClient = None  # type: ignore[assignment]
+    WRDSConfig = None  # type: ignore[assignment]
 
 __all__ = [
     # CRSP Local Provider

--- a/libs/data/data_providers/__init__.py
+++ b/libs/data/data_providers/__init__.py
@@ -13,6 +13,8 @@ This module provides:
 - DataProvider: Protocol for data provider implementations
 """
 
+import logging as _logging
+
 from libs.data.data_providers.compustat_local_provider import (
     AmbiguousGVKEYError,
     CompustatLocalProvider,
@@ -68,17 +70,37 @@ from libs.data.data_providers.yfinance_provider import (
     YFinanceProvider,
 )
 
+_dp_logger = _logging.getLogger(__name__)
+
 try:
     from libs.data.data_providers.sync_manager import SyncManager, SyncProgress
-except ModuleNotFoundError:
-    SyncManager = None  # type: ignore[assignment,misc]
-    SyncProgress = None  # type: ignore[assignment,misc]
+except ModuleNotFoundError as _exc:
+    if _exc.name is not None and (
+        _exc.name == "libs.data.data_providers.sync_manager"
+        or not _exc.name.startswith("libs.")
+    ):
+        _dp_logger.info(
+            "sync_manager_unavailable: %s (missing_package=%s)", _exc, _exc.name
+        )
+        SyncManager = None  # type: ignore[assignment,misc]
+        SyncProgress = None  # type: ignore[assignment,misc]
+    else:
+        raise
 
 try:
     from libs.data.data_providers.wrds_client import WRDSClient, WRDSConfig
-except ModuleNotFoundError:
-    WRDSClient = None  # type: ignore[assignment,misc]
-    WRDSConfig = None  # type: ignore[assignment,misc]
+except ModuleNotFoundError as _exc:
+    if _exc.name is not None and (
+        _exc.name == "libs.data.data_providers.wrds_client"
+        or not _exc.name.startswith("libs.")
+    ):
+        _dp_logger.info(
+            "wrds_client_unavailable: %s (missing_package=%s)", _exc, _exc.name
+        )
+        WRDSClient = None  # type: ignore[assignment,misc]
+        WRDSConfig = None  # type: ignore[assignment,misc]
+    else:
+        raise
 
 __all__ = [
     # CRSP Local Provider

--- a/libs/data/data_providers/__init__.py
+++ b/libs/data/data_providers/__init__.py
@@ -72,13 +72,29 @@ from libs.data.data_providers.yfinance_provider import (
 
 _dp_logger = _logging.getLogger(__name__)
 
+# Known optional third-party packages that data-provider submodules may
+# depend on.  If these are absent we degrade gracefully; any *other*
+# missing module is a genuine regression and must fail fast.
+_OPTIONAL_PACKAGES = frozenset({
+    "wrds",       # WRDS database driver
+    "sas7bdat",   # SAS file reader
+    "saspy",      # SAS scripting
+    "paramiko",   # SSH transport for WRDS
+})
+
+
+def _is_optional_dep(exc: ModuleNotFoundError) -> bool:
+    """Return True when *exc* is caused by a known optional package."""
+    return exc.name is not None and any(
+        exc.name == pkg or exc.name.startswith(f"{pkg}.")
+        for pkg in _OPTIONAL_PACKAGES
+    )
+
+
 try:
     from libs.data.data_providers.sync_manager import SyncManager, SyncProgress
 except ModuleNotFoundError as _exc:
-    if _exc.name is not None and (
-        _exc.name == "libs.data.data_providers.sync_manager"
-        or not _exc.name.startswith("libs.")
-    ):
+    if _exc.name == "libs.data.data_providers.sync_manager" or _is_optional_dep(_exc):
         _dp_logger.info(
             "sync_manager_unavailable: %s (missing_package=%s)", _exc, _exc.name
         )
@@ -90,10 +106,7 @@ except ModuleNotFoundError as _exc:
 try:
     from libs.data.data_providers.wrds_client import WRDSClient, WRDSConfig
 except ModuleNotFoundError as _exc:
-    if _exc.name is not None and (
-        _exc.name == "libs.data.data_providers.wrds_client"
-        or not _exc.name.startswith("libs.")
-    ):
+    if _exc.name == "libs.data.data_providers.wrds_client" or _is_optional_dep(_exc):
         _dp_logger.info(
             "wrds_client_unavailable: %s (missing_package=%s)", _exc, _exc.name
         )

--- a/libs/data/data_providers/__init__.py
+++ b/libs/data/data_providers/__init__.py
@@ -71,14 +71,14 @@ from libs.data.data_providers.yfinance_provider import (
 try:
     from libs.data.data_providers.sync_manager import SyncManager, SyncProgress
 except ModuleNotFoundError:
-    SyncManager = None  # type: ignore[assignment]
-    SyncProgress = None  # type: ignore[assignment]
+    SyncManager = None  # type: ignore[assignment,misc]
+    SyncProgress = None  # type: ignore[assignment,misc]
 
 try:
     from libs.data.data_providers.wrds_client import WRDSClient, WRDSConfig
 except ModuleNotFoundError:
-    WRDSClient = None  # type: ignore[assignment]
-    WRDSConfig = None  # type: ignore[assignment]
+    WRDSClient = None  # type: ignore[assignment,misc]
+    WRDSConfig = None  # type: ignore[assignment,misc]
 
 __all__ = [
     # CRSP Local Provider

--- a/libs/data/data_providers/__init__.py
+++ b/libs/data/data_providers/__init__.py
@@ -94,7 +94,7 @@ def _is_optional_dep(exc: ModuleNotFoundError) -> bool:
 try:
     from libs.data.data_providers.sync_manager import SyncManager, SyncProgress
 except ModuleNotFoundError as _exc:
-    if _exc.name == "libs.data.data_providers.sync_manager" or _is_optional_dep(_exc):
+    if _is_optional_dep(_exc):
         _dp_logger.info(
             "sync_manager_unavailable: %s (missing_package=%s)", _exc, _exc.name
         )
@@ -106,7 +106,7 @@ except ModuleNotFoundError as _exc:
 try:
     from libs.data.data_providers.wrds_client import WRDSClient, WRDSConfig
 except ModuleNotFoundError as _exc:
-    if _exc.name == "libs.data.data_providers.wrds_client" or _is_optional_dep(_exc):
+    if _is_optional_dep(_exc):
         _dp_logger.info(
             "wrds_client_unavailable: %s (missing_package=%s)", _exc, _exc.name
         )

--- a/libs/platform/alerts/channels/__init__.py
+++ b/libs/platform/alerts/channels/__init__.py
@@ -4,15 +4,29 @@ from libs.platform.alerts.channels.base import BaseChannel
 from libs.platform.alerts.channels.pagerduty import PagerDutyChannel
 from libs.platform.alerts.channels.slack import SlackChannel
 
+# EmailChannel depends on aiosmtplib (optional).  Only suppress that
+# specific missing package; re-raise for any other import failure so
+# internal regressions are not silently hidden.
 try:
     from libs.platform.alerts.channels.email import EmailChannel
-except ModuleNotFoundError:
-    EmailChannel = None  # type: ignore[assignment,misc]
+except ModuleNotFoundError as _exc:
+    if _exc.name is not None and (
+        _exc.name == "aiosmtplib" or _exc.name.startswith("aiosmtplib.")
+    ):
+        EmailChannel = None  # type: ignore[assignment,misc]
+    else:
+        raise
 
+# SMSChannel depends on twilio (optional).
 try:
     from libs.platform.alerts.channels.sms import SMSChannel
-except ModuleNotFoundError:
-    SMSChannel = None  # type: ignore[assignment,misc]
+except ModuleNotFoundError as _exc:
+    if _exc.name is not None and (
+        _exc.name == "twilio" or _exc.name.startswith("twilio.")
+    ):
+        SMSChannel = None  # type: ignore[assignment,misc]
+    else:
+        raise
 
 __all__ = [
     "BaseChannel",

--- a/libs/platform/alerts/channels/__init__.py
+++ b/libs/platform/alerts/channels/__init__.py
@@ -7,12 +7,12 @@ from libs.platform.alerts.channels.slack import SlackChannel
 try:
     from libs.platform.alerts.channels.email import EmailChannel
 except ModuleNotFoundError:
-    EmailChannel = None  # type: ignore[assignment]
+    EmailChannel = None  # type: ignore[assignment,misc]
 
 try:
     from libs.platform.alerts.channels.sms import SMSChannel
 except ModuleNotFoundError:
-    SMSChannel = None  # type: ignore[assignment]
+    SMSChannel = None  # type: ignore[assignment,misc]
 
 __all__ = [
     "BaseChannel",

--- a/libs/platform/alerts/channels/__init__.py
+++ b/libs/platform/alerts/channels/__init__.py
@@ -1,8 +1,16 @@
 """Alert delivery channel implementations."""
 
+from __future__ import annotations
+
+import logging as _logging
+from typing import TYPE_CHECKING
+
 from libs.platform.alerts.channels.base import BaseChannel
 from libs.platform.alerts.channels.pagerduty import PagerDutyChannel
 from libs.platform.alerts.channels.slack import SlackChannel
+
+if TYPE_CHECKING:
+    from libs.platform.alerts.models import ChannelType
 
 # EmailChannel depends on aiosmtplib (optional).  Only suppress that
 # specific missing package; re-raise for any other import failure so
@@ -28,10 +36,79 @@ except ModuleNotFoundError as _exc:
     else:
         raise
 
+def build_channel_handlers(
+    *,
+    logger: _logging.Logger | None = None,
+) -> dict[ChannelType, BaseChannel]:
+    """Build available channel handlers, skipping unconfigured channels.
+
+    Shared factory used by both the alert worker and the web console
+    alert service, eliminating duplicated initialization logic.
+
+    Email requires ``aiosmtplib``; SMS requires ``twilio`` credentials.
+    If either dependency is missing or credentials are absent, the channel
+    is skipped and a warning is logged.  Slack and PagerDuty are always
+    enabled.
+
+    Returns:
+        Mapping of ``ChannelType`` to instantiated handler.
+    """
+    from libs.core.common.exceptions import ConfigurationError
+    from libs.platform.alerts.models import ChannelType
+
+    _log = logger or _logging.getLogger(__name__)
+
+    handlers: dict[ChannelType, BaseChannel] = {
+        ChannelType.SLACK: SlackChannel(),
+    }
+
+    # Email — requires aiosmtplib
+    if EmailChannel is None:
+        _log.warning(
+            "email_channel_disabled",
+            extra={
+                "reason": "email dependencies unavailable",
+                "hint": "Install aiosmtplib to enable SMTP email notifications",
+            },
+        )
+    else:
+        handlers[ChannelType.EMAIL] = EmailChannel()
+
+    # SMS — requires twilio + credentials
+    if SMSChannel is None:
+        _log.warning(
+            "sms_channel_disabled",
+            extra={
+                "reason": "SMS dependencies unavailable",
+                "hint": (
+                    "Install twilio and set TWILIO_ACCOUNT_SID, "
+                    "TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER"
+                ),
+            },
+        )
+    else:
+        try:
+            handlers[ChannelType.SMS] = SMSChannel()
+        except ConfigurationError as exc:
+            _log.warning(
+                "sms_channel_disabled",
+                extra={
+                    "reason": str(exc),
+                    "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+                },
+            )
+
+    # PagerDuty — routing key per-recipient, no global credentials needed
+    handlers[ChannelType.PAGERDUTY] = PagerDutyChannel()
+
+    return handlers
+
+
 __all__ = [
     "BaseChannel",
     "EmailChannel",
     "PagerDutyChannel",
     "SlackChannel",
     "SMSChannel",
+    "build_channel_handlers",
 ]

--- a/libs/platform/alerts/channels/__init__.py
+++ b/libs/platform/alerts/channels/__init__.py
@@ -39,6 +39,7 @@ except ModuleNotFoundError as _exc:
 def build_channel_handlers(
     *,
     logger: _logging.Logger | None = None,
+    strict: bool = False,
 ) -> dict[ChannelType, BaseChannel]:
     """Build available channel handlers, skipping unconfigured channels.
 
@@ -47,16 +48,31 @@ def build_channel_handlers(
 
     Email requires ``aiosmtplib``; SMS requires ``twilio`` credentials.
     If either dependency is missing or credentials are absent, the channel
-    is skipped and a warning is logged.  Slack and PagerDuty are always
-    enabled.
+    is skipped and an error is logged so operators are alerted that email
+    or SMS deliveries will fail at delivery time.  Set *strict=True* to
+    raise immediately instead of degrading (useful for startup validation).
+
+    Args:
+        logger: Logger instance; defaults to module logger.
+        strict: When True, raise ``RuntimeError`` if any channel
+            dependency is missing instead of degrading gracefully.
 
     Returns:
         Mapping of ``ChannelType`` to instantiated handler.
     """
+    import os
+
     from libs.core.common.exceptions import ConfigurationError
     from libs.platform.alerts.models import ChannelType
 
     _log = logger or _logging.getLogger(__name__)
+
+    # Honour ALERT_CHANNELS_STRICT env var as a deploy-time knob
+    _strict = strict or os.environ.get("ALERT_CHANNELS_STRICT", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
     handlers: dict[ChannelType, BaseChannel] = {
         ChannelType.SLACK: SlackChannel(),
@@ -64,10 +80,18 @@ def build_channel_handlers(
 
     # Email — requires aiosmtplib
     if EmailChannel is None:
-        _log.warning(
+        msg = (
+            "email_channel_disabled: aiosmtplib is not installed. "
+            "Any email alert rules will fail at delivery time. "
+            "Install aiosmtplib to enable SMTP email notifications."
+        )
+        if _strict:
+            raise RuntimeError(msg)
+        _log.error(
             "email_channel_disabled",
             extra={
-                "reason": "email dependencies unavailable",
+                "reason": "aiosmtplib not installed",
+                "impact": "email deliveries will fail",
                 "hint": "Install aiosmtplib to enable SMTP email notifications",
             },
         )
@@ -76,10 +100,17 @@ def build_channel_handlers(
 
     # SMS — requires twilio + credentials
     if SMSChannel is None:
-        _log.warning(
+        msg = (
+            "sms_channel_disabled: twilio is not installed. "
+            "Any SMS alert rules will fail at delivery time."
+        )
+        if _strict:
+            raise RuntimeError(msg)
+        _log.error(
             "sms_channel_disabled",
             extra={
-                "reason": "SMS dependencies unavailable",
+                "reason": "twilio not installed",
+                "impact": "SMS deliveries will fail",
                 "hint": (
                     "Install twilio and set TWILIO_ACCOUNT_SID, "
                     "TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER"

--- a/libs/platform/alerts/channels/__init__.py
+++ b/libs/platform/alerts/channels/__init__.py
@@ -1,10 +1,18 @@
 """Alert delivery channel implementations."""
 
 from libs.platform.alerts.channels.base import BaseChannel
-from libs.platform.alerts.channels.email import EmailChannel
 from libs.platform.alerts.channels.pagerduty import PagerDutyChannel
 from libs.platform.alerts.channels.slack import SlackChannel
-from libs.platform.alerts.channels.sms import SMSChannel
+
+try:
+    from libs.platform.alerts.channels.email import EmailChannel
+except ModuleNotFoundError:
+    EmailChannel = None  # type: ignore[assignment]
+
+try:
+    from libs.platform.alerts.channels.sms import SMSChannel
+except ModuleNotFoundError:
+    SMSChannel = None  # type: ignore[assignment]
 
 __all__ = [
     "BaseChannel",

--- a/libs/web_console_services/alert_service.py
+++ b/libs/web_console_services/alert_service.py
@@ -12,10 +12,7 @@ from uuid import uuid4
 from pydantic import BaseModel, ConfigDict
 
 from libs.core.common.db import acquire_connection
-from libs.core.common.exceptions import ConfigurationError
-from libs.platform.alerts.channels.base import BaseChannel
-from libs.platform.alerts.channels.pagerduty import PagerDutyChannel
-from libs.platform.alerts.channels.slack import SlackChannel
+from libs.platform.alerts.channels import BaseChannel, build_channel_handlers
 from libs.platform.alerts.models import AlertEvent, AlertRule, ChannelConfig, ChannelType
 from libs.platform.alerts.pii import mask_for_logs
 from libs.platform.alerts.poison_queue import _sanitize_error_for_log
@@ -23,41 +20,6 @@ from libs.platform.web_console_auth.audit_log import AuditLogger
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 
 logger = logging.getLogger(__name__)
-
-# Only suppress the specific optional third-party packages (aiosmtplib / twilio).
-# Any other missing module is a genuine regression and must fail fast.
-_EMAIL_CHANNEL_IMPORT_ERROR: str | None
-try:
-    from libs.platform.alerts.channels.email import EmailChannel as _ImportedEmailChannel
-except ModuleNotFoundError as exc:
-    if exc.name is not None and (
-        exc.name == "aiosmtplib" or exc.name.startswith("aiosmtplib.")
-    ):
-        _EmailChannel: type[BaseChannel] | None = None
-        _EMAIL_CHANNEL_IMPORT_ERROR = str(exc)
-    else:
-        raise
-else:
-    _EmailChannel = _ImportedEmailChannel
-    _EMAIL_CHANNEL_IMPORT_ERROR = None
-
-_SMS_CHANNEL_IMPORT_ERROR: str | None
-try:
-    from libs.platform.alerts.channels.sms import SMSChannel as _ImportedSMSChannel
-except ModuleNotFoundError as exc:
-    if exc.name is not None and (
-        exc.name == "twilio" or exc.name.startswith("twilio.")
-    ):
-        _SMSChannel: type[BaseChannel] | None = None
-        _SMS_CHANNEL_IMPORT_ERROR = str(exc)
-    else:
-        raise
-else:
-    _SMSChannel = _ImportedSMSChannel
-    _SMS_CHANNEL_IMPORT_ERROR = None
-
-EmailChannel: type[BaseChannel] | None = _EmailChannel
-SMSChannel: type[BaseChannel] | None = _SMSChannel
 
 # Default limit for alert event queries
 DEFAULT_ALERT_EVENT_LIMIT = 20
@@ -108,56 +70,12 @@ class AlertConfigService:
     def _get_channel_handlers(self) -> dict[ChannelType, BaseChannel]:
         """Build channel handlers, lazily skipping unconfigured channels.
 
-        Email requires aiosmtplib; SMS requires Twilio credentials.
-        If the dependency is missing or credentials are absent, the channel
-        is skipped and a warning is logged. Slack and PagerDuty are always enabled.
+        Delegates to the shared ``build_channel_handlers`` factory so that
+        channel initialization logic is not duplicated across services.
         """
         if self._channel_handlers is None:
-            self._channel_handlers = {
-                ChannelType.SLACK: SlackChannel(),
-            }
-            if EmailChannel is None:
-                logger.warning(
-                    "email_channel_disabled",
-                    extra={
-                        "reason": _EMAIL_CHANNEL_IMPORT_ERROR or "email dependencies unavailable",
-                        "hint": "Install aiosmtplib to enable SMTP email notifications",
-                    },
-                )
-            else:
-                self._channel_handlers[ChannelType.EMAIL] = EmailChannel()
-
-            # SMS requires Twilio credentials - skip if not configured
-            self._add_sms_channel_handler(self._channel_handlers)
-            # PagerDuty uses routing key per-recipient, no global credentials needed
-            self._channel_handlers[ChannelType.PAGERDUTY] = PagerDutyChannel()
+            self._channel_handlers = build_channel_handlers(logger=logger)
         return self._channel_handlers
-
-    def _add_sms_channel_handler(self, handlers: dict[ChannelType, BaseChannel]) -> None:
-        """Attach SMS handler when dependencies and credentials are available."""
-        if SMSChannel is None:
-            logger.warning(
-                "sms_channel_disabled",
-                extra={
-                    "reason": _SMS_CHANNEL_IMPORT_ERROR or "sms dependencies unavailable",
-                    "hint": (
-                        "Install twilio and set TWILIO_ACCOUNT_SID, "
-                        "TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER"
-                    ),
-                },
-            )
-            return
-
-        try:
-            handlers[ChannelType.SMS] = SMSChannel()
-        except ConfigurationError as exc:
-            logger.warning(
-                "sms_channel_disabled",
-                extra={
-                    "reason": str(exc),
-                    "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
-                },
-            )
 
     async def get_rules(self) -> list[AlertRule]:
         """Fetch all alert rules."""

--- a/libs/web_console_services/alert_service.py
+++ b/libs/web_console_services/alert_service.py
@@ -115,32 +115,36 @@ class AlertConfigService:
                 self._channel_handlers[ChannelType.EMAIL] = EmailChannel()
 
             # SMS requires Twilio credentials - skip if not configured
-            if SMSChannel is None:
-                logger.warning(
-                    "sms_channel_disabled",
-                    extra={
-                        "reason": _SMS_CHANNEL_IMPORT_ERROR or "sms dependencies unavailable",
-                        "hint": (
-                            "Install twilio and set TWILIO_ACCOUNT_SID, "
-                            "TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER"
-                        ),
-                    },
-                )
-            # PagerDuty uses routing key per-recipient, no global credentials needed
-            else:
-                try:
-                    self._channel_handlers[ChannelType.SMS] = SMSChannel()
-                except ConfigurationError as exc:
-                    logger.warning(
-                        "sms_channel_disabled",
-                        extra={
-                            "reason": str(exc),
-                            "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
-                        },
-                    )
+            self._add_sms_channel_handler(self._channel_handlers)
             # PagerDuty uses routing key per-recipient, no global credentials needed
             self._channel_handlers[ChannelType.PAGERDUTY] = PagerDutyChannel()
         return self._channel_handlers
+
+    def _add_sms_channel_handler(self, handlers: dict[ChannelType, BaseChannel]) -> None:
+        """Attach SMS handler when dependencies and credentials are available."""
+        if SMSChannel is None:
+            logger.warning(
+                "sms_channel_disabled",
+                extra={
+                    "reason": _SMS_CHANNEL_IMPORT_ERROR or "sms dependencies unavailable",
+                    "hint": (
+                        "Install twilio and set TWILIO_ACCOUNT_SID, "
+                        "TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER"
+                    ),
+                },
+            )
+            return
+
+        try:
+            handlers[ChannelType.SMS] = SMSChannel()
+        except ConfigurationError as exc:
+            logger.warning(
+                "sms_channel_disabled",
+                extra={
+                    "reason": str(exc),
+                    "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+                },
+            )
 
     async def get_rules(self) -> list[AlertRule]:
         """Fetch all alert rules."""

--- a/libs/web_console_services/alert_service.py
+++ b/libs/web_console_services/alert_service.py
@@ -96,8 +96,9 @@ class AlertConfigService:
     def _get_channel_handlers(self) -> dict[ChannelType, BaseChannel]:
         """Build channel handlers, lazily skipping unconfigured channels.
 
-        SMS channel requires Twilio credentials. If not configured, SMS is
-        skipped and a warning is logged. Email, Slack, and PagerDuty are always enabled.
+        Email requires aiosmtplib; SMS requires Twilio credentials.
+        If the dependency is missing or credentials are absent, the channel
+        is skipped and a warning is logged. Slack and PagerDuty are always enabled.
         """
         if self._channel_handlers is None:
             self._channel_handlers = {

--- a/libs/web_console_services/alert_service.py
+++ b/libs/web_console_services/alert_service.py
@@ -24,12 +24,19 @@ from libs.platform.web_console_auth.permissions import Permission, has_permissio
 
 logger = logging.getLogger(__name__)
 
+# Only suppress the specific optional third-party packages (aiosmtplib / twilio).
+# Any other missing module is a genuine regression and must fail fast.
 _EMAIL_CHANNEL_IMPORT_ERROR: str | None
 try:
     from libs.platform.alerts.channels.email import EmailChannel as _ImportedEmailChannel
 except ModuleNotFoundError as exc:
-    _EmailChannel: type[BaseChannel] | None = None
-    _EMAIL_CHANNEL_IMPORT_ERROR = str(exc)
+    if exc.name is not None and (
+        exc.name == "aiosmtplib" or exc.name.startswith("aiosmtplib.")
+    ):
+        _EmailChannel: type[BaseChannel] | None = None
+        _EMAIL_CHANNEL_IMPORT_ERROR = str(exc)
+    else:
+        raise
 else:
     _EmailChannel = _ImportedEmailChannel
     _EMAIL_CHANNEL_IMPORT_ERROR = None
@@ -38,8 +45,13 @@ _SMS_CHANNEL_IMPORT_ERROR: str | None
 try:
     from libs.platform.alerts.channels.sms import SMSChannel as _ImportedSMSChannel
 except ModuleNotFoundError as exc:
-    _SMSChannel: type[BaseChannel] | None = None
-    _SMS_CHANNEL_IMPORT_ERROR = str(exc)
+    if exc.name is not None and (
+        exc.name == "twilio" or exc.name.startswith("twilio.")
+    ):
+        _SMSChannel: type[BaseChannel] | None = None
+        _SMS_CHANNEL_IMPORT_ERROR = str(exc)
+    else:
+        raise
 else:
     _SMSChannel = _ImportedSMSChannel
     _SMS_CHANNEL_IMPORT_ERROR = None

--- a/libs/web_console_services/alert_service.py
+++ b/libs/web_console_services/alert_service.py
@@ -13,13 +13,9 @@ from pydantic import BaseModel, ConfigDict
 
 from libs.core.common.db import acquire_connection
 from libs.core.common.exceptions import ConfigurationError
-from libs.platform.alerts.channels import (
-    BaseChannel,
-    EmailChannel,
-    PagerDutyChannel,
-    SlackChannel,
-    SMSChannel,
-)
+from libs.platform.alerts.channels.base import BaseChannel
+from libs.platform.alerts.channels.pagerduty import PagerDutyChannel
+from libs.platform.alerts.channels.slack import SlackChannel
 from libs.platform.alerts.models import AlertEvent, AlertRule, ChannelConfig, ChannelType
 from libs.platform.alerts.pii import mask_for_logs
 from libs.platform.alerts.poison_queue import _sanitize_error_for_log
@@ -27,6 +23,25 @@ from libs.platform.web_console_auth.audit_log import AuditLogger
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 
 logger = logging.getLogger(__name__)
+
+try:
+    from libs.platform.alerts.channels.email import EmailChannel as _EmailChannel
+except ModuleNotFoundError as exc:
+    _EmailChannel = None
+    _EMAIL_CHANNEL_IMPORT_ERROR = str(exc)
+else:
+    _EMAIL_CHANNEL_IMPORT_ERROR = None
+
+try:
+    from libs.platform.alerts.channels.sms import SMSChannel as _SMSChannel
+except ModuleNotFoundError as exc:
+    _SMSChannel = None
+    _SMS_CHANNEL_IMPORT_ERROR = str(exc)
+else:
+    _SMS_CHANNEL_IMPORT_ERROR = None
+
+EmailChannel: type[BaseChannel] | None = _EmailChannel
+SMSChannel: type[BaseChannel] | None = _SMSChannel
 
 # Default limit for alert event queries
 DEFAULT_ALERT_EVENT_LIMIT = 20
@@ -82,20 +97,43 @@ class AlertConfigService:
         """
         if self._channel_handlers is None:
             self._channel_handlers = {
-                ChannelType.EMAIL: EmailChannel(),
                 ChannelType.SLACK: SlackChannel(),
             }
+            if EmailChannel is None:
+                logger.warning(
+                    "email_channel_disabled",
+                    extra={
+                        "reason": _EMAIL_CHANNEL_IMPORT_ERROR or "email dependencies unavailable",
+                        "hint": "Install aiosmtplib to enable SMTP email notifications",
+                    },
+                )
+            else:
+                self._channel_handlers[ChannelType.EMAIL] = EmailChannel()
+
             # SMS requires Twilio credentials - skip if not configured
-            try:
-                self._channel_handlers[ChannelType.SMS] = SMSChannel()
-            except ConfigurationError as exc:
+            if SMSChannel is None:
                 logger.warning(
                     "sms_channel_disabled",
                     extra={
-                        "reason": str(exc),
-                        "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+                        "reason": _SMS_CHANNEL_IMPORT_ERROR or "sms dependencies unavailable",
+                        "hint": (
+                            "Install twilio and set TWILIO_ACCOUNT_SID, "
+                            "TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER"
+                        ),
                     },
                 )
+            # PagerDuty uses routing key per-recipient, no global credentials needed
+            else:
+                try:
+                    self._channel_handlers[ChannelType.SMS] = SMSChannel()
+                except ConfigurationError as exc:
+                    logger.warning(
+                        "sms_channel_disabled",
+                        extra={
+                            "reason": str(exc),
+                            "hint": "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+                        },
+                    )
             # PagerDuty uses routing key per-recipient, no global credentials needed
             self._channel_handlers[ChannelType.PAGERDUTY] = PagerDutyChannel()
         return self._channel_handlers

--- a/libs/web_console_services/alert_service.py
+++ b/libs/web_console_services/alert_service.py
@@ -24,20 +24,24 @@ from libs.platform.web_console_auth.permissions import Permission, has_permissio
 
 logger = logging.getLogger(__name__)
 
+_EMAIL_CHANNEL_IMPORT_ERROR: str | None
 try:
-    from libs.platform.alerts.channels.email import EmailChannel as _EmailChannel
+    from libs.platform.alerts.channels.email import EmailChannel as _ImportedEmailChannel
 except ModuleNotFoundError as exc:
-    _EmailChannel = None
+    _EmailChannel: type[BaseChannel] | None = None
     _EMAIL_CHANNEL_IMPORT_ERROR = str(exc)
 else:
+    _EmailChannel = _ImportedEmailChannel
     _EMAIL_CHANNEL_IMPORT_ERROR = None
 
+_SMS_CHANNEL_IMPORT_ERROR: str | None
 try:
-    from libs.platform.alerts.channels.sms import SMSChannel as _SMSChannel
+    from libs.platform.alerts.channels.sms import SMSChannel as _ImportedSMSChannel
 except ModuleNotFoundError as exc:
-    _SMSChannel = None
+    _SMSChannel: type[BaseChannel] | None = None
     _SMS_CHANNEL_IMPORT_ERROR = str(exc)
 else:
+    _SMSChannel = _ImportedSMSChannel
     _SMS_CHANNEL_IMPORT_ERROR = None
 
 EmailChannel: type[BaseChannel] | None = _EmailChannel

--- a/scripts/ops/ensure_web_console_jwt_keys.py
+++ b/scripts/ops/ensure_web_console_jwt_keys.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 
 def main() -> int:
-    repo_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(__file__).resolve().parents[2]
     sys.path.insert(0, str(repo_root))
-    from scripts.generate_certs import generate_jwt_keypair
+    from scripts.dev.generate_certs import generate_jwt_keypair
 
     certs_dir = repo_root / "apps" / "web_console_ng" / "certs"
     jwt_private = certs_dir / "jwt_private.key"

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -250,10 +250,10 @@ class TestGetChannels:
         """Test _get_channels creates EMAIL, SLACK, and PAGERDUTY channels."""
         with (
             patch("apps.alert_worker.entrypoint._CHANNELS", None),
-            patch("apps.alert_worker.entrypoint.EmailChannel") as mock_email,
-            patch("apps.alert_worker.entrypoint.SlackChannel") as mock_slack,
-            patch("apps.alert_worker.entrypoint.SMSChannel") as mock_sms,
-            patch("apps.alert_worker.entrypoint.PagerDutyChannel") as mock_pd,
+            patch("libs.platform.alerts.channels.EmailChannel") as mock_email,
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.PagerDutyChannel") as mock_pd,
         ):
             mock_email_instance = Mock()
             mock_slack_instance = Mock()
@@ -276,10 +276,10 @@ class TestGetChannels:
         """Test _get_channels skips SMS when Twilio credentials are missing."""
         with (
             patch("apps.alert_worker.entrypoint._CHANNELS", None),
-            patch("apps.alert_worker.entrypoint.EmailChannel"),
-            patch("apps.alert_worker.entrypoint.SlackChannel"),
-            patch("apps.alert_worker.entrypoint.SMSChannel") as mock_sms,
-            patch("apps.alert_worker.entrypoint.PagerDutyChannel"),
+            patch("libs.platform.alerts.channels.EmailChannel"),
+            patch("libs.platform.alerts.channels.SlackChannel"),
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.PagerDutyChannel"),
         ):
             mock_sms.side_effect = ConfigurationError("Twilio credentials missing")
 
@@ -291,10 +291,10 @@ class TestGetChannels:
         """Test _get_channels includes SMS when Twilio credentials are present."""
         with (
             patch("apps.alert_worker.entrypoint._CHANNELS", None),
-            patch("apps.alert_worker.entrypoint.EmailChannel"),
-            patch("apps.alert_worker.entrypoint.SlackChannel"),
-            patch("apps.alert_worker.entrypoint.SMSChannel") as mock_sms,
-            patch("apps.alert_worker.entrypoint.PagerDutyChannel"),
+            patch("libs.platform.alerts.channels.EmailChannel"),
+            patch("libs.platform.alerts.channels.SlackChannel"),
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.PagerDutyChannel"),
         ):
             mock_sms_instance = Mock()
             mock_sms.return_value = mock_sms_instance
@@ -308,10 +308,10 @@ class TestGetChannels:
         """Test _get_channels skips EMAIL when EmailChannel is None (dep missing)."""
         with (
             patch("apps.alert_worker.entrypoint._CHANNELS", None),
-            patch("apps.alert_worker.entrypoint.EmailChannel", None),
-            patch("apps.alert_worker.entrypoint.SlackChannel") as mock_slack,
-            patch("apps.alert_worker.entrypoint.SMSChannel") as mock_sms,
-            patch("apps.alert_worker.entrypoint.PagerDutyChannel") as mock_pd,
+            patch("libs.platform.alerts.channels.EmailChannel", None),
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.PagerDutyChannel") as mock_pd,
         ):
             mock_sms.side_effect = ConfigurationError("Twilio not configured")
             mock_slack.return_value = Mock()
@@ -327,10 +327,10 @@ class TestGetChannels:
         """Test _get_channels skips SMS when SMSChannel is None (dep missing)."""
         with (
             patch("apps.alert_worker.entrypoint._CHANNELS", None),
-            patch("apps.alert_worker.entrypoint.EmailChannel") as mock_email,
-            patch("apps.alert_worker.entrypoint.SlackChannel") as mock_slack,
-            patch("apps.alert_worker.entrypoint.SMSChannel", None),
-            patch("apps.alert_worker.entrypoint.PagerDutyChannel") as mock_pd,
+            patch("libs.platform.alerts.channels.EmailChannel") as mock_email,
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel", None),
+            patch("libs.platform.alerts.channels.PagerDutyChannel") as mock_pd,
         ):
             mock_email.return_value = Mock()
             mock_slack.return_value = Mock()
@@ -345,10 +345,10 @@ class TestGetChannels:
     def test_get_channels_returns_cached_instance(self):
         """Test _get_channels returns cached instance on subsequent calls."""
         with (
-            patch("apps.alert_worker.entrypoint.EmailChannel") as mock_email,
-            patch("apps.alert_worker.entrypoint.SlackChannel") as mock_slack,
-            patch("apps.alert_worker.entrypoint.SMSChannel") as mock_sms,
-            patch("apps.alert_worker.entrypoint.PagerDutyChannel"),
+            patch("libs.platform.alerts.channels.EmailChannel") as mock_email,
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.PagerDutyChannel"),
         ):
             mock_sms.side_effect = ConfigurationError("Twilio not configured")
 

--- a/tests/apps/alert_worker/test_entrypoint.py
+++ b/tests/apps/alert_worker/test_entrypoint.py
@@ -304,6 +304,44 @@ class TestGetChannels:
             assert ChannelType.SMS in channels
             assert channels[ChannelType.SMS] == mock_sms_instance
 
+    def test_get_channels_skips_email_when_dependency_missing(self):
+        """Test _get_channels skips EMAIL when EmailChannel is None (dep missing)."""
+        with (
+            patch("apps.alert_worker.entrypoint._CHANNELS", None),
+            patch("apps.alert_worker.entrypoint.EmailChannel", None),
+            patch("apps.alert_worker.entrypoint.SlackChannel") as mock_slack,
+            patch("apps.alert_worker.entrypoint.SMSChannel") as mock_sms,
+            patch("apps.alert_worker.entrypoint.PagerDutyChannel") as mock_pd,
+        ):
+            mock_sms.side_effect = ConfigurationError("Twilio not configured")
+            mock_slack.return_value = Mock()
+            mock_pd.return_value = Mock()
+
+            channels = _get_channels()
+
+            assert ChannelType.EMAIL not in channels
+            assert ChannelType.SLACK in channels
+            assert ChannelType.PAGERDUTY in channels
+
+    def test_get_channels_skips_sms_when_dependency_missing(self):
+        """Test _get_channels skips SMS when SMSChannel is None (dep missing)."""
+        with (
+            patch("apps.alert_worker.entrypoint._CHANNELS", None),
+            patch("apps.alert_worker.entrypoint.EmailChannel") as mock_email,
+            patch("apps.alert_worker.entrypoint.SlackChannel") as mock_slack,
+            patch("apps.alert_worker.entrypoint.SMSChannel", None),
+            patch("apps.alert_worker.entrypoint.PagerDutyChannel") as mock_pd,
+        ):
+            mock_email.return_value = Mock()
+            mock_slack.return_value = Mock()
+            mock_pd.return_value = Mock()
+
+            channels = _get_channels()
+
+            assert ChannelType.SMS not in channels
+            assert ChannelType.EMAIL in channels
+            assert ChannelType.SLACK in channels
+
     def test_get_channels_returns_cached_instance(self):
         """Test _get_channels returns cached instance on subsequent calls."""
         with (

--- a/tests/apps/web_console_ng/api/test_workspace.py
+++ b/tests/apps/web_console_ng/api/test_workspace.py
@@ -13,6 +13,7 @@ from apps.web_console_ng.api import workspace as workspace_api
 from apps.web_console_ng.core.workspace_persistence import (
     MAX_STATE_SIZE,
     DatabaseUnavailableError,
+    WorkspaceSchemaUnavailableError,
 )
 
 
@@ -259,6 +260,32 @@ async def test_save_grid_state_db_unavailable(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.asyncio()
+async def test_save_grid_state_schema_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _StubWorkspaceService(
+        save_exc=WorkspaceSchemaUnavailableError(
+            "save_grid_state",
+            "grid.positions_grid",
+        )
+    )
+    app = _build_app(monkeypatch, service)
+
+    async def _noop_csrf(_request: Request) -> None:
+        return None
+
+    monkeypatch.setattr(workspace_api, "verify_csrf_token", _noop_csrf)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/workspace/grid/positions_grid",
+            json={"columns": []},
+            headers={"X-CSRF-Token": "token"},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Workspace schema unavailable"
+
+
+@pytest.mark.asyncio()
 async def test_load_grid_state_success(monkeypatch: pytest.MonkeyPatch) -> None:
     service = _StubWorkspaceService(load_result={"columns": [{"id": "col"}]})
     app = _build_app(monkeypatch, service)
@@ -269,6 +296,23 @@ async def test_load_grid_state_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response.status_code == 200
     assert response.json() == {"columns": [{"id": "col"}]}
     assert service.load_calls == [("user-1", "positions_grid")]
+
+
+@pytest.mark.asyncio()
+async def test_load_grid_state_schema_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _StubWorkspaceService(
+        load_exc=WorkspaceSchemaUnavailableError(
+            "load_grid_state",
+            "grid.positions_grid",
+        )
+    )
+    app = _build_app(monkeypatch, service)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/workspace/grid/positions_grid")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Workspace schema unavailable"
 
 
 @pytest.mark.asyncio()
@@ -290,3 +334,28 @@ async def test_reset_grid_state_success(monkeypatch: pytest.MonkeyPatch) -> None
     assert response.status_code == 200
     assert response.json() == {"success": True}
     assert service.reset_calls == [("user-1", "grid.positions_grid")]
+
+
+@pytest.mark.asyncio()
+async def test_reset_grid_state_schema_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _StubWorkspaceService(
+        reset_exc=WorkspaceSchemaUnavailableError(
+            "reset_workspace",
+            "grid.positions_grid",
+        )
+    )
+    app = _build_app(monkeypatch, service)
+
+    async def _noop_csrf(_request: Request) -> None:
+        return None
+
+    monkeypatch.setattr(workspace_api, "verify_csrf_token", _noop_csrf)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.delete(
+            "/api/workspace/grid/positions_grid",
+            headers={"X-CSRF-Token": "token"},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Workspace schema unavailable"

--- a/tests/apps/web_console_ng/auth/test_middleware.py
+++ b/tests/apps/web_console_ng/auth/test_middleware.py
@@ -447,6 +447,41 @@ class TestAuthMiddleware:
         call_next.assert_called_once_with(request)
 
     @pytest.mark.asyncio()
+    async def test_dispatch_handles_no_response_for_disconnected_client(
+        self, make_request: callable, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test AuthMiddleware suppresses disconnect race from downstream stack."""
+        monkeypatch.setattr(middleware_module.config, "AUTH_TYPE", "cookie")
+
+        request = make_request(path="/dashboard")
+        request.state.user = {"username": "existing_user", "role": "admin"}
+        request.is_disconnected = AsyncMock(return_value=True)
+
+        middleware = middleware_module.AuthMiddleware(app=MagicMock())
+        call_next = AsyncMock(side_effect=RuntimeError("No response returned."))
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio()
+    async def test_dispatch_propagates_no_response_when_client_connected(
+        self, make_request: callable, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test AuthMiddleware still raises when request is still connected."""
+        monkeypatch.setattr(middleware_module.config, "AUTH_TYPE", "cookie")
+
+        request = make_request(path="/dashboard")
+        request.state.user = {"username": "existing_user", "role": "admin"}
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        middleware = middleware_module.AuthMiddleware(app=MagicMock())
+        call_next = AsyncMock(side_effect=RuntimeError("No response returned."))
+
+        with pytest.raises(RuntimeError, match="No response returned\\."):
+            await middleware.dispatch(request, call_next)
+
+    @pytest.mark.asyncio()
     async def test_dispatch_fallback_validates_session(
         self,
         make_request: callable,
@@ -642,6 +677,26 @@ class TestSessionMiddleware:
             response = await middleware.dispatch(request, call_next)
 
         assert response.status_code == 200
+
+    @pytest.mark.asyncio()
+    async def test_dispatch_handles_no_response_for_disconnected_client(
+        self, make_request: callable, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test SessionMiddleware suppresses disconnect race from downstream stack."""
+        mock_cookie_cfg = MagicMock()
+        mock_cookie_cfg.get_cookie_name.return_value = "trading_session"
+
+        request = make_request(path="/dashboard")
+        request.is_disconnected = AsyncMock(return_value=True)
+
+        middleware = middleware_module.SessionMiddleware(app=MagicMock())
+        call_next = AsyncMock(side_effect=RuntimeError("No response returned."))
+
+        with patch("apps.web_console_ng.auth.cookie_config.CookieConfig") as mock_cc:
+            mock_cc.from_env.return_value = mock_cookie_cfg
+            response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 204
 
     @pytest.mark.asyncio()
     async def test_dispatch_valid_session(

--- a/tests/apps/web_console_ng/core/test_workspace_persistence.py
+++ b/tests/apps/web_console_ng/core/test_workspace_persistence.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from psycopg.errors import UndefinedTable
 
 from apps.web_console_ng.core import workspace_persistence
 from apps.web_console_ng.core.workspace_persistence import (
@@ -90,9 +91,6 @@ async def test_save_grid_state_success(service: WorkspacePersistenceService, mon
 async def test_save_grid_state_missing_table_returns_false(
     service: WorkspacePersistenceService, monkeypatch
 ) -> None:
-    class UndefinedTable(Exception):
-        pass
-
     cursor = AsyncMock()
     cursor.execute.side_effect = UndefinedTable('relation "workspace_state" does not exist')
     pool = _make_pool(cursor)
@@ -136,9 +134,6 @@ async def test_load_grid_state_missing(service: WorkspacePersistenceService, mon
 async def test_load_grid_state_missing_table_returns_none(
     service: WorkspacePersistenceService, monkeypatch
 ) -> None:
-    class UndefinedTable(Exception):
-        pass
-
     cursor = AsyncMock()
     cursor.execute.side_effect = UndefinedTable('relation "workspace_state" does not exist')
     pool = _make_pool(cursor)
@@ -274,9 +269,6 @@ async def test_reset_workspace_all(service: WorkspacePersistenceService, monkeyp
 async def test_reset_workspace_missing_table_noop(
     service: WorkspacePersistenceService, monkeypatch
 ) -> None:
-    class UndefinedTable(Exception):
-        pass
-
     cursor = AsyncMock()
     cursor.execute.side_effect = UndefinedTable('relation "workspace_state" does not exist')
     pool = _make_pool(cursor)

--- a/tests/apps/web_console_ng/core/test_workspace_persistence.py
+++ b/tests/apps/web_console_ng/core/test_workspace_persistence.py
@@ -87,6 +87,23 @@ async def test_save_grid_state_success(service: WorkspacePersistenceService, mon
 
 
 @pytest.mark.asyncio()
+async def test_save_grid_state_missing_table_returns_false(
+    service: WorkspacePersistenceService, monkeypatch
+) -> None:
+    class UndefinedTable(Exception):
+        pass
+
+    cursor = AsyncMock()
+    cursor.execute.side_effect = UndefinedTable('relation "workspace_state" does not exist')
+    pool = _make_pool(cursor)
+    monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
+
+    result = await service.save_grid_state("user-1", "grid-1", {"columns": []})
+
+    assert result is False
+
+
+@pytest.mark.asyncio()
 async def test_save_panel_state_success(service: WorkspacePersistenceService, monkeypatch) -> None:
     cursor = AsyncMock()
     pool = _make_pool(cursor)
@@ -109,6 +126,21 @@ async def test_save_panel_state_success(service: WorkspacePersistenceService, mo
 async def test_load_grid_state_missing(service: WorkspacePersistenceService, monkeypatch) -> None:
     cursor = AsyncMock()
     cursor.fetchone.return_value = None
+    pool = _make_pool(cursor)
+    monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
+
+    assert await service.load_grid_state("user", "grid") is None
+
+
+@pytest.mark.asyncio()
+async def test_load_grid_state_missing_table_returns_none(
+    service: WorkspacePersistenceService, monkeypatch
+) -> None:
+    class UndefinedTable(Exception):
+        pass
+
+    cursor = AsyncMock()
+    cursor.execute.side_effect = UndefinedTable('relation "workspace_state" does not exist')
     pool = _make_pool(cursor)
     monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
 
@@ -236,6 +268,23 @@ async def test_reset_workspace_all(service: WorkspacePersistenceService, monkeyp
         "DELETE FROM workspace_state WHERE user_id = %s",
         ("user-1",),
     )
+
+
+@pytest.mark.asyncio()
+async def test_reset_workspace_missing_table_noop(
+    service: WorkspacePersistenceService, monkeypatch
+) -> None:
+    class UndefinedTable(Exception):
+        pass
+
+    cursor = AsyncMock()
+    cursor.execute.side_effect = UndefinedTable('relation "workspace_state" does not exist')
+    pool = _make_pool(cursor)
+    monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
+
+    await service.reset_workspace("user-1")
+
+    cursor.execute.assert_called_once()
 
 
 def test_get_workspace_service_singleton() -> None:

--- a/tests/apps/web_console_ng/core/test_workspace_persistence.py
+++ b/tests/apps/web_console_ng/core/test_workspace_persistence.py
@@ -11,6 +11,7 @@ from apps.web_console_ng.core import workspace_persistence
 from apps.web_console_ng.core.workspace_persistence import (
     DatabaseUnavailableError,
     WorkspacePersistenceService,
+    WorkspaceSchemaUnavailableError,
     get_workspace_service,
 )
 
@@ -88,7 +89,7 @@ async def test_save_grid_state_success(service: WorkspacePersistenceService, mon
 
 
 @pytest.mark.asyncio()
-async def test_save_grid_state_missing_table_returns_false(
+async def test_save_grid_state_missing_table_raises_schema_unavailable(
     service: WorkspacePersistenceService, monkeypatch
 ) -> None:
     cursor = AsyncMock()
@@ -96,9 +97,8 @@ async def test_save_grid_state_missing_table_returns_false(
     pool = _make_pool(cursor)
     monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
 
-    result = await service.save_grid_state("user-1", "grid-1", {"columns": []})
-
-    assert result is False
+    with pytest.raises(WorkspaceSchemaUnavailableError):
+        await service.save_grid_state("user-1", "grid-1", {"columns": []})
 
 
 @pytest.mark.asyncio()
@@ -131,7 +131,7 @@ async def test_load_grid_state_missing(service: WorkspacePersistenceService, mon
 
 
 @pytest.mark.asyncio()
-async def test_load_grid_state_missing_table_returns_none(
+async def test_load_grid_state_missing_table_raises_schema_unavailable(
     service: WorkspacePersistenceService, monkeypatch
 ) -> None:
     cursor = AsyncMock()
@@ -139,7 +139,8 @@ async def test_load_grid_state_missing_table_returns_none(
     pool = _make_pool(cursor)
     monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
 
-    assert await service.load_grid_state("user", "grid") is None
+    with pytest.raises(WorkspaceSchemaUnavailableError):
+        await service.load_grid_state("user", "grid")
 
 
 @pytest.mark.asyncio()
@@ -266,7 +267,7 @@ async def test_reset_workspace_all(service: WorkspacePersistenceService, monkeyp
 
 
 @pytest.mark.asyncio()
-async def test_reset_workspace_missing_table_noop(
+async def test_reset_workspace_missing_table_raises_schema_unavailable(
     service: WorkspacePersistenceService, monkeypatch
 ) -> None:
     cursor = AsyncMock()
@@ -274,7 +275,8 @@ async def test_reset_workspace_missing_table_noop(
     pool = _make_pool(cursor)
     monkeypatch.setattr(workspace_persistence, "get_db_pool", Mock(return_value=pool))
 
-    await service.reset_workspace("user-1")
+    with pytest.raises(WorkspaceSchemaUnavailableError):
+        await service.reset_workspace("user-1")
 
     cursor.execute.assert_called_once()
 

--- a/tests/apps/web_console_ng/pages/test_backtest.py
+++ b/tests/apps/web_console_ng/pages/test_backtest.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import polars as pl
 import pytest
+from psycopg.errors import UndefinedColumn
 
 from apps.web_console_ng.pages import backtest as backtest_module
 
@@ -520,9 +521,6 @@ def test_get_user_jobs_sync_no_jobs_returns_empty() -> None:
 
 def test_get_user_jobs_sync_missing_cost_summary_column_falls_back() -> None:
     """Older schemas without cost_summary should still render backtest jobs."""
-
-    class UndefinedColumn(Exception):
-        pass
 
     class FakeCursor:
         def __init__(self) -> None:

--- a/tests/apps/web_console_ng/pages/test_backtest.py
+++ b/tests/apps/web_console_ng/pages/test_backtest.py
@@ -518,6 +518,91 @@ def test_get_user_jobs_sync_no_jobs_returns_empty() -> None:
     assert jobs == []
 
 
+def test_get_user_jobs_sync_missing_cost_summary_column_falls_back() -> None:
+    """Older schemas without cost_summary should still render backtest jobs."""
+
+    class UndefinedColumn(Exception):
+        pass
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.execute_calls = 0
+
+        def execute(self, *_: Any, **__: Any) -> None:
+            self.execute_calls += 1
+            if self.execute_calls == 1:
+                raise UndefinedColumn('column "cost_summary" does not exist')
+
+        def __enter__(self) -> FakeCursor:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def fetchall(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "job_id": "j1",
+                    "alpha_name": "alpha1",
+                    "start_date": date(2025, 1, 1),
+                    "end_date": date(2025, 2, 1),
+                    "status": "completed",
+                    "created_at": datetime(2025, 1, 1, 12, 0, 0),
+                    "error_message": None,
+                    "mean_ic": 0.1,
+                    "icir": 1.2,
+                    "hit_rate": 0.6,
+                    "coverage": 0.9,
+                    "average_turnover": 0.2,
+                    "result_path": "/tmp/result.parquet",
+                    "cost_summary": None,
+                    "provider": "crsp",
+                }
+            ]
+
+    class FakeConn:
+        def __init__(self, cursor: FakeCursor) -> None:
+            self._cursor = cursor
+            self.rollback_calls = 0
+
+        def cursor(self, *args: Any, **kwargs: Any) -> FakeCursor:
+            return self._cursor
+
+        def rollback(self) -> None:
+            self.rollback_calls += 1
+
+        def __enter__(self) -> FakeConn:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class FakePool:
+        def __init__(self) -> None:
+            self.cursor = FakeCursor()
+            self.conn = FakeConn(self.cursor)
+
+        def connection(self) -> FakeConn:
+            return self.conn
+
+    class FakeRedis:
+        def mget(self, *_: Any, **__: Any) -> list[bytes | None]:
+            return [None]
+
+    pool = FakePool()
+    jobs = backtest_module._get_user_jobs_sync(
+        created_by="u1",
+        status=["completed"],
+        db_pool=pool,  # type: ignore[arg-type]
+        redis_client=FakeRedis(),  # type: ignore[arg-type]
+    )
+
+    assert len(jobs) == 1
+    assert jobs[0]["cost_summary"] is None
+    assert pool.cursor.execute_calls == 2
+    assert pool.conn.rollback_calls == 1
+
+
 def test_verify_job_ownership_returns_true_for_owner() -> None:
     """Test _verify_job_ownership returns True when job belongs to user."""
 

--- a/tests/apps/web_console_ng/pages/test_page_registration.py
+++ b/tests/apps/web_console_ng/pages/test_page_registration.py
@@ -42,7 +42,11 @@ class TestPageRegistrationSkipBehavior:
 
         def _mock_import(name: str) -> ModuleType:
             if name == "apps.web_console_ng.pages.dashboard":
-                raise ModuleNotFoundError(name="apps.web_console_ng.core.something")
+                exc = ModuleNotFoundError(
+                    "No module named 'apps.web_console_ng.core.something'"
+                )
+                exc.name = "apps.web_console_ng.core.something"
+                raise exc
             return original_import(name)
 
         with (

--- a/tests/apps/web_console_ng/pages/test_page_registration.py
+++ b/tests/apps/web_console_ng/pages/test_page_registration.py
@@ -1,0 +1,77 @@
+"""Tests for page module registration and optional-dependency skip behavior."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+
+class TestPageRegistrationSkipBehavior:
+    """Verify that page __init__ correctly skips optional deps and fails on real errors."""
+
+    def _reload_pages_init(self) -> ModuleType:
+        """Reload pages.__init__ to re-execute the module-level registration loop."""
+        import apps.web_console_ng.pages as pages_mod
+
+        return importlib.reload(pages_mod)
+
+    def test_optional_package_missing_is_skipped(self) -> None:
+        """When an optional package (e.g. 'rq') is missing, the page is skipped."""
+        original_import = importlib.import_module
+
+        def _mock_import(name: str) -> ModuleType:
+            if name == "apps.web_console_ng.pages.backtest":
+                raise ModuleNotFoundError(name="rq")
+            return original_import(name)
+
+        with patch("importlib.import_module", side_effect=_mock_import):
+            mod = self._reload_pages_init()
+
+        skipped = mod.get_skipped_page_modules()
+        assert any(
+            mod_name == "apps.web_console_ng.pages.backtest" and pkg == "rq"
+            for mod_name, pkg in skipped
+        ), f"Expected backtest to be skipped due to 'rq', got: {skipped}"
+
+    def test_non_optional_package_missing_raises(self) -> None:
+        """When a non-optional internal module is missing, the error is re-raised."""
+        original_import = importlib.import_module
+
+        def _mock_import(name: str) -> ModuleType:
+            if name == "apps.web_console_ng.pages.dashboard":
+                raise ModuleNotFoundError(name="apps.web_console_ng.core.something")
+            return original_import(name)
+
+        with (
+            patch("importlib.import_module", side_effect=_mock_import),
+            pytest.raises(ModuleNotFoundError, match="apps.web_console_ng.core.something"),
+        ):
+            self._reload_pages_init()
+
+    def test_page_module_itself_missing_raises(self) -> None:
+        """If a page module file itself is missing, the error is re-raised."""
+        original_import = importlib.import_module
+
+        def _mock_import(name: str) -> ModuleType:
+            if name == "apps.web_console_ng.pages.admin":
+                raise ModuleNotFoundError(name="apps.web_console_ng.pages.admin")
+            return original_import(name)
+
+        with (
+            patch("importlib.import_module", side_effect=_mock_import),
+            pytest.raises(ModuleNotFoundError),
+        ):
+            self._reload_pages_init()
+
+    def test_get_skipped_page_modules_returns_list(self) -> None:
+        """get_skipped_page_modules returns a list (possibly empty) of tuples."""
+        from apps.web_console_ng.pages import get_skipped_page_modules
+
+        result = get_skipped_page_modules()
+        assert isinstance(result, list)
+        for item in result:
+            assert isinstance(item, tuple)
+            assert len(item) == 2

--- a/tests/apps/web_console_ng/pages/test_position_management.py
+++ b/tests/apps/web_console_ng/pages/test_position_management.py
@@ -408,6 +408,34 @@ async def test_position_management_loads_positions_and_summary(
 
 
 @pytest.mark.asyncio()
+async def test_position_management_summary_handles_string_numeric_values(
+    fake_ui: FakeUI,
+    trading_client: MagicMock,
+    lifecycle: FakeLifecycleManager,
+    realtime: type[FakeRealtimeUpdater],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions = [
+        {"symbol": "AAPL", "qty": "10", "market_value": "1,000.50", "unrealized_pl": "-25.25"},
+        {"symbol": "MSFT", "qty": "5", "market_value": "500", "unrealized_pl": "75"},
+    ]
+    trading_client.fetch_positions = AsyncMock(return_value={"positions": positions})
+    monkeypatch.setattr(
+        position_management_module,
+        "get_current_user",
+        lambda: {"user_id": "u1", "role": "operator"},
+    )
+    client = SimpleNamespace(storage={})
+
+    await _unwrap_page(position_management_module.position_management_page)(client)
+
+    total_label = _find_element(fake_ui.elements, kind="label", text_prefix="Total Value:")
+    pnl_label = _find_element(fake_ui.elements, kind="label", text_prefix="Unrealized P&L:")
+    assert total_label.text == "Total Value: $1,500.50"
+    assert pnl_label.text == "Unrealized P&L: $49.75"
+
+
+@pytest.mark.asyncio()
 async def test_position_management_close_position_success(
     fake_ui: FakeUI,
     trading_client: MagicMock,

--- a/tests/apps/web_console_ng/test_main.py
+++ b/tests/apps/web_console_ng/test_main.py
@@ -339,6 +339,33 @@ async def test_log_unhandled_exception_suppresses_disconnected_no_response(
 
 
 @pytest.mark.asyncio()
+async def test_log_unhandled_exception_no_response_while_connected_returns_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _import_main(monkeypatch)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/login",
+            "headers": [],
+        }
+    )
+
+    async def _connected() -> bool:
+        return False
+
+    request.is_disconnected = _connected  # type: ignore[method-assign]
+
+    response = await module.log_unhandled_exception(request, RuntimeError("No response returned."))
+
+    assert isinstance(response, PlainTextResponse)
+    assert response.status_code == 500
+    assert response.body == b"Server error"
+
+
+@pytest.mark.asyncio()
 async def test_socket_io_redirect_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _import_main(monkeypatch)
 
@@ -437,7 +464,7 @@ async def test_suppress_no_response_returned_middleware_swallows_runtime(
     middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
 
     async def _receive() -> dict[str, str]:
-        return {"type": "http.request"}
+        return {"type": "http.disconnect"}
 
     async def _send(_message: dict[str, Any]) -> None:
         return None
@@ -461,7 +488,7 @@ async def test_suppress_no_response_returned_middleware_swallows_exception_group
     middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
 
     async def _receive() -> dict[str, str]:
-        return {"type": "http.request"}
+        return {"type": "http.disconnect"}
 
     async def _send(_message: dict[str, Any]) -> None:
         return None
@@ -488,6 +515,28 @@ async def test_suppress_no_response_returned_middleware_preserves_other_runtime(
         return None
 
     with pytest.raises(RuntimeError, match="boom"):
+        await middleware({"type": "http"}, _receive, _send)
+
+
+@pytest.mark.asyncio()
+async def test_suppress_no_response_returned_middleware_raises_when_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify no-response sentinel is re-raised if client is still connected."""
+    module = _import_main(monkeypatch)
+
+    async def _failing_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        raise RuntimeError("No response returned.")
+
+    middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
+
+    async def _receive() -> dict[str, str]:
+        return {"type": "http.request"}
+
+    async def _send(_message: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(RuntimeError, match="No response returned."):
         await middleware({"type": "http"}, _receive, _send)
 
 

--- a/tests/apps/web_console_ng/test_main.py
+++ b/tests/apps/web_console_ng/test_main.py
@@ -271,6 +271,7 @@ def test_app_configuration_and_middleware(monkeypatch: pytest.MonkeyPatch) -> No
         "SessionMiddleware",
         "AdmissionControlMiddleware",
         "TrustedHostMiddleware",
+        "SuppressNoResponseReturnedMiddleware",
     ]
 
 
@@ -308,6 +309,33 @@ async def test_log_unhandled_exception_returns_plaintext(monkeypatch: pytest.Mon
     assert isinstance(response, PlainTextResponse)
     assert response.status_code == 500
     assert response.body == b"Server error"
+
+
+@pytest.mark.asyncio()
+async def test_log_unhandled_exception_suppresses_disconnected_no_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _import_main(monkeypatch)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/login",
+            "headers": [],
+        }
+    )
+
+    async def _disconnected() -> bool:
+        return True
+
+    request.is_disconnected = _disconnected  # type: ignore[method-assign]
+
+    response = await module.log_unhandled_exception(request, RuntimeError("No response returned."))
+
+    assert isinstance(response, PlainTextResponse)
+    assert response.status_code == 204
+    assert response.body == b""
 
 
 @pytest.mark.asyncio()
@@ -394,6 +422,98 @@ def test_trusted_host_middleware_configuration(monkeypatch: pytest.MonkeyPatch) 
     assert trusted_host is not None
     _, kwargs = trusted_host
     assert "allowed_hosts" in kwargs
+
+
+@pytest.mark.asyncio()
+async def test_suppress_no_response_returned_middleware_swallows_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify middleware suppresses Starlette's disconnect sentinel runtime error."""
+    module = _import_main(monkeypatch)
+
+    async def _failing_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        raise RuntimeError("No response returned.")
+
+    middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
+
+    async def _receive() -> dict[str, str]:
+        return {"type": "http.request"}
+
+    async def _send(_message: dict[str, Any]) -> None:
+        return None
+
+    await middleware({"type": "http"}, _receive, _send)
+
+
+@pytest.mark.asyncio()
+async def test_suppress_no_response_returned_middleware_swallows_exception_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify middleware suppresses ExceptionGroup containing only sentinel errors."""
+    module = _import_main(monkeypatch)
+
+    async def _failing_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        raise ExceptionGroup(
+            "wrapped",
+            [RuntimeError("No response returned."), RuntimeError("No response returned.")],
+        )
+
+    middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
+
+    async def _receive() -> dict[str, str]:
+        return {"type": "http.request"}
+
+    async def _send(_message: dict[str, Any]) -> None:
+        return None
+
+    await middleware({"type": "http"}, _receive, _send)
+
+
+@pytest.mark.asyncio()
+async def test_suppress_no_response_returned_middleware_preserves_other_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify middleware does not swallow unrelated runtime errors."""
+    module = _import_main(monkeypatch)
+
+    async def _failing_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        raise RuntimeError("boom")
+
+    middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
+
+    async def _receive() -> dict[str, str]:
+        return {"type": "http.request"}
+
+    async def _send(_message: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await middleware({"type": "http"}, _receive, _send)
+
+
+@pytest.mark.asyncio()
+async def test_suppress_no_response_returned_middleware_preserves_mixed_exception_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify middleware does not swallow mixed exception groups."""
+    module = _import_main(monkeypatch)
+
+    async def _failing_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        raise ExceptionGroup(
+            "mixed",
+            [RuntimeError("No response returned."), ValueError("boom")],
+        )
+
+    middleware = module.SuppressNoResponseReturnedMiddleware(_failing_app)
+
+    async def _receive() -> dict[str, str]:
+        return {"type": "http.request"}
+
+    async def _send(_message: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(ExceptionGroup):
+        await middleware({"type": "http"}, _receive, _send)
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/test_main.py
+++ b/tests/apps/web_console_ng/test_main.py
@@ -312,9 +312,13 @@ async def test_log_unhandled_exception_returns_plaintext(monkeypatch: pytest.Mon
 
 
 @pytest.mark.asyncio()
-async def test_log_unhandled_exception_suppresses_disconnected_no_response(
+async def test_log_unhandled_exception_no_response_returns_500(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """'No response returned.' is handled by SuppressNoResponseReturnedMiddleware.
+
+    The exception handler treats it as any other unhandled error (500).
+    """
     module = _import_main(monkeypatch)
 
     request = Request(
@@ -325,38 +329,6 @@ async def test_log_unhandled_exception_suppresses_disconnected_no_response(
             "headers": [],
         }
     )
-
-    async def _disconnected() -> bool:
-        return True
-
-    request.is_disconnected = _disconnected  # type: ignore[method-assign]
-
-    response = await module.log_unhandled_exception(request, RuntimeError("No response returned."))
-
-    assert isinstance(response, PlainTextResponse)
-    assert response.status_code == 204
-    assert response.body == b""
-
-
-@pytest.mark.asyncio()
-async def test_log_unhandled_exception_no_response_while_connected_returns_500(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module = _import_main(monkeypatch)
-
-    request = Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/login",
-            "headers": [],
-        }
-    )
-
-    async def _connected() -> bool:
-        return False
-
-    request.is_disconnected = _connected  # type: ignore[method-assign]
 
     response = await module.log_unhandled_exception(request, RuntimeError("No response returned."))
 

--- a/tests/libs/web_console_services/test_alert_service.py
+++ b/tests/libs/web_console_services/test_alert_service.py
@@ -124,9 +124,9 @@ class TestAlertServiceInitialization:
         assert alert_service._channel_handlers is None
 
         with (
-            patch("libs.web_console_services.alert_service.EmailChannel") as mock_email,
-            patch("libs.web_console_services.alert_service.SlackChannel") as mock_slack,
-            patch("libs.web_console_services.alert_service.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.EmailChannel") as mock_email,
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
         ):
             handlers = alert_service._get_channel_handlers()
 
@@ -143,9 +143,9 @@ class TestAlertServiceInitialization:
     ) -> None:
         """Test channel handlers are cached after first initialization."""
         with (
-            patch("libs.web_console_services.alert_service.EmailChannel") as mock_email,
-            patch("libs.web_console_services.alert_service.SlackChannel") as mock_slack,
-            patch("libs.web_console_services.alert_service.SMSChannel") as mock_sms,
+            patch("libs.platform.alerts.channels.EmailChannel") as mock_email,
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
         ):
             handlers1 = alert_service._get_channel_handlers()
             handlers2 = alert_service._get_channel_handlers()
@@ -161,34 +161,27 @@ class TestAlertServiceInitialization:
     ) -> None:
         """Test SMS channel is skipped if Twilio credentials not configured."""
         with (
-            patch("libs.web_console_services.alert_service.EmailChannel"),
-            patch("libs.web_console_services.alert_service.SlackChannel"),
+            patch("libs.platform.alerts.channels.EmailChannel"),
+            patch("libs.platform.alerts.channels.SlackChannel"),
             patch(
-                "libs.web_console_services.alert_service.SMSChannel",
+                "libs.platform.alerts.channels.SMSChannel",
                 side_effect=ConfigurationError("Missing Twilio credentials"),
             ),
-            patch("libs.web_console_services.alert_service.logger") as mock_logger,
         ):
             handlers = alert_service._get_channel_handlers()
 
             assert ChannelType.EMAIL in handlers
             assert ChannelType.SLACK in handlers
             assert ChannelType.SMS not in handlers
-            mock_logger.warning.assert_called_once()
 
     def test_email_channel_disabled_when_dependency_missing(
         self, alert_service: AlertConfigService
     ) -> None:
         """Test email channel is skipped if SMTP dependency is unavailable."""
         with (
-            patch("libs.web_console_services.alert_service.EmailChannel", None),
-            patch(
-                "libs.web_console_services.alert_service._EMAIL_CHANNEL_IMPORT_ERROR",
-                "No module named 'aiosmtplib'",
-            ),
-            patch("libs.web_console_services.alert_service.SlackChannel") as mock_slack,
-            patch("libs.web_console_services.alert_service.SMSChannel") as mock_sms,
-            patch("libs.web_console_services.alert_service.logger") as mock_logger,
+            patch("libs.platform.alerts.channels.EmailChannel", None),
+            patch("libs.platform.alerts.channels.SlackChannel") as mock_slack,
+            patch("libs.platform.alerts.channels.SMSChannel") as mock_sms,
         ):
 
             handlers = alert_service._get_channel_handlers()
@@ -198,7 +191,6 @@ class TestAlertServiceInitialization:
             assert ChannelType.SMS in handlers
             mock_slack.assert_called_once()
             mock_sms.assert_called_once()
-            mock_logger.warning.assert_called_once()
 
 
 class TestGetRules:

--- a/tests/libs/web_console_services/test_alert_service.py
+++ b/tests/libs/web_console_services/test_alert_service.py
@@ -176,6 +176,30 @@ class TestAlertServiceInitialization:
             assert ChannelType.SMS not in handlers
             mock_logger.warning.assert_called_once()
 
+    def test_email_channel_disabled_when_dependency_missing(
+        self, alert_service: AlertConfigService
+    ) -> None:
+        """Test email channel is skipped if SMTP dependency is unavailable."""
+        with (
+            patch("libs.web_console_services.alert_service.EmailChannel", None),
+            patch(
+                "libs.web_console_services.alert_service._EMAIL_CHANNEL_IMPORT_ERROR",
+                "No module named 'aiosmtplib'",
+            ),
+            patch("libs.web_console_services.alert_service.SlackChannel") as mock_slack,
+            patch("libs.web_console_services.alert_service.SMSChannel") as mock_sms,
+            patch("libs.web_console_services.alert_service.logger") as mock_logger,
+        ):
+
+            handlers = alert_service._get_channel_handlers()
+
+            assert ChannelType.EMAIL not in handlers
+            assert ChannelType.SLACK in handlers
+            assert ChannelType.SMS in handlers
+            mock_slack.assert_called_once()
+            mock_sms.assert_called_once()
+            mock_logger.warning.assert_called_once()
+
 
 class TestGetRules:
     """Tests for get_rules method."""

--- a/tests/regression/golden_results/manifest.json
+++ b/tests/regression/golden_results/manifest.json
@@ -1,13 +1,13 @@
 {
   "version": "v1.0.0",
-  "created_at": "2026-01-15T03:02:02.524999Z",
+  "created_at": "2026-04-16T11:53:40.074278Z",
   "dataset_snapshot_id": "golden_v1.0.0",
   "regeneration_triggers": [
     "Major alpha logic change",
     "Dataset schema change",
     "Quarterly refresh (optional)"
   ],
-  "last_regenerated": "2026-01-15T03:02:02.525541Z",
+  "last_regenerated": "2026-04-16T11:53:40.074617Z",
   "regenerated_by": "scripts/generate_golden_results.py",
   "storage_size_mb": 0.0,
   "storage_size_note": "Decimal MB (1MB = 1,000,000 bytes), includes manifest",


### PR DESCRIPTION
## Summary
- patch NiceGUI request tracking middleware during app startup to suppress disconnect-race "No response returned" failures
- harden auth/session middleware to gracefully handle client disconnects in the web console stack
- restore and stabilize legacy route behavior and page-loading paths used by the web UI
- add regression tests covering middleware disconnect handling and startup middleware patching
- refresh the mocked web UI sweep artifact after fixes

## Validation
- pytest -q tests/apps/web_console_ng/test_main.py tests/apps/web_console_ng/auth/test_middleware.py
- dockerized web console stress check with rapid /login and /notebooks disconnect churn (no "No response returned" / ASGI unhandled exception logs)
