### PR TITLE
fix(auth_service): strip INTERNAL_REFRESH_SECRET consistently (#176)

### DIFF
--- a/apps/auth_service/dependencies.py
+++ b/apps/auth_service/dependencies.py
@@ -47,6 +47,17 @@ class AuthServiceConfig:
         )
 
 
+def get_internal_refresh_secret() -> str | None:
+    """Return the stripped ``INTERNAL_REFRESH_SECRET`` env var, or ``None`` if unset.
+
+    Single source of truth for how the secret is normalized (whitespace stripped,
+    empty treated as unset) — shared by startup validation in ``main.py`` and the
+    request-time comparison in ``routes/refresh.py`` so the two cannot drift.
+    See issue #176 for the whitespace-mismatch incident this prevents.
+    """
+    return os.getenv("INTERNAL_REFRESH_SECRET", "").strip() or None
+
+
 @lru_cache
 def get_redis_client() -> redis.asyncio.Redis:
     """Get Redis client singleton (DB 1 for sessions)."""

--- a/apps/auth_service/main.py
+++ b/apps/auth_service/main.py
@@ -18,7 +18,11 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 
-from apps.auth_service.dependencies import get_config, get_oauth2_handler
+from apps.auth_service.dependencies import (
+    get_config,
+    get_internal_refresh_secret,
+    get_oauth2_handler,
+)
 from apps.auth_service.middleware.csp_middleware import CSPMiddleware
 from apps.auth_service.routes import callback, csp_report, example_page, logout, refresh
 from apps.auth_service.utils.csp_policy import build_csp_policy
@@ -197,7 +201,7 @@ def _validate_internal_refresh_secret() -> str | None:
     Raises:
         RuntimeError: If secret not configured in production/staging
     """
-    secret = os.getenv("INTERNAL_REFRESH_SECRET", "").strip()
+    secret = get_internal_refresh_secret()
     env = os.getenv("ENVIRONMENT", "dev").lower()
 
     # Empty secret = feature disabled

--- a/apps/auth_service/routes/refresh.py
+++ b/apps/auth_service/routes/refresh.py
@@ -19,8 +19,7 @@ INTERNAL_REFRESH_HEADER = "X-Internal-Auth"
 # Without stripping, a secret configured with stray whitespace would pass
 # startup checks but silently fail ``secrets.compare_digest`` at request time
 # (see issue #176).
-_INTERNAL_REFRESH_SECRET_RAW = os.getenv("INTERNAL_REFRESH_SECRET", "").strip()
-INTERNAL_REFRESH_SECRET: str | None = _INTERNAL_REFRESH_SECRET_RAW or None
+INTERNAL_REFRESH_SECRET: str | None = os.getenv("INTERNAL_REFRESH_SECRET", "").strip() or None
 
 
 @router.post("/refresh")

--- a/apps/auth_service/routes/refresh.py
+++ b/apps/auth_service/routes/refresh.py
@@ -15,7 +15,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 INTERNAL_REFRESH_HEADER = "X-Internal-Auth"
-INTERNAL_REFRESH_SECRET = os.getenv("INTERNAL_REFRESH_SECRET") or None
+# Strip whitespace to stay consistent with startup validation in ``main.py``.
+# Without stripping, a secret configured with stray whitespace would pass
+# startup checks but silently fail ``secrets.compare_digest`` at request time
+# (see issue #176).
+_INTERNAL_REFRESH_SECRET_RAW = os.getenv("INTERNAL_REFRESH_SECRET", "").strip()
+INTERNAL_REFRESH_SECRET: str | None = _INTERNAL_REFRESH_SECRET_RAW or None
 
 
 @router.post("/refresh")

--- a/apps/auth_service/routes/refresh.py
+++ b/apps/auth_service/routes/refresh.py
@@ -1,25 +1,24 @@
 """Token refresh endpoint with rotation and optional binding validation."""
 
 import logging
-import os
 import secrets
 from typing import Any
 
 from fastapi import APIRouter, Cookie, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from apps.auth_service.dependencies import get_oauth2_handler, get_rate_limiters
+from apps.auth_service.dependencies import (
+    get_internal_refresh_secret,
+    get_oauth2_handler,
+    get_rate_limiters,
+)
 from libs.core.common.network_utils import extract_client_ip_from_fastapi
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 INTERNAL_REFRESH_HEADER = "X-Internal-Auth"
-# Strip whitespace to stay consistent with startup validation in ``main.py``.
-# Without stripping, a secret configured with stray whitespace would pass
-# startup checks but silently fail ``secrets.compare_digest`` at request time
-# (see issue #176).
-INTERNAL_REFRESH_SECRET: str | None = os.getenv("INTERNAL_REFRESH_SECRET", "").strip() or None
+INTERNAL_REFRESH_SECRET: str | None = get_internal_refresh_secret()
 
 
 @router.post("/refresh")

--- a/tests/apps/auth_service/routes/test_refresh.py
+++ b/tests/apps/auth_service/routes/test_refresh.py
@@ -146,9 +146,10 @@ def test_internal_refresh_secret_env_is_stripped(
     try:
         assert reloaded.INTERNAL_REFRESH_SECRET == "shared-secret"
     finally:
-        # Restore module state to whatever the current environment dictates so
-        # later tests see a clean slate.
-        monkeypatch.delenv("INTERNAL_REFRESH_SECRET", raising=False)
+        # Restore the original environment (including any pre-existing
+        # INTERNAL_REFRESH_SECRET value) before reloading so later tests see a
+        # clean module state rather than the delenv-forced ``None``.
+        monkeypatch.undo()
         importlib.reload(refresh_module)
 
 
@@ -162,7 +163,7 @@ def test_internal_refresh_secret_whitespace_only_becomes_none(
     try:
         assert reloaded.INTERNAL_REFRESH_SECRET is None
     finally:
-        monkeypatch.delenv("INTERNAL_REFRESH_SECRET", raising=False)
+        monkeypatch.undo()
         importlib.reload(refresh_module)
 
 
@@ -219,7 +220,7 @@ def test_refresh_internal_bypass_succeeds_when_env_has_whitespace(
             enforce_binding=False,
         )
     finally:
-        monkeypatch.delenv("INTERNAL_REFRESH_SECRET", raising=False)
+        monkeypatch.undo()
         importlib.reload(refresh_module)
 
 

--- a/tests/apps/auth_service/routes/test_refresh.py
+++ b/tests/apps/auth_service/routes/test_refresh.py
@@ -168,7 +168,7 @@ def test_internal_refresh_secret_whitespace_only_becomes_none(
 
 
 def test_refresh_internal_bypass_succeeds_when_env_has_whitespace(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression for #176: whitespace in env must not break compare_digest.
 

--- a/tests/apps/auth_service/routes/test_refresh.py
+++ b/tests/apps/auth_service/routes/test_refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -127,6 +128,99 @@ def test_refresh_internal_bypass_skips_binding(
         user_agent=None,
         enforce_binding=False,
     )
+
+
+def test_internal_refresh_secret_env_is_stripped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #176: whitespace-padded env var must be stripped.
+
+    ``main._validate_internal_refresh_secret`` strips the env var during
+    startup validation; the refresh route must do the same so
+    ``secrets.compare_digest`` succeeds when callers send the intended
+    (unstripped) secret.
+    """
+    monkeypatch.setenv("INTERNAL_REFRESH_SECRET", "  shared-secret  ")
+
+    reloaded = importlib.reload(refresh_module)
+    try:
+        assert reloaded.INTERNAL_REFRESH_SECRET == "shared-secret"
+    finally:
+        # Restore module state to whatever the current environment dictates so
+        # later tests see a clean slate.
+        monkeypatch.delenv("INTERNAL_REFRESH_SECRET", raising=False)
+        importlib.reload(refresh_module)
+
+
+def test_internal_refresh_secret_whitespace_only_becomes_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only env var must be treated as unset (disabled feature)."""
+    monkeypatch.setenv("INTERNAL_REFRESH_SECRET", "   ")
+
+    reloaded = importlib.reload(refresh_module)
+    try:
+        assert reloaded.INTERNAL_REFRESH_SECRET is None
+    finally:
+        monkeypatch.delenv("INTERNAL_REFRESH_SECRET", raising=False)
+        importlib.reload(refresh_module)
+
+
+def test_refresh_internal_bypass_succeeds_when_env_has_whitespace(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #176: whitespace in env must not break compare_digest.
+
+    Simulates the production setup where ``INTERNAL_REFRESH_SECRET`` was
+    configured with stray whitespace. The route should authenticate callers
+    that send the intended (stripped) value in ``X-Internal-Auth``.
+    """
+    # Load the module with a padded env var so the module-level constant is
+    # populated via the real ``os.getenv(...).strip()`` code path.
+    monkeypatch.setenv("INTERNAL_REFRESH_SECRET", "  shared-secret  ")
+    reloaded = importlib.reload(refresh_module)
+
+    try:
+        assert reloaded.INTERNAL_REFRESH_SECRET == "shared-secret"
+
+        app = FastAPI()
+        app.include_router(reloaded.router)
+        local_client = TestClient(app)
+
+        rate_limiter = AsyncMock()
+        rate_limiter.is_allowed = AsyncMock(return_value=True)
+
+        session_data = SimpleNamespace(user_id="auth0|user")
+        handler = MagicMock()
+        handler.refresh_tokens = AsyncMock(return_value=session_data)
+
+        with (
+            patch(
+                "apps.auth_service.routes.refresh.get_rate_limiters",
+                return_value={"refresh": rate_limiter},
+            ),
+            patch(
+                "apps.auth_service.routes.refresh.get_oauth2_handler",
+                return_value=handler,
+            ),
+        ):
+            response = local_client.post(
+                "/refresh",
+                cookies={"session_id": "session_123"},
+                headers={"X-Internal-Auth": "shared-secret"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+        handler.refresh_tokens.assert_called_once_with(
+            session_id="session_123",
+            ip_address=None,
+            user_agent=None,
+            enforce_binding=False,
+        )
+    finally:
+        monkeypatch.delenv("INTERNAL_REFRESH_SECRET", raising=False)
+        importlib.reload(refresh_module)
 
 
 def test_refresh_invalid_internal_header_returns_401(


### PR DESCRIPTION
## Summary
- `apps/auth_service/main.py` stripped whitespace from `INTERNAL_REFRESH_SECRET` at startup, but `apps/auth_service/routes/refresh.py` read it raw at import time — padded values passed startup validation then silently failed `secrets.compare_digest` in the refresh path.
- Align `refresh.py` to use `.strip()` while preserving the `or None` semantics so empty/whitespace-only values disable the bypass.
- Added 3 regression tests exercising the real module-load path via `importlib.reload`.

## Test plan
- [x] `pytest tests/apps/auth_service/` → 70/70 pass
- [x] `ruff format`, `ruff check`, `mypy` clean on changed files
- [ ] CI to confirm

Fixes #164... no — Fixes #176