### PR TITLE
fix(export): replace placeholder Excel workbook with real grid data

### DIFF
--- a/apps/execution_gateway/requirements-docker.txt
+++ b/apps/execution_gateway/requirements-docker.txt
@@ -45,3 +45,6 @@ scipy>=1.11.0
 
 # Structured logging
 structlog>=24.0.0
+
+# Excel export
+openpyxl>=3.1.0

--- a/apps/execution_gateway/requirements.txt
+++ b/apps/execution_gateway/requirements.txt
@@ -62,3 +62,6 @@ pytest-asyncio>=0.21.0  # For async Redis tests
 
 # Task scheduling (P2 - TWAP Order Slicer)
 apscheduler>=3.10.0
+
+# Excel export (P6T8)
+openpyxl>=3.1.0

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -969,11 +969,21 @@ def _build_text_condition(
     clauses: list[str], params: list[Any],
 ) -> None:
     """Append SQL for an AG Grid text filter condition."""
+    ftype = spec.get("type", "")
+    text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+
+    # Handle NULL-check types first (no filter value needed).
+    if ftype == "blank":
+        clauses.append(f"{text_col} IS NULL")
+        return
+    if ftype == "notBlank":
+        clauses.append(f"{text_col} IS NOT NULL")
+        return
+
     value = spec.get("filter")
     if value is None:
         return
     value = str(value)
-    text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
     esc = f" ESCAPE '{_LIKE_ESCAPE}'"
     escaped = _escape_like(value)
     # Map AG Grid text types to (SQL operator, param pattern).
@@ -981,12 +991,12 @@ def _build_text_condition(
     # use ILIKE to match the grid's behaviour.
     _TEXT_OPS: dict[str, tuple[str, str]] = {
         "contains": ("ILIKE", f"%{escaped}%"),
+        "notContains": ("NOT ILIKE", f"%{escaped}%"),
         "equals": ("ILIKE", escaped),
         "startsWith": ("ILIKE", f"{escaped}%"),
         "endsWith": ("ILIKE", f"%{escaped}"),
         "notEqual": ("NOT ILIKE", escaped),
     }
-    ftype = spec.get("type", "")
     if ftype in _TEXT_OPS:
         op, param = _TEXT_OPS[ftype]
         clauses.append(f"{text_col} {op} %s{esc}")
@@ -1114,6 +1124,36 @@ def _build_single_condition(
         builder(col, qcol, spec, clauses, params)
 
 
+def _build_compound_recursive(
+    col: str,
+    qcol: str,
+    spec: dict[str, Any],
+    clauses: list[str],
+    params: list[Any],
+) -> None:
+    """Recursively build SQL for an AG Grid compound or simple condition.
+
+    If *spec* contains ``conditions`` (a compound filter), the children
+    are joined with the spec's ``operator`` (AND / OR).  Each child is
+    processed recursively so any nesting depth is supported.  Leaf
+    conditions are dispatched to ``_build_single_condition``.
+    """
+    conditions = spec.get("conditions")
+    if isinstance(conditions, list) and conditions:
+        operator = spec.get("operator", "AND").upper()
+        sql_op = " OR " if operator == "OR" else " AND "
+        sub_clauses: list[str] = []
+        sub_params: list[Any] = []
+        for cond in conditions:
+            if isinstance(cond, dict):
+                _build_compound_recursive(col, qcol, cond, sub_clauses, sub_params)
+        if sub_clauses:
+            clauses.append(f"({sql_op.join(sub_clauses)})")
+            params.extend(sub_params)
+    else:
+        _build_single_condition(col, qcol, spec, clauses, params)
+
+
 def _build_filter_clause(
     filter_params: dict[str, Any] | None,
     allowed_columns: list[str],
@@ -1175,40 +1215,10 @@ def _build_filter_clause(
             qcol = _quote_identifier(f"{col_prefix}{col}")
 
         # AG Grid compound filter: ``operator`` + ``conditions`` list.
-        # Example: {"operator": "AND", "conditions": [{...}, {...}]}
         # Conditions may themselves be compound (nested) when the
-        # toolbar merges overlapping filters, so we recurse.
-        conditions = spec.get("conditions")
-        if isinstance(conditions, list) and conditions:
-            operator = spec.get("operator", "AND").upper()
-            sql_op = " OR " if operator == "OR" else " AND "
-            sub_clauses: list[str] = []
-            sub_params: list[Any] = []
-            for cond in conditions:
-                if not isinstance(cond, dict):
-                    continue
-                # Recurse if the condition is itself compound
-                nested_conditions = cond.get("conditions")
-                if isinstance(nested_conditions, list) and nested_conditions:
-                    nested_op = cond.get("operator", "AND").upper()
-                    nested_sql_op = " OR " if nested_op == "OR" else " AND "
-                    nested_clauses: list[str] = []
-                    nested_params: list[Any] = []
-                    for nested_cond in nested_conditions:
-                        if isinstance(nested_cond, dict):
-                            _build_single_condition(col, qcol, nested_cond, nested_clauses, nested_params)
-                    if nested_clauses:
-                        sub_clauses.append(f"({nested_sql_op.join(nested_clauses)})")
-                        sub_params.extend(nested_params)
-                else:
-                    _build_single_condition(col, qcol, cond, sub_clauses, sub_params)
-            if sub_clauses:
-                # Wrap in parentheses to preserve operator precedence
-                clauses.append(f"({sql_op.join(sub_clauses)})")
-                params.extend(sub_params)
-        else:
-            # Simple (non-compound) filter
-            _build_single_condition(col, qcol, spec, clauses, params)
+        # toolbar merges overlapping filters.  Use a recursive helper
+        # so any depth of nesting is handled correctly.
+        _build_compound_recursive(col, qcol, spec, clauses, params)
 
     result_sql = " AND ".join(clauses)
     if result_sql:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -36,6 +36,7 @@ from apps.execution_gateway.app_context import AppContext
 from apps.execution_gateway.dependencies import get_context
 from apps.execution_gateway.services.auth_helpers import build_user_context
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
+from libs.data.sql.strategy_mapping_sql import SYMBOL_STRATEGY_CTE
 from libs.platform.security import sanitize_for_export
 from libs.platform.web_console_auth.permissions import Permission, get_authorized_strategies
 
@@ -815,27 +816,28 @@ def _fetch_positions_data(
 ) -> list[dict[str, Any]]:
     """Fetch positions data scoped to authorized strategies.
 
-    Positions are scoped by filtering to symbols that have at least one
-    order for the given *strategy_ids*.  The ``positions`` table does not
-    carry a ``strategy_id`` column itself, so a subquery against
-    ``orders`` is used.
+    The ``positions`` table is symbol-scoped (no ``strategy_id`` column),
+    so ownership is inferred via the shared fail-closed mapping from
+    ``libs.data.sql.strategy_mapping_sql``: a symbol is attributed to a
+    strategy only when exactly ONE strategy has ever traded it.  Symbols
+    traded by multiple strategies are excluded to prevent cross-strategy
+    data leakage.
     """
-    order_clause = _build_order_clause(sort_model, columns, "symbol ASC")
-    col_list = ", ".join(columns)
+    order_clause = _build_order_clause(sort_model, columns, "p.symbol ASC")
+    col_list = ", ".join(f"p.{c}" for c in columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                f"SELECT {col_list} FROM positions "  # noqa: S608
-                f"WHERE symbol IN ("
-                f"  SELECT DISTINCT symbol FROM orders "
-                f"  WHERE strategy_id = ANY(%s)"
-                f") AND qty != 0 "
+                f"WITH {SYMBOL_STRATEGY_CTE} "  # noqa: S608
+                f"SELECT {col_list} FROM positions p "
+                f"JOIN symbol_strategy ss ON p.symbol = ss.symbol "
+                f"WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_orders_data(
@@ -857,7 +859,7 @@ def _fetch_orders_data(
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_fills_data(
@@ -880,7 +882,7 @@ def _fetch_fills_data(
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_audit_data(
@@ -894,8 +896,10 @@ def _fetch_audit_data(
     Audit entries are scoped by matching the ``strategy_id`` key inside
     the ``details`` JSONB column against the authorized *strategy_ids*.
     System-level entries (those without a ``strategy_id`` in their
-    details, e.g. kill-switch operations) are included as well so that
-    the full operational context is preserved.
+    details) are excluded to enforce least-privilege -- exporting only
+    strategy-related audit entries prevents leaking sensitive system
+    operations to users who may only be authorized for specific
+    strategies.
     """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
@@ -904,13 +908,12 @@ def _fetch_audit_data(
             cur.execute(
                 f"SELECT {col_list} FROM audit_log "  # noqa: S608
                 f"WHERE details->>'strategy_id' = ANY(%s) "
-                f"   OR details->>'strategy_id' IS NULL "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 def _fetch_tca_data(
@@ -951,7 +954,7 @@ def _fetch_tca_data(
                 (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
 
 # Dispatch table for grid data fetchers
@@ -1034,8 +1037,9 @@ async def _generate_excel_content(
             elif raw_value is None:
                 value_to_set = ""
             elif isinstance(raw_value, datetime):
-                # openpyxl does not support timezone-aware datetimes
-                value_to_set = raw_value.replace(tzinfo=None)
+                # openpyxl does not support timezone-aware datetimes.
+                # Ensure UTC first, then strip for Excel compatibility.
+                value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
             else:
                 value_to_set = raw_value
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
+from psycopg import sql
 from pydantic import BaseModel, Field
 
 from apps.execution_gateway.api.dependencies import build_gateway_authenticator
@@ -800,13 +801,27 @@ def _validate_columns(
     ``"executed_at"``).  Only columns that exist in the allowlist are
     kept (in the requested order).  Unknown columns are silently dropped
     to prevent SQL injection or data leakage.
+
+    When the majority of requested columns are not in the allowlist (i.e.
+    fewer than half survive validation), the full allowlist is returned
+    instead of a misleadingly small subset.  This handles grids like TCA
+    whose frontend sends computed display columns (``fill_rate_pct``,
+    ``is_bps``, etc.) alongside a few raw DB columns -- returning only
+    ``symbol`` and ``side`` would be incomplete and confusing.
     """
     allowed = _GRID_COLUMNS[grid_name]
     if not visible_columns:
         return allowed
     aliases = _COLUMN_ALIASES.get(grid_name, {})
     resolved = [aliases.get(c, c) for c in visible_columns]
-    return [c for c in resolved if c in allowed] or allowed
+    valid = [c for c in resolved if c in allowed]
+    if not valid:
+        return allowed
+    # Fall back to full schema when most requested columns were
+    # computed/frontend-only (fewer than half survived validation).
+    if len(valid) < len(resolved) / 2:
+        return allowed
+    return valid
 
 
 def _resolve_sort_aliases(
@@ -857,6 +872,7 @@ def _build_filter_clause(
     allowed_columns: list[str],
     *,
     col_prefix: str = "",
+    col_prefix_map: dict[str, str] | None = None,
 ) -> tuple[str, list[Any]]:
     """Build a parameterized WHERE fragment from AG Grid filter model.
 
@@ -873,7 +889,12 @@ def _build_filter_clause(
         filter_params: AG Grid filter model dict.
         allowed_columns: Server-side column allowlist.
         col_prefix: Optional table alias prefix (e.g. ``"p."``).
-            Applied to every column reference in the generated SQL.
+            Applied to every column reference in the generated SQL
+            unless overridden by *col_prefix_map*.
+        col_prefix_map: Optional per-column qualified name mapping
+            (e.g. ``{"order_qty": "o.qty"}``).  When a column appears
+            in this map, the mapped value is used instead of
+            ``col_prefix + col``.
 
     Returns:
         A tuple of (sql_fragment, param_list).  *sql_fragment* is a
@@ -893,7 +914,12 @@ def _build_filter_clause(
         if not isinstance(spec, dict):
             continue
 
-        qcol = f"{col_prefix}{col}"
+        # Use per-column mapping when available, otherwise fall back
+        # to the blanket prefix.
+        if col_prefix_map and col in col_prefix_map:
+            qcol = col_prefix_map[col]
+        else:
+            qcol = f"{col_prefix}{col}"
         filter_type = spec.get("filterType", "text")
         ftype = spec.get("type", "")
 
@@ -999,23 +1025,36 @@ def _fetch_positions_data(
     order_clause = _build_order_clause(
         qualified_sort, qualified_columns, "p.symbol ASC",
     )
-    col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
+    # Build SELECT list using psycopg.sql.Identifier for column names.
+    select_cols = sql.SQL(", ").join(
+        sql.SQL("{tbl}.{col} AS {alias}").format(
+            tbl=sql.Identifier("p"),
+            col=sql.Identifier(c),
+            alias=sql.Identifier(c),
+        )
+        for c in columns
+    )
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"WITH {SYMBOL_STRATEGY_CTE} "  # noqa: S608
-                f"SELECT {col_list} FROM positions p "
-                f"JOIN symbol_strategy ss ON p.symbol = ss.symbol "
-                f"WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
-                f"{filter_clause}"
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                query_params,
+            query = sql.SQL(
+                "WITH {cte} "
+                "SELECT {cols} FROM positions p "
+                "JOIN symbol_strategy ss ON p.symbol = ss.symbol "
+                "WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
+                "{filter_clause}"
+                "ORDER BY {order_clause} "
+                "LIMIT %s"
+            ).format(
+                cte=sql.SQL(SYMBOL_STRATEGY_CTE),
+                cols=select_cols,
+                filter_clause=sql.SQL(filter_clause),
+                order_clause=sql.SQL(order_clause),
             )
+            cur.execute(query, query_params)
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1030,21 +1069,25 @@ def _fetch_orders_data(
 ) -> list[dict[str, Any]]:
     """Fetch orders scoped to authorized strategies."""
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
-    col_list = ", ".join(columns)
+    select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {col_list} FROM orders "  # noqa: S608
-                f"WHERE strategy_id = ANY(%s) "
-                f"{filter_clause}"
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                query_params,
+            query = sql.SQL(
+                "SELECT {cols} FROM orders "
+                "WHERE strategy_id = ANY(%s) "
+                "{filter_clause}"
+                "ORDER BY {order_clause} "
+                "LIMIT %s"
+            ).format(
+                cols=select_cols,
+                filter_clause=sql.SQL(filter_clause),
+                order_clause=sql.SQL(order_clause),
             )
+            cur.execute(query, query_params)
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1059,22 +1102,32 @@ def _fetch_fills_data(
 ) -> list[dict[str, Any]]:
     """Fetch fills (trades) scoped to authorized strategies."""
     order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
-    col_list = ", ".join(f"t.{c}" for c in columns)
+    select_cols = sql.SQL(", ").join(
+        sql.SQL("{tbl}.{col}").format(
+            tbl=sql.Identifier("t"),
+            col=sql.Identifier(c),
+        )
+        for c in columns
+    )
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {col_list} FROM trades t "  # noqa: S608
-                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
-                f"AND t.strategy_id = ANY(%s) "
-                f"{filter_clause}"
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                query_params,
+            query = sql.SQL(
+                "SELECT {cols} FROM trades t "
+                "WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                "AND t.strategy_id = ANY(%s) "
+                "{filter_clause}"
+                "ORDER BY {order_clause} "
+                "LIMIT %s"
+            ).format(
+                cols=select_cols,
+                filter_clause=sql.SQL(filter_clause),
+                order_clause=sql.SQL(order_clause),
             )
+            cur.execute(query, query_params)
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1098,23 +1151,49 @@ def _fetch_audit_data(
     strategies.
     """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
-    col_list = ", ".join(columns)
+    select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {col_list} FROM audit_log "  # noqa: S608
-                f"WHERE details->>'strategy_id' = ANY(%s) "
-                f"{filter_clause}"
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                query_params,
+            query = sql.SQL(
+                "SELECT {cols} FROM audit_log "
+                "WHERE details->>'strategy_id' = ANY(%s) "
+                "{filter_clause}"
+                "ORDER BY {order_clause} "
+                "LIMIT %s"
+            ).format(
+                cols=select_cols,
+                filter_clause=sql.SQL(filter_clause),
+                order_clause=sql.SQL(order_clause),
             )
+            cur.execute(query, query_params)
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
+
+
+# Map TCA column names to their qualified table references.
+# Every column in _GRID_COLUMNS["tca"] MUST have an entry here so
+# that SELECT / ORDER BY / filter references are unambiguous across
+# the trades (t) and orders (o) tables.  Columns missing from this
+# map are silently skipped to prevent incorrect table attribution.
+# Defined at module level so both _fetch_tca_data and
+# _generate_excel_content can use it for filter qualification.
+_TCA_COL_MAP: dict[str, str] = {
+    "trade_id": "t.trade_id",
+    "client_order_id": "t.client_order_id",
+    "strategy_id": "t.strategy_id",
+    "symbol": "t.symbol",
+    "side": "t.side",
+    "qty": "t.qty",
+    "price": "t.price",
+    "executed_at": "t.executed_at",
+    "order_submitted_at": "o.submitted_at",
+    "order_qty": "o.qty",
+    "filled_avg_price": "o.filled_avg_price",
+}
 
 
 def _fetch_tca_data(
@@ -1126,42 +1205,31 @@ def _fetch_tca_data(
     filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch TCA trade data with order context, scoped to authorized strategies."""
-    # Map column names to their qualified table references.
-    # Every column in _GRID_COLUMNS["tca"] MUST have an entry here so
-    # that SELECT / ORDER BY / filter references are unambiguous across
-    # the trades (t) and orders (o) tables.  Columns missing from this
-    # map are silently skipped to prevent incorrect table attribution.
-    tca_col_map: dict[str, str] = {
-        "trade_id": "t.trade_id",
-        "client_order_id": "t.client_order_id",
-        "strategy_id": "t.strategy_id",
-        "symbol": "t.symbol",
-        "side": "t.side",
-        "qty": "t.qty",
-        "price": "t.price",
-        "executed_at": "t.executed_at",
-        "order_submitted_at": "o.submitted_at",
-        "order_qty": "o.qty",
-        "filled_avg_price": "o.filled_avg_price",
-    }
     # Only include columns that have an explicit mapping to prevent
     # incorrect table attribution for unmapped columns.
-    mapped_columns = [c for c in columns if c in tca_col_map]
-    select_cols = ", ".join(
-        f"{tca_col_map[c]} AS {c}" for c in mapped_columns
+    mapped_columns = [c for c in columns if c in _TCA_COL_MAP]
+    # Build SELECT list using psycopg.sql for the alias identifiers.
+    # The qualified source reference (e.g. "t.trade_id") comes from the
+    # hardcoded _TCA_COL_MAP so it's safe to wrap with sql.SQL().
+    select_cols = sql.SQL(", ").join(
+        sql.SQL("{src} AS {alias}").format(
+            src=sql.SQL(_TCA_COL_MAP[c]),
+            alias=sql.Identifier(c),
+        )
+        for c in mapped_columns
     )
-    # Qualify sort columns with table aliases via tca_col_map to
+    # Qualify sort columns with table aliases via _TCA_COL_MAP to
     # avoid ambiguity when trades and orders share column names
     # (e.g. symbol, qty, client_order_id).  Only mapped columns
     # are accepted; unmapped sort entries are dropped.
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": tca_col_map[item.get("colId", "")]}
+            {**item, "colId": _TCA_COL_MAP[item.get("colId", "")]}
             for item in sort_model
-            if item.get("colId", "") in tca_col_map
+            if item.get("colId", "") in _TCA_COL_MAP
         ]
-    qualified_tca_columns = [tca_col_map[c] for c in mapped_columns]
+    qualified_tca_columns = [_TCA_COL_MAP[c] for c in mapped_columns]
     order_clause = _build_order_clause(
         qualified_sort, qualified_tca_columns, "t.executed_at DESC",
     )
@@ -1171,17 +1239,21 @@ def _fetch_tca_data(
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {select_cols} "  # noqa: S608
-                f"FROM trades t "
-                f"LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
-                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
-                f"AND t.strategy_id = ANY(%s) "
-                f"{filter_clause}"
-                f"ORDER BY {order_clause} "
-                f"LIMIT %s",
-                query_params,
+            query = sql.SQL(
+                "SELECT {cols} "
+                "FROM trades t "
+                "LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
+                "WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                "AND t.strategy_id = ANY(%s) "
+                "{filter_clause}"
+                "ORDER BY {order_clause} "
+                "LIMIT %s"
+            ).format(
+                cols=select_cols,
+                filter_clause=sql.SQL(filter_clause),
+                order_clause=sql.SQL(order_clause),
             )
+            cur.execute(query, query_params)
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
 
@@ -1214,7 +1286,7 @@ async def _generate_excel_content(
         ctx: Application context with database access
         grid_name: Name of grid to export
         strategy_ids: Authorized strategy IDs for filtering
-        filter_params: AG Grid filter model (reserved for future use)
+        filter_params: AG Grid filter model applied to export query
         visible_columns: Columns to include (validated against allowlist)
         sort_model: AG Grid sort model
 
@@ -1225,7 +1297,7 @@ async def _generate_excel_content(
         NotImplementedError: If grid type not supported or openpyxl missing
     """
     try:
-        from openpyxl import Workbook  # type: ignore[import-untyped]
+        from openpyxl import Workbook
     except ImportError as e:
         raise NotImplementedError(
             "Excel export requires openpyxl: pip install openpyxl"
@@ -1245,9 +1317,14 @@ async def _generate_excel_content(
     _GRID_FILTER_PREFIX: dict[str, str] = {
         "positions": "p.",
         "fills": "t.",
-        "tca": "t.",
     }
     col_prefix = _GRID_FILTER_PREFIX.get(grid_name, "")
+
+    # TCA spans two tables (trades t, orders o), so we use the
+    # per-column mapping instead of a blanket prefix.
+    tca_filter_map: dict[str, str] | None = None
+    if grid_name == "tca":
+        tca_filter_map = _TCA_COL_MAP
 
     # Also resolve aliases in filter_params keys before building the
     # filter clause (e.g. "type" -> "order_type" for orders grid).
@@ -1262,6 +1339,7 @@ async def _generate_excel_content(
     # Build filter WHERE clause from AG Grid filter model
     filter_clause, filter_params_list = _build_filter_clause(
         resolved_filter, columns, col_prefix=col_prefix,
+        col_prefix_map=tca_filter_map,
     )
 
     # Offload synchronous DB fetch to a worker thread to avoid blocking
@@ -1276,6 +1354,7 @@ async def _generate_excel_content(
     def _build_workbook() -> bytes:
         wb = Workbook()
         ws = wb.active
+        assert ws is not None, "Workbook.active should never be None for a new Workbook"
         ws.title = grid_name.title()
 
         # Header row -- sanitize headers

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -19,6 +19,7 @@ Design Pattern:
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import logging
@@ -749,6 +750,12 @@ _GRID_COLUMNS: dict[str, list[str]] = {
         "details",
         "reason",
     ],
+    # NOTE: The TCA grid in the web console displays computed metrics
+    # (e.g. ``is_bps``, ``fill_rate_pct``) that are derived client-side.
+    # The export provides the raw underlying trade/order data so users
+    # can compute their own analytics.  When the grid sends computed
+    # column names via ``visible_columns``, ``_validate_columns`` drops
+    # them and falls back to this full raw-data allowlist.
     "tca": [
         "trade_id",
         "client_order_id",
@@ -1008,53 +1015,70 @@ async def _generate_excel_content(
     # Validate requested columns against server allowlist
     columns = _validate_columns(grid_name, visible_columns)
 
-    # Fetch real data
+    # Log when filter_params are provided but not yet applied.
+    # AG Grid filter model support is not yet implemented; exports
+    # return strategy-scoped data without additional column filters.
+    if filter_params:
+        logger.warning(
+            "export_filter_params_not_applied",
+            extra={
+                "grid_name": grid_name,
+                "filter_keys": list(filter_params.keys()),
+            },
+        )
+
+    # Offload synchronous DB fetch to a worker thread to avoid blocking
+    # the FastAPI event loop.
     fetcher = _GRID_FETCHERS[grid_name]
-    rows = fetcher(ctx, strategy_ids, columns, sort_model)
+    rows = await asyncio.to_thread(fetcher, ctx, strategy_ids, columns, sort_model)
 
-    # Build workbook
-    wb = Workbook()
-    ws = wb.active
-    ws.title = grid_name.title()
+    # Build workbook (CPU-bound; done in worker thread below)
+    def _build_workbook() -> bytes:
+        wb = Workbook()
+        ws = wb.active
+        ws.title = grid_name.title()
 
-    # Header row — sanitize headers
-    for col_idx, header in enumerate(columns, 1):
-        ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
+        # Header row -- sanitize headers
+        for col_idx, header in enumerate(columns, 1):
+            ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Data rows — sanitize only string values to prevent formula injection
-    # while preserving native Excel types (numbers, dates) for proper
-    # formatting and calculations.
-    for row_idx, row_data in enumerate(rows, 2):
-        for col_idx, col_name in enumerate(columns, 1):
-            raw_value = row_data.get(col_name)
-            if isinstance(raw_value, dict | list):
-                raw_value = json.dumps(raw_value, default=str)
+        # Data rows -- sanitize only string values to prevent formula
+        # injection while preserving native Excel types (numbers, dates)
+        # for proper formatting and calculations.
+        for row_idx, row_data in enumerate(rows, 2):
+            for col_idx, col_name in enumerate(columns, 1):
+                raw_value = row_data.get(col_name)
+                if isinstance(raw_value, dict | list):
+                    raw_value = json.dumps(raw_value, default=str)
 
-            # Only sanitize strings to prevent formula injection while
-            # preserving numeric/date types that openpyxl handles natively.
-            if isinstance(raw_value, str):
-                value_to_set: Any = sanitize_for_export(raw_value)
-            elif raw_value is None:
-                value_to_set = ""
-            elif isinstance(raw_value, datetime):
-                # openpyxl does not support timezone-aware datetimes.
-                # Ensure UTC first, then strip for Excel compatibility.
-                value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
-            else:
-                value_to_set = raw_value
+                # Only sanitize strings to prevent formula injection
+                # while preserving numeric/date types that openpyxl
+                # handles natively.
+                if isinstance(raw_value, str):
+                    value_to_set: Any = sanitize_for_export(raw_value)
+                elif raw_value is None:
+                    value_to_set = ""
+                elif isinstance(raw_value, datetime):
+                    # openpyxl does not support timezone-aware datetimes.
+                    # Ensure UTC first, then strip for Excel compatibility.
+                    value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+                else:
+                    value_to_set = raw_value
 
-            ws.cell(
-                row=row_idx,
-                column=col_idx,
-                value=value_to_set,
-            )
+                ws.cell(
+                    row=row_idx,
+                    column=col_idx,
+                    value=value_to_set,
+                )
 
-    output = io.BytesIO()
-    wb.save(output)
-    output.seek(0)
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        return buf.getvalue()
 
+    excel_bytes = await asyncio.to_thread(_build_workbook)
     row_count = len(rows)
-    return output.getvalue(), row_count
+    return excel_bytes, row_count
 
 
 @router.get(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -807,12 +807,13 @@ def _validate_columns(
     kept (in the requested order).  Unknown columns are silently dropped
     to prevent SQL injection or data leakage.
 
-    When the majority of requested columns are not in the allowlist (i.e.
-    fewer than half survive validation), the full allowlist is returned
-    instead of a misleadingly small subset.  This handles grids like TCA
-    whose frontend sends computed display columns (``fill_rate_pct``,
-    ``is_bps``, etc.) alongside a few raw DB columns -- returning only
-    ``symbol`` and ``side`` would be incomplete and confusing.
+    For the **TCA** grid only, when the majority of requested columns
+    are not in the allowlist (fewer than half survive validation), the
+    full allowlist is returned instead of a misleadingly small subset.
+    The TCA frontend sends computed display columns (``fill_rate_pct``,
+    ``is_bps``, etc.) that have no DB counterpart, so this fallback
+    ensures a useful export.  Other grids do NOT widen — they return
+    only the validated intersection.
     """
     allowed = _GRID_COLUMNS[grid_name]
     if not visible_columns:
@@ -822,9 +823,11 @@ def _validate_columns(
     valid = [c for c in resolved if c in allowed]
     if not valid:
         return allowed
-    # Fall back to full schema when most requested columns were
-    # computed/frontend-only (fewer than half survived validation).
-    if len(valid) < len(resolved) / 2:
+    # TCA-only fallback: when most requested columns were computed/
+    # frontend-only (fewer than half survived validation), return the
+    # full raw-data allowlist.  Other grids return only the validated
+    # intersection to avoid silently widening the export scope.
+    if grid_name == "tca" and len(valid) < len(resolved) / 2:
         return allowed
     return valid
 
@@ -1147,6 +1150,8 @@ def _build_filter_clause(
 
         # AG Grid compound filter: ``operator`` + ``conditions`` list.
         # Example: {"operator": "AND", "conditions": [{...}, {...}]}
+        # Conditions may themselves be compound (nested) when the
+        # toolbar merges overlapping filters, so we recurse.
         conditions = spec.get("conditions")
         if isinstance(conditions, list) and conditions:
             operator = spec.get("operator", "AND").upper()
@@ -1154,7 +1159,22 @@ def _build_filter_clause(
             sub_clauses: list[str] = []
             sub_params: list[Any] = []
             for cond in conditions:
-                if isinstance(cond, dict):
+                if not isinstance(cond, dict):
+                    continue
+                # Recurse if the condition is itself compound
+                nested_conditions = cond.get("conditions")
+                if isinstance(nested_conditions, list) and nested_conditions:
+                    nested_op = cond.get("operator", "AND").upper()
+                    nested_sql_op = " OR " if nested_op == "OR" else " AND "
+                    nested_clauses: list[str] = []
+                    nested_params: list[Any] = []
+                    for nested_cond in nested_conditions:
+                        if isinstance(nested_cond, dict):
+                            _build_single_condition(col, qcol, nested_cond, nested_clauses, nested_params)
+                    if nested_clauses:
+                        sub_clauses.append(f"({nested_sql_op.join(nested_clauses)})")
+                        sub_params.extend(nested_params)
+                else:
                     _build_single_condition(col, qcol, cond, sub_clauses, sub_params)
             if sub_clauses:
                 # Wrap in parentheses to preserve operator precedence

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -903,15 +903,20 @@ def _resolve_filter_aliases(
 
 
 def _quote_identifier(name: str) -> str:
-    """Quote a possibly table-qualified identifier via psycopg.sql.
+    """Quote a possibly table-qualified identifier for SQL interpolation.
 
-    ``psycopg.sql.Identifier`` accepts multiple string parts for qualified
-    names (e.g. ``Identifier("p", "symbol")`` produces ``"p"."symbol"``).
-    This helper splits on ``.`` and delegates to ``Identifier`` so that
-    both simple and qualified names are safely quoted.
+    Splits on ``.`` and double-quotes each part to produce safe
+    identifiers (e.g. ``"p"."symbol"``).  This is equivalent to
+    ``psycopg.sql.Identifier(...).as_string(conn)`` but avoids the
+    need for a live connection context, which ``as_string(None)``
+    only supports in psycopg >= 3.2.
+
+    **Safety:** All callers pass column names from hardcoded allowlists
+    (``_GRID_COLUMNS``, ``_TCA_COL_MAP``) or hardcoded table-alias
+    prefixes.  No user input reaches this function.
     """
     parts = name.split(".")
-    return sql.Identifier(*parts).as_string(None)
+    return ".".join(f'"{p}"' for p in parts)
 
 
 def _build_order_clause(
@@ -1115,8 +1120,8 @@ def _build_single_condition(
     ``_build_filter_clause`` before calling this helper.
 
     **Safety:** ``qcol`` is produced by ``_quote_identifier()`` which
-    delegates to ``psycopg.sql.Identifier(...).as_string(None)`` --
-    all identifiers are properly double-quoted before interpolation.
+    double-quotes each identifier part -- all identifiers originate
+    from hardcoded allowlists, never from user input.
     """
     filter_type = spec.get("filterType", "text")
     builder = _FILTER_TYPE_BUILDERS.get(filter_type)
@@ -1417,7 +1422,17 @@ def _fetch_audit_data(
     top-level key in the JSONB ``details`` column.  This matches the
     current audit_log schema.  If the schema evolves to nest strategy_id
     differently, update the WHERE clause below and the corresponding
-    GIN index on ``audit_log.details``.
+    index on ``audit_log.details``.
+
+    **Index requirement:** The ``->>`` text extraction operator cannot
+    leverage a generic GIN index on the ``details`` column.  A
+    functional B-tree index is needed for performant lookups::
+
+        CREATE INDEX idx_audit_log_strategy_id
+            ON audit_log ((details->>'strategy_id'));
+
+    If this index does not yet exist, add it via a migration before
+    the audit table grows large enough for sequential scans to matter.
     """
     # Use full grid allowlist for sort qualification so that sorts
     # on hidden columns are preserved in the exported row order.

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -700,6 +700,251 @@ async def download_excel_export(
 # This ensures a single source of truth for formula injection protection.
 
 
+# ---------------------------------------------------------------------------
+# Allowed columns per grid — server-side allowlist for export security.
+# Only columns in these sets may appear in exported files.
+# ---------------------------------------------------------------------------
+_GRID_COLUMNS: dict[str, list[str]] = {
+    "positions": [
+        "symbol",
+        "qty",
+        "avg_entry_price",
+        "current_price",
+        "unrealized_pl",
+        "realized_pl",
+        "updated_at",
+    ],
+    "orders": [
+        "client_order_id",
+        "strategy_id",
+        "symbol",
+        "side",
+        "qty",
+        "order_type",
+        "limit_price",
+        "stop_price",
+        "time_in_force",
+        "status",
+        "filled_qty",
+        "filled_avg_price",
+        "created_at",
+        "filled_at",
+    ],
+    "fills": [
+        "trade_id",
+        "client_order_id",
+        "strategy_id",
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "executed_at",
+    ],
+    "audit": [
+        "id",
+        "timestamp",
+        "user_id",
+        "action",
+        "details",
+        "reason",
+    ],
+    "tca": [
+        "trade_id",
+        "client_order_id",
+        "strategy_id",
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "executed_at",
+        "order_submitted_at",
+        "order_qty",
+        "filled_avg_price",
+    ],
+}
+
+# Maximum rows per export to prevent excessive memory / query time
+_EXPORT_ROW_LIMIT = 10_000
+
+
+def _validate_columns(
+    grid_name: str, visible_columns: list[str] | None
+) -> list[str]:
+    """Return the export column list, validated against the server allowlist.
+
+    If *visible_columns* is provided, only columns that exist in the
+    allowlist are kept (in the requested order).  Unknown columns are
+    silently dropped to prevent SQL injection or data leakage.
+    """
+    allowed = _GRID_COLUMNS[grid_name]
+    if not visible_columns:
+        return allowed
+    return [c for c in visible_columns if c in allowed] or allowed
+
+
+def _build_order_clause(
+    sort_model: list[dict[str, Any]] | None,
+    allowed_columns: list[str],
+    default_order: str,
+) -> str:
+    """Build a safe ORDER BY clause from an AG Grid sort model.
+
+    Only column names that appear in *allowed_columns* are accepted.
+    """
+    if not sort_model:
+        return default_order
+    parts: list[str] = []
+    for item in sort_model:
+        col = item.get("colId", "")
+        direction = "DESC" if item.get("sort") == "desc" else "ASC"
+        if col in allowed_columns:
+            parts.append(f"{col} {direction}")
+    return ", ".join(parts) if parts else default_order
+
+
+# ---------------------------------------------------------------------------
+# Per-grid data fetchers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_positions_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch positions data scoped to authorized strategies."""
+    order_clause = _build_order_clause(sort_model, columns, "symbol ASC")
+    col_list = ", ".join(columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM positions "  # noqa: S608
+                f"WHERE qty != 0 ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (_EXPORT_ROW_LIMIT,),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_orders_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch orders scoped to authorized strategies."""
+    order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
+    col_list = ", ".join(columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM orders "  # noqa: S608
+                f"WHERE strategy_id = ANY(%s) "
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (strategy_ids, _EXPORT_ROW_LIMIT),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_fills_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch fills (trades) scoped to authorized strategies."""
+    order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
+    col_list = ", ".join(f"t.{c}" for c in columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM trades t "  # noqa: S608
+                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                f"AND t.strategy_id = ANY(%s) "
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (strategy_ids, _EXPORT_ROW_LIMIT),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_audit_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch audit log entries."""
+    order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
+    col_list = ", ".join(columns)
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {col_list} FROM audit_log "  # noqa: S608
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (_EXPORT_ROW_LIMIT,),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+def _fetch_tca_data(
+    ctx: AppContext,
+    strategy_ids: list[str],
+    columns: list[str],
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Fetch TCA trade data with order context, scoped to authorized strategies."""
+    # Map column names to their qualified table references
+    tca_col_map: dict[str, str] = {
+        "trade_id": "t.trade_id",
+        "client_order_id": "t.client_order_id",
+        "strategy_id": "t.strategy_id",
+        "symbol": "t.symbol",
+        "side": "t.side",
+        "qty": "t.qty",
+        "price": "t.price",
+        "executed_at": "t.executed_at",
+        "order_submitted_at": "o.submitted_at",
+        "order_qty": "o.qty",
+        "filled_avg_price": "o.filled_avg_price",
+    }
+    select_cols = ", ".join(
+        f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns
+    )
+    order_clause = _build_order_clause(sort_model, columns, "t.executed_at DESC")
+    with ctx.db.transaction() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {select_cols} "  # noqa: S608
+                f"FROM trades t "
+                f"LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
+                f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
+                f"AND t.strategy_id = ANY(%s) "
+                f"ORDER BY {order_clause} "
+                f"LIMIT %s",
+                (strategy_ids, _EXPORT_ROW_LIMIT),
+            )
+            col_names = [desc[0] for desc in cur.description]
+            return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
+
+
+# Dispatch table for grid data fetchers
+_GRID_FETCHERS = {
+    "positions": _fetch_positions_data,
+    "orders": _fetch_orders_data,
+    "fills": _fetch_fills_data,
+    "audit": _fetch_audit_data,
+    "tca": _fetch_tca_data,
+}
+
+
 async def _generate_excel_content(
     ctx: AppContext,
     grid_name: str,
@@ -710,27 +955,24 @@ async def _generate_excel_content(
 ) -> tuple[bytes, int]:
     """Generate Excel file content for a grid.
 
-    This is a placeholder that will be implemented for each grid type.
-    Uses openpyxl for Excel generation with formula sanitization.
-
-    IMPORTANT: All cell values MUST be sanitized via sanitize_for_export()
-    to prevent formula injection attacks.
+    Fetches real data from the database for the requested grid, applies
+    column validation against a server-side allowlist, and sanitises every
+    cell value to prevent formula-injection attacks.
 
     Args:
         ctx: Application context with database access
         grid_name: Name of grid to export
         strategy_ids: Authorized strategy IDs for filtering
-        filter_params: AG Grid filter model
-        visible_columns: Columns to include
+        filter_params: AG Grid filter model (reserved for future use)
+        visible_columns: Columns to include (validated against allowlist)
         sort_model: AG Grid sort model
 
     Returns:
         Tuple of (excel_bytes, row_count)
 
     Raises:
-        NotImplementedError: If grid type not supported
+        NotImplementedError: If grid type not supported or openpyxl missing
     """
-    # Import openpyxl only when needed
     try:
         from openpyxl import Workbook  # type: ignore[import-untyped]
     except ImportError as e:
@@ -738,47 +980,45 @@ async def _generate_excel_content(
             "Excel export requires openpyxl: pip install openpyxl"
         ) from e
 
-    # Supported grids and their data fetchers
-    # TODO: Implement per-grid data fetchers with PII column filtering
-    supported_grids = {
-        "positions": "_fetch_positions_data",
-        "orders": "_fetch_orders_data",
-        "fills": "_fetch_fills_data",
-        "audit": "_fetch_audit_data",
-        "tca": "_fetch_tca_data",
-    }
-
-    if grid_name not in supported_grids:
+    if grid_name not in _GRID_FETCHERS:
         raise NotImplementedError(f"Excel export not implemented for grid: {grid_name}")
 
-    # For now, return a placeholder Excel file
-    # TODO: Implement actual data fetching and Excel generation
-    # NOTE: When implementing real data, MUST:
-    # 1. Sanitize ALL cell values via sanitize_for_export()
-    # 2. Enforce PII column filtering server-side based on user role
-    # 3. Validate visible_columns against allowed columns per grid
+    # Validate requested columns against server allowlist
+    columns = _validate_columns(grid_name, visible_columns)
+
+    # Fetch real data
+    fetcher = _GRID_FETCHERS[grid_name]
+    rows = fetcher(ctx, strategy_ids, columns, sort_model)
+
+    # Build workbook
     wb = Workbook()
     ws = wb.active
     ws.title = grid_name.title()
 
-    # Add header row (sanitize headers too)
-    headers = visible_columns or ["Column1", "Column2", "Column3"]
-    for col_idx, header in enumerate(headers, 1):
+    # Header row — sanitize headers
+    for col_idx, header in enumerate(columns, 1):
         ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Placeholder data - sanitize all values
-    ws.cell(row=2, column=1, value=sanitize_for_export("Excel export implementation pending"))
-    ws.cell(row=2, column=2, value=sanitize_for_export(f"Grid: {grid_name}"))
-    ws.cell(row=2, column=3, value=sanitize_for_export(f"Strategies: {len(strategy_ids)}"))
+    # Data rows — sanitize every value
+    for row_idx, row_data in enumerate(rows, 2):
+        for col_idx, col_name in enumerate(columns, 1):
+            raw_value = row_data.get(col_name)
+            # Convert complex types to string for Excel compatibility
+            if isinstance(raw_value, dict | list):
+                raw_value = json.dumps(raw_value)
+            ws.cell(
+                row=row_idx,
+                column=col_idx,
+                value=sanitize_for_export(
+                    str(raw_value) if raw_value is not None else ""
+                ),
+            )
 
-    # Save to bytes
     output = io.BytesIO()
     wb.save(output)
     output.seek(0)
 
-    # Row count (excluding header)
-    row_count = 1  # Placeholder row
-
+    row_count = len(rows)
     return output.getvalue(), row_count
 
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -830,8 +830,19 @@ def _fetch_positions_data(
     traded by multiple strategies are excluded to prevent cross-strategy
     data leakage.
     """
-    order_clause = _build_order_clause(sort_model, columns, "p.symbol ASC")
-    col_list = ", ".join(f"p.{c}" for c in columns)
+    # Qualify sort columns with the "p." alias to avoid ambiguity when
+    # joining positions with the symbol_strategy CTE.
+    qualified_sort: list[dict[str, Any]] | None = None
+    if sort_model:
+        qualified_sort = [
+            {**item, "colId": f"p.{item['colId']}"} if item.get("colId") in columns else item
+            for item in sort_model
+        ]
+    qualified_columns = [f"p.{c}" for c in columns]
+    order_clause = _build_order_clause(
+        qualified_sort, qualified_columns, "p.symbol ASC",
+    )
+    col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -813,16 +813,26 @@ def _fetch_positions_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
-    """Fetch positions data scoped to authorized strategies."""
+    """Fetch positions data scoped to authorized strategies.
+
+    Positions are scoped by filtering to symbols that have at least one
+    order for the given *strategy_ids*.  The ``positions`` table does not
+    carry a ``strategy_id`` column itself, so a subquery against
+    ``orders`` is used.
+    """
     order_clause = _build_order_clause(sort_model, columns, "symbol ASC")
     col_list = ", ".join(columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM positions "  # noqa: S608
-                f"WHERE qty != 0 ORDER BY {order_clause} "
+                f"WHERE symbol IN ("
+                f"  SELECT DISTINCT symbol FROM orders "
+                f"  WHERE strategy_id = ANY(%s)"
+                f") AND qty != 0 "
+                f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (_EXPORT_ROW_LIMIT,),
+                (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
@@ -879,16 +889,25 @@ def _fetch_audit_data(
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
-    """Fetch audit log entries."""
+    """Fetch audit log entries scoped to authorized strategies.
+
+    Audit entries are scoped by matching the ``strategy_id`` key inside
+    the ``details`` JSONB column against the authorized *strategy_ids*.
+    System-level entries (those without a ``strategy_id`` in their
+    details, e.g. kill-switch operations) are included as well so that
+    the full operational context is preserved.
+    """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM audit_log "  # noqa: S608
+                f"WHERE details->>'strategy_id' = ANY(%s) "
+                f"   OR details->>'strategy_id' IS NULL "
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (_EXPORT_ROW_LIMIT,),
+                (strategy_ids, _EXPORT_ROW_LIMIT),
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=False)) for row in cur.fetchall()]
@@ -999,19 +1018,31 @@ async def _generate_excel_content(
     for col_idx, header in enumerate(columns, 1):
         ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
 
-    # Data rows — sanitize every value
+    # Data rows — sanitize only string values to prevent formula injection
+    # while preserving native Excel types (numbers, dates) for proper
+    # formatting and calculations.
     for row_idx, row_data in enumerate(rows, 2):
         for col_idx, col_name in enumerate(columns, 1):
             raw_value = row_data.get(col_name)
-            # Convert complex types to string for Excel compatibility
             if isinstance(raw_value, dict | list):
-                raw_value = json.dumps(raw_value)
+                raw_value = json.dumps(raw_value, default=str)
+
+            # Only sanitize strings to prevent formula injection while
+            # preserving numeric/date types that openpyxl handles natively.
+            if isinstance(raw_value, str):
+                value_to_set: Any = sanitize_for_export(raw_value)
+            elif raw_value is None:
+                value_to_set = ""
+            elif isinstance(raw_value, datetime):
+                # openpyxl does not support timezone-aware datetimes
+                value_to_set = raw_value.replace(tzinfo=None)
+            else:
+                value_to_set = raw_value
+
             ws.cell(
                 row=row_idx,
                 column=col_idx,
-                value=sanitize_for_export(
-                    str(raw_value) if raw_value is not None else ""
-                ),
+                value=value_to_set,
             )
 
     output = io.BytesIO()

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -30,7 +30,6 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
-from openpyxl import Workbook
 from psycopg import sql
 from psycopg.rows import dict_row
 from pydantic import BaseModel, Field
@@ -1605,7 +1604,22 @@ def _build_workbook(
 
     Returns:
         Raw bytes of the ``.xlsx`` file.
+
+    Note:
+        The final bytes object is materialized in memory.  With the
+        ``_EXPORT_ROW_LIMIT`` (10 000 rows) this is typically a few MB.
+        If concurrent export volume grows, consider streaming the
+        response directly via ``StreamingResponse`` instead.
+
+    Raises:
+        NotImplementedError: If openpyxl is not installed.
     """
+    try:
+        from openpyxl import Workbook
+    except ImportError as exc:
+        raise NotImplementedError(
+            "Excel export requires openpyxl: pip install openpyxl"
+        ) from exc
     wb = Workbook(write_only=True)
     ws = wb.create_sheet(grid_name.title())
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -775,19 +775,38 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 _EXPORT_ROW_LIMIT = 10_000
 
 
+# ---------------------------------------------------------------------------
+# Frontend → DB column alias mapping.
+# The web console grids may use display-friendly field names (e.g. "time"
+# instead of "executed_at").  This mapping translates them before the
+# allowlist check so that valid columns are not silently dropped.
+# ---------------------------------------------------------------------------
+_COLUMN_ALIASES: dict[str, dict[str, str]] = {
+    "orders": {
+        "type": "order_type",
+    },
+    "fills": {
+        "time": "executed_at",
+    },
+}
+
+
 def _validate_columns(
     grid_name: str, visible_columns: list[str] | None
 ) -> list[str]:
     """Return the export column list, validated against the server allowlist.
 
-    If *visible_columns* is provided, only columns that exist in the
-    allowlist are kept (in the requested order).  Unknown columns are
-    silently dropped to prevent SQL injection or data leakage.
+    Frontend column aliases are resolved first (e.g. ``"time"`` →
+    ``"executed_at"``).  Only columns that exist in the allowlist are
+    kept (in the requested order).  Unknown columns are silently dropped
+    to prevent SQL injection or data leakage.
     """
     allowed = _GRID_COLUMNS[grid_name]
     if not visible_columns:
         return allowed
-    return [c for c in visible_columns if c in allowed] or allowed
+    aliases = _COLUMN_ALIASES.get(grid_name, {})
+    resolved = [aliases.get(c, c) for c in visible_columns]
+    return [c for c in resolved if c in allowed] or allowed
 
 
 def _build_order_clause(
@@ -958,7 +977,21 @@ def _fetch_tca_data(
     select_cols = ", ".join(
         f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns
     )
-    order_clause = _build_order_clause(sort_model, columns, "t.executed_at DESC")
+    # Qualify sort columns with table aliases via tca_col_map to
+    # avoid ambiguity when trades and orders share column names
+    # (e.g. symbol, qty, client_order_id).
+    qualified_sort: list[dict[str, Any]] | None = None
+    if sort_model:
+        qualified_sort = [
+            {**item, "colId": tca_col_map.get(item.get("colId", ""), f"t.{item.get('colId', '')}")}
+            if item.get("colId") in columns
+            else item
+            for item in sort_model
+        ]
+    qualified_tca_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
+    order_clause = _build_order_clause(
+        qualified_sort, qualified_tca_columns, "t.executed_at DESC",
+    )
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -776,23 +776,6 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 # Maximum rows per export to prevent excessive memory / query time
 _EXPORT_ROW_LIMIT = 10_000
 
-# Working (active) order statuses.  Orders in these statuses are shown
-# on the "Working Orders" tab.  This constant is shared with the web
-# console (``apps.web_console_ng.components.tabbed_panel``) and can be
-# used when the frontend passes a ``tab_context`` indicating the export
-# originated from the Working tab.
-# TODO(#151): Frontend should inject a status filter into filter_params
-# when exporting from the Working Orders tab so that export/view parity
-# is maintained without server-side guessing.
-WORKING_ORDER_STATUSES = frozenset({
-    "new",
-    "pending_new",
-    "partially_filled",
-    "accepted",
-    "pending_cancel",
-    "pending_replace",
-})
-
 
 # ---------------------------------------------------------------------------
 # Frontend → DB column alias mapping.
@@ -911,6 +894,109 @@ def _build_order_clause(
 _JSONB_COLUMNS: frozenset[str] = frozenset({"details"})
 
 
+def _build_single_condition(
+    col: str,
+    qcol: str,
+    spec: dict[str, Any],
+    clauses: list[str],
+    params: list[Any],
+) -> None:
+    """Append SQL for a single AG Grid filter condition.
+
+    This handles one atomic condition (``type`` + ``filter``).  Compound
+    filters (``operator`` + ``conditions``) are decomposed by
+    ``_build_filter_clause`` before calling this helper.
+    """
+    filter_type = spec.get("filterType", "text")
+    ftype = spec.get("type", "")
+
+    if filter_type == "text":
+        value = spec.get("filter")
+        if value is None:
+            return
+        value = str(value)
+        # JSONB columns need an explicit ::text cast for text
+        # operators; for text/varchar columns the cast is omitted
+        # to allow B-tree index usage.
+        text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+        if ftype == "contains":
+            clauses.append(f"{text_col} ILIKE %s")
+            params.append(f"%{value}%")
+        elif ftype == "equals":
+            clauses.append(f"{text_col} = %s")
+            params.append(value)
+        elif ftype == "startsWith":
+            clauses.append(f"{text_col} ILIKE %s")
+            params.append(f"{value}%")
+        elif ftype == "endsWith":
+            clauses.append(f"{text_col} ILIKE %s")
+            params.append(f"%{value}")
+        elif ftype == "notEqual":
+            clauses.append(f"{text_col} != %s")
+            params.append(value)
+
+    elif filter_type == "number":
+        value = spec.get("filter")
+        if ftype == "equals" and value is not None:
+            clauses.append(f"{qcol} = %s")
+            params.append(value)
+        elif ftype == "greaterThan" and value is not None:
+            clauses.append(f"{qcol} > %s")
+            params.append(value)
+        elif ftype == "lessThan" and value is not None:
+            clauses.append(f"{qcol} < %s")
+            params.append(value)
+        elif ftype == "greaterThanOrEqual" and value is not None:
+            clauses.append(f"{qcol} >= %s")
+            params.append(value)
+        elif ftype == "lessThanOrEqual" and value is not None:
+            clauses.append(f"{qcol} <= %s")
+            params.append(value)
+        elif ftype == "inRange":
+            lo = spec.get("filter")
+            hi = spec.get("filterTo")
+            if lo is not None and hi is not None:
+                clauses.append(f"{qcol} >= %s AND {qcol} <= %s")
+                params.extend([lo, hi])
+
+    elif filter_type == "date":
+        date_from = spec.get("dateFrom")
+        date_to = spec.get("dateTo")
+        # Use range comparisons on the raw timestamp column instead of
+        # ::date casts, which prevent B-tree index usage on large tables.
+        # AG Grid sends dates as 'YYYY-MM-DD' strings; we compare them
+        # as timestamps to enable index scans.
+        if ftype == "equals" and date_from is not None:
+            # "equals day" means >= start of day AND < next day
+            clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
+            params.extend([date_from, date_from])
+        elif ftype == "greaterThan" and date_from is not None:
+            # After the end of the given day
+            clauses.append(f"{qcol} >= %s::date + interval '1 day'")
+            params.append(date_from)
+        elif ftype == "lessThan" and date_from is not None:
+            clauses.append(f"{qcol} < %s")
+            params.append(date_from)
+        elif ftype == "greaterThanOrEqual" and date_from is not None:
+            clauses.append(f"{qcol} >= %s")
+            params.append(date_from)
+        elif ftype == "lessThanOrEqual" and date_from is not None:
+            # Include all of the given day
+            clauses.append(f"{qcol} < %s::date + interval '1 day'")
+            params.append(date_from)
+        elif ftype == "inRange" and date_from is not None and date_to is not None:
+            clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
+            params.extend([date_from, date_to])
+
+    elif filter_type == "set":
+        values = spec.get("values")
+        if isinstance(values, list) and values:
+            # Use ANY(%s) with a list parameter for set membership
+            text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+            clauses.append(f"{text_col} = ANY(%s)")
+            params.append(values)
+
+
 def _build_filter_clause(
     filter_params: dict[str, Any] | None,
     allowed_columns: list[str],
@@ -925,6 +1011,10 @@ def _build_filter_clause(
     - ``number`` filters (equals, greaterThan, lessThan, inRange, etc.)
     - ``date`` filters (equals, greaterThan, lessThan, inRange)
     - ``set`` filters (values list for IN-clause matching)
+
+    Also handles **compound** filters where AG Grid sends an
+    ``operator`` (``"AND"`` / ``"OR"``) with a ``conditions`` list
+    instead of a single ``type``/``filter`` pair.
 
     Only columns present in *allowed_columns* are accepted; unknown
     columns are silently dropped.  All values are passed as query
@@ -965,99 +1055,30 @@ def _build_filter_clause(
             qcol = col_prefix_map[col]
         else:
             qcol = f"{col_prefix}{col}"
-        filter_type = spec.get("filterType", "text")
-        ftype = spec.get("type", "")
 
-        if filter_type == "text":
-            value = spec.get("filter")
-            if value is None:
-                continue
-            value = str(value)
-            # JSONB columns need an explicit ::text cast for text
-            # operators; for text/varchar columns the cast is omitted
-            # to allow B-tree index usage.
-            text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
-            if ftype == "contains":
-                clauses.append(f"{text_col} ILIKE %s")
-                params.append(f"%{value}%")
-            elif ftype == "equals":
-                clauses.append(f"{text_col} = %s")
-                params.append(value)
-            elif ftype == "startsWith":
-                clauses.append(f"{text_col} ILIKE %s")
-                params.append(f"{value}%")
-            elif ftype == "endsWith":
-                clauses.append(f"{text_col} ILIKE %s")
-                params.append(f"%{value}")
-            elif ftype == "notEqual":
-                clauses.append(f"{text_col} != %s")
-                params.append(value)
+        # AG Grid compound filter: ``operator`` + ``conditions`` list.
+        # Example: {"operator": "AND", "conditions": [{...}, {...}]}
+        conditions = spec.get("conditions")
+        if isinstance(conditions, list) and conditions:
+            operator = spec.get("operator", "AND").upper()
+            sql_op = " OR " if operator == "OR" else " AND "
+            sub_clauses: list[str] = []
+            sub_params: list[Any] = []
+            for cond in conditions:
+                if isinstance(cond, dict):
+                    _build_single_condition(col, qcol, cond, sub_clauses, sub_params)
+            if sub_clauses:
+                # Wrap in parentheses to preserve operator precedence
+                clauses.append(f"({sql_op.join(sub_clauses)})")
+                params.extend(sub_params)
+        else:
+            # Simple (non-compound) filter
+            _build_single_condition(col, qcol, spec, clauses, params)
 
-        elif filter_type == "number":
-            value = spec.get("filter")
-            if ftype == "equals" and value is not None:
-                clauses.append(f"{qcol} = %s")
-                params.append(value)
-            elif ftype == "greaterThan" and value is not None:
-                clauses.append(f"{qcol} > %s")
-                params.append(value)
-            elif ftype == "lessThan" and value is not None:
-                clauses.append(f"{qcol} < %s")
-                params.append(value)
-            elif ftype == "greaterThanOrEqual" and value is not None:
-                clauses.append(f"{qcol} >= %s")
-                params.append(value)
-            elif ftype == "lessThanOrEqual" and value is not None:
-                clauses.append(f"{qcol} <= %s")
-                params.append(value)
-            elif ftype == "inRange":
-                lo = spec.get("filter")
-                hi = spec.get("filterTo")
-                if lo is not None and hi is not None:
-                    clauses.append(f"{qcol} >= %s AND {qcol} <= %s")
-                    params.extend([lo, hi])
-
-        elif filter_type == "date":
-            date_from = spec.get("dateFrom")
-            date_to = spec.get("dateTo")
-            # Use range comparisons on the raw timestamp column instead of
-            # ::date casts, which prevent B-tree index usage on large tables.
-            # AG Grid sends dates as 'YYYY-MM-DD' strings; we compare them
-            # as timestamps to enable index scans.
-            if ftype == "equals" and date_from is not None:
-                # "equals day" means >= start of day AND < next day
-                clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
-                params.extend([date_from, date_from])
-            elif ftype == "greaterThan" and date_from is not None:
-                # After the end of the given day
-                clauses.append(f"{qcol} >= %s::date + interval '1 day'")
-                params.append(date_from)
-            elif ftype == "lessThan" and date_from is not None:
-                clauses.append(f"{qcol} < %s")
-                params.append(date_from)
-            elif ftype == "greaterThanOrEqual" and date_from is not None:
-                clauses.append(f"{qcol} >= %s")
-                params.append(date_from)
-            elif ftype == "lessThanOrEqual" and date_from is not None:
-                # Include all of the given day
-                clauses.append(f"{qcol} < %s::date + interval '1 day'")
-                params.append(date_from)
-            elif ftype == "inRange" and date_from is not None and date_to is not None:
-                clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
-                params.extend([date_from, date_to])
-
-        elif filter_type == "set":
-            values = spec.get("values")
-            if isinstance(values, list) and values:
-                # Use ANY(%s) with a list parameter for set membership
-                text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
-                clauses.append(f"{text_col} = ANY(%s)")
-                params.append(values)
-
-    sql = " AND ".join(clauses)
-    if sql:
-        sql = f"AND {sql} "
-    return sql, params
+    result_sql = " AND ".join(clauses)
+    if result_sql:
+        result_sql = f"AND {result_sql} "
+    return result_sql, params
 
 
 # ---------------------------------------------------------------------------
@@ -1361,15 +1382,48 @@ _GRID_FETCHERS = {
 }
 
 
+def _sanitize_cell_value(raw_value: Any) -> Any:
+    """Sanitise a single cell value for Excel export.
+
+    Strings are sanitised against formula injection.  Temporal types
+    are normalised to UTC and stripped of timezone info (openpyxl
+    does not support tz-aware datetimes).  JSONB dicts/lists are
+    serialised to JSON strings.
+
+    Returns the sanitised value ready for ``ws.append()``.
+    """
+    if isinstance(raw_value, dict | list):
+        raw_value = json.dumps(raw_value, default=str)
+    if isinstance(raw_value, str):
+        return sanitize_for_export(raw_value)
+    if raw_value is None:
+        return ""
+    if isinstance(raw_value, datetime):
+        # openpyxl does not support timezone-aware datetimes.
+        # Normalize all datetimes to UTC before stripping tzinfo.
+        if raw_value.tzinfo is None:
+            raw_value = raw_value.replace(tzinfo=UTC)
+        return raw_value.astimezone(UTC).replace(tzinfo=None)
+    if isinstance(raw_value, date):
+        # PostgreSQL DATE columns are returned as datetime.date
+        # objects by psycopg.  openpyxl handles date natively.
+        return raw_value
+    return raw_value
+
+
 def _build_workbook(
     grid_name: str,
     columns: list[str],
     rows: list[dict[str, Any]],
 ) -> bytes:
-    """Build an Excel workbook from grid data.
+    """Build an Excel workbook from grid data using streaming mode.
 
-    Sanitises every cell value to prevent formula-injection attacks.
-    Numeric and temporal types are preserved as native Excel types.
+    Uses ``write_only=True`` to stream rows to disk without building
+    the full XML tree in memory, keeping peak usage low even for the
+    maximum ``_EXPORT_ROW_LIMIT`` (10 000 rows).
+
+    Every cell value is sanitised via ``_sanitize_cell_value`` to
+    prevent formula-injection attacks.
 
     Args:
         grid_name: Name of the grid (used as worksheet title).
@@ -1379,54 +1433,19 @@ def _build_workbook(
     Returns:
         Raw bytes of the ``.xlsx`` file.
     """
-    wb = Workbook()
-    ws = wb.active
-    assert ws is not None  # A new Workbook always has an active sheet
-    ws.title = grid_name.title()
+    wb = Workbook(write_only=True)
+    ws = wb.create_sheet(grid_name.title())
 
     # Header row -- sanitize headers
-    for col_idx, header in enumerate(columns, 1):
-        ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
+    ws.append([sanitize_for_export(h) for h in columns])
 
-    # Data rows -- sanitize only string values to prevent formula
-    # injection while preserving native Excel types (numbers, dates)
-    # for proper formatting and calculations.
-    for row_idx, row_data in enumerate(rows, 2):
-        for col_idx, col_name in enumerate(columns, 1):
-            raw_value = row_data.get(col_name)
-            if isinstance(raw_value, dict | list):
-                raw_value = json.dumps(raw_value, default=str)
-
-            # Only sanitize strings to prevent formula injection
-            # while preserving numeric/date types that openpyxl
-            # handles natively.
-            if isinstance(raw_value, str):
-                value_to_set: Any = sanitize_for_export(raw_value)
-            elif raw_value is None:
-                value_to_set = ""
-            elif isinstance(raw_value, datetime):
-                # openpyxl does not support timezone-aware datetimes.
-                # Normalize all datetimes to UTC before stripping tzinfo:
-                # - tz-aware: convert to UTC via astimezone()
-                # - naive: assume UTC per project coding standards and
-                #   explicitly tag with UTC for documentation clarity
-                # Then strip tzinfo to satisfy openpyxl.
-                if raw_value.tzinfo is None:
-                    raw_value = raw_value.replace(tzinfo=UTC)
-                value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
-            elif isinstance(raw_value, date):
-                # PostgreSQL DATE columns are returned as datetime.date
-                # objects by psycopg.  openpyxl handles date natively,
-                # so pass through as-is (date has no timezone concept).
-                value_to_set = raw_value
-            else:
-                value_to_set = raw_value
-
-            ws.cell(
-                row=row_idx,
-                column=col_idx,
-                value=value_to_set,
-            )
+    # Data rows -- sanitize values to prevent formula injection
+    # while preserving native Excel types (numbers, dates).
+    for row_data in rows:
+        ws.append([
+            _sanitize_cell_value(row_data.get(col_name))
+            for col_name in columns
+        ])
 
     buf = io.BytesIO()
     wb.save(buf)

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1015,6 +1015,7 @@ def _build_single_condition(
     elif filter_type == "number":
         _NUM_OPS: dict[str, str] = {
             "equals": "=",
+            "notEqual": "!=",
             "greaterThan": ">",
             "lessThan": "<",
             "greaterThanOrEqual": ">=",
@@ -1040,7 +1041,11 @@ def _build_single_condition(
         # as timestamps to enable index scans.
         if ftype == "equals" and date_from is not None:
             # "equals day" means >= start of day AND < next day
-            clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
+            clauses.append(f"{qcol} >= %s::date AND {qcol} < %s::date + interval '1 day'")
+            params.extend([date_from, date_from])
+        elif ftype == "notEqual" and date_from is not None:
+            # "not equals day" means outside the given day
+            clauses.append(f"({qcol} < %s::date OR {qcol} >= %s::date + interval '1 day')")
             params.extend([date_from, date_from])
         elif ftype == "greaterThan" and date_from is not None:
             # After the end of the given day
@@ -1057,8 +1062,12 @@ def _build_single_condition(
             clauses.append(f"{qcol} < %s::date + interval '1 day'")
             params.append(date_from)
         elif ftype == "inRange" and date_from is not None and date_to is not None:
-            clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
+            clauses.append(f"{qcol} >= %s::date AND {qcol} < %s::date + interval '1 day'")
             params.extend([date_from, date_to])
+        elif ftype == "blank":
+            clauses.append(f"{qcol} IS NULL")
+        elif ftype == "notBlank":
+            clauses.append(f"{qcol} IS NOT NULL")
 
     elif filter_type == "set":
         values = spec.get("values")

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -846,10 +846,56 @@ def _resolve_sort_aliases(
     aliases = _COLUMN_ALIASES.get(grid_name, {})
     if not aliases:
         return sort_model
-    return [
-        {**item, "colId": aliases.get(item.get("colId", ""), item.get("colId", ""))}
-        for item in sort_model
-    ]
+    resolved: list[dict[str, Any]] = []
+    for item in sort_model:
+        col_id = item.get("colId", "")
+        resolved.append({**item, "colId": aliases.get(col_id, col_id)})
+    return resolved
+
+
+def _qualify_sort_model(
+    sort_model: list[dict[str, Any]] | None,
+    allowed_columns: list[str],
+    prefix: str,
+) -> list[dict[str, Any]] | None:
+    """Prefix sort model column IDs with a table alias.
+
+    Columns whose ``colId`` appears in *allowed_columns* are prefixed
+    with *prefix* (e.g. ``"p."``, ``"t."``).  Unrecognised columns
+    are kept as-is so that ``_build_order_clause`` can silently drop
+    them.  This helper is shared by ``_fetch_positions_data`` and
+    ``_fetch_fills_data`` to avoid duplicating the qualification loop.
+    """
+    if not sort_model:
+        return None
+    qualified: list[dict[str, Any]] = []
+    for item in sort_model:
+        col_id = item.get("colId", "")
+        if col_id in allowed_columns:
+            qualified.append({**item, "colId": f"{prefix}{col_id}"})
+        else:
+            qualified.append(item)
+    return qualified
+
+
+def _resolve_filter_aliases(
+    grid_name: str,
+    filter_params: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Resolve frontend column aliases in AG Grid filter model keys.
+
+    Translates display-friendly filter keys (e.g. ``"type"`` for
+    orders, ``"execution_date"`` for TCA) to their database column
+    names via ``_COLUMN_ALIASES``.  This ensures the filter passes the
+    allowlist check in ``_build_filter_clause`` without being silently
+    dropped.
+    """
+    if not filter_params:
+        return filter_params
+    aliases = _COLUMN_ALIASES.get(grid_name, {})
+    if not aliases:
+        return filter_params
+    return {aliases.get(k, k): v for k, v in filter_params.items()}
 
 
 def _quote_identifier(name: str) -> str:
@@ -1121,15 +1167,7 @@ def _fetch_positions_data(
     # grid allowlist (not just the visible export columns) so that
     # sorts on hidden columns are preserved in the exported order.
     full_allowed = _GRID_COLUMNS["positions"]
-    qualified_sort: list[dict[str, Any]] | None = None
-    if sort_model:
-        qualified_sort = []
-        for item in sort_model:
-            col_id = item.get("colId", "")
-            if col_id in full_allowed:
-                qualified_sort.append({**item, "colId": f"p.{col_id}"})
-            else:
-                qualified_sort.append(item)
+    qualified_sort = _qualify_sort_model(sort_model, full_allowed, "p.")
     qualified_allowed = [f"p.{c}" for c in full_allowed]
     order_clause = _build_order_clause(
         qualified_sort, qualified_allowed, "p.symbol ASC",
@@ -1239,15 +1277,7 @@ def _fetch_fills_data(
     # Use full grid allowlist for sort qualification so that sorts
     # on hidden columns are preserved in the exported row order.
     full_allowed = _GRID_COLUMNS["fills"]
-    qualified_sort: list[dict[str, Any]] | None = None
-    if sort_model:
-        qualified_sort = []
-        for item in sort_model:
-            col_id = item.get("colId", "")
-            if col_id in full_allowed:
-                qualified_sort.append({**item, "colId": f"t.{col_id}"})
-            else:
-                qualified_sort.append(item)
+    qualified_sort = _qualify_sort_model(sort_model, full_allowed, "t.")
     qualified_allowed = [f"t.{c}" for c in full_allowed]
     order_clause = _build_order_clause(qualified_sort, qualified_allowed, "t.executed_at DESC")
     select_cols = sql.SQL(", ").join(
@@ -1561,13 +1591,7 @@ async def _generate_excel_content(
     # "execution_date" -> "executed_at" for TCA).  This ensures that
     # filters using display-friendly names pass the allowlist check
     # in ``_build_filter_clause`` without being silently dropped.
-    resolved_filter = filter_params
-    if filter_params:
-        aliases = _COLUMN_ALIASES.get(grid_name, {})
-        if aliases:
-            resolved_filter = {
-                aliases.get(k, k): v for k, v in filter_params.items()
-            }
+    resolved_filter = _resolve_filter_aliases(grid_name, filter_params)
 
     # Build filter WHERE clause from AG Grid filter model.
     # Use the full grid allowlist (not just the export projection) so

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -923,6 +923,7 @@ def _build_filter_clause(
     - ``text`` filters (contains, equals, startsWith, endsWith, notEqual)
     - ``number`` filters (equals, greaterThan, lessThan, inRange, etc.)
     - ``date`` filters (equals, greaterThan, lessThan, inRange)
+    - ``set`` filters (values list for IN-clause matching)
 
     Only columns present in *allowed_columns* are accepted; unknown
     columns are silently dropped.  All values are passed as query
@@ -1043,6 +1044,14 @@ def _build_filter_clause(
             elif ftype == "inRange" and date_from is not None and date_to is not None:
                 clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
                 params.extend([date_from, date_to])
+
+        elif filter_type == "set":
+            values = spec.get("values")
+            if isinstance(values, list) and values:
+                # Use ANY(%s) with a list parameter for set membership
+                text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+                clauses.append(f"{text_col} = ANY(%s)")
+                params.append(values)
 
     sql = " AND ".join(clauses)
     if sql:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
+from openpyxl import Workbook
 from psycopg import sql
 from pydantic import BaseModel, Field
 
@@ -1360,6 +1361,79 @@ _GRID_FETCHERS = {
 }
 
 
+def _build_workbook(
+    grid_name: str,
+    columns: list[str],
+    rows: list[dict[str, Any]],
+) -> bytes:
+    """Build an Excel workbook from grid data.
+
+    Sanitises every cell value to prevent formula-injection attacks.
+    Numeric and temporal types are preserved as native Excel types.
+
+    Args:
+        grid_name: Name of the grid (used as worksheet title).
+        columns: Ordered list of column names to include.
+        rows: Row data dicts keyed by column name.
+
+    Returns:
+        Raw bytes of the ``.xlsx`` file.
+    """
+    wb = Workbook()
+    ws = wb.active
+    assert ws is not None  # A new Workbook always has an active sheet
+    ws.title = grid_name.title()
+
+    # Header row -- sanitize headers
+    for col_idx, header in enumerate(columns, 1):
+        ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
+
+    # Data rows -- sanitize only string values to prevent formula
+    # injection while preserving native Excel types (numbers, dates)
+    # for proper formatting and calculations.
+    for row_idx, row_data in enumerate(rows, 2):
+        for col_idx, col_name in enumerate(columns, 1):
+            raw_value = row_data.get(col_name)
+            if isinstance(raw_value, dict | list):
+                raw_value = json.dumps(raw_value, default=str)
+
+            # Only sanitize strings to prevent formula injection
+            # while preserving numeric/date types that openpyxl
+            # handles natively.
+            if isinstance(raw_value, str):
+                value_to_set: Any = sanitize_for_export(raw_value)
+            elif raw_value is None:
+                value_to_set = ""
+            elif isinstance(raw_value, datetime):
+                # openpyxl does not support timezone-aware datetimes.
+                # Normalize all datetimes to UTC before stripping tzinfo:
+                # - tz-aware: convert to UTC via astimezone()
+                # - naive: assume UTC per project coding standards and
+                #   explicitly tag with UTC for documentation clarity
+                # Then strip tzinfo to satisfy openpyxl.
+                if raw_value.tzinfo is None:
+                    raw_value = raw_value.replace(tzinfo=UTC)
+                value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+            elif isinstance(raw_value, date):
+                # PostgreSQL DATE columns are returned as datetime.date
+                # objects by psycopg.  openpyxl handles date natively,
+                # so pass through as-is (date has no timezone concept).
+                value_to_set = raw_value
+            else:
+                value_to_set = raw_value
+
+            ws.cell(
+                row=row_idx,
+                column=col_idx,
+                value=value_to_set,
+            )
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf.getvalue()
+
+
 async def _generate_excel_content(
     ctx: AppContext,
     grid_name: str,
@@ -1398,13 +1472,6 @@ async def _generate_excel_content(
     Raises:
         NotImplementedError: If grid type not supported or openpyxl missing
     """
-    try:
-        from openpyxl import Workbook
-    except ImportError as e:
-        raise NotImplementedError(
-            "Excel export requires openpyxl: pip install openpyxl"
-        ) from e
-
     if grid_name not in _GRID_FETCHERS:
         raise NotImplementedError(f"Excel export not implemented for grid: {grid_name}")
 
@@ -1457,63 +1524,9 @@ async def _generate_excel_content(
         filter_clause, filter_params_list,
     )
 
-    # Build workbook (CPU-bound; done in worker thread below)
-    def _build_workbook() -> bytes:
-        wb = Workbook()
-        # A new Workbook always has an active worksheet.
-        ws = wb.active if wb.active is not None else wb.create_sheet()
-        ws.title = grid_name.title()
-
-        # Header row -- sanitize headers
-        for col_idx, header in enumerate(columns, 1):
-            ws.cell(row=1, column=col_idx, value=sanitize_for_export(header))
-
-        # Data rows -- sanitize only string values to prevent formula
-        # injection while preserving native Excel types (numbers, dates)
-        # for proper formatting and calculations.
-        for row_idx, row_data in enumerate(rows, 2):
-            for col_idx, col_name in enumerate(columns, 1):
-                raw_value = row_data.get(col_name)
-                if isinstance(raw_value, dict | list):
-                    raw_value = json.dumps(raw_value, default=str)
-
-                # Only sanitize strings to prevent formula injection
-                # while preserving numeric/date types that openpyxl
-                # handles natively.
-                if isinstance(raw_value, str):
-                    value_to_set: Any = sanitize_for_export(raw_value)
-                elif raw_value is None:
-                    value_to_set = ""
-                elif isinstance(raw_value, datetime):
-                    # openpyxl does not support timezone-aware datetimes.
-                    # Normalize all datetimes to UTC before stripping tzinfo:
-                    # - tz-aware: convert to UTC via astimezone()
-                    # - naive: assume UTC per project coding standards and
-                    #   explicitly tag with UTC for documentation clarity
-                    # Then strip tzinfo to satisfy openpyxl.
-                    if raw_value.tzinfo is None:
-                        raw_value = raw_value.replace(tzinfo=UTC)
-                    value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
-                elif isinstance(raw_value, date):
-                    # PostgreSQL DATE columns are returned as datetime.date
-                    # objects by psycopg.  openpyxl handles date natively,
-                    # so pass through as-is (date has no timezone concept).
-                    value_to_set = raw_value
-                else:
-                    value_to_set = raw_value
-
-                ws.cell(
-                    row=row_idx,
-                    column=col_idx,
-                    value=value_to_set,
-                )
-
-        buf = io.BytesIO()
-        wb.save(buf)
-        buf.seek(0)
-        return buf.getvalue()
-
-    excel_bytes = await asyncio.to_thread(_build_workbook)
+    excel_bytes = await asyncio.to_thread(
+        _build_workbook, grid_name, columns, rows,
+    )
     row_count = len(rows)
     return excel_bytes, row_count
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1178,17 +1178,24 @@ def _fetch_orders_data(
     """Fetch orders scoped to authorized strategies.
 
     This fetcher returns ALL orders matching strategy scope and the
-    caller-provided filter clause.  It intentionally does NOT inject
-    implicit status predicates because the server cannot know which UI
-    tab originated the export request.
+    caller-provided ``filter_clause``.  It intentionally does NOT
+    inject implicit status predicates because the server cannot know
+    which UI tab originated the export request.
 
-    **Frontend contract:** When the user exports from a status-scoped
-    tab (e.g. the "Working Orders" tab, which pre-filters to
-    pending/open/partially_filled statuses before calling
-    ``setRowData``), the UI component MUST inject the corresponding
-    ``status`` filter into the AG Grid ``filterModel`` before sending
-    the export audit request.  ``GridExportToolbar`` is responsible for
-    this; see ``apps/web_console_ng/components/grid_export_toolbar.py``.
+    **Working-status scoping is handled by the caller chain:**
+
+    1. ``GridExportToolbar`` in
+       ``apps/web_console_ng/components/grid_export_toolbar.py``
+       injects a ``status`` set filter via ``extra_filters`` for the
+       Working Orders tab (see ``tabbed_panel.py`` lines 289-294).
+    2. The injected filter is merged into the AG Grid ``filterModel``
+       before the export audit record is created (line 179 of
+       ``grid_export_toolbar.py``).
+    3. ``_generate_excel_content`` resolves aliases and builds the
+       ``filter_clause`` from the full grid allowlist (lines 1554-1571
+       below), which includes the status predicate.
+    4. This fetcher receives the ``filter_clause`` already containing
+       ``AND "status" = ANY(%s)`` with working-status values.
 
     If the frontend omits the status filter, the export will correctly
     return all strategy-scoped orders -- which is the expected behavior
@@ -1549,8 +1556,11 @@ async def _generate_excel_content(
     if grid_name == "tca":
         tca_filter_map = _TCA_COL_MAP
 
-    # Also resolve aliases in filter_params keys before building the
-    # filter clause (e.g. "type" -> "order_type" for orders grid).
+    # Resolve frontend aliases in filter_params keys before building
+    # the filter clause (e.g. "type" -> "order_type" for orders,
+    # "execution_date" -> "executed_at" for TCA).  This ensures that
+    # filters using display-friendly names pass the allowlist check
+    # in ``_build_filter_clause`` without being silently dropped.
     resolved_filter = filter_params
     if filter_params:
         aliases = _COLUMN_ALIASES.get(grid_name, {})

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -953,21 +953,16 @@ def _build_single_condition(
             params.append(value)
 
     elif filter_type == "number":
+        _NUM_OPS: dict[str, str] = {
+            "equals": "=",
+            "greaterThan": ">",
+            "lessThan": "<",
+            "greaterThanOrEqual": ">=",
+            "lessThanOrEqual": "<=",
+        }
         value = spec.get("filter")
-        if ftype == "equals" and value is not None:
-            clauses.append(f"{qcol} = %s")
-            params.append(value)
-        elif ftype == "greaterThan" and value is not None:
-            clauses.append(f"{qcol} > %s")
-            params.append(value)
-        elif ftype == "lessThan" and value is not None:
-            clauses.append(f"{qcol} < %s")
-            params.append(value)
-        elif ftype == "greaterThanOrEqual" and value is not None:
-            clauses.append(f"{qcol} >= %s")
-            params.append(value)
-        elif ftype == "lessThanOrEqual" and value is not None:
-            clauses.append(f"{qcol} <= %s")
+        if ftype in _NUM_OPS and value is not None:
+            clauses.append(f"{qcol} {_NUM_OPS[ftype]} %s")
             params.append(value)
         elif ftype == "inRange":
             lo = spec.get("filter")
@@ -1128,10 +1123,13 @@ def _fetch_positions_data(
     full_allowed = _GRID_COLUMNS["positions"]
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
-        qualified_sort = [
-            {**item, "colId": f"p.{item.get('colId', '')}"} if item.get("colId") in full_allowed else item
-            for item in sort_model
-        ]
+        qualified_sort = []
+        for item in sort_model:
+            col_id = item.get("colId", "")
+            if col_id in full_allowed:
+                qualified_sort.append({**item, "colId": f"p.{col_id}"})
+            else:
+                qualified_sort.append(item)
     qualified_allowed = [f"p.{c}" for c in full_allowed]
     order_clause = _build_order_clause(
         qualified_sort, qualified_allowed, "p.symbol ASC",
@@ -1236,10 +1234,13 @@ def _fetch_fills_data(
     full_allowed = _GRID_COLUMNS["fills"]
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
-        qualified_sort = [
-            {**item, "colId": f"t.{item.get('colId', '')}"} if item.get("colId") in full_allowed else item
-            for item in sort_model
-        ]
+        qualified_sort = []
+        for item in sort_model:
+            col_id = item.get("colId", "")
+            if col_id in full_allowed:
+                qualified_sort.append({**item, "colId": f"t.{col_id}"})
+            else:
+                qualified_sort.append(item)
     qualified_allowed = [f"t.{c}" for c in full_allowed]
     order_clause = _build_order_clause(qualified_sort, qualified_allowed, "t.executed_at DESC")
     select_cols = sql.SQL(", ").join(
@@ -1376,9 +1377,11 @@ def _fetch_tca_data(
             for item in sort_model
             if item.get("colId", "") in _TCA_COL_MAP
         ]
-    qualified_tca_columns = [_TCA_COL_MAP[c] for c in mapped_columns]
+    # Use the full _TCA_COL_MAP for sort qualification (not just the
+    # export projection) so that sorts on hidden columns are preserved.
+    all_tca_qualified = list(_TCA_COL_MAP.values())
     order_clause = _build_order_clause(
-        qualified_sort, qualified_tca_columns, "t.executed_at DESC",
+        qualified_sort, all_tca_qualified, "t.executed_at DESC",
     )
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -31,6 +31,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from openpyxl import Workbook
 from psycopg import sql
+from psycopg.rows import dict_row
 from pydantic import BaseModel, Field
 
 from apps.execution_gateway.api.dependencies import build_gateway_authenticator
@@ -912,6 +913,13 @@ def _build_single_condition(
     This handles one atomic condition (``type`` + ``filter``).  Compound
     filters (``operator`` + ``conditions``) are decomposed by
     ``_build_filter_clause`` before calling this helper.
+
+    **Safety:** ``qcol`` is produced by ``_quote_identifier()`` which
+    delegates to ``psycopg.sql.Identifier(...).as_string(None)`` --
+    all identifiers are properly double-quoted before interpolation.
+    The resulting clause strings are assembled with parameterized
+    ``%s`` placeholders and the final query is built via
+    ``psycopg.sql.SQL`` composition.
     """
     filter_type = spec.get("filterType", "text")
     ftype = spec.get("type", "")
@@ -929,7 +937,9 @@ def _build_single_condition(
             clauses.append(f"{text_col} ILIKE %s")
             params.append(f"%{value}%")
         elif ftype == "equals":
-            clauses.append(f"{text_col} = %s")
+            # AG Grid text filtering is case-insensitive by default,
+            # so use ILIKE to match the grid's behaviour.
+            clauses.append(f"{text_col} ILIKE %s")
             params.append(value)
         elif ftype == "startsWith":
             clauses.append(f"{text_col} ILIKE %s")
@@ -938,7 +948,8 @@ def _build_single_condition(
             clauses.append(f"{text_col} ILIKE %s")
             params.append(f"%{value}")
         elif ftype == "notEqual":
-            clauses.append(f"{text_col} != %s")
+            # Case-insensitive to match AG Grid behaviour.
+            clauses.append(f"{text_col} NOT ILIKE %s")
             params.append(value)
 
     elif filter_type == "number":
@@ -1111,16 +1122,19 @@ def _fetch_positions_data(
     data leakage.
     """
     # Qualify sort columns with the "p." alias to avoid ambiguity when
-    # joining positions with the symbol_strategy CTE.
+    # joining positions with the symbol_strategy CTE.  Use the full
+    # grid allowlist (not just the visible export columns) so that
+    # sorts on hidden columns are preserved in the exported order.
+    full_allowed = _GRID_COLUMNS["positions"]
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": f"p.{item.get('colId', '')}"} if item.get("colId") in columns else item
+            {**item, "colId": f"p.{item.get('colId', '')}"} if item.get("colId") in full_allowed else item
             for item in sort_model
         ]
-    qualified_columns = [f"p.{c}" for c in columns]
+    qualified_allowed = [f"p.{c}" for c in full_allowed]
     order_clause = _build_order_clause(
-        qualified_sort, qualified_columns, "p.symbol ASC",
+        qualified_sort, qualified_allowed, "p.symbol ASC",
     )
     # Build SELECT list using psycopg.sql.Identifier for column names.
     select_cols = sql.SQL(", ").join(
@@ -1136,7 +1150,7 @@ def _fetch_positions_data(
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
-        with conn.cursor() as cur:
+        with conn.cursor(row_factory=dict_row) as cur:
             query = sql.SQL(
                 "WITH {cte} "
                 "SELECT {cols} FROM positions p "
@@ -1152,8 +1166,7 @@ def _fetch_positions_data(
                 order_clause=sql.SQL(order_clause),
             )
             cur.execute(query, query_params)
-            col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
+            return list(cur.fetchall())
 
 
 def _fetch_orders_data(
@@ -1183,14 +1196,17 @@ def _fetch_orders_data(
     return all strategy-scoped orders -- which is the expected behavior
     for the "All Orders" / "History" views.
     """
-    order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
+    # Use the full grid allowlist for sort qualification so that sorts
+    # on hidden columns are preserved in the exported row order.
+    full_allowed = _GRID_COLUMNS["orders"]
+    order_clause = _build_order_clause(sort_model, full_allowed, "created_at DESC")
     select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
-        with conn.cursor() as cur:
+        with conn.cursor(row_factory=dict_row) as cur:
             query = sql.SQL(
                 "SELECT {cols} FROM orders "
                 "WHERE strategy_id = ANY(%s) "
@@ -1203,8 +1219,7 @@ def _fetch_orders_data(
                 order_clause=sql.SQL(order_clause),
             )
             cur.execute(query, query_params)
-            col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
+            return list(cur.fetchall())
 
 
 def _fetch_fills_data(
@@ -1216,7 +1231,17 @@ def _fetch_fills_data(
     filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch fills (trades) scoped to authorized strategies."""
-    order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
+    # Use full grid allowlist for sort qualification so that sorts
+    # on hidden columns are preserved in the exported row order.
+    full_allowed = _GRID_COLUMNS["fills"]
+    qualified_sort: list[dict[str, Any]] | None = None
+    if sort_model:
+        qualified_sort = [
+            {**item, "colId": f"t.{item.get('colId', '')}"} if item.get("colId") in full_allowed else item
+            for item in sort_model
+        ]
+    qualified_allowed = [f"t.{c}" for c in full_allowed]
+    order_clause = _build_order_clause(qualified_sort, qualified_allowed, "t.executed_at DESC")
     select_cols = sql.SQL(", ").join(
         sql.SQL("{tbl}.{col}").format(
             tbl=sql.Identifier("t"),
@@ -1229,7 +1254,7 @@ def _fetch_fills_data(
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
-        with conn.cursor() as cur:
+        with conn.cursor(row_factory=dict_row) as cur:
             query = sql.SQL(
                 "SELECT {cols} FROM trades t "
                 "WHERE COALESCE(t.superseded, FALSE) = FALSE "
@@ -1243,8 +1268,7 @@ def _fetch_fills_data(
                 order_clause=sql.SQL(order_clause),
             )
             cur.execute(query, query_params)
-            col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
+            return list(cur.fetchall())
 
 
 def _fetch_audit_data(
@@ -1271,14 +1295,17 @@ def _fetch_audit_data(
     differently, update the WHERE clause below and the corresponding
     GIN index on ``audit_log.details``.
     """
-    order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
+    # Use full grid allowlist for sort qualification so that sorts
+    # on hidden columns are preserved in the exported row order.
+    full_allowed = _GRID_COLUMNS["audit"]
+    order_clause = _build_order_clause(sort_model, full_allowed, "timestamp DESC, id DESC")
     select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
     query_params: list[Any] = [strategy_ids]
     if filter_params_list:
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
-        with conn.cursor() as cur:
+        with conn.cursor(row_factory=dict_row) as cur:
             query = sql.SQL(
                 "SELECT {cols} FROM audit_log "
                 "WHERE details->>'strategy_id' = ANY(%s) "
@@ -1291,8 +1318,7 @@ def _fetch_audit_data(
                 order_clause=sql.SQL(order_clause),
             )
             cur.execute(query, query_params)
-            col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
+            return list(cur.fetchall())
 
 
 # Map TCA column names to their qualified table references.
@@ -1359,7 +1385,7 @@ def _fetch_tca_data(
         query_params.extend(filter_params_list)
     query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
-        with conn.cursor() as cur:
+        with conn.cursor(row_factory=dict_row) as cur:
             query = sql.SQL(
                 "SELECT {cols} "
                 "FROM trades t "
@@ -1375,8 +1401,7 @@ def _fetch_tca_data(
                 order_clause=sql.SQL(order_clause),
             )
             cur.execute(query, query_params)
-            col_names = [desc[0] for desc in cur.description]
-            return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
+            return list(cur.fetchall())
 
 
 # Dispatch table for grid data fetchers

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -903,6 +903,11 @@ def _build_order_clause(
     return ", ".join(parts) if parts else default_order
 
 
+# Columns that are JSONB in the database and need an explicit ::text
+# cast when used in text filter operations (ILIKE, =, !=).
+_JSONB_COLUMNS: frozenset[str] = frozenset({"details"})
+
+
 def _build_filter_clause(
     filter_params: dict[str, Any] | None,
     allowed_columns: list[str],
@@ -964,23 +969,24 @@ def _build_filter_clause(
             if value is None:
                 continue
             value = str(value)
-            # Avoid explicit ::text casts -- they are redundant for text/varchar
-            # columns and can prevent the database from using B-tree indexes.
-            # PostgreSQL implicitly handles text comparisons via ILIKE/=.
+            # JSONB columns need an explicit ::text cast for text
+            # operators; for text/varchar columns the cast is omitted
+            # to allow B-tree index usage.
+            text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
             if ftype == "contains":
-                clauses.append(f"{qcol} ILIKE %s")
+                clauses.append(f"{text_col} ILIKE %s")
                 params.append(f"%{value}%")
             elif ftype == "equals":
-                clauses.append(f"{qcol} = %s")
+                clauses.append(f"{text_col} = %s")
                 params.append(value)
             elif ftype == "startsWith":
-                clauses.append(f"{qcol} ILIKE %s")
+                clauses.append(f"{text_col} ILIKE %s")
                 params.append(f"{value}%")
             elif ftype == "endsWith":
-                clauses.append(f"{qcol} ILIKE %s")
+                clauses.append(f"{text_col} ILIKE %s")
                 params.append(f"%{value}")
             elif ftype == "notEqual":
-                clauses.append(f"{qcol} != %s")
+                clauses.append(f"{text_col} != %s")
                 params.append(value)
 
         elif filter_type == "number":
@@ -1412,9 +1418,14 @@ async def _generate_excel_content(
                 aliases.get(k, k): v for k, v in filter_params.items()
             }
 
-    # Build filter WHERE clause from AG Grid filter model
+    # Build filter WHERE clause from AG Grid filter model.
+    # Use the full grid allowlist (not just the export projection) so
+    # that filters on hidden columns are preserved.  For example, if
+    # a user filters by "status" but only exports "symbol"/"qty", the
+    # status predicate must still be applied.
+    full_allowlist = _GRID_COLUMNS[grid_name]
     filter_clause, filter_params_list = _build_filter_clause(
-        resolved_filter, columns, col_prefix=col_prefix,
+        resolved_filter, full_allowlist, col_prefix=col_prefix,
         col_prefix_map=tca_filter_map,
     )
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -945,9 +945,15 @@ def _build_filter_clause(
         elif filter_type == "date":
             date_from = spec.get("dateFrom")
             date_to = spec.get("dateTo")
-            if ftype in ("equals", "greaterThan", "lessThan") and date_from is not None:
-                op = {"equals": "=", "greaterThan": ">", "lessThan": "<"}[ftype]
-                clauses.append(f"{qcol}::date {op} %s")
+            _date_ops = {
+                "equals": "=",
+                "greaterThan": ">",
+                "lessThan": "<",
+                "greaterThanOrEqual": ">=",
+                "lessThanOrEqual": "<=",
+            }
+            if ftype in _date_ops and date_from is not None:
+                clauses.append(f"{qcol}::date {_date_ops[ftype]} %s")
                 params.append(date_from)
             elif ftype == "inRange" and date_from is not None and date_to is not None:
                 clauses.append(f"{qcol}::date >= %s AND {qcol}::date <= %s")
@@ -1120,7 +1126,11 @@ def _fetch_tca_data(
     filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch TCA trade data with order context, scoped to authorized strategies."""
-    # Map column names to their qualified table references
+    # Map column names to their qualified table references.
+    # Every column in _GRID_COLUMNS["tca"] MUST have an entry here so
+    # that SELECT / ORDER BY / filter references are unambiguous across
+    # the trades (t) and orders (o) tables.  Columns missing from this
+    # map are silently skipped to prevent incorrect table attribution.
     tca_col_map: dict[str, str] = {
         "trade_id": "t.trade_id",
         "client_order_id": "t.client_order_id",
@@ -1134,21 +1144,24 @@ def _fetch_tca_data(
         "order_qty": "o.qty",
         "filled_avg_price": "o.filled_avg_price",
     }
+    # Only include columns that have an explicit mapping to prevent
+    # incorrect table attribution for unmapped columns.
+    mapped_columns = [c for c in columns if c in tca_col_map]
     select_cols = ", ".join(
-        f"{tca_col_map.get(c, 't.' + c)} AS {c}" for c in columns
+        f"{tca_col_map[c]} AS {c}" for c in mapped_columns
     )
     # Qualify sort columns with table aliases via tca_col_map to
     # avoid ambiguity when trades and orders share column names
-    # (e.g. symbol, qty, client_order_id).
+    # (e.g. symbol, qty, client_order_id).  Only mapped columns
+    # are accepted; unmapped sort entries are dropped.
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": tca_col_map.get(item.get("colId", ""), f"t.{item.get('colId', '')}")}
-            if item.get("colId") in columns
-            else item
+            {**item, "colId": tca_col_map[item.get("colId", "")]}
             for item in sort_model
+            if item.get("colId", "") in tca_col_map
         ]
-    qualified_tca_columns = [tca_col_map.get(c, f"t.{c}") for c in columns]
+    qualified_tca_columns = [tca_col_map[c] for c in mapped_columns]
     order_clause = _build_order_clause(
         qualified_sort, qualified_tca_columns, "t.executed_at DESC",
     )

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -775,6 +775,23 @@ _GRID_COLUMNS: dict[str, list[str]] = {
 # Maximum rows per export to prevent excessive memory / query time
 _EXPORT_ROW_LIMIT = 10_000
 
+# Working (active) order statuses.  Orders in these statuses are shown
+# on the "Working Orders" tab.  This constant is shared with the web
+# console (``apps.web_console_ng.components.tabbed_panel``) and can be
+# used when the frontend passes a ``tab_context`` indicating the export
+# originated from the Working tab.
+# TODO(#151): Frontend should inject a status filter into filter_params
+# when exporting from the Working Orders tab so that export/view parity
+# is maintained without server-side guessing.
+WORKING_ORDER_STATUSES = frozenset({
+    "new",
+    "pending_new",
+    "partially_filled",
+    "accepted",
+    "pending_cancel",
+    "pending_replace",
+})
+
 
 # ---------------------------------------------------------------------------
 # Frontend → DB column alias mapping.
@@ -860,6 +877,14 @@ def _build_order_clause(
     Only column names that appear in *allowed_columns* are accepted.
     Items are sorted by their ``sortIndex`` (if present) so that
     multi-column sort precedence matches the user's grid configuration.
+
+    Note: Column names are interpolated via f-string rather than
+    ``psycopg.sql.Identifier`` because ``allowed_columns`` may contain
+    table-qualified references (e.g. ``"p.symbol"``, ``"t.executed_at"``)
+    which ``Identifier`` would incorrectly quote as a single identifier.
+    All values in ``allowed_columns`` originate from the hardcoded
+    ``_GRID_COLUMNS`` allowlist or ``_TCA_COL_MAP``, never from user
+    input, so this is safe.
     """
     if not sort_model:
         return default_order

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -946,6 +946,19 @@ def _build_order_clause(
 # cast when used in text filter operations (ILIKE, =, !=).
 _JSONB_COLUMNS: frozenset[str] = frozenset({"details"})
 
+# Character used as the ESCAPE character in LIKE/ILIKE patterns.
+_LIKE_ESCAPE = "\\"
+
+
+def _escape_like(value: str) -> str:
+    """Escape SQL LIKE metacharacters (``%`` and ``_``) in *value*.
+
+    Returns the escaped string suitable for use with ``ILIKE %s ESCAPE '\\``'.
+    This ensures user-supplied filter values like ``ops_team`` are matched
+    literally rather than treating ``_`` as a single-character wildcard.
+    """
+    return value.replace(_LIKE_ESCAPE, _LIKE_ESCAPE * 2).replace("%", f"{_LIKE_ESCAPE}%").replace("_", f"{_LIKE_ESCAPE}_")
+
 
 def _build_single_condition(
     col: str,
@@ -979,24 +992,25 @@ def _build_single_condition(
         # operators; for text/varchar columns the cast is omitted
         # to allow B-tree index usage.
         text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+        _ESC_SUFFIX = f" ESCAPE '{_LIKE_ESCAPE}'"
         if ftype == "contains":
-            clauses.append(f"{text_col} ILIKE %s")
-            params.append(f"%{value}%")
+            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
+            params.append(f"%{_escape_like(value)}%")
         elif ftype == "equals":
             # AG Grid text filtering is case-insensitive by default,
             # so use ILIKE to match the grid's behaviour.
-            clauses.append(f"{text_col} ILIKE %s")
-            params.append(value)
+            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
+            params.append(_escape_like(value))
         elif ftype == "startsWith":
-            clauses.append(f"{text_col} ILIKE %s")
-            params.append(f"{value}%")
+            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
+            params.append(f"{_escape_like(value)}%")
         elif ftype == "endsWith":
-            clauses.append(f"{text_col} ILIKE %s")
-            params.append(f"%{value}")
+            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
+            params.append(f"%{_escape_like(value)}")
         elif ftype == "notEqual":
             # Case-insensitive to match AG Grid behaviour.
-            clauses.append(f"{text_col} NOT ILIKE %s")
-            params.append(value)
+            clauses.append(f"{text_col} NOT ILIKE %s{_ESC_SUFFIX}")
+            params.append(_escape_like(value))
 
     elif filter_type == "number":
         _NUM_OPS: dict[str, str] = {

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -939,20 +939,23 @@ def _build_filter_clause(
             if value is None:
                 continue
             value = str(value)
+            # Avoid explicit ::text casts -- they are redundant for text/varchar
+            # columns and can prevent the database from using B-tree indexes.
+            # PostgreSQL implicitly handles text comparisons via ILIKE/=.
             if ftype == "contains":
-                clauses.append(f"{qcol}::text ILIKE %s")
+                clauses.append(f"{qcol} ILIKE %s")
                 params.append(f"%{value}%")
             elif ftype == "equals":
-                clauses.append(f"{qcol}::text = %s")
+                clauses.append(f"{qcol} = %s")
                 params.append(value)
             elif ftype == "startsWith":
-                clauses.append(f"{qcol}::text ILIKE %s")
+                clauses.append(f"{qcol} ILIKE %s")
                 params.append(f"{value}%")
             elif ftype == "endsWith":
-                clauses.append(f"{qcol}::text ILIKE %s")
+                clauses.append(f"{qcol} ILIKE %s")
                 params.append(f"%{value}")
             elif ftype == "notEqual":
-                clauses.append(f"{qcol}::text != %s")
+                clauses.append(f"{qcol} != %s")
                 params.append(value)
 
         elif filter_type == "number":
@@ -982,18 +985,30 @@ def _build_filter_clause(
         elif filter_type == "date":
             date_from = spec.get("dateFrom")
             date_to = spec.get("dateTo")
-            _date_ops = {
-                "equals": "=",
-                "greaterThan": ">",
-                "lessThan": "<",
-                "greaterThanOrEqual": ">=",
-                "lessThanOrEqual": "<=",
-            }
-            if ftype in _date_ops and date_from is not None:
-                clauses.append(f"{qcol}::date {_date_ops[ftype]} %s")
+            # Use range comparisons on the raw timestamp column instead of
+            # ::date casts, which prevent B-tree index usage on large tables.
+            # AG Grid sends dates as 'YYYY-MM-DD' strings; we compare them
+            # as timestamps to enable index scans.
+            if ftype == "equals" and date_from is not None:
+                # "equals day" means >= start of day AND < next day
+                clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
+                params.extend([date_from, date_from])
+            elif ftype == "greaterThan" and date_from is not None:
+                # After the end of the given day
+                clauses.append(f"{qcol} >= %s::date + interval '1 day'")
+                params.append(date_from)
+            elif ftype == "lessThan" and date_from is not None:
+                clauses.append(f"{qcol} < %s")
+                params.append(date_from)
+            elif ftype == "greaterThanOrEqual" and date_from is not None:
+                clauses.append(f"{qcol} >= %s")
+                params.append(date_from)
+            elif ftype == "lessThanOrEqual" and date_from is not None:
+                # Include all of the given day
+                clauses.append(f"{qcol} < %s::date + interval '1 day'")
                 params.append(date_from)
             elif ftype == "inRange" and date_from is not None and date_to is not None:
-                clauses.append(f"{qcol}::date >= %s AND {qcol}::date <= %s")
+                clauses.append(f"{qcol} >= %s AND {qcol} < %s::date + interval '1 day'")
                 params.extend([date_from, date_to])
 
     sql = " AND ".join(clauses)
@@ -1078,7 +1093,16 @@ def _fetch_orders_data(
     filter_clause: str = "",
     filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch orders scoped to authorized strategies."""
+    """Fetch orders scoped to authorized strategies.
+
+    This fetcher returns ALL orders matching strategy scope and the
+    caller-provided filter clause.  Status filtering (e.g. restricting
+    to working/pending orders for the "Working Orders" tab) is the
+    responsibility of the caller via ``filter_params``.  The frontend
+    must include a status filter in the AG Grid filter model when
+    exporting from status-scoped tabs to ensure export parity with the
+    visible grid.
+    """
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
     select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
     query_params: list[Any] = [strategy_ids]
@@ -1299,11 +1323,21 @@ async def _generate_excel_content(
     column validation against a server-side allowlist, and sanitises every
     cell value to prevent formula-injection attacks.
 
+    **Important:** This function uses ``filter_params`` (the AG Grid filter
+    model) as the single source of truth for row filtering.  If the
+    frontend applies additional filters outside the AG Grid filter model
+    (e.g. a dashboard symbol dropdown that pre-filters ``setRowData``),
+    those filters must be propagated into ``filter_params`` before the
+    export audit is created, or the export will include rows not visible
+    in the current grid view.
+
     Args:
         ctx: Application context with database access
         grid_name: Name of grid to export
         strategy_ids: Authorized strategy IDs for filtering
-        filter_params: AG Grid filter model applied to export query
+        filter_params: AG Grid filter model applied to export query.
+            Must include any status/scope filters from the active tab
+            (e.g. working-order status when exporting from "Working" tab).
         visible_columns: Columns to include (validated against allowlist)
         sort_model: AG Grid sort model
 
@@ -1396,13 +1430,14 @@ async def _generate_excel_content(
                     value_to_set = ""
                 elif isinstance(raw_value, datetime):
                     # openpyxl does not support timezone-aware datetimes.
-                    # If tz-aware, convert to UTC then strip; if naive,
-                    # assume already UTC (per project coding standards)
-                    # and use as-is.
-                    if raw_value.tzinfo is not None:
-                        value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
-                    else:
-                        value_to_set = raw_value
+                    # Normalize all datetimes to UTC before stripping tzinfo:
+                    # - tz-aware: convert to UTC via astimezone()
+                    # - naive: assume UTC per project coding standards and
+                    #   explicitly tag with UTC for documentation clarity
+                    # Then strip tzinfo to satisfy openpyxl.
+                    if raw_value.tzinfo is None:
+                        raw_value = raw_value.replace(tzinfo=UTC)
+                    value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
                 elif isinstance(raw_value, date):
                     # PostgreSQL DATE columns are returned as datetime.date
                     # objects by psycopg.  openpyxl handles date natively,

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1115,7 +1115,7 @@ def _fetch_positions_data(
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": f"p.{item.get('colId')}"} if item.get("colId") in columns else item
+            {**item, "colId": f"p.{item.get('colId', '')}"} if item.get("colId") in columns else item
             for item in sort_model
         ]
     qualified_columns = [f"p.{c}" for c in columns]
@@ -1404,7 +1404,7 @@ def _sanitize_cell_value(raw_value: Any) -> Any:
     if isinstance(raw_value, str):
         return sanitize_for_export(raw_value)
     if raw_value is None:
-        return ""
+        return None
     if isinstance(raw_value, datetime):
         # openpyxl does not support timezone-aware datetimes.
         # Normalize all datetimes to UTC before stripping tzinfo.

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1104,8 +1104,13 @@ async def _generate_excel_content(
                     value_to_set = ""
                 elif isinstance(raw_value, datetime):
                     # openpyxl does not support timezone-aware datetimes.
-                    # Ensure UTC first, then strip for Excel compatibility.
-                    value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+                    # If tz-aware, convert to UTC then strip; if naive,
+                    # assume already UTC (per project coding standards)
+                    # and use as-is.
+                    if raw_value.tzinfo is not None:
+                        value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
+                    else:
+                        value_to_set = raw_value
                 else:
                     value_to_set = raw_value
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -878,13 +878,15 @@ def _build_order_clause(
     Items are sorted by their ``sortIndex`` (if present) so that
     multi-column sort precedence matches the user's grid configuration.
 
-    Note: Column names are interpolated via f-string rather than
-    ``psycopg.sql.Identifier`` because ``allowed_columns`` may contain
-    table-qualified references (e.g. ``"p.symbol"``, ``"t.executed_at"``)
-    which ``Identifier`` would incorrectly quote as a single identifier.
-    All values in ``allowed_columns`` originate from the hardcoded
-    ``_GRID_COLUMNS`` allowlist or ``_TCA_COL_MAP``, never from user
-    input, so this is safe.
+    **Safety:** ``allowed_columns`` may contain table-qualified
+    references (e.g. ``"p.symbol"``, ``"t.executed_at"``) which
+    ``psycopg.sql.Identifier`` would incorrectly quote as a single
+    identifier (``"p.symbol"`` instead of ``"p"."symbol"``).  Because
+    every value in ``allowed_columns`` originates from the hardcoded
+    ``_GRID_COLUMNS`` allowlist or ``_TCA_COL_MAP`` -- never from user
+    input -- f-string interpolation is safe here.  The callers then
+    wrap the returned string in ``sql.SQL()`` for composition with
+    parameterized queries.
     """
     if not sort_model:
         return default_order
@@ -1127,12 +1129,21 @@ def _fetch_orders_data(
     """Fetch orders scoped to authorized strategies.
 
     This fetcher returns ALL orders matching strategy scope and the
-    caller-provided filter clause.  Status filtering (e.g. restricting
-    to working/pending orders for the "Working Orders" tab) is the
-    responsibility of the caller via ``filter_params``.  The frontend
-    must include a status filter in the AG Grid filter model when
-    exporting from status-scoped tabs to ensure export parity with the
-    visible grid.
+    caller-provided filter clause.  It intentionally does NOT inject
+    implicit status predicates because the server cannot know which UI
+    tab originated the export request.
+
+    **Frontend contract:** When the user exports from a status-scoped
+    tab (e.g. the "Working Orders" tab, which pre-filters to
+    pending/open/partially_filled statuses before calling
+    ``setRowData``), the UI component MUST inject the corresponding
+    ``status`` filter into the AG Grid ``filterModel`` before sending
+    the export audit request.  ``GridExportToolbar`` is responsible for
+    this; see ``apps/web_console_ng/components/grid_export_toolbar.py``.
+
+    If the frontend omits the status filter, the export will correctly
+    return all strategy-scoped orders -- which is the expected behavior
+    for the "All Orders" / "History" views.
     """
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
     select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
@@ -1440,8 +1451,8 @@ async def _generate_excel_content(
     # Build workbook (CPU-bound; done in worker thread below)
     def _build_workbook() -> bytes:
         wb = Workbook()
-        ws = wb.active
-        assert ws is not None, "Workbook.active should never be None for a new Workbook"
+        # A new Workbook always has an active worksheet.
+        ws = wb.active if wb.active is not None else wb.create_sheet()
         ws.title = grid_name.title()
 
         # Header row -- sanitize headers

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -23,7 +23,7 @@ import asyncio
 import io
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any, Literal
 from uuid import UUID
 
@@ -789,6 +789,9 @@ _COLUMN_ALIASES: dict[str, dict[str, str]] = {
     "fills": {
         "time": "executed_at",
     },
+    "tca": {
+        "execution_date": "executed_at",
+    },
 }
 
 
@@ -855,11 +858,19 @@ def _build_order_clause(
     """Build a safe ORDER BY clause from an AG Grid sort model.
 
     Only column names that appear in *allowed_columns* are accepted.
+    Items are sorted by their ``sortIndex`` (if present) so that
+    multi-column sort precedence matches the user's grid configuration.
     """
     if not sort_model:
         return default_order
+    # Sort by sortIndex to preserve multi-column sort precedence.
+    # Items without sortIndex are appended in their original order.
+    indexed = sorted(
+        sort_model,
+        key=lambda item: (item.get("sortIndex") is None, item.get("sortIndex", 0)),
+    )
     parts: list[str] = []
-    for item in sort_model:
+    for item in indexed:
         col = item.get("colId", "")
         direction = "DESC" if item.get("sort") == "desc" else "ASC"
         if col in allowed_columns:
@@ -1149,6 +1160,12 @@ def _fetch_audit_data(
     strategy-related audit entries prevents leaking sensitive system
     operations to users who may only be authorized for specific
     strategies.
+
+    Note: ``details->>'strategy_id'`` assumes strategy_id is stored as a
+    top-level key in the JSONB ``details`` column.  This matches the
+    current audit_log schema.  If the schema evolves to nest strategy_id
+    differently, update the WHERE clause below and the corresponding
+    GIN index on ``audit_log.details``.
     """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     select_cols = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
@@ -1386,6 +1403,11 @@ async def _generate_excel_content(
                         value_to_set = raw_value.astimezone(UTC).replace(tzinfo=None)
                     else:
                         value_to_set = raw_value
+                elif isinstance(raw_value, date):
+                    # PostgreSQL DATE columns are returned as datetime.date
+                    # objects by psycopg.  openpyxl handles date natively,
+                    # so pass through as-is (date has no timezone concept).
+                    value_to_set = raw_value
                 else:
                     value_to_set = raw_value
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -809,6 +809,29 @@ def _validate_columns(
     return [c for c in resolved if c in allowed] or allowed
 
 
+def _resolve_sort_aliases(
+    grid_name: str,
+    sort_model: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Resolve frontend column aliases in sort_model items.
+
+    The web console grids may emit display-friendly column IDs in the
+    sort model (e.g. ``"type"`` instead of ``"order_type"``).  This
+    translates each ``colId`` through ``_COLUMN_ALIASES`` so that the
+    downstream ``_build_order_clause`` can match them against the
+    server-side allowlist.
+    """
+    if not sort_model:
+        return sort_model
+    aliases = _COLUMN_ALIASES.get(grid_name, {})
+    if not aliases:
+        return sort_model
+    return [
+        {**item, "colId": aliases.get(item.get("colId", ""), item.get("colId", ""))}
+        for item in sort_model
+    ]
+
+
 def _build_order_clause(
     sort_model: list[dict[str, Any]] | None,
     allowed_columns: list[str],
@@ -829,6 +852,113 @@ def _build_order_clause(
     return ", ".join(parts) if parts else default_order
 
 
+def _build_filter_clause(
+    filter_params: dict[str, Any] | None,
+    allowed_columns: list[str],
+    *,
+    col_prefix: str = "",
+) -> tuple[str, list[Any]]:
+    """Build a parameterized WHERE fragment from AG Grid filter model.
+
+    Supports the common AG Grid filter types:
+    - ``text`` filters (contains, equals, startsWith, endsWith, notEqual)
+    - ``number`` filters (equals, greaterThan, lessThan, inRange, etc.)
+    - ``date`` filters (equals, greaterThan, lessThan, inRange)
+
+    Only columns present in *allowed_columns* are accepted; unknown
+    columns are silently dropped.  All values are passed as query
+    parameters (never interpolated) to prevent SQL injection.
+
+    Args:
+        filter_params: AG Grid filter model dict.
+        allowed_columns: Server-side column allowlist.
+        col_prefix: Optional table alias prefix (e.g. ``"p."``).
+            Applied to every column reference in the generated SQL.
+
+    Returns:
+        A tuple of (sql_fragment, param_list).  *sql_fragment* is a
+        string like ``"AND col1 ILIKE %s AND col2 >= %s"`` (empty
+        string when there are no applicable filters).  *param_list*
+        contains the corresponding bind values.
+    """
+    if not filter_params:
+        return "", []
+
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    for col, spec in filter_params.items():
+        if col not in allowed_columns:
+            continue
+        if not isinstance(spec, dict):
+            continue
+
+        qcol = f"{col_prefix}{col}"
+        filter_type = spec.get("filterType", "text")
+        ftype = spec.get("type", "")
+
+        if filter_type == "text":
+            value = spec.get("filter")
+            if value is None:
+                continue
+            value = str(value)
+            if ftype == "contains":
+                clauses.append(f"{qcol}::text ILIKE %s")
+                params.append(f"%{value}%")
+            elif ftype == "equals":
+                clauses.append(f"{qcol}::text = %s")
+                params.append(value)
+            elif ftype == "startsWith":
+                clauses.append(f"{qcol}::text ILIKE %s")
+                params.append(f"{value}%")
+            elif ftype == "endsWith":
+                clauses.append(f"{qcol}::text ILIKE %s")
+                params.append(f"%{value}")
+            elif ftype == "notEqual":
+                clauses.append(f"{qcol}::text != %s")
+                params.append(value)
+
+        elif filter_type == "number":
+            value = spec.get("filter")
+            if ftype == "equals" and value is not None:
+                clauses.append(f"{qcol} = %s")
+                params.append(value)
+            elif ftype == "greaterThan" and value is not None:
+                clauses.append(f"{qcol} > %s")
+                params.append(value)
+            elif ftype == "lessThan" and value is not None:
+                clauses.append(f"{qcol} < %s")
+                params.append(value)
+            elif ftype == "greaterThanOrEqual" and value is not None:
+                clauses.append(f"{qcol} >= %s")
+                params.append(value)
+            elif ftype == "lessThanOrEqual" and value is not None:
+                clauses.append(f"{qcol} <= %s")
+                params.append(value)
+            elif ftype == "inRange":
+                lo = spec.get("filter")
+                hi = spec.get("filterTo")
+                if lo is not None and hi is not None:
+                    clauses.append(f"{qcol} >= %s AND {qcol} <= %s")
+                    params.extend([lo, hi])
+
+        elif filter_type == "date":
+            date_from = spec.get("dateFrom")
+            date_to = spec.get("dateTo")
+            if ftype in ("equals", "greaterThan", "lessThan") and date_from is not None:
+                op = {"equals": "=", "greaterThan": ">", "lessThan": "<"}[ftype]
+                clauses.append(f"{qcol}::date {op} %s")
+                params.append(date_from)
+            elif ftype == "inRange" and date_from is not None and date_to is not None:
+                clauses.append(f"{qcol}::date >= %s AND {qcol}::date <= %s")
+                params.extend([date_from, date_to])
+
+    sql = " AND ".join(clauses)
+    if sql:
+        sql = f"AND {sql} "
+    return sql, params
+
+
 # ---------------------------------------------------------------------------
 # Per-grid data fetchers
 # ---------------------------------------------------------------------------
@@ -839,6 +969,8 @@ def _fetch_positions_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_clause: str = "",
+    filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch positions data scoped to authorized strategies.
 
@@ -854,7 +986,7 @@ def _fetch_positions_data(
     qualified_sort: list[dict[str, Any]] | None = None
     if sort_model:
         qualified_sort = [
-            {**item, "colId": f"p.{item['colId']}"} if item.get("colId") in columns else item
+            {**item, "colId": f"p.{item.get('colId')}"} if item.get("colId") in columns else item
             for item in sort_model
         ]
     qualified_columns = [f"p.{c}" for c in columns]
@@ -862,6 +994,10 @@ def _fetch_positions_data(
         qualified_sort, qualified_columns, "p.symbol ASC",
     )
     col_list = ", ".join(f"p.{c} AS {c}" for c in columns)
+    query_params: list[Any] = [strategy_ids]
+    if filter_params_list:
+        query_params.extend(filter_params_list)
+    query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -869,9 +1005,10 @@ def _fetch_positions_data(
                 f"SELECT {col_list} FROM positions p "
                 f"JOIN symbol_strategy ss ON p.symbol = ss.symbol "
                 f"WHERE p.qty != 0 AND ss.strategy = ANY(%s) "
+                f"{filter_clause}"
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                query_params,
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -882,18 +1019,25 @@ def _fetch_orders_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_clause: str = "",
+    filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch orders scoped to authorized strategies."""
     order_clause = _build_order_clause(sort_model, columns, "created_at DESC")
     col_list = ", ".join(columns)
+    query_params: list[Any] = [strategy_ids]
+    if filter_params_list:
+        query_params.extend(filter_params_list)
+    query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM orders "  # noqa: S608
                 f"WHERE strategy_id = ANY(%s) "
+                f"{filter_clause}"
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                query_params,
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -904,19 +1048,26 @@ def _fetch_fills_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_clause: str = "",
+    filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch fills (trades) scoped to authorized strategies."""
     order_clause = _build_order_clause(sort_model, columns, "executed_at DESC")
     col_list = ", ".join(f"t.{c}" for c in columns)
+    query_params: list[Any] = [strategy_ids]
+    if filter_params_list:
+        query_params.extend(filter_params_list)
+    query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM trades t "  # noqa: S608
                 f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
                 f"AND t.strategy_id = ANY(%s) "
+                f"{filter_clause}"
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                query_params,
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -927,6 +1078,8 @@ def _fetch_audit_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_clause: str = "",
+    filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch audit log entries scoped to authorized strategies.
 
@@ -940,14 +1093,19 @@ def _fetch_audit_data(
     """
     order_clause = _build_order_clause(sort_model, columns, "timestamp DESC, id DESC")
     col_list = ", ".join(columns)
+    query_params: list[Any] = [strategy_ids]
+    if filter_params_list:
+        query_params.extend(filter_params_list)
+    query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT {col_list} FROM audit_log "  # noqa: S608
                 f"WHERE details->>'strategy_id' = ANY(%s) "
+                f"{filter_clause}"
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                query_params,
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -958,6 +1116,8 @@ def _fetch_tca_data(
     strategy_ids: list[str],
     columns: list[str],
     sort_model: list[dict[str, Any]] | None,
+    filter_clause: str = "",
+    filter_params_list: list[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch TCA trade data with order context, scoped to authorized strategies."""
     # Map column names to their qualified table references
@@ -992,6 +1152,10 @@ def _fetch_tca_data(
     order_clause = _build_order_clause(
         qualified_sort, qualified_tca_columns, "t.executed_at DESC",
     )
+    query_params: list[Any] = [strategy_ids]
+    if filter_params_list:
+        query_params.extend(filter_params_list)
+    query_params.append(_EXPORT_ROW_LIMIT)
     with ctx.db.transaction() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -1000,9 +1164,10 @@ def _fetch_tca_data(
                 f"LEFT JOIN orders o ON t.client_order_id = o.client_order_id "
                 f"WHERE COALESCE(t.superseded, FALSE) = FALSE "
                 f"AND t.strategy_id = ANY(%s) "
+                f"{filter_clause}"
                 f"ORDER BY {order_clause} "
                 f"LIMIT %s",
-                (strategy_ids, _EXPORT_ROW_LIMIT),
+                query_params,
             )
             col_names = [desc[0] for desc in cur.description]
             return [dict(zip(col_names, row, strict=True)) for row in cur.fetchall()]
@@ -1059,22 +1224,40 @@ async def _generate_excel_content(
     # Validate requested columns against server allowlist
     columns = _validate_columns(grid_name, visible_columns)
 
-    # Log when filter_params are provided but not yet applied.
-    # AG Grid filter model support is not yet implemented; exports
-    # return strategy-scoped data without additional column filters.
+    # Resolve frontend aliases in sort_model before building ORDER BY
+    resolved_sort = _resolve_sort_aliases(grid_name, sort_model)
+
+    # Grids that use table aliases in their SQL queries need a prefix
+    # so that filter column references match the aliased table.
+    _GRID_FILTER_PREFIX: dict[str, str] = {
+        "positions": "p.",
+        "fills": "t.",
+        "tca": "t.",
+    }
+    col_prefix = _GRID_FILTER_PREFIX.get(grid_name, "")
+
+    # Also resolve aliases in filter_params keys before building the
+    # filter clause (e.g. "type" -> "order_type" for orders grid).
+    resolved_filter = filter_params
     if filter_params:
-        logger.warning(
-            "export_filter_params_not_applied",
-            extra={
-                "grid_name": grid_name,
-                "filter_keys": list(filter_params.keys()),
-            },
-        )
+        aliases = _COLUMN_ALIASES.get(grid_name, {})
+        if aliases:
+            resolved_filter = {
+                aliases.get(k, k): v for k, v in filter_params.items()
+            }
+
+    # Build filter WHERE clause from AG Grid filter model
+    filter_clause, filter_params_list = _build_filter_clause(
+        resolved_filter, columns, col_prefix=col_prefix,
+    )
 
     # Offload synchronous DB fetch to a worker thread to avoid blocking
     # the FastAPI event loop.
     fetcher = _GRID_FETCHERS[grid_name]
-    rows = await asyncio.to_thread(fetcher, ctx, strategy_ids, columns, sort_model)
+    rows = await asyncio.to_thread(
+        fetcher, ctx, strategy_ids, columns, resolved_sort,
+        filter_clause, filter_params_list,
+    )
 
     # Build workbook (CPU-bound; done in worker thread below)
     def _build_workbook() -> bytes:

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -23,6 +23,7 @@ import asyncio
 import io
 import json
 import logging
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any, Literal
 from uuid import UUID
@@ -963,6 +964,133 @@ def _escape_like(value: str) -> str:
     return value.replace(_LIKE_ESCAPE, _LIKE_ESCAPE * 2).replace("%", f"{_LIKE_ESCAPE}%").replace("_", f"{_LIKE_ESCAPE}_")
 
 
+def _build_text_condition(
+    col: str, qcol: str, spec: dict[str, Any],
+    clauses: list[str], params: list[Any],
+) -> None:
+    """Append SQL for an AG Grid text filter condition."""
+    value = spec.get("filter")
+    if value is None:
+        return
+    value = str(value)
+    text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+    esc = f" ESCAPE '{_LIKE_ESCAPE}'"
+    escaped = _escape_like(value)
+    # Map AG Grid text types to (SQL operator, param pattern).
+    # AG Grid text filtering is case-insensitive by default so we
+    # use ILIKE to match the grid's behaviour.
+    _TEXT_OPS: dict[str, tuple[str, str]] = {
+        "contains": ("ILIKE", f"%{escaped}%"),
+        "equals": ("ILIKE", escaped),
+        "startsWith": ("ILIKE", f"{escaped}%"),
+        "endsWith": ("ILIKE", f"%{escaped}"),
+        "notEqual": ("NOT ILIKE", escaped),
+    }
+    ftype = spec.get("type", "")
+    if ftype in _TEXT_OPS:
+        op, param = _TEXT_OPS[ftype]
+        clauses.append(f"{text_col} {op} %s{esc}")
+        params.append(param)
+
+
+def _build_number_condition(
+    _col: str, qcol: str, spec: dict[str, Any],
+    clauses: list[str], params: list[Any],
+) -> None:
+    """Append SQL for an AG Grid number filter condition."""
+    _NUM_OPS: dict[str, str] = {
+        "equals": "=",
+        "notEqual": "!=",
+        "greaterThan": ">",
+        "lessThan": "<",
+        "greaterThanOrEqual": ">=",
+        "lessThanOrEqual": "<=",
+    }
+    ftype = spec.get("type", "")
+    value = spec.get("filter")
+    if ftype in _NUM_OPS and value is not None:
+        clauses.append(f"{qcol} {_NUM_OPS[ftype]} %s")
+        params.append(value)
+    elif ftype == "inRange":
+        lo = spec.get("filter")
+        hi = spec.get("filterTo")
+        if lo is not None and hi is not None:
+            clauses.append(f"{qcol} >= %s AND {qcol} <= %s")
+            params.extend([lo, hi])
+
+
+def _build_date_condition(
+    _col: str, qcol: str, spec: dict[str, Any],
+    clauses: list[str], params: list[Any],
+) -> None:
+    """Append SQL for an AG Grid date filter condition.
+
+    Uses range comparisons on the raw timestamp column instead of
+    ``::date`` casts on the column, which would prevent B-tree index
+    usage.  AG Grid sends dates as ``'YYYY-MM-DD'`` strings; we cast
+    the *parameter* to ``::date`` to enable index scans.
+    """
+    ftype = spec.get("type", "")
+    date_from = spec.get("dateFrom")
+    date_to = spec.get("dateTo")
+    if ftype == "equals" and date_from is not None:
+        clauses.append(f"{qcol} >= %s::date AND {qcol} < %s::date + interval '1 day'")
+        params.extend([date_from, date_from])
+    elif ftype == "notEqual" and date_from is not None:
+        clauses.append(f"({qcol} < %s::date OR {qcol} >= %s::date + interval '1 day')")
+        params.extend([date_from, date_from])
+    elif ftype == "greaterThan" and date_from is not None:
+        clauses.append(f"{qcol} >= %s::date + interval '1 day'")
+        params.append(date_from)
+    elif ftype == "lessThan" and date_from is not None:
+        clauses.append(f"{qcol} < %s::date")
+        params.append(date_from)
+    elif ftype == "greaterThanOrEqual" and date_from is not None:
+        clauses.append(f"{qcol} >= %s::date")
+        params.append(date_from)
+    elif ftype == "lessThanOrEqual" and date_from is not None:
+        clauses.append(f"{qcol} < %s::date + interval '1 day'")
+        params.append(date_from)
+    elif ftype == "inRange" and date_from is not None and date_to is not None:
+        clauses.append(f"{qcol} >= %s::date AND {qcol} < %s::date + interval '1 day'")
+        params.extend([date_from, date_to])
+    elif ftype == "blank":
+        clauses.append(f"{qcol} IS NULL")
+    elif ftype == "notBlank":
+        clauses.append(f"{qcol} IS NOT NULL")
+
+
+def _build_set_condition(
+    col: str, qcol: str, spec: dict[str, Any],
+    clauses: list[str], params: list[Any],
+) -> None:
+    """Append SQL for an AG Grid set filter condition."""
+    values = spec.get("values")
+    if isinstance(values, list):
+        if values:
+            text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+            clauses.append(f"{text_col} = ANY(%s)")
+            params.append(values)
+        else:
+            # Empty values list: no rows should match.
+            clauses.append("FALSE")
+
+
+# Dispatch table mapping AG Grid filterType to handler.
+_FILTER_TYPE_BUILDERS: dict[
+    str,
+    Callable[
+        [str, str, dict[str, Any], list[str], list[Any]],
+        None,
+    ],
+] = {
+    "text": _build_text_condition,
+    "number": _build_number_condition,
+    "date": _build_date_condition,
+    "set": _build_set_condition,
+}
+
+
 def _build_single_condition(
     col: str,
     qcol: str,
@@ -972,120 +1100,18 @@ def _build_single_condition(
 ) -> None:
     """Append SQL for a single AG Grid filter condition.
 
-    This handles one atomic condition (``type`` + ``filter``).  Compound
-    filters (``operator`` + ``conditions``) are decomposed by
+    Dispatches to per-type handlers (``_build_text_condition``, etc.).
+    Compound filters (``operator`` + ``conditions``) are decomposed by
     ``_build_filter_clause`` before calling this helper.
 
     **Safety:** ``qcol`` is produced by ``_quote_identifier()`` which
     delegates to ``psycopg.sql.Identifier(...).as_string(None)`` --
     all identifiers are properly double-quoted before interpolation.
-    The resulting clause strings are assembled with parameterized
-    ``%s`` placeholders and the final query is built via
-    ``psycopg.sql.SQL`` composition.
     """
     filter_type = spec.get("filterType", "text")
-    ftype = spec.get("type", "")
-
-    if filter_type == "text":
-        value = spec.get("filter")
-        if value is None:
-            return
-        value = str(value)
-        # JSONB columns need an explicit ::text cast for text
-        # operators; for text/varchar columns the cast is omitted
-        # to allow B-tree index usage.
-        text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
-        _ESC_SUFFIX = f" ESCAPE '{_LIKE_ESCAPE}'"
-        if ftype == "contains":
-            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
-            params.append(f"%{_escape_like(value)}%")
-        elif ftype == "equals":
-            # AG Grid text filtering is case-insensitive by default,
-            # so use ILIKE to match the grid's behaviour.
-            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
-            params.append(_escape_like(value))
-        elif ftype == "startsWith":
-            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
-            params.append(f"{_escape_like(value)}%")
-        elif ftype == "endsWith":
-            clauses.append(f"{text_col} ILIKE %s{_ESC_SUFFIX}")
-            params.append(f"%{_escape_like(value)}")
-        elif ftype == "notEqual":
-            # Case-insensitive to match AG Grid behaviour.
-            clauses.append(f"{text_col} NOT ILIKE %s{_ESC_SUFFIX}")
-            params.append(_escape_like(value))
-
-    elif filter_type == "number":
-        _NUM_OPS: dict[str, str] = {
-            "equals": "=",
-            "notEqual": "!=",
-            "greaterThan": ">",
-            "lessThan": "<",
-            "greaterThanOrEqual": ">=",
-            "lessThanOrEqual": "<=",
-        }
-        value = spec.get("filter")
-        if ftype in _NUM_OPS and value is not None:
-            clauses.append(f"{qcol} {_NUM_OPS[ftype]} %s")
-            params.append(value)
-        elif ftype == "inRange":
-            lo = spec.get("filter")
-            hi = spec.get("filterTo")
-            if lo is not None and hi is not None:
-                clauses.append(f"{qcol} >= %s AND {qcol} <= %s")
-                params.extend([lo, hi])
-
-    elif filter_type == "date":
-        date_from = spec.get("dateFrom")
-        date_to = spec.get("dateTo")
-        # Use range comparisons on the raw timestamp column instead of
-        # ::date casts, which prevent B-tree index usage on large tables.
-        # AG Grid sends dates as 'YYYY-MM-DD' strings; we compare them
-        # as timestamps to enable index scans.
-        if ftype == "equals" and date_from is not None:
-            # "equals day" means >= start of day AND < next day
-            clauses.append(f"{qcol} >= %s::date AND {qcol} < %s::date + interval '1 day'")
-            params.extend([date_from, date_from])
-        elif ftype == "notEqual" and date_from is not None:
-            # "not equals day" means outside the given day
-            clauses.append(f"({qcol} < %s::date OR {qcol} >= %s::date + interval '1 day')")
-            params.extend([date_from, date_from])
-        elif ftype == "greaterThan" and date_from is not None:
-            # After the end of the given day
-            clauses.append(f"{qcol} >= %s::date + interval '1 day'")
-            params.append(date_from)
-        elif ftype == "lessThan" and date_from is not None:
-            clauses.append(f"{qcol} < %s::date")
-            params.append(date_from)
-        elif ftype == "greaterThanOrEqual" and date_from is not None:
-            clauses.append(f"{qcol} >= %s::date")
-            params.append(date_from)
-        elif ftype == "lessThanOrEqual" and date_from is not None:
-            # Include all of the given day
-            clauses.append(f"{qcol} < %s::date + interval '1 day'")
-            params.append(date_from)
-        elif ftype == "inRange" and date_from is not None and date_to is not None:
-            clauses.append(f"{qcol} >= %s::date AND {qcol} < %s::date + interval '1 day'")
-            params.extend([date_from, date_to])
-        elif ftype == "blank":
-            clauses.append(f"{qcol} IS NULL")
-        elif ftype == "notBlank":
-            clauses.append(f"{qcol} IS NOT NULL")
-
-    elif filter_type == "set":
-        values = spec.get("values")
-        if isinstance(values, list):
-            if values:
-                # Use ANY(%s) with a list parameter for set membership
-                text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
-                clauses.append(f"{text_col} = ANY(%s)")
-                params.append(values)
-            else:
-                # Empty values list: no rows should match.
-                # This occurs when page-level and grid set filters have
-                # no common values (empty intersection).  Emit a
-                # false-constant predicate to produce zero results.
-                clauses.append("FALSE")
+    builder = _FILTER_TYPE_BUILDERS.get(filter_type)
+    if builder is not None:
+        builder(col, qcol, spec, clauses, params)
 
 
 def _build_filter_clause(

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -851,6 +851,18 @@ def _resolve_sort_aliases(
     ]
 
 
+def _quote_identifier(name: str) -> str:
+    """Quote a possibly table-qualified identifier via psycopg.sql.
+
+    ``psycopg.sql.Identifier`` accepts multiple string parts for qualified
+    names (e.g. ``Identifier("p", "symbol")`` produces ``"p"."symbol"``).
+    This helper splits on ``.`` and delegates to ``Identifier`` so that
+    both simple and qualified names are safely quoted.
+    """
+    parts = name.split(".")
+    return sql.Identifier(*parts).as_string(None)
+
+
 def _build_order_clause(
     sort_model: list[dict[str, Any]] | None,
     allowed_columns: list[str],
@@ -862,15 +874,9 @@ def _build_order_clause(
     Items are sorted by their ``sortIndex`` (if present) so that
     multi-column sort precedence matches the user's grid configuration.
 
-    **Safety:** ``allowed_columns`` may contain table-qualified
-    references (e.g. ``"p.symbol"``, ``"t.executed_at"``) which
-    ``psycopg.sql.Identifier`` would incorrectly quote as a single
-    identifier (``"p.symbol"`` instead of ``"p"."symbol"``).  Because
-    every value in ``allowed_columns`` originates from the hardcoded
-    ``_GRID_COLUMNS`` allowlist or ``_TCA_COL_MAP`` -- never from user
-    input -- f-string interpolation is safe here.  The callers then
-    wrap the returned string in ``sql.SQL()`` for composition with
-    parameterized queries.
+    All identifiers are quoted via ``psycopg.sql.Identifier`` to prevent
+    any possibility of SQL injection, even though ``allowed_columns``
+    originates from hardcoded allowlists.
     """
     if not sort_model:
         return default_order
@@ -885,7 +891,7 @@ def _build_order_clause(
         col = item.get("colId", "")
         direction = "DESC" if item.get("sort") == "desc" else "ASC"
         if col in allowed_columns:
-            parts.append(f"{col} {direction}")
+            parts.append(f"{_quote_identifier(col)} {direction}")
     return ", ".join(parts) if parts else default_order
 
 
@@ -975,10 +981,10 @@ def _build_single_condition(
             clauses.append(f"{qcol} >= %s::date + interval '1 day'")
             params.append(date_from)
         elif ftype == "lessThan" and date_from is not None:
-            clauses.append(f"{qcol} < %s")
+            clauses.append(f"{qcol} < %s::date")
             params.append(date_from)
         elif ftype == "greaterThanOrEqual" and date_from is not None:
-            clauses.append(f"{qcol} >= %s")
+            clauses.append(f"{qcol} >= %s::date")
             params.append(date_from)
         elif ftype == "lessThanOrEqual" and date_from is not None:
             # Include all of the given day
@@ -1050,11 +1056,12 @@ def _build_filter_clause(
             continue
 
         # Use per-column mapping when available, otherwise fall back
-        # to the blanket prefix.
+        # to the blanket prefix.  All identifiers are quoted via
+        # _quote_identifier to prevent any injection possibility.
         if col_prefix_map and col in col_prefix_map:
-            qcol = col_prefix_map[col]
+            qcol = _quote_identifier(col_prefix_map[col])
         else:
-            qcol = f"{col_prefix}{col}"
+            qcol = _quote_identifier(f"{col_prefix}{col}")
 
         # AG Grid compound filter: ``operator`` + ``conditions`` list.
         # Example: {"operator": "AND", "conditions": [{...}, {...}]}

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -877,7 +877,7 @@ def _qualify_sort_model(
         if col_id in allowed_columns:
             qualified.append({**item, "colId": f"{prefix}{col_id}"})
         else:
-            qualified.append(item)
+            qualified.append(item.copy())
     return qualified
 
 

--- a/apps/execution_gateway/routes/export.py
+++ b/apps/execution_gateway/routes/export.py
@@ -1062,11 +1062,18 @@ def _build_single_condition(
 
     elif filter_type == "set":
         values = spec.get("values")
-        if isinstance(values, list) and values:
-            # Use ANY(%s) with a list parameter for set membership
-            text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
-            clauses.append(f"{text_col} = ANY(%s)")
-            params.append(values)
+        if isinstance(values, list):
+            if values:
+                # Use ANY(%s) with a list parameter for set membership
+                text_col = f"{qcol}::text" if col in _JSONB_COLUMNS else qcol
+                clauses.append(f"{text_col} = ANY(%s)")
+                params.append(values)
+            else:
+                # Empty values list: no rows should match.
+                # This occurs when page-level and grid set filters have
+                # no common values (empty intersection).  Emit a
+                # false-constant predicate to produce zero results.
+                clauses.append("FALSE")
 
 
 def _build_filter_clause(

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -171,17 +171,39 @@ class GridExportToolbar:
         try:
             import httpx
 
-            # Merge extra_filters into the AG Grid filter model so that
-            # tab-scoped predicates are included in the export query.
-            # Page-level scope constraints (extra_filters) are used as
-            # defaults; grid-level filters override on matching keys to
-            # preserve the user's narrower selections (e.g. user filters
-            # to only "accepted" within the working-status set).  This is
-            # safe because the page-level pre-filtering removes rows
-            # before setRowData, so in-grid filters for the same column
-            # are necessarily subsets of the page-level scope.
-            filter_model = dict(self.extra_filters)
-            filter_model.update(grid_state.get("filterModel") or {})
+            # Merge extra_filters into the AG Grid filter model.
+            # For non-overlapping keys, both are simply included.
+            # For overlapping keys, intersect set-filter values (so the
+            # user's narrower selection within the page scope is honoured)
+            # and let extra_filters win for other filter types (page-level
+            # scope constraints like the symbol dropdown cannot be widened
+            # by a conflicting in-grid filter).
+            grid_filters = grid_state.get("filterModel") or {}
+            filter_model = dict(grid_filters)
+            for key, extra_spec in self.extra_filters.items():
+                grid_spec = grid_filters.get(key)
+                if grid_spec is None:
+                    # No overlap -- add the extra filter.
+                    filter_model[key] = extra_spec
+                elif (
+                    isinstance(extra_spec, dict)
+                    and isinstance(grid_spec, dict)
+                    and extra_spec.get("filterType") == "set"
+                    and grid_spec.get("filterType") == "set"
+                ):
+                    # Both are set filters on the same column -- intersect
+                    # values so the user's selection is honoured within
+                    # the page scope.
+                    extra_vals = set(extra_spec.get("values") or [])
+                    grid_vals = set(grid_spec.get("values") or [])
+                    intersected = sorted(extra_vals & grid_vals)
+                    filter_model[key] = {
+                        "filterType": "set",
+                        "values": intersected if intersected else sorted(extra_vals),
+                    }
+                else:
+                    # Non-set overlap -- page-level scope wins.
+                    filter_model[key] = extra_spec
 
             headers = self._get_auth_headers()
             async with httpx.AsyncClient() as client:

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -173,8 +173,11 @@ class GridExportToolbar:
 
             # Merge extra_filters into the AG Grid filter model so that
             # tab-scoped predicates are included in the export query.
-            filter_model = dict(grid_state.get("filterModel") or {})
-            filter_model.update(self.extra_filters)
+            # User-specified filters take precedence over extra_filters
+            # to preserve narrower selections (e.g. user filters to only
+            # "accepted" within the working-status set).
+            filter_model = dict(self.extra_filters)
+            filter_model.update(grid_state.get("filterModel") or {})
 
             headers = self._get_auth_headers()
             async with httpx.AsyncClient() as client:

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -50,6 +50,7 @@ class GridExportToolbar:
         on_export_start: Callable[[str], None] | None = None,
         on_export_complete: Callable[[str, int], None] | None = None,
         api_base_url: str = "/api/v1",
+        extra_filters: dict[str, Any] | None = None,
     ) -> None:
         """Initialize export toolbar.
 
@@ -62,6 +63,10 @@ class GridExportToolbar:
             on_export_start: Callback when export starts
             on_export_complete: Callback when export completes (type, row_count)
             api_base_url: Base URL for export API endpoints
+            extra_filters: Additional AG Grid filter entries to inject into
+                the filter model before creating the audit record.  Use this
+                for tab-scoped predicates that the UI applies outside the AG
+                Grid filter model (e.g. working-order status filter).
         """
         self.grid_id = grid_id
         self.grid_name = grid_name
@@ -71,6 +76,7 @@ class GridExportToolbar:
         self.on_export_start = on_export_start
         self.on_export_complete = on_export_complete
         self.api_base_url = api_base_url
+        self.extra_filters = extra_filters or {}
 
         self._csv_button: ui.button | None = None
         self._excel_button: ui.button | None = None
@@ -156,10 +162,19 @@ class GridExportToolbar:
     ) -> str | None:
         """Create export audit record via API.
 
+        Merges ``self.extra_filters`` into the AG Grid filter model so
+        that tab-scoped predicates (e.g. working-order status) are
+        included in the server-side export query.
+
         Returns audit_id or None if failed.
         """
         try:
             import httpx
+
+            # Merge extra_filters into the AG Grid filter model so that
+            # tab-scoped predicates are included in the export query.
+            filter_model = dict(grid_state.get("filterModel") or {})
+            filter_model.update(self.extra_filters)
 
             headers = self._get_auth_headers()
             async with httpx.AsyncClient() as client:
@@ -169,7 +184,7 @@ class GridExportToolbar:
                     json={
                         "export_type": export_type,
                         "grid_name": self.grid_name,
-                        "filter_params": grid_state.get("filterModel"),
+                        "filter_params": filter_model,
                         "visible_columns": grid_state.get("columns"),
                         "sort_model": grid_state.get("sortModel"),
                         "export_scope": "visible",

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -205,11 +205,21 @@ class GridExportToolbar:
                 else:
                     # Non-set overlap -- combine as an AND compound
                     # filter so both constraints must be satisfied.
-                    # This ensures the export cannot widen beyond
-                    # what the page scope and grid filter allow.
+                    # Flatten any already-compound conditions to avoid
+                    # nesting that the server-side parser must recurse.
+                    conditions: list[dict[str, Any]] = []
+                    for s in (extra_spec, grid_spec):
+                        if (
+                            isinstance(s, dict)
+                            and isinstance(s.get("conditions"), list)
+                            and s.get("operator", "").upper() == "AND"
+                        ):
+                            conditions.extend(s["conditions"])
+                        else:
+                            conditions.append(s)
                     filter_model[key] = {
                         "operator": "AND",
-                        "conditions": [extra_spec, grid_spec],
+                        "conditions": conditions,
                     }
 
             headers = self._get_auth_headers()

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -193,13 +193,14 @@ class GridExportToolbar:
                 ):
                     # Both are set filters on the same column -- intersect
                     # values so the user's selection is honoured within
-                    # the page scope.
+                    # the page scope.  An empty intersection is kept
+                    # (produces zero results) to preserve view/export
+                    # parity rather than silently widening the export.
                     extra_vals = set(extra_spec.get("values") or [])
                     grid_vals = set(grid_spec.get("values") or [])
-                    intersected = sorted(extra_vals & grid_vals)
                     filter_model[key] = {
                         "filterType": "set",
-                        "values": intersected if intersected else sorted(extra_vals),
+                        "values": sorted(extra_vals & grid_vals),
                     }
                 else:
                     # Non-set overlap -- page-level scope wins.

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -173,9 +173,13 @@ class GridExportToolbar:
 
             # Merge extra_filters into the AG Grid filter model so that
             # tab-scoped predicates are included in the export query.
-            # User-specified filters take precedence over extra_filters
-            # to preserve narrower selections (e.g. user filters to only
-            # "accepted" within the working-status set).
+            # Page-level scope constraints (extra_filters) are used as
+            # defaults; grid-level filters override on matching keys to
+            # preserve the user's narrower selections (e.g. user filters
+            # to only "accepted" within the working-status set).  This is
+            # safe because the page-level pre-filtering removes rows
+            # before setRowData, so in-grid filters for the same column
+            # are necessarily subsets of the page-level scope.
             filter_model = dict(self.extra_filters)
             filter_model.update(grid_state.get("filterModel") or {})
 

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -34,6 +34,57 @@ EXPORT_STRICT_AUDIT_MODE = os.getenv("EXPORT_STRICT_AUDIT_MODE", "false").lower(
 # See libs/platform/security/sanitization.py for the canonical implementation.
 
 
+def merge_filter_models(
+    grid_filters: dict[str, Any],
+    extra_filters: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge extra (tab/page-scoped) filters into an AG Grid filter model.
+
+    For non-overlapping keys both filters are simply included.  For
+    overlapping keys:
+    - **set** filters: values are intersected so the user's narrower
+      selection within the page scope is honoured.  An empty intersection
+      is kept (produces zero results) to preserve view/export parity.
+    - **other** filters: combined into an AND compound filter.  Any
+      already-compound AND conditions are flattened to avoid nesting.
+
+    Returns a new dict — neither input is mutated.
+    """
+    merged = dict(grid_filters)
+    for key, extra_spec in extra_filters.items():
+        grid_spec = grid_filters.get(key)
+        if grid_spec is None:
+            merged[key] = extra_spec
+        elif (
+            isinstance(extra_spec, dict)
+            and isinstance(grid_spec, dict)
+            and extra_spec.get("filterType") == "set"
+            and grid_spec.get("filterType") == "set"
+        ):
+            extra_vals = set(extra_spec.get("values") or [])
+            grid_vals = set(grid_spec.get("values") or [])
+            merged[key] = {
+                "filterType": "set",
+                "values": sorted(extra_vals & grid_vals),
+            }
+        else:
+            conditions: list[dict[str, Any]] = []
+            for s in (extra_spec, grid_spec):
+                if (
+                    isinstance(s, dict)
+                    and isinstance(s.get("conditions"), list)
+                    and s.get("operator", "").upper() == "AND"
+                ):
+                    conditions.extend(s["conditions"])
+                else:
+                    conditions.append(s)
+            merged[key] = {
+                "operator": "AND",
+                "conditions": conditions,
+            }
+    return merged
+
+
 class GridExportToolbar:
     """Export toolbar component for AG Grids.
 
@@ -171,56 +222,8 @@ class GridExportToolbar:
         try:
             import httpx
 
-            # Merge extra_filters into the AG Grid filter model.
-            # For non-overlapping keys, both are simply included.
-            # For overlapping keys, intersect set-filter values (so the
-            # user's narrower selection within the page scope is honoured)
-            # and let extra_filters win for other filter types (page-level
-            # scope constraints like the symbol dropdown cannot be widened
-            # by a conflicting in-grid filter).
             grid_filters = grid_state.get("filterModel") or {}
-            filter_model = dict(grid_filters)
-            for key, extra_spec in self.extra_filters.items():
-                grid_spec = grid_filters.get(key)
-                if grid_spec is None:
-                    # No overlap -- add the extra filter.
-                    filter_model[key] = extra_spec
-                elif (
-                    isinstance(extra_spec, dict)
-                    and isinstance(grid_spec, dict)
-                    and extra_spec.get("filterType") == "set"
-                    and grid_spec.get("filterType") == "set"
-                ):
-                    # Both are set filters on the same column -- intersect
-                    # values so the user's selection is honoured within
-                    # the page scope.  An empty intersection is kept
-                    # (produces zero results) to preserve view/export
-                    # parity rather than silently widening the export.
-                    extra_vals = set(extra_spec.get("values") or [])
-                    grid_vals = set(grid_spec.get("values") or [])
-                    filter_model[key] = {
-                        "filterType": "set",
-                        "values": sorted(extra_vals & grid_vals),
-                    }
-                else:
-                    # Non-set overlap -- combine as an AND compound
-                    # filter so both constraints must be satisfied.
-                    # Flatten any already-compound conditions to avoid
-                    # nesting that the server-side parser must recurse.
-                    conditions: list[dict[str, Any]] = []
-                    for s in (extra_spec, grid_spec):
-                        if (
-                            isinstance(s, dict)
-                            and isinstance(s.get("conditions"), list)
-                            and s.get("operator", "").upper() == "AND"
-                        ):
-                            conditions.extend(s["conditions"])
-                        else:
-                            conditions.append(s)
-                    filter_model[key] = {
-                        "operator": "AND",
-                        "conditions": conditions,
-                    }
+            filter_model = merge_filter_models(grid_filters, self.extra_filters)
 
             headers = self._get_auth_headers()
             async with httpx.AsyncClient() as client:
@@ -473,6 +476,7 @@ class GridExportToolbar:
 
 __all__ = [
     "GridExportToolbar",
+    "merge_filter_models",
     "sanitize_for_export",
     "EXPORT_STRICT_AUDIT_MODE",
 ]

--- a/apps/web_console_ng/components/grid_export_toolbar.py
+++ b/apps/web_console_ng/components/grid_export_toolbar.py
@@ -203,8 +203,14 @@ class GridExportToolbar:
                         "values": sorted(extra_vals & grid_vals),
                     }
                 else:
-                    # Non-set overlap -- page-level scope wins.
-                    filter_model[key] = extra_spec
+                    # Non-set overlap -- combine as an AND compound
+                    # filter so both constraints must be satisfied.
+                    # This ensures the export cannot widen beyond
+                    # what the page scope and grid filter allow.
+                    filter_model[key] = {
+                        "operator": "AND",
+                        "conditions": [extra_spec, grid_spec],
+                    }
 
             headers = self._get_auth_headers()
             async with httpx.AsyncClient() as client:

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -286,14 +286,26 @@ def create_tabbed_panel(
 
             # Create export toolbars (one per tab, show/hide based on active)
             if enable_export:
+                # Working tab needs extra_filters to restrict export to
+                # working-order statuses, which the UI applies before
+                # setRowData (outside the AG Grid filter model).
+                _working_status_filter: dict[str, Any] = {
+                    "status": {
+                        "filterType": "set",
+                        "values": sorted(WORKING_ORDER_STATUSES),
+                    },
+                }
+
                 for tab_name in (TAB_POSITIONS, TAB_WORKING, TAB_FILLS, TAB_HISTORY):
                     config = TAB_GRID_CONFIG.get(tab_name, {})
+                    extra = _working_status_filter if tab_name == TAB_WORKING else None
                     with ui.element("div").classes("") as toolbar_container:
                         toolbar = GridExportToolbar(
                             grid_id=config.get("grid_id", ""),
                             grid_name=config.get("grid_name", tab_name),
                             filename_prefix=config.get("prefix", tab_name),
                             api_base_url=api_base_url,
+                            extra_filters=extra,
                         )
                         toolbar.create()
                     # Only show toolbar for active tab

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -25,6 +25,7 @@ from apps.web_console_ng.ui.trading_layout import (
     apply_compact_grid_classes,
     apply_compact_grid_options,
 )
+from libs.trading.order_constants import WORKING_ORDER_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -48,15 +49,6 @@ TAB_GRID_CONFIG = {
     TAB_WORKING: {"grid_id": "_ordersGridApi", "grid_name": "orders", "prefix": "orders"},
     TAB_FILLS: {"grid_id": "_fillsGridApi", "grid_name": "fills", "prefix": "fills"},
     TAB_HISTORY: {"grid_id": "_historyGridApi", "grid_name": "history", "prefix": "history"},
-}
-
-WORKING_ORDER_STATUSES = {
-    "new",
-    "pending_new",
-    "partially_filled",
-    "accepted",
-    "pending_cancel",
-    "pending_replace",
 }
 
 

--- a/apps/web_console_ng/components/tabbed_panel.py
+++ b/apps/web_console_ng/components/tabbed_panel.py
@@ -212,6 +212,24 @@ class TabbedPanel:
             self._on_tab_change(new_tab)
         asyncio.create_task(self._safe_save_state())
 
+    def update_symbol_filter(self, symbol: str | None) -> None:
+        """Propagate the page-level symbol filter to all export toolbars.
+
+        The dashboard symbol dropdown is applied before ``setRowData``
+        (outside the AG Grid filter model), so the export toolbar must
+        inject the corresponding ``symbol`` filter into ``extra_filters``
+        to maintain export/view parity.
+        """
+        for toolbar in self._export_toolbars.values():
+            if symbol:
+                toolbar.extra_filters["symbol"] = {
+                    "filterType": "text",
+                    "type": "equals",
+                    "filter": symbol,
+                }
+            else:
+                toolbar.extra_filters.pop("symbol", None)
+
     def _update_toolbar_visibility(self, old_tab: str, new_tab: str) -> None:
         """Show/hide export toolbars based on active tab."""
         # Hide old toolbar
@@ -261,8 +279,14 @@ def create_tabbed_panel(
     """
     state.active_tab = state.normalize_tab(state.active_tab)
 
+    # Store panel ref so filter callback can propagate symbol to toolbars.
+    # Assigned after panel creation below.
+    panel_ref: list[TabbedPanel | None] = [None]
+
     def _on_filter_change(value: str | None) -> None:
         state.symbol_filter = value
+        if panel_ref[0] is not None:
+            panel_ref[0].update_symbol_filter(value)
         if on_filter_change is not None:
             on_filter_change(value)
 
@@ -344,7 +368,13 @@ def create_tabbed_panel(
         toolbar_containers=toolbar_containers,
     )
 
+    panel_ref[0] = panel
+
     tabs.on_value_change(lambda event: panel._handle_tab_change(getattr(event, "value", None)))
+
+    # Propagate any initial symbol filter to export toolbars
+    if state.symbol_filter:
+        panel.update_symbol_filter(state.symbol_filter)
 
     # Lazily create the initial tab content
     panel.ensure_tab(state.active_tab)

--- a/apps/web_console_ng/pages/journal.py
+++ b/apps/web_console_ng/pages/journal.py
@@ -668,7 +668,7 @@ async def _export_excel(
     filters: dict[str, Any],
 ) -> tuple[bytes, int]:
     """Export trades to Excel using streaming write mode."""
-    from openpyxl import Workbook  # type: ignore[import-untyped]
+    from openpyxl import Workbook
 
     wb = Workbook(write_only=True)
     ws = wb.create_sheet("Trades")

--- a/docs/ARCHITECTURE/system_map.config.json
+++ b/docs/ARCHITECTURE/system_map.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./system_map.schema.json",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Configuration for architecture visualization generation",
 
   "layers": [

--- a/docs/GETTING_STARTED/REPO_MAP.md
+++ b/docs/GETTING_STARTED/REPO_MAP.md
@@ -1,6 +1,6 @@
 # Repository Map
 
-**Last Updated:** 2026-04-06
+**Last Updated:** 2026-04-16
 
 This document provides a comprehensive map of the trading platform repository structure, explaining the purpose of each directory and key files.
 

--- a/libs/trading/order_constants.py
+++ b/libs/trading/order_constants.py
@@ -1,0 +1,23 @@
+"""Shared order-related constants.
+
+These constants are used across multiple services (execution gateway,
+web console) and must remain in sync.  Centralising them here prevents
+duplication and ensures consistent behaviour.
+"""
+
+from __future__ import annotations
+
+# Order statuses considered "working" (active / in-flight).
+# Orders in these statuses are shown on the "Working Orders" tab
+# in the web console and should be the only statuses included
+# when exporting from that tab.
+WORKING_ORDER_STATUSES: frozenset[str] = frozenset({
+    "new",
+    "pending_new",
+    "partially_filled",
+    "accepted",
+    "pending_cancel",
+    "pending_replace",
+})
+
+__all__ = ["WORKING_ORDER_STATUSES"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,10 @@ module = "nest_asyncio"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "openpyxl.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
 disallow_incomplete_defs = false

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -128,6 +128,7 @@ class TestBuildFilterClause:
         filt = {"symbol": {"filterType": "text", "type": "contains", "filter": "AAPL"}}
         sql, params = _build_filter_clause(filt, ["symbol"])
         assert "ILIKE" in sql
+        assert "ESCAPE" in sql
         assert "%AAPL%" in params
 
     def test_text_equals_filter(self) -> None:
@@ -135,8 +136,16 @@ class TestBuildFilterClause:
         sql, params = _build_filter_clause(filt, ["status"])
         # AG Grid text filtering is case-insensitive by default,
         # so equals uses ILIKE to match grid behaviour.
-        assert "ILIKE %s" in sql
+        assert "ILIKE" in sql
+        assert "ESCAPE" in sql
         assert "filled" in params
+
+    def test_text_equals_escapes_like_wildcards(self) -> None:
+        """LIKE metacharacters (% and _) are escaped for literal matching."""
+        filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "ops_team"}}
+        sql, params = _build_filter_clause(filt, ["symbol"])
+        # The _ should be escaped so it matches literally
+        assert r"ops\_team" in params
 
     def test_number_greater_than_filter(self) -> None:
         filt = {"qty": {"filterType": "number", "type": "greaterThan", "filter": 10}}
@@ -623,8 +632,9 @@ class TestGenerateExcelContent:
         # psycopg.sql.Composed objects are passed to execute(); convert
         # to string representation for assertion.
         executed_sql = str(cursor.execute.call_args[0][0])
-        # Text equals uses ILIKE for case-insensitive matching
+        # Text equals uses ILIKE for case-insensitive matching with ESCAPE
         assert '"symbol" ILIKE %s' in executed_sql
+        assert "ESCAPE" in executed_sql
         # The bind parameters should include the filter value
         executed_params = cursor.execute.call_args[0][1]
         assert "AAPL" in executed_params

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -280,11 +280,16 @@ class TestBuildFilterClause:
         assert '"status" = ANY(%s)' in result_sql
         assert params == [["new", "pending_new", "partially_filled"]]
 
-    def test_set_filter_empty_values_ignored(self) -> None:
-        """Set filter with empty values list is silently skipped."""
+    def test_set_filter_empty_values_produces_false(self) -> None:
+        """Set filter with empty values list produces a no-match predicate.
+
+        This ensures that empty set intersections (e.g. from page-level
+        and grid filters with no common values) correctly produce zero
+        results instead of silently dropping the filter.
+        """
         filt = {"status": {"filterType": "set", "values": []}}
         result_sql, params = _build_filter_clause(filt, ["status"])
-        assert result_sql == ""
+        assert "FALSE" in result_sql
         assert params == []
 
     def test_set_filter_respects_allowlist(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -283,6 +283,54 @@ class TestBuildFilterClause:
         assert result_sql == ""
         assert params == []
 
+    def test_compound_filter_and_operator(self) -> None:
+        """AG Grid compound filter with AND operator."""
+        filt = {
+            "qty": {
+                "operator": "AND",
+                "conditions": [
+                    {"filterType": "number", "type": "greaterThan", "filter": 5},
+                    {"filterType": "number", "type": "lessThan", "filter": 100},
+                ],
+            }
+        }
+        result_sql, params = _build_filter_clause(filt, ["qty"])
+        assert ">" in result_sql
+        assert "<" in result_sql
+        assert "AND" in result_sql
+        assert 5 in params
+        assert 100 in params
+
+    def test_compound_filter_or_operator(self) -> None:
+        """AG Grid compound filter with OR operator."""
+        filt = {
+            "symbol": {
+                "operator": "OR",
+                "conditions": [
+                    {"filterType": "text", "type": "equals", "filter": "AAPL"},
+                    {"filterType": "text", "type": "equals", "filter": "MSFT"},
+                ],
+            }
+        }
+        result_sql, params = _build_filter_clause(filt, ["symbol"])
+        assert "OR" in result_sql
+        assert "AAPL" in params
+        assert "MSFT" in params
+
+    def test_compound_filter_unknown_column_dropped(self) -> None:
+        """Compound filter on unknown column is dropped."""
+        filt = {
+            "evil": {
+                "operator": "AND",
+                "conditions": [
+                    {"filterType": "text", "type": "equals", "filter": "x"},
+                ],
+            }
+        }
+        result_sql, params = _build_filter_clause(filt, ["symbol"])
+        assert result_sql == ""
+        assert params == []
+
 
 class TestBuildOrderClause:
     def test_default_order_when_no_sort_model(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -159,9 +159,10 @@ class TestBuildFilterClause:
                 "dateTo": "2026-02-01",
             }
         }
-        sql, params = _build_filter_clause(filt, ["created_at"])
-        assert "::date >= %s" in sql
-        assert "::date <= %s" in sql
+        result_sql, params = _build_filter_clause(filt, ["created_at"])
+        # Range uses >= start and < end+1day for index-friendly comparisons
+        assert ">= %s" in result_sql
+        assert "interval '1 day'" in result_sql
         assert "2026-01-01" in params
         assert "2026-02-01" in params
 
@@ -200,8 +201,8 @@ class TestBuildFilterClause:
                 "dateFrom": "2026-03-01",
             }
         }
-        sql, params = _build_filter_clause(filt, ["created_at"])
-        assert "::date >= %s" in sql
+        result_sql, params = _build_filter_clause(filt, ["created_at"])
+        assert ">= %s" in result_sql
         assert "2026-03-01" in params
 
     def test_date_less_than_or_equal_filter(self) -> None:
@@ -212,8 +213,9 @@ class TestBuildFilterClause:
                 "dateFrom": "2026-06-01",
             }
         }
-        sql, params = _build_filter_clause(filt, ["created_at"])
-        assert "::date <= %s" in sql
+        result_sql, params = _build_filter_clause(filt, ["created_at"])
+        # lessThanOrEqual uses < date + 1 day to include the full day
+        assert "interval '1 day'" in result_sql
         assert "2026-06-01" in params
 
     def test_col_prefix_map_overrides_col_prefix(self) -> None:
@@ -524,7 +526,7 @@ class TestGenerateExcelContent:
         # psycopg.sql.Composed objects are passed to execute(); convert
         # to string representation for assertion.
         executed_sql = str(cursor.execute.call_args[0][0])
-        assert "symbol::text = %s" in executed_sql
+        assert "symbol = %s" in executed_sql
         # The bind parameters should include the filter value
         executed_params = cursor.execute.call_args[0][1]
         assert "AAPL" in executed_params

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -166,6 +166,30 @@ class TestBuildFilterClause:
         assert sql == ""
         assert params == []
 
+    def test_date_greater_than_or_equal_filter(self) -> None:
+        filt = {
+            "created_at": {
+                "filterType": "date",
+                "type": "greaterThanOrEqual",
+                "dateFrom": "2026-03-01",
+            }
+        }
+        sql, params = _build_filter_clause(filt, ["created_at"])
+        assert "::date >= %s" in sql
+        assert "2026-03-01" in params
+
+    def test_date_less_than_or_equal_filter(self) -> None:
+        filt = {
+            "created_at": {
+                "filterType": "date",
+                "type": "lessThanOrEqual",
+                "dateFrom": "2026-06-01",
+            }
+        }
+        sql, params = _build_filter_clause(filt, ["created_at"])
+        assert "::date <= %s" in sql
+        assert "2026-06-01" in params
+
 
 class TestBuildOrderClause:
     def test_default_order_when_no_sort_model(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -1,0 +1,231 @@
+"""Tests for Excel export in apps/execution_gateway/routes/export.py.
+
+Verifies that _generate_excel_content returns real grid data (not placeholders)
+and that all cell values are sanitised against formula injection.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from apps.execution_gateway.app_factory import create_mock_context, create_test_config
+from apps.execution_gateway.dependencies import get_config, get_context
+from apps.execution_gateway.routes import export as export_module
+from apps.execution_gateway.routes.export import (
+    _GRID_COLUMNS,
+    _build_order_clause,
+    _validate_columns,
+)
+from libs.core.common.api_auth_dependency import AuthContext
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestValidateColumns:
+    def test_returns_allowlist_when_no_visible_columns(self) -> None:
+        result = _validate_columns("positions", None)
+        assert result == _GRID_COLUMNS["positions"]
+
+    def test_filters_unknown_columns(self) -> None:
+        result = _validate_columns("positions", ["symbol", "EVIL_COL", "qty"])
+        assert result == ["symbol", "qty"]
+
+    def test_preserves_requested_order(self) -> None:
+        result = _validate_columns("orders", ["status", "symbol", "side"])
+        assert result == ["status", "symbol", "side"]
+
+    def test_falls_back_to_default_when_all_invalid(self) -> None:
+        result = _validate_columns("fills", ["bad1", "bad2"])
+        assert result == _GRID_COLUMNS["fills"]
+
+
+class TestBuildOrderClause:
+    def test_default_order_when_no_sort_model(self) -> None:
+        assert _build_order_clause(None, ["symbol"], "symbol ASC") == "symbol ASC"
+
+    def test_valid_sort_model(self) -> None:
+        model = [{"colId": "symbol", "sort": "desc"}]
+        result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
+        assert result == "symbol DESC"
+
+    def test_ignores_unknown_columns(self) -> None:
+        model = [{"colId": "DROP TABLE", "sort": "asc"}]
+        result = _build_order_clause(model, ["symbol"], "symbol ASC")
+        assert result == "symbol ASC"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for _generate_excel_content
+# ---------------------------------------------------------------------------
+
+
+def _make_cursor_mock(rows: list[tuple[Any, ...]], col_names: list[str]) -> MagicMock:
+    """Create a mock cursor that returns the given rows."""
+    cursor = MagicMock()
+    cursor.description = [(name,) for name in col_names]
+    cursor.fetchall.return_value = rows
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    return cursor
+
+
+def _make_conn_mock(cursor: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+def _make_ctx_with_rows(
+    rows: list[tuple[Any, ...]], col_names: list[str]
+) -> MagicMock:
+    cursor = _make_cursor_mock(rows, col_names)
+    conn = _make_conn_mock(cursor)
+    ctx = create_mock_context()
+    ctx.db.transaction.return_value = conn
+    return ctx
+
+
+@pytest.mark.asyncio
+class TestGenerateExcelContent:
+    async def test_positions_returns_real_data(self) -> None:
+        rows = [
+            ("AAPL", Decimal("10"), Decimal("150.25"), Decimal("152.00"), Decimal("17.50"), Decimal("0"), datetime(2026, 1, 1, tzinfo=UTC)),
+            ("MSFT", Decimal("5"), Decimal("400.00"), Decimal("405.00"), Decimal("25.00"), Decimal("10"), datetime(2026, 1, 2, tzinfo=UTC)),
+        ]
+        col_names = ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        assert row_count == 2
+        assert isinstance(content, bytes)
+        assert len(content) > 0
+
+        # Verify it's a valid Excel file by reading it
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        assert ws.title == "Positions"
+        # Header row
+        assert ws.cell(1, 1).value == "symbol"
+        # Data — NOT placeholder text
+        assert ws.cell(2, 1).value == "AAPL"
+        assert ws.cell(3, 1).value == "MSFT"
+        assert "placeholder" not in str(ws.cell(2, 1).value).lower()
+        assert "pending" not in str(ws.cell(2, 1).value).lower()
+
+    async def test_orders_returns_real_data(self) -> None:
+        rows = [
+            ("ord-1", "alpha", "AAPL", "buy", 10, "market", None, None, "day", "filled", Decimal("10"), Decimal("150"), datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 1, 0, 1, tzinfo=UTC)),
+        ]
+        col_names = ["client_order_id", "strategy_id", "symbol", "side", "qty", "order_type", "limit_price", "stop_price", "time_in_force", "status", "filled_qty", "filled_avg_price", "created_at", "filled_at"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="orders",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=["symbol", "side", "qty", "status"],
+            sort_model=None,
+        )
+
+        assert row_count == 1
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # Only requested (valid) columns appear
+        assert ws.cell(1, 1).value == "symbol"
+        assert ws.cell(1, 2).value == "side"
+
+    async def test_unsupported_grid_raises(self) -> None:
+        ctx = create_mock_context()
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            await export_module._generate_excel_content(
+                ctx=ctx,
+                grid_name="unknown_grid",
+                strategy_ids=["alpha"],
+                filter_params=None,
+                visible_columns=None,
+                sort_model=None,
+            )
+
+    async def test_empty_result_returns_zero_row_count(self) -> None:
+        ctx = _make_ctx_with_rows([], ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"])
+
+        content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        assert row_count == 0
+
+    async def test_formula_injection_sanitised(self) -> None:
+        """Values starting with = are prefixed with ' to prevent formula injection."""
+        rows = [("=IMPORTDATA(url)", Decimal("1"), Decimal("1"), Decimal("1"), Decimal("0"), Decimal("0"), datetime(2026, 1, 1, tzinfo=UTC))]
+        col_names = ["symbol", "qty", "avg_entry_price", "current_price", "unrealized_pl", "realized_pl", "updated_at"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, _ = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # The dangerous formula should be prefixed with '
+        assert ws.cell(2, 1).value == "'=IMPORTDATA(url)"
+
+    async def test_audit_row_count_matches_data(self) -> None:
+        """Verify row_count reflects actual exported rows, not a placeholder."""
+        rows = [
+            (1, datetime(2026, 1, 1, tzinfo=UTC), "admin", "login", "{}", None),
+            (2, datetime(2026, 1, 2, tzinfo=UTC), "admin", "export", "{}", "test"),
+            (3, datetime(2026, 1, 3, tzinfo=UTC), "admin", "logout", "{}", None),
+        ]
+        col_names = ["id", "timestamp", "user_id", "action", "details", "reason"]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        _, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="audit",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        assert row_count == 3

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -56,6 +56,23 @@ class TestValidateColumns:
         result = _validate_columns("orders", ["symbol", "type", "status"])
         assert result == ["symbol", "order_type", "status"]
 
+    def test_tca_falls_back_when_mostly_computed_columns(self) -> None:
+        """TCA grid sends computed columns (fill_rate_pct, is_bps etc.) alongside
+        a few raw ones.  When fewer than half survive validation, fall back to
+        the full allowlist so TCA exports are not misleadingly incomplete."""
+        # Simulate what the TCA grid sends: mostly computed + a couple raw
+        result = _validate_columns(
+            "tca",
+            ["execution_date", "fill_rate_pct", "is_bps", "symbol", "side"],
+        )
+        # Only symbol and side are valid (2/5 < half), so full fallback
+        assert result == _GRID_COLUMNS["tca"]
+
+    def test_no_fallback_when_majority_valid(self) -> None:
+        """When the majority of requested columns are valid, keep the subset."""
+        result = _validate_columns("orders", ["symbol", "side", "qty", "bad_col"])
+        assert result == ["symbol", "side", "qty"]
+
 
 class TestResolveSortAliases:
     def test_returns_none_when_no_sort_model(self) -> None:
@@ -189,6 +206,31 @@ class TestBuildFilterClause:
         sql, params = _build_filter_clause(filt, ["created_at"])
         assert "::date <= %s" in sql
         assert "2026-06-01" in params
+
+    def test_col_prefix_map_overrides_col_prefix(self) -> None:
+        """Per-column mapping takes precedence over blanket col_prefix."""
+        filt = {
+            "order_qty": {"filterType": "number", "type": "greaterThan", "filter": 5},
+            "symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"},
+        }
+        prefix_map = {"order_qty": "o.qty", "symbol": "t.symbol"}
+        result_sql, params = _build_filter_clause(
+            filt, ["order_qty", "symbol"], col_prefix="t.", col_prefix_map=prefix_map,
+        )
+        assert "o.qty" in result_sql
+        assert "t.symbol" in result_sql
+        assert 5 in params
+        assert "AAPL" in params
+
+    def test_col_prefix_map_fallback_to_prefix(self) -> None:
+        """Columns not in col_prefix_map fall back to col_prefix."""
+        filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
+        prefix_map = {"order_qty": "o.qty"}  # symbol not mapped
+        result_sql, params = _build_filter_clause(
+            filt, ["symbol"], col_prefix="t.", col_prefix_map=prefix_map,
+        )
+        assert "t.symbol" in result_sql
+        assert "AAPL" in params
 
 
 class TestBuildOrderClause:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -257,6 +257,32 @@ class TestBuildFilterClause:
         assert "symbol ILIKE %s" in result_sql
         assert "::text" not in result_sql
 
+    def test_set_filter(self) -> None:
+        """Set filter generates IN-clause with ANY(%s)."""
+        filt = {
+            "status": {
+                "filterType": "set",
+                "values": ["new", "pending_new", "partially_filled"],
+            }
+        }
+        result_sql, params = _build_filter_clause(filt, ["status"])
+        assert "status = ANY(%s)" in result_sql
+        assert params == [["new", "pending_new", "partially_filled"]]
+
+    def test_set_filter_empty_values_ignored(self) -> None:
+        """Set filter with empty values list is silently skipped."""
+        filt = {"status": {"filterType": "set", "values": []}}
+        result_sql, params = _build_filter_clause(filt, ["status"])
+        assert result_sql == ""
+        assert params == []
+
+    def test_set_filter_respects_allowlist(self) -> None:
+        """Set filter on a column not in allowlist is dropped."""
+        filt = {"status": {"filterType": "set", "values": ["new"]}}
+        result_sql, params = _build_filter_clause(filt, ["symbol"])
+        assert result_sql == ""
+        assert params == []
+
 
 class TestBuildOrderClause:
     def test_default_order_when_no_sort_model(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -7,7 +7,7 @@ and that all cell values are sanitised against formula injection.
 from __future__ import annotations
 
 import io
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
@@ -60,13 +60,22 @@ class TestValidateColumns:
         """TCA grid sends computed columns (fill_rate_pct, is_bps etc.) alongside
         a few raw ones.  When fewer than half survive validation, fall back to
         the full allowlist so TCA exports are not misleadingly incomplete."""
-        # Simulate what the TCA grid sends: mostly computed + a couple raw
+        # Simulate TCA grid sending mostly computed columns (no aliases)
         result = _validate_columns(
             "tca",
-            ["execution_date", "fill_rate_pct", "is_bps", "symbol", "side"],
+            ["fill_rate_pct", "is_bps", "slippage_bps", "vwap_deviation", "symbol"],
         )
-        # Only symbol and side are valid (2/5 < half), so full fallback
+        # Only symbol is valid (1/5 < half), so full fallback
         assert result == _GRID_COLUMNS["tca"]
+
+    def test_tca_execution_date_alias_resolved(self) -> None:
+        """Frontend alias 'execution_date' is resolved to 'executed_at' for TCA."""
+        result = _validate_columns(
+            "tca",
+            ["execution_date", "symbol", "side", "qty", "price"],
+        )
+        # All 5 resolve to valid columns (execution_date -> executed_at)
+        assert result == ["executed_at", "symbol", "side", "qty", "price"]
 
     def test_no_fallback_when_majority_valid(self) -> None:
         """When the majority of requested columns are valid, keep the subset."""
@@ -246,6 +255,24 @@ class TestBuildOrderClause:
         model = [{"colId": "DROP TABLE", "sort": "asc"}]
         result = _build_order_clause(model, ["symbol"], "symbol ASC")
         assert result == "symbol ASC"
+
+    def test_sort_index_determines_precedence(self) -> None:
+        """Multi-column sorts should respect sortIndex for precedence."""
+        model = [
+            {"colId": "qty", "sort": "asc", "sortIndex": 1},
+            {"colId": "symbol", "sort": "desc", "sortIndex": 0},
+        ]
+        result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
+        assert result == "symbol DESC, qty ASC"
+
+    def test_sort_index_missing_appended_at_end(self) -> None:
+        """Items without sortIndex are appended after indexed items."""
+        model = [
+            {"colId": "qty", "sort": "asc"},
+            {"colId": "symbol", "sort": "desc", "sortIndex": 0},
+        ]
+        result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
+        assert result == "symbol DESC, qty ASC"
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +462,44 @@ class TestGenerateExcelContent:
             f"updated_at should be datetime, got str: {updated_val!r}"
         )
 
+    async def test_date_objects_preserved_in_excel(self) -> None:
+        """PostgreSQL DATE columns (datetime.date) should be stored natively."""
+        rows = [
+            (
+                "AAPL",
+                Decimal("10"),
+                Decimal("150.25"),
+                Decimal("152.00"),
+                Decimal("17.50"),
+                Decimal("0"),
+                date(2026, 1, 1),
+            ),
+        ]
+        col_names = [
+            "symbol", "qty", "avg_entry_price", "current_price",
+            "unrealized_pl", "realized_pl", "updated_at",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, _ = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # date object should be preserved as a date, not stringified
+        updated_val = ws.cell(2, 7).value
+        assert not isinstance(updated_val, str), (
+            f"updated_at should be date, got str: {updated_val!r}"
+        )
+
     async def test_filter_params_applied_to_query(self) -> None:
         """Verify that filter_params produce SQL WHERE clauses in the query."""
         rows = [
@@ -455,8 +520,10 @@ class TestGenerateExcelContent:
             sort_model=None,
         )
 
-        # The SQL executed should contain the filter clause
-        executed_sql = cursor.execute.call_args[0][0]
+        # The SQL executed should contain the filter clause.
+        # psycopg.sql.Composed objects are passed to execute(); convert
+        # to string representation for assertion.
+        executed_sql = str(cursor.execute.call_args[0][0])
         assert "symbol::text = %s" in executed_sql
         # The bind parameters should include the filter value
         executed_params = cursor.execute.call_args[0][1]
@@ -483,7 +550,7 @@ class TestGenerateExcelContent:
         )
 
         # "type" should be resolved to "order_type" in the ORDER BY
-        executed_sql = cursor.execute.call_args[0][0]
+        executed_sql = str(cursor.execute.call_args[0][0])
         assert "order_type DESC" in executed_sql
 
     async def test_audit_row_count_matches_data(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -175,7 +175,7 @@ class TestBuildFilterClause:
     def test_col_prefix_applied(self) -> None:
         filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
         sql, params = _build_filter_clause(filt, ["symbol"], col_prefix="p.")
-        assert "p.symbol" in sql
+        assert '"p"."symbol"' in sql
         assert "AAPL" in params
 
     def test_multiple_filters(self) -> None:
@@ -228,8 +228,8 @@ class TestBuildFilterClause:
         result_sql, params = _build_filter_clause(
             filt, ["order_qty", "symbol"], col_prefix="t.", col_prefix_map=prefix_map,
         )
-        assert "o.qty" in result_sql
-        assert "t.symbol" in result_sql
+        assert '"o"."qty"' in result_sql
+        assert '"t"."symbol"' in result_sql
         assert 5 in params
         assert "AAPL" in params
 
@@ -240,21 +240,21 @@ class TestBuildFilterClause:
         result_sql, params = _build_filter_clause(
             filt, ["symbol"], col_prefix="t.", col_prefix_map=prefix_map,
         )
-        assert "t.symbol" in result_sql
+        assert '"t"."symbol"' in result_sql
         assert "AAPL" in params
 
     def test_jsonb_column_gets_text_cast(self) -> None:
         """JSONB columns like 'details' need ::text for text operators."""
         filt = {"details": {"filterType": "text", "type": "contains", "filter": "login"}}
         result_sql, params = _build_filter_clause(filt, ["details"])
-        assert "details::text ILIKE %s" in result_sql
+        assert '"details"::text ILIKE %s' in result_sql
         assert "%login%" in params
 
     def test_non_jsonb_column_no_text_cast(self) -> None:
         """Regular text columns should not get ::text cast."""
         filt = {"symbol": {"filterType": "text", "type": "contains", "filter": "AAPL"}}
         result_sql, params = _build_filter_clause(filt, ["symbol"])
-        assert "symbol ILIKE %s" in result_sql
+        assert '"symbol" ILIKE %s' in result_sql
         assert "::text" not in result_sql
 
     def test_set_filter(self) -> None:
@@ -266,7 +266,7 @@ class TestBuildFilterClause:
             }
         }
         result_sql, params = _build_filter_clause(filt, ["status"])
-        assert "status = ANY(%s)" in result_sql
+        assert '"status" = ANY(%s)' in result_sql
         assert params == [["new", "pending_new", "partially_filled"]]
 
     def test_set_filter_empty_values_ignored(self) -> None:
@@ -339,7 +339,7 @@ class TestBuildOrderClause:
     def test_valid_sort_model(self) -> None:
         model = [{"colId": "symbol", "sort": "desc"}]
         result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
-        assert result == "symbol DESC"
+        assert result == '"symbol" DESC'
 
     def test_ignores_unknown_columns(self) -> None:
         model = [{"colId": "DROP TABLE", "sort": "asc"}]
@@ -353,7 +353,7 @@ class TestBuildOrderClause:
             {"colId": "symbol", "sort": "desc", "sortIndex": 0},
         ]
         result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
-        assert result == "symbol DESC, qty ASC"
+        assert result == '"symbol" DESC, "qty" ASC'
 
     def test_sort_index_missing_appended_at_end(self) -> None:
         """Items without sortIndex are appended after indexed items."""
@@ -362,7 +362,7 @@ class TestBuildOrderClause:
             {"colId": "symbol", "sort": "desc", "sortIndex": 0},
         ]
         result = _build_order_clause(model, ["symbol", "qty"], "symbol ASC")
-        assert result == "symbol DESC, qty ASC"
+        assert result == '"symbol" DESC, "qty" ASC'
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +614,7 @@ class TestGenerateExcelContent:
         # psycopg.sql.Composed objects are passed to execute(); convert
         # to string representation for assertion.
         executed_sql = str(cursor.execute.call_args[0][0])
-        assert "symbol = %s" in executed_sql
+        assert '"symbol" = %s' in executed_sql
         # The bind parameters should include the filter value
         executed_params = cursor.execute.call_args[0][1]
         assert "AAPL" in executed_params
@@ -641,7 +641,7 @@ class TestGenerateExcelContent:
 
         # "type" should be resolved to "order_type" in the ORDER BY
         executed_sql = str(cursor.execute.call_args[0][0])
-        assert "order_type DESC" in executed_sql
+        assert '"order_type" DESC' in executed_sql
 
     async def test_audit_row_count_matches_data(self) -> None:
         """Verify row_count reflects actual exported rows, not a placeholder."""

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -18,7 +18,9 @@ from apps.execution_gateway.app_factory import create_mock_context
 from apps.execution_gateway.routes import export as export_module
 from apps.execution_gateway.routes.export import (
     _GRID_COLUMNS,
+    _build_filter_clause,
     _build_order_clause,
+    _resolve_sort_aliases,
     _validate_columns,
 )
 
@@ -53,6 +55,116 @@ class TestValidateColumns:
         """Frontend alias "type" is resolved to "order_type" for orders."""
         result = _validate_columns("orders", ["symbol", "type", "status"])
         assert result == ["symbol", "order_type", "status"]
+
+
+class TestResolveSortAliases:
+    def test_returns_none_when_no_sort_model(self) -> None:
+        assert _resolve_sort_aliases("orders", None) is None
+
+    def test_resolves_orders_type_alias(self) -> None:
+        model = [{"colId": "type", "sort": "asc"}]
+        result = _resolve_sort_aliases("orders", model)
+        assert result is not None
+        assert result[0]["colId"] == "order_type"
+
+    def test_resolves_fills_time_alias(self) -> None:
+        model = [{"colId": "time", "sort": "desc"}]
+        result = _resolve_sort_aliases("fills", model)
+        assert result is not None
+        assert result[0]["colId"] == "executed_at"
+
+    def test_no_change_for_grids_without_aliases(self) -> None:
+        model = [{"colId": "symbol", "sort": "asc"}]
+        result = _resolve_sort_aliases("positions", model)
+        assert result is model  # Same object returned (no aliases to resolve)
+
+    def test_preserves_sort_direction(self) -> None:
+        model = [{"colId": "type", "sort": "desc"}]
+        result = _resolve_sort_aliases("orders", model)
+        assert result is not None
+        assert result[0]["sort"] == "desc"
+
+    def test_unknown_aliases_pass_through(self) -> None:
+        model = [{"colId": "symbol", "sort": "asc"}, {"colId": "type", "sort": "desc"}]
+        result = _resolve_sort_aliases("orders", model)
+        assert result is not None
+        assert result[0]["colId"] == "symbol"
+        assert result[1]["colId"] == "order_type"
+
+
+class TestBuildFilterClause:
+    def test_returns_empty_when_no_filter(self) -> None:
+        sql, params = _build_filter_clause(None, ["symbol"])
+        assert sql == ""
+        assert params == []
+
+    def test_text_contains_filter(self) -> None:
+        filt = {"symbol": {"filterType": "text", "type": "contains", "filter": "AAPL"}}
+        sql, params = _build_filter_clause(filt, ["symbol"])
+        assert "ILIKE" in sql
+        assert "%AAPL%" in params
+
+    def test_text_equals_filter(self) -> None:
+        filt = {"status": {"filterType": "text", "type": "equals", "filter": "filled"}}
+        sql, params = _build_filter_clause(filt, ["status"])
+        assert "= %s" in sql
+        assert "filled" in params
+
+    def test_number_greater_than_filter(self) -> None:
+        filt = {"qty": {"filterType": "number", "type": "greaterThan", "filter": 10}}
+        sql, params = _build_filter_clause(filt, ["qty"])
+        assert "> %s" in sql
+        assert 10 in params
+
+    def test_number_in_range_filter(self) -> None:
+        filt = {"qty": {"filterType": "number", "type": "inRange", "filter": 5, "filterTo": 20}}
+        sql, params = _build_filter_clause(filt, ["qty"])
+        assert ">= %s" in sql
+        assert "<= %s" in sql
+        assert 5 in params
+        assert 20 in params
+
+    def test_date_in_range_filter(self) -> None:
+        filt = {
+            "created_at": {
+                "filterType": "date",
+                "type": "inRange",
+                "dateFrom": "2026-01-01",
+                "dateTo": "2026-02-01",
+            }
+        }
+        sql, params = _build_filter_clause(filt, ["created_at"])
+        assert "::date >= %s" in sql
+        assert "::date <= %s" in sql
+        assert "2026-01-01" in params
+        assert "2026-02-01" in params
+
+    def test_ignores_unknown_columns(self) -> None:
+        filt = {"evil_col": {"filterType": "text", "type": "contains", "filter": "x"}}
+        sql, params = _build_filter_clause(filt, ["symbol"])
+        assert sql == ""
+        assert params == []
+
+    def test_col_prefix_applied(self) -> None:
+        filt = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
+        sql, params = _build_filter_clause(filt, ["symbol"], col_prefix="p.")
+        assert "p.symbol" in sql
+        assert "AAPL" in params
+
+    def test_multiple_filters(self) -> None:
+        filt = {
+            "symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"},
+            "qty": {"filterType": "number", "type": "greaterThan", "filter": 5},
+        }
+        sql, params = _build_filter_clause(filt, ["symbol", "qty"])
+        assert "AND" in sql
+        assert len(params) == 2
+
+    def test_non_dict_spec_skipped(self) -> None:
+        filt = {"symbol": "not-a-dict"}
+        sql, params = _build_filter_clause(filt, ["symbol"])
+        assert sql == ""
+        assert params == []
 
 
 class TestBuildOrderClause:
@@ -256,6 +368,57 @@ class TestGenerateExcelContent:
         assert not isinstance(updated_val, str), (
             f"updated_at should be datetime, got str: {updated_val!r}"
         )
+
+    async def test_filter_params_applied_to_query(self) -> None:
+        """Verify that filter_params produce SQL WHERE clauses in the query."""
+        rows = [
+            ("ord-1", "alpha", "AAPL", "buy", 10, "market", None, None, "day", "filled", Decimal("10"), Decimal("150"), datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 1, 0, 1, tzinfo=UTC)),
+        ]
+        col_names = ["client_order_id", "strategy_id", "symbol", "side", "qty", "order_type", "limit_price", "stop_price", "time_in_force", "status", "filled_qty", "filled_avg_price", "created_at", "filled_at"]
+        cursor = _make_cursor_mock(rows, col_names)
+        conn = _make_conn_mock(cursor)
+        ctx = create_mock_context()
+        ctx.db.transaction.return_value = conn
+
+        _content, row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="orders",
+            strategy_ids=["alpha"],
+            filter_params={"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}},
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        # The SQL executed should contain the filter clause
+        executed_sql = cursor.execute.call_args[0][0]
+        assert "symbol::text = %s" in executed_sql
+        # The bind parameters should include the filter value
+        executed_params = cursor.execute.call_args[0][1]
+        assert "AAPL" in executed_params
+
+    async def test_sort_aliases_resolved_before_order_by(self) -> None:
+        """Verify that frontend aliases in sort_model are resolved before ORDER BY."""
+        rows = [
+            ("ord-1", "alpha", "AAPL", "buy", 10, "market", None, None, "day", "filled", Decimal("10"), Decimal("150"), datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 1, 0, 1, tzinfo=UTC)),
+        ]
+        col_names = ["client_order_id", "strategy_id", "symbol", "side", "qty", "order_type", "limit_price", "stop_price", "time_in_force", "status", "filled_qty", "filled_avg_price", "created_at", "filled_at"]
+        cursor = _make_cursor_mock(rows, col_names)
+        conn = _make_conn_mock(cursor)
+        ctx = create_mock_context()
+        ctx.db.transaction.return_value = conn
+
+        _content, _row_count = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="orders",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=[{"colId": "type", "sort": "desc"}],
+        )
+
+        # "type" should be resolved to "order_type" in the ORDER BY
+        executed_sql = cursor.execute.call_args[0][0]
+        assert "order_type DESC" in executed_sql
 
     async def test_audit_row_count_matches_data(self) -> None:
         """Verify row_count reflects actual exported rows, not a placeholder."""

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -44,6 +44,16 @@ class TestValidateColumns:
         result = _validate_columns("fills", ["bad1", "bad2"])
         assert result == _GRID_COLUMNS["fills"]
 
+    def test_resolves_frontend_column_aliases(self) -> None:
+        """Frontend alias "time" is resolved to "executed_at" for fills."""
+        result = _validate_columns("fills", ["time", "symbol", "qty"])
+        assert result == ["executed_at", "symbol", "qty"]
+
+    def test_resolves_orders_type_alias(self) -> None:
+        """Frontend alias "type" is resolved to "order_type" for orders."""
+        result = _validate_columns("orders", ["symbol", "type", "status"])
+        assert result == ["symbol", "order_type", "status"]
+
 
 class TestBuildOrderClause:
     def test_default_order_when_no_sort_model(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -243,6 +243,20 @@ class TestBuildFilterClause:
         assert "t.symbol" in result_sql
         assert "AAPL" in params
 
+    def test_jsonb_column_gets_text_cast(self) -> None:
+        """JSONB columns like 'details' need ::text for text operators."""
+        filt = {"details": {"filterType": "text", "type": "contains", "filter": "login"}}
+        result_sql, params = _build_filter_clause(filt, ["details"])
+        assert "details::text ILIKE %s" in result_sql
+        assert "%login%" in params
+
+    def test_non_jsonb_column_no_text_cast(self) -> None:
+        """Regular text columns should not get ::text cast."""
+        filt = {"symbol": {"filterType": "text", "type": "contains", "filter": "AAPL"}}
+        result_sql, params = _build_filter_clause(filt, ["symbol"])
+        assert "symbol ILIKE %s" in result_sql
+        assert "::text" not in result_sql
+
 
 class TestBuildOrderClause:
     def test_default_order_when_no_sort_model(self) -> None:

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -7,26 +7,20 @@ and that all cell values are sanitised against formula injection.
 from __future__ import annotations
 
 import io
-import json
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI, Request
-from fastapi.testclient import TestClient
 
-from apps.execution_gateway.app_factory import create_mock_context, create_test_config
-from apps.execution_gateway.dependencies import get_config, get_context
+from apps.execution_gateway.app_factory import create_mock_context
 from apps.execution_gateway.routes import export as export_module
 from apps.execution_gateway.routes.export import (
     _GRID_COLUMNS,
     _build_order_clause,
     _validate_columns,
 )
-from libs.core.common.api_auth_dependency import AuthContext
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for helper functions
@@ -99,7 +93,7 @@ def _make_ctx_with_rows(
     return ctx
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestGenerateExcelContent:
     async def test_positions_returns_real_data(self) -> None:
         rows = [
@@ -208,6 +202,50 @@ class TestGenerateExcelContent:
         ws = wb.active
         # The dangerous formula should be prefixed with '
         assert ws.cell(2, 1).value == "'=IMPORTDATA(url)"
+
+    async def test_numeric_types_preserved_in_excel(self) -> None:
+        """Numeric and datetime values are stored as native types, not strings."""
+        rows = [
+            (
+                "AAPL",
+                Decimal("10"),
+                Decimal("150.25"),
+                Decimal("152.00"),
+                Decimal("17.50"),
+                Decimal("0"),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ]
+        col_names = [
+            "symbol", "qty", "avg_entry_price", "current_price",
+            "unrealized_pl", "realized_pl", "updated_at",
+        ]
+        ctx = _make_ctx_with_rows(rows, col_names)
+
+        content, _ = await export_module._generate_excel_content(
+            ctx=ctx,
+            grid_name="positions",
+            strategy_ids=["alpha"],
+            filter_params=None,
+            visible_columns=None,
+            sort_model=None,
+        )
+
+        from openpyxl import load_workbook
+
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # String column stays string
+        assert ws.cell(2, 1).value == "AAPL"
+        # Numeric columns must NOT be stringified — openpyxl stores Decimal
+        # as a number, so the cell value should be numeric (not a string).
+        qty_val = ws.cell(2, 2).value
+        assert not isinstance(qty_val, str), f"qty should be numeric, got str: {qty_val!r}"
+        # datetime should be preserved as a datetime
+        updated_val = ws.cell(2, 7).value
+        assert not isinstance(updated_val, str), (
+            f"updated_at should be datetime, got str: {updated_val!r}"
+        )
 
     async def test_audit_row_count_matches_data(self) -> None:
         """Verify row_count reflects actual exported rows, not a placeholder."""

--- a/tests/apps/execution_gateway/routes/test_export.py
+++ b/tests/apps/execution_gateway/routes/test_export.py
@@ -133,7 +133,9 @@ class TestBuildFilterClause:
     def test_text_equals_filter(self) -> None:
         filt = {"status": {"filterType": "text", "type": "equals", "filter": "filled"}}
         sql, params = _build_filter_clause(filt, ["status"])
-        assert "= %s" in sql
+        # AG Grid text filtering is case-insensitive by default,
+        # so equals uses ILIKE to match grid behaviour.
+        assert "ILIKE %s" in sql
         assert "filled" in params
 
     def test_number_greater_than_filter(self) -> None:
@@ -371,10 +373,17 @@ class TestBuildOrderClause:
 
 
 def _make_cursor_mock(rows: list[tuple[Any, ...]], col_names: list[str]) -> MagicMock:
-    """Create a mock cursor that returns the given rows."""
+    """Create a mock cursor that returns the given rows as dicts.
+
+    The production code uses ``psycopg.rows.dict_row`` row factory, so
+    ``fetchall()`` returns a list of dicts keyed by column name.  This
+    helper converts the provided tuples into dicts for compatibility.
+    """
     cursor = MagicMock()
     cursor.description = [(name,) for name in col_names]
-    cursor.fetchall.return_value = rows
+    cursor.fetchall.return_value = [
+        dict(zip(col_names, row, strict=True)) for row in rows
+    ]
     cursor.__enter__ = MagicMock(return_value=cursor)
     cursor.__exit__ = MagicMock(return_value=False)
     return cursor
@@ -614,7 +623,8 @@ class TestGenerateExcelContent:
         # psycopg.sql.Composed objects are passed to execute(); convert
         # to string representation for assertion.
         executed_sql = str(cursor.execute.call_args[0][0])
-        assert '"symbol" = %s' in executed_sql
+        # Text equals uses ILIKE for case-insensitive matching
+        assert '"symbol" ILIKE %s' in executed_sql
         # The bind parameters should include the filter value
         executed_params = cursor.execute.call_args[0][1]
         assert "AAPL" in executed_params

--- a/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
+++ b/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
@@ -282,7 +282,10 @@ class TestFilterMerge:
                     "values": sorted(extra_vals & grid_vals),
                 }
             else:
-                filter_model[key] = extra_spec
+                filter_model[key] = {
+                    "operator": "AND",
+                    "conditions": [extra_spec, grid_spec],
+                }
         return filter_model
 
     def test_no_overlap_includes_both(self) -> None:
@@ -317,9 +320,10 @@ class TestFilterMerge:
         result = self._merge_filters(extra, grid)
         assert result["status"]["values"] == []
 
-    def test_text_filter_overlap_extra_wins(self) -> None:
-        """Non-set overlapping filters: extra_filters wins."""
+    def test_text_filter_overlap_combined_as_and(self) -> None:
+        """Non-set overlapping filters: combined as AND compound filter."""
         extra = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
         grid = {"symbol": {"filterType": "text", "type": "equals", "filter": "MSFT"}}
         result = self._merge_filters(extra, grid)
-        assert result["symbol"]["filter"] == "AAPL"
+        assert result["symbol"]["operator"] == "AND"
+        assert len(result["symbol"]["conditions"]) == 2

--- a/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
+++ b/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
@@ -277,10 +277,9 @@ class TestFilterMerge:
             ):
                 extra_vals = set(extra_spec.get("values") or [])
                 grid_vals = set(grid_spec.get("values") or [])
-                intersected = sorted(extra_vals & grid_vals)
                 filter_model[key] = {
                     "filterType": "set",
-                    "values": intersected if intersected else sorted(extra_vals),
+                    "values": sorted(extra_vals & grid_vals),
                 }
             else:
                 filter_model[key] = extra_spec
@@ -311,12 +310,12 @@ class TestFilterMerge:
         result = self._merge_filters(extra, grid)
         assert result["status"]["values"] == ["accepted"]
 
-    def test_set_filter_empty_intersection_falls_back(self) -> None:
-        """Empty intersection falls back to extra_filters values."""
+    def test_set_filter_empty_intersection_produces_empty(self) -> None:
+        """Empty intersection is kept to preserve view/export parity."""
         extra = {"status": {"filterType": "set", "values": ["new", "pending_new"]}}
         grid = {"status": {"filterType": "set", "values": ["filled"]}}
         result = self._merge_filters(extra, grid)
-        assert result["status"]["values"] == ["new", "pending_new"]
+        assert result["status"]["values"] == []
 
     def test_text_filter_overlap_extra_wins(self) -> None:
         """Non-set overlapping filters: extra_filters wins."""

--- a/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
+++ b/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
@@ -253,3 +253,74 @@ class TestGridExportToolbarWithUI:
 
         # Should create multiple buttons (CSV, Excel, Clipboard)
         assert mock_ui.button.call_count >= 1
+
+
+class TestFilterMerge:
+    """Tests for filter merge logic in _create_audit_record."""
+
+    def _merge_filters(
+        self,
+        extra_filters: dict,
+        grid_filters: dict,
+    ) -> dict:
+        """Replicate the merge logic from _create_audit_record."""
+        filter_model = dict(grid_filters)
+        for key, extra_spec in extra_filters.items():
+            grid_spec = grid_filters.get(key)
+            if grid_spec is None:
+                filter_model[key] = extra_spec
+            elif (
+                isinstance(extra_spec, dict)
+                and isinstance(grid_spec, dict)
+                and extra_spec.get("filterType") == "set"
+                and grid_spec.get("filterType") == "set"
+            ):
+                extra_vals = set(extra_spec.get("values") or [])
+                grid_vals = set(grid_spec.get("values") or [])
+                intersected = sorted(extra_vals & grid_vals)
+                filter_model[key] = {
+                    "filterType": "set",
+                    "values": intersected if intersected else sorted(extra_vals),
+                }
+            else:
+                filter_model[key] = extra_spec
+        return filter_model
+
+    def test_no_overlap_includes_both(self) -> None:
+        """Non-overlapping filters are both included."""
+        extra = {"status": {"filterType": "set", "values": ["new", "pending_new"]}}
+        grid = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
+        result = self._merge_filters(extra, grid)
+        assert "status" in result
+        assert "symbol" in result
+
+    def test_set_filter_intersection(self) -> None:
+        """Overlapping set filters are intersected."""
+        extra = {
+            "status": {
+                "filterType": "set",
+                "values": ["new", "pending_new", "partially_filled", "accepted"],
+            }
+        }
+        grid = {
+            "status": {
+                "filterType": "set",
+                "values": ["accepted"],
+            }
+        }
+        result = self._merge_filters(extra, grid)
+        assert result["status"]["values"] == ["accepted"]
+
+    def test_set_filter_empty_intersection_falls_back(self) -> None:
+        """Empty intersection falls back to extra_filters values."""
+        extra = {"status": {"filterType": "set", "values": ["new", "pending_new"]}}
+        grid = {"status": {"filterType": "set", "values": ["filled"]}}
+        result = self._merge_filters(extra, grid)
+        assert result["status"]["values"] == ["new", "pending_new"]
+
+    def test_text_filter_overlap_extra_wins(self) -> None:
+        """Non-set overlapping filters: extra_filters wins."""
+        extra = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
+        grid = {"symbol": {"filterType": "text", "type": "equals", "filter": "MSFT"}}
+        result = self._merge_filters(extra, grid)
+        assert result["symbol"]["filter"] == "AAPL"

--- a/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
+++ b/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
@@ -140,6 +140,18 @@ class TestGridExportToolbar:
         assert toolbar.on_export_start is None
         assert toolbar.on_export_complete is None
         assert toolbar.api_base_url == "/api/v1"
+        assert toolbar.extra_filters == {}
+
+    def test_init_with_extra_filters(self) -> None:
+        """Extra filters are stored for injection into audit filter model."""
+        extra = {"status": {"filterType": "set", "values": ["new", "pending_new"]}}
+        toolbar = GridExportToolbar(
+            grid_id="_gridApi",
+            grid_name="orders",
+            filename_prefix="orders",
+            extra_filters=extra,
+        )
+        assert toolbar.extra_filters == extra
 
     def test_get_filename_format(self, toolbar: GridExportToolbar) -> None:
         """Filename follows expected format."""

--- a/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
+++ b/tests/apps/web_console_ng/components/test_grid_export_toolbar.py
@@ -17,6 +17,7 @@ import pytest
 
 from apps.web_console_ng.components.grid_export_toolbar import (
     GridExportToolbar,
+    merge_filter_models,
     sanitize_for_export,
 )
 
@@ -256,43 +257,13 @@ class TestGridExportToolbarWithUI:
 
 
 class TestFilterMerge:
-    """Tests for filter merge logic in _create_audit_record."""
-
-    def _merge_filters(
-        self,
-        extra_filters: dict,
-        grid_filters: dict,
-    ) -> dict:
-        """Replicate the merge logic from _create_audit_record."""
-        filter_model = dict(grid_filters)
-        for key, extra_spec in extra_filters.items():
-            grid_spec = grid_filters.get(key)
-            if grid_spec is None:
-                filter_model[key] = extra_spec
-            elif (
-                isinstance(extra_spec, dict)
-                and isinstance(grid_spec, dict)
-                and extra_spec.get("filterType") == "set"
-                and grid_spec.get("filterType") == "set"
-            ):
-                extra_vals = set(extra_spec.get("values") or [])
-                grid_vals = set(grid_spec.get("values") or [])
-                filter_model[key] = {
-                    "filterType": "set",
-                    "values": sorted(extra_vals & grid_vals),
-                }
-            else:
-                filter_model[key] = {
-                    "operator": "AND",
-                    "conditions": [extra_spec, grid_spec],
-                }
-        return filter_model
+    """Tests for merge_filter_models utility."""
 
     def test_no_overlap_includes_both(self) -> None:
         """Non-overlapping filters are both included."""
         extra = {"status": {"filterType": "set", "values": ["new", "pending_new"]}}
         grid = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
-        result = self._merge_filters(extra, grid)
+        result = merge_filter_models(grid, extra)
         assert "status" in result
         assert "symbol" in result
 
@@ -310,20 +281,20 @@ class TestFilterMerge:
                 "values": ["accepted"],
             }
         }
-        result = self._merge_filters(extra, grid)
+        result = merge_filter_models(grid, extra)
         assert result["status"]["values"] == ["accepted"]
 
     def test_set_filter_empty_intersection_produces_empty(self) -> None:
         """Empty intersection is kept to preserve view/export parity."""
         extra = {"status": {"filterType": "set", "values": ["new", "pending_new"]}}
         grid = {"status": {"filterType": "set", "values": ["filled"]}}
-        result = self._merge_filters(extra, grid)
+        result = merge_filter_models(grid, extra)
         assert result["status"]["values"] == []
 
     def test_text_filter_overlap_combined_as_and(self) -> None:
         """Non-set overlapping filters: combined as AND compound filter."""
         extra = {"symbol": {"filterType": "text", "type": "equals", "filter": "AAPL"}}
         grid = {"symbol": {"filterType": "text", "type": "equals", "filter": "MSFT"}}
-        result = self._merge_filters(extra, grid)
+        result = merge_filter_models(grid, extra)
         assert result["symbol"]["operator"] == "AND"
         assert len(result["symbol"]["conditions"]) == 2

--- a/tests/regression/golden_results/manifest.json
+++ b/tests/regression/golden_results/manifest.json
@@ -1,13 +1,13 @@
 {
   "version": "v1.0.0",
-  "created_at": "2026-04-16T11:53:40.074278Z",
+  "created_at": "2026-04-16T18:27:55.683157Z",
   "dataset_snapshot_id": "golden_v1.0.0",
   "regeneration_triggers": [
     "Major alpha logic change",
     "Dataset schema change",
     "Quarterly refresh (optional)"
   ],
-  "last_regenerated": "2026-04-16T11:53:40.074617Z",
+  "last_regenerated": "2026-04-16T18:27:55.683494Z",
   "regenerated_by": "scripts/generate_golden_results.py",
   "storage_size_mb": 0.0,
   "storage_size_note": "Decimal MB (1MB = 1,000,000 bytes), includes manifest",


### PR DESCRIPTION
## Summary

- Replace placeholder Excel export with real database-backed grid data for all 5 grids (positions, orders, fills, audit, TCA)
- Add server-side column allowlists, AG Grid filter/sort translation, and formula injection sanitization
- Add working-order status filter propagation and symbol scope injection for export/view parity
- Fix CI: add openpyxl to Docker requirements, regenerate stale golden manifest
- Address all review feedback from PR #200 (12 rounds, now consolidated)

## Key Changes

**Export backend** (`apps/execution_gateway/routes/export.py`):
- Per-grid data fetchers with strategy-scoped SQL queries
- AG Grid filter → SQL translation (text, number, date, set, compound filters)
- Column alias resolution, sort precedence, LIKE wildcard escaping
- Streaming Excel generation via `write_only=True` mode

**Export frontend** (`grid_export_toolbar.py`, `tabbed_panel.py`):
- `extra_filters` injection for tab-scoped predicates (working-order status)
- Symbol dropdown filter propagation to export via `update_symbol_filter()`
- Set filter intersection merge for overlapping page/grid filters
- Shared `WORKING_ORDER_STATUSES` from `libs/trading/order_constants`

## Test plan

- [x] `make ci-local` passes (11964 passed, 1 pre-existing flaky failure)
- [x] Export route tests: 53 passed
- [x] Grid export toolbar tests: 27 passed
- [x] Golden manifest staleness test passes
- [ ] E2E Docker test (openpyxl now in requirements-docker.txt)

Replaces #200 (closed — too many review rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)