### PR TITLE
fix(market_data_service): increment websocket, reconnect, and position-sync counters (#169)

### DIFF
--- a/apps/market_data_service/main.py
+++ b/apps/market_data_service/main.py
@@ -110,6 +110,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             redis_client=redis_client,
             event_publisher=event_publisher,
             price_ttl=settings.price_cache_ttl,
+            messages_received_counter=websocket_messages_received_total,
+            reconnect_attempts_counter=reconnect_attempts_total,
         )
 
         # Start WebSocket in background task
@@ -121,6 +123,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             execution_gateway_url=settings.execution_gateway_url,
             sync_interval=settings.subscription_sync_interval,
             initial_sync=True,
+            syncs_counter=position_syncs_total,
         )
 
         # Start subscription sync loop in background

--- a/apps/market_data_service/position_sync.py
+++ b/apps/market_data_service/position_sync.py
@@ -271,6 +271,9 @@ class PositionBasedSubscription:
                         f"{sorted(new_symbols)}"
                     )
                 except SubscriptionError as e:
+                    # Mark sync as error so Prometheus alerting reflects partial failures
+                    # that would otherwise be hidden behind status="success".
+                    sync_status = "error"
                     logger.error(f"Failed to subscribe to new symbols: {e}")
 
             # H5 Fix: Unsubscribe with source="position" - only removes position source
@@ -283,6 +286,9 @@ class PositionBasedSubscription:
                         f"{sorted(closed_symbols)}"
                     )
                 except SubscriptionError as e:
+                    # Mark sync as error so Prometheus alerting reflects partial failures
+                    # that would otherwise be hidden behind status="success".
+                    sync_status = "error"
                     logger.error(f"Failed to unsubscribe from closed symbols: {e}")
 
             # Log summary

--- a/apps/market_data_service/position_sync.py
+++ b/apps/market_data_service/position_sync.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any
 
 import httpx
+from prometheus_client import Counter
 
 from libs.data.market_data import AlpacaMarketDataStream
 from libs.data.market_data.exceptions import SubscriptionError
@@ -42,6 +43,7 @@ class PositionBasedSubscription:
         execution_gateway_url: str,
         sync_interval: int = 300,  # 5 minutes
         initial_sync: bool = True,
+        syncs_counter: Counter | None = None,
     ):
         """
         Initialize position-based subscription manager.
@@ -51,11 +53,14 @@ class PositionBasedSubscription:
             execution_gateway_url: Execution Gateway base URL
             sync_interval: Seconds between syncs (default: 300 = 5 minutes)
             initial_sync: Run initial sync on startup (default: True)
+            syncs_counter: Optional Prometheus Counter incremented once per sync
+                cycle. Must declare a ``status`` label (``success``/``error``).
         """
         self.stream = stream
         self.gateway_url = execution_gateway_url.rstrip("/")
         self.sync_interval = sync_interval
         self.initial_sync = initial_sync
+        self._syncs_counter = syncs_counter
 
         self._running = False
         self._last_position_symbols: set[str] = set()
@@ -237,12 +242,14 @@ class PositionBasedSubscription:
         1. Subscribes to new symbols (not currently subscribed)
         2. Unsubscribes from closed symbols (no longer have position)
         """
+        sync_status = "success"
         try:
             # Fetch positions from Execution Gateway
             position_symbols = await self._fetch_position_symbols()
 
             if position_symbols is None:
                 logger.warning("Failed to fetch positions, skipping sync")
+                sync_status = "error"
                 return
 
             # Determine what changed
@@ -293,18 +300,21 @@ class PositionBasedSubscription:
             self._last_position_symbols = position_symbols
 
         except SubscriptionError as e:
+            sync_status = "error"
             logger.error(
                 "Subscription sync failed - SubscriptionError",
                 extra={"error": str(e), "error_type": type(e).__name__},
                 exc_info=True,
             )
         except httpx.HTTPStatusError as e:
+            sync_status = "error"
             logger.error(
                 "Subscription sync failed - HTTP error",
                 extra={"status_code": e.response.status_code, "url": str(e.request.url)},
                 exc_info=True,
             )
         except (httpx.ConnectTimeout, httpx.ConnectError, httpx.NetworkError) as e:
+            sync_status = "error"
             logger.error(
                 "Subscription sync failed - Network error",
                 extra={
@@ -315,11 +325,19 @@ class PositionBasedSubscription:
                 exc_info=True,
             )
         except Exception as e:
+            sync_status = "error"
             logger.error(
                 "Subscription sync failed - Unexpected error",
                 extra={"error": str(e), "error_type": type(e).__name__},
                 exc_info=True,
             )
+        finally:
+            # Record one observation per sync cycle for Prometheus alerting.
+            if self._syncs_counter is not None:
+                try:
+                    self._syncs_counter.labels(status=sync_status).inc()
+                except Exception:  # pragma: no cover - defensive
+                    logger.debug("Failed to increment position_syncs_total", exc_info=True)
 
     async def _fetch_position_symbols(self) -> set[str] | None:
         """

--- a/apps/market_data_service/position_sync.py
+++ b/apps/market_data_service/position_sync.py
@@ -242,7 +242,7 @@ class PositionBasedSubscription:
         1. Subscribes to new symbols (not currently subscribed)
         2. Unsubscribes from closed symbols (no longer have position)
         """
-        sync_status = "success"
+        sync_status: str | None = "success"
         try:
             # Fetch positions from Execution Gateway
             position_symbols = await self._fetch_position_symbols()
@@ -305,6 +305,12 @@ class PositionBasedSubscription:
             # Update tracking
             self._last_position_symbols = position_symbols
 
+        except asyncio.CancelledError:
+            # Task cancellation (e.g. shutdown) is not a sync outcome — skip
+            # the counter increment entirely so aborted cycles don't bias the
+            # success/error signal. Re-raise to honor cooperative cancellation.
+            sync_status = None
+            raise
         except SubscriptionError as e:
             sync_status = "error"
             logger.error(
@@ -339,10 +345,18 @@ class PositionBasedSubscription:
             )
         finally:
             # Record one observation per sync cycle for Prometheus alerting.
-            if self._syncs_counter is not None:
+            # sync_status is set to None when the cycle was cancelled mid-flight
+            # (shutdown), in which case we skip the increment so cancelled
+            # cycles don't bias the success/error monitoring signal.
+            if self._syncs_counter is not None and sync_status is not None:
                 try:
                     self._syncs_counter.labels(status=sync_status).inc()
                 except Exception:  # pragma: no cover - defensive
+                    # Intentional deviation from "catch, log, re-raise" standard:
+                    # a metrics backend failure must not mask the real sync
+                    # outcome. The counter is pure observability, so log and
+                    # continue; propagating would convert every metrics hiccup
+                    # into a sync-cycle failure.
                     logger.debug("Failed to increment position_syncs_total", exc_info=True)
 
     async def _fetch_position_symbols(self) -> set[str] | None:

--- a/libs/data/market_data/alpaca_stream.py
+++ b/libs/data/market_data/alpaca_stream.py
@@ -262,6 +262,10 @@ class AlpacaMarketDataStream:
             try:
                 self._messages_received_counter.labels(message_type="quote").inc()
             except Exception:  # pragma: no cover - defensive: never let metrics break the stream
+                # Intentional deviation from "catch, log, re-raise" standard:
+                # a prometheus_client failure here would crash the quote
+                # handler for every inbound message. The counter is pure
+                # observability, so we log at debug and continue.
                 logger.debug("Failed to increment websocket_messages_received_total", exc_info=True)
 
         try:
@@ -357,8 +361,29 @@ class AlpacaMarketDataStream:
         """
         self._running = True
         retry_delay = 5  # Base delay in seconds
+        # Track whether this iteration is a reconnect (i.e. not the very first
+        # connection attempt). We count reconnect attempts at a single place —
+        # the top of each iteration after the first — so clean-return and
+        # exception paths don't both increment for the same logical reconnect.
+        is_reconnect_iteration = False
 
         while self._running and self._reconnect_attempts < self._max_reconnect_attempts:
+            # Count every reconnect attempt exactly once, at the start of the
+            # iteration. Skips the initial connection attempt. This covers both
+            # the clean-return ("flapping") path and the exception-driven path
+            # without double-counting a single failed reconnect after a clean
+            # close.
+            if is_reconnect_iteration and self._reconnect_attempts_counter is not None:
+                try:
+                    self._reconnect_attempts_counter.inc()
+                except Exception:  # pragma: no cover - defensive
+                    # Intentional deviation from "catch, log, re-raise" standard:
+                    # a metrics backend failure must not tear down the WebSocket
+                    # reconnect loop (which is already in a degraded state).
+                    # The monitoring counter is strictly observability, not a
+                    # correctness signal, so we log and swallow.
+                    logger.debug("Failed to increment reconnect_attempts_total", exc_info=True)
+
             try:
                 logger.info(
                     f"Starting WebSocket connection "
@@ -388,28 +413,17 @@ class AlpacaMarketDataStream:
                     logger.warning(
                         "WebSocket connection closed unexpectedly, will reconnect immediately."
                     )
-                    # Count this flapping reconnect cycle. Without this, clean-return
-                    # reconnect loops (stream.run() returns while _running is True)
-                    # are invisible to the market_data_reconnect_attempts_total metric,
-                    # weakening reconnect-rate alerts and dashboards.
-                    if self._reconnect_attempts_counter is not None:
-                        try:
-                            self._reconnect_attempts_counter.inc()
-                        except Exception:  # pragma: no cover - defensive
-                            logger.debug(
-                                "Failed to increment reconnect_attempts_total", exc_info=True
-                            )
+                    # Next iteration is a reconnect (flapping) — count it at the
+                    # top of the next loop pass.
+                    is_reconnect_iteration = True
 
             except Exception as e:
                 self._connected = False
                 self._reconnect_attempts += 1
-
-                # Record reconnect attempt for Prometheus alerting/dashboards.
-                if self._reconnect_attempts_counter is not None:
-                    try:
-                        self._reconnect_attempts_counter.inc()
-                    except Exception:  # pragma: no cover - defensive
-                        logger.debug("Failed to increment reconnect_attempts_total", exc_info=True)
+                # Next iteration is a reconnect — count it at the top of the
+                # next loop pass (avoids double-counting with the clean-return
+                # path when a reconnect follows a clean close).
+                is_reconnect_iteration = True
 
                 if self._reconnect_attempts >= self._max_reconnect_attempts:
                     logger.error("Max reconnection attempts reached. Giving up.")

--- a/libs/data/market_data/alpaca_stream.py
+++ b/libs/data/market_data/alpaca_stream.py
@@ -74,6 +74,14 @@ class AlpacaMarketDataStream:
         self.price_ttl = price_ttl
         self._messages_received_counter = messages_received_counter
         self._reconnect_attempts_counter = reconnect_attempts_counter
+        # Pre-bind the labeled child once so the hot-path _handle_quote doesn't
+        # pay the per-message .labels() lookup (dict get + child construction)
+        # on every inbound WebSocket message.
+        self._quote_message_counter = (
+            messages_received_counter.labels(message_type="quote")
+            if messages_received_counter is not None
+            else None
+        )
 
         # Initialize Alpaca WebSocket client
         self.stream = StockDataStream(api_key, secret_key)
@@ -258,9 +266,11 @@ class AlpacaMarketDataStream:
         """
         # Record receipt of the message before any processing so the counter
         # reflects inbound WebSocket volume even if parsing/validation fails.
-        if self._messages_received_counter is not None:
+        # Use the pre-bound labeled child to avoid a per-message .labels()
+        # lookup on the WebSocket hot path.
+        if self._quote_message_counter is not None:
             try:
-                self._messages_received_counter.labels(message_type="quote").inc()
+                self._quote_message_counter.inc()
             except Exception:  # pragma: no cover - defensive: never let metrics break the stream
                 # Intentional deviation from "catch, log, re-raise" standard:
                 # a prometheus_client failure here would crash the quote

--- a/libs/data/market_data/alpaca_stream.py
+++ b/libs/data/market_data/alpaca_stream.py
@@ -388,6 +388,17 @@ class AlpacaMarketDataStream:
                     logger.warning(
                         "WebSocket connection closed unexpectedly, will reconnect immediately."
                     )
+                    # Count this flapping reconnect cycle. Without this, clean-return
+                    # reconnect loops (stream.run() returns while _running is True)
+                    # are invisible to the market_data_reconnect_attempts_total metric,
+                    # weakening reconnect-rate alerts and dashboards.
+                    if self._reconnect_attempts_counter is not None:
+                        try:
+                            self._reconnect_attempts_counter.inc()
+                        except Exception:  # pragma: no cover - defensive
+                            logger.debug(
+                                "Failed to increment reconnect_attempts_total", exc_info=True
+                            )
 
             except Exception as e:
                 self._connected = False

--- a/libs/data/market_data/alpaca_stream.py
+++ b/libs/data/market_data/alpaca_stream.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from alpaca.data.live import StockDataStream
 from alpaca.data.models import Quote
+from prometheus_client import Counter
 from pydantic import ValidationError
 from redis.exceptions import RedisError
 
@@ -49,6 +50,8 @@ class AlpacaMarketDataStream:
         redis_client: RedisClient,
         event_publisher: EventPublisher,
         price_ttl: int = 300,  # 5 minutes
+        messages_received_counter: Counter | None = None,
+        reconnect_attempts_counter: Counter | None = None,
     ):
         """
         Initialize Alpaca market data stream.
@@ -59,12 +62,18 @@ class AlpacaMarketDataStream:
             redis_client: Redis client for price caching
             event_publisher: Event publisher for price updates
             price_ttl: TTL for price cache in seconds (default: 5 minutes)
+            messages_received_counter: Optional Prometheus Counter incremented per
+                received WebSocket message. Must declare a ``message_type`` label.
+            reconnect_attempts_counter: Optional Prometheus Counter incremented once
+                per WebSocket reconnection attempt (no labels).
         """
         self.api_key = api_key
         self.secret_key = secret_key
         self.redis = redis_client
         self.publisher = event_publisher
         self.price_ttl = price_ttl
+        self._messages_received_counter = messages_received_counter
+        self._reconnect_attempts_counter = reconnect_attempts_counter
 
         # Initialize Alpaca WebSocket client
         self.stream = StockDataStream(api_key, secret_key)
@@ -247,6 +256,14 @@ class AlpacaMarketDataStream:
             - This prevents individual quote errors from crashing the WebSocket stream
             - Failed quotes are logged with full traceback for debugging
         """
+        # Record receipt of the message before any processing so the counter
+        # reflects inbound WebSocket volume even if parsing/validation fails.
+        if self._messages_received_counter is not None:
+            try:
+                self._messages_received_counter.labels(message_type="quote").inc()
+            except Exception:  # pragma: no cover - defensive: never let metrics break the stream
+                logger.debug("Failed to increment websocket_messages_received_total", exc_info=True)
+
         try:
             # Convert Alpaca Quote to our QuoteData model
             symbol = quote["symbol"] if isinstance(quote, Mapping) else quote.symbol
@@ -375,6 +392,13 @@ class AlpacaMarketDataStream:
             except Exception as e:
                 self._connected = False
                 self._reconnect_attempts += 1
+
+                # Record reconnect attempt for Prometheus alerting/dashboards.
+                if self._reconnect_attempts_counter is not None:
+                    try:
+                        self._reconnect_attempts_counter.inc()
+                    except Exception:  # pragma: no cover - defensive
+                        logger.debug("Failed to increment reconnect_attempts_total", exc_info=True)
 
                 if self._reconnect_attempts >= self._max_reconnect_attempts:
                     logger.error("Max reconnection attempts reached. Giving up.")

--- a/tests/apps/market_data_service/test_counter_increments.py
+++ b/tests/apps/market_data_service/test_counter_increments.py
@@ -1,0 +1,301 @@
+"""
+Tests for Prometheus counter increment wiring (issue #169).
+
+Verifies that the counters defined in ``apps/market_data_service/main.py`` are
+actually incremented at the expected lifecycle points:
+
+- ``market_data_websocket_messages_received_total`` on each received message
+- ``market_data_reconnect_attempts_total`` on each WebSocket reconnect attempt
+- ``market_data_position_syncs_total`` on each position-sync cycle
+
+These replace the "counter is defined" assertions in test_metrics.py with
+"counter actually moves" assertions, so the alerts in
+``infra/prometheus/alerts.yml`` have real signal to fire on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from prometheus_client import CollectorRegistry, Counter
+
+from apps.market_data_service.position_sync import PositionBasedSubscription
+from libs.data.market_data.alpaca_stream import AlpacaMarketDataStream
+
+
+def _counter_value(counter: Counter, **labels: str) -> float:
+    """Return the current value of a Prometheus counter (label-aware)."""
+    if labels:
+        return counter.labels(**labels)._value.get()  # type: ignore[attr-defined]
+    # Unlabelled counters expose the value directly via ``_value``.
+    return counter._value.get()  # type: ignore[attr-defined]
+
+
+@pytest.fixture()
+def messages_counter() -> Counter:
+    """Fresh counter in an isolated registry (mirrors main.py definition)."""
+    registry = CollectorRegistry()
+    return Counter(
+        "market_data_websocket_messages_received_total",
+        "Total number of WebSocket messages received",
+        ["message_type"],
+        registry=registry,
+    )
+
+
+@pytest.fixture()
+def reconnect_counter() -> Counter:
+    """Fresh counter in an isolated registry (mirrors main.py definition)."""
+    registry = CollectorRegistry()
+    return Counter(
+        "market_data_reconnect_attempts_total",
+        "Total number of WebSocket reconnection attempts",
+        registry=registry,
+    )
+
+
+@pytest.fixture()
+def syncs_counter() -> Counter:
+    """Fresh counter in an isolated registry (mirrors main.py definition)."""
+    registry = CollectorRegistry()
+    return Counter(
+        "market_data_position_syncs_total",
+        "Total number of position-based subscription syncs",
+        ["status"],
+        registry=registry,
+    )
+
+
+@pytest.fixture()
+def mock_redis() -> MagicMock:
+    redis = MagicMock()
+    redis.set = MagicMock()
+    return redis
+
+
+@pytest.fixture()
+def mock_publisher() -> MagicMock:
+    publisher = MagicMock()
+    publisher.publish = MagicMock()
+    return publisher
+
+
+@pytest.fixture()
+def stream(
+    mock_redis: MagicMock,
+    mock_publisher: MagicMock,
+    messages_counter: Counter,
+    reconnect_counter: Counter,
+) -> AlpacaMarketDataStream:
+    with patch("libs.data.market_data.alpaca_stream.StockDataStream") as stream_cls:
+        stream_cls.return_value = MagicMock()
+        s = AlpacaMarketDataStream(
+            api_key="k",
+            secret_key="s",
+            redis_client=mock_redis,
+            event_publisher=mock_publisher,
+            price_ttl=300,
+            messages_received_counter=messages_counter,
+            reconnect_attempts_counter=reconnect_counter,
+        )
+        s.stream = stream_cls.return_value
+        yield s
+
+
+def _make_quote(symbol: str = "AAPL") -> Mock:
+    q = Mock()
+    q.symbol = symbol
+    q.bid_price = 150.00
+    q.ask_price = 150.10
+    q.bid_size = 100
+    q.ask_size = 200
+    q.timestamp = datetime.now(UTC)
+    q.ask_exchange = "NASDAQ"
+    return q
+
+
+class TestWebsocketMessagesReceivedCounter:
+    """Each received WebSocket message increments the counter."""
+
+    @pytest.mark.asyncio()
+    async def test_valid_quote_increments_counter(
+        self, stream: AlpacaMarketDataStream, messages_counter: Counter
+    ) -> None:
+        assert _counter_value(messages_counter, message_type="quote") == 0.0
+
+        await stream._handle_quote(_make_quote())
+
+        assert _counter_value(messages_counter, message_type="quote") == 1.0
+
+    @pytest.mark.asyncio()
+    async def test_counter_increments_per_message(
+        self, stream: AlpacaMarketDataStream, messages_counter: Counter
+    ) -> None:
+        for _ in range(3):
+            await stream._handle_quote(_make_quote())
+
+        assert _counter_value(messages_counter, message_type="quote") == 3.0
+
+    @pytest.mark.asyncio()
+    async def test_invalid_quote_still_counted(
+        self, stream: AlpacaMarketDataStream, messages_counter: Counter
+    ) -> None:
+        """Even malformed messages count toward inbound volume."""
+        bad = Mock()
+        bad.symbol = "AAPL"
+        bad.bid_price = "not-a-number"
+        bad.ask_price = 150.00
+        bad.bid_size = 100
+        bad.ask_size = 200
+        bad.timestamp = datetime.now(UTC)
+        bad.ask_exchange = "NASDAQ"
+
+        # Should not raise (stream resilience) and should still increment.
+        await stream._handle_quote(bad)
+
+        assert _counter_value(messages_counter, message_type="quote") == 1.0
+
+
+class TestReconnectAttemptsCounter:
+    """Each WebSocket reconnect attempt increments the counter."""
+
+    @pytest.mark.asyncio()
+    async def test_reconnect_increments_counter(
+        self, stream: AlpacaMarketDataStream, reconnect_counter: Counter
+    ) -> None:
+        assert _counter_value(reconnect_counter) == 0.0
+
+        # Fail twice, then bail by raising so we exit the retry loop quickly.
+        call_count = {"n": 0}
+
+        def fake_run() -> None:
+            call_count["n"] += 1
+            raise RuntimeError("boom")
+
+        stream.stream.run = fake_run
+        stream._max_reconnect_attempts = 2  # bail after 2 attempts
+
+        # Patch sleep to avoid the exponential backoff in tests.
+        with patch("libs.data.market_data.alpaca_stream.asyncio.sleep", new=AsyncMock()):
+            from libs.data.market_data.exceptions import ConnectionError as MDConnErr
+
+            with pytest.raises(MDConnErr):
+                await stream.start()
+
+        assert _counter_value(reconnect_counter) == 2.0
+
+
+class TestPositionSyncsCounter:
+    """Each position-sync cycle increments the counter with a status label."""
+
+    @pytest.fixture()
+    def mock_stream(self) -> AsyncMock:
+        s = AsyncMock(spec=AlpacaMarketDataStream)
+        s.get_subscribed_symbols.return_value = []
+        s.subscribe_symbols = AsyncMock()
+        s.unsubscribe_symbols = AsyncMock()
+        return s
+
+    @pytest.mark.asyncio()
+    async def test_successful_sync_increments_success(
+        self, mock_stream: AsyncMock, syncs_counter: Counter
+    ) -> None:
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+
+        with patch.object(mgr, "_fetch_position_symbols", new=AsyncMock(return_value={"AAPL"})):
+            await mgr._sync_subscriptions()
+
+        assert _counter_value(syncs_counter, status="success") == 1.0
+        assert _counter_value(syncs_counter, status="error") == 0.0
+
+    @pytest.mark.asyncio()
+    async def test_failed_fetch_increments_error(
+        self, mock_stream: AsyncMock, syncs_counter: Counter
+    ) -> None:
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+
+        # _fetch_position_symbols returns None on failure (documented contract).
+        with patch.object(mgr, "_fetch_position_symbols", new=AsyncMock(return_value=None)):
+            await mgr._sync_subscriptions()
+
+        assert _counter_value(syncs_counter, status="error") == 1.0
+        assert _counter_value(syncs_counter, status="success") == 0.0
+
+    @pytest.mark.asyncio()
+    async def test_exception_increments_error(
+        self, mock_stream: AsyncMock, syncs_counter: Counter
+    ) -> None:
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+
+        with patch.object(
+            mgr,
+            "_fetch_position_symbols",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            # _sync_subscriptions swallows unexpected errors internally.
+            await mgr._sync_subscriptions()
+
+        assert _counter_value(syncs_counter, status="error") == 1.0
+
+    @pytest.mark.asyncio()
+    async def test_multiple_syncs_accumulate(
+        self, mock_stream: AsyncMock, syncs_counter: Counter
+    ) -> None:
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+
+        with patch.object(mgr, "_fetch_position_symbols", new=AsyncMock(return_value=set())):
+            for _ in range(3):
+                await mgr._sync_subscriptions()
+
+        assert _counter_value(syncs_counter, status="success") == 3.0
+
+
+# Sanity check: importing main.py wires the counters into the long-lived
+# stream/subscription-manager objects. We can't easily run the lifespan here,
+# but we can assert that the Counter singletons exist and match expected labels.
+class TestMainModuleWiring:
+    def test_main_counters_declare_expected_labels(self) -> None:
+        from apps.market_data_service import main as md_main
+
+        # websocket_messages_received_total uses `message_type` label.
+        md_main.websocket_messages_received_total.labels(message_type="quote")
+        # position_syncs_total uses `status` label.
+        md_main.position_syncs_total.labels(status="success")
+        md_main.position_syncs_total.labels(status="error")
+        # reconnect_attempts_total is unlabelled.
+        md_main.reconnect_attempts_total.inc(0)  # no-op
+        # Also sanity-check instance types.
+        assert isinstance(md_main.websocket_messages_received_total, Counter)
+        assert isinstance(md_main.position_syncs_total, Counter)
+        assert isinstance(md_main.reconnect_attempts_total, Counter)
+
+
+# Suppress unused-import warning for asyncio (used implicitly via pytest-asyncio).
+_ = asyncio

--- a/tests/apps/market_data_service/test_counter_increments.py
+++ b/tests/apps/market_data_service/test_counter_increments.py
@@ -188,6 +188,39 @@ class TestReconnectAttemptsCounter:
         assert _counter_value(reconnect_counter) == 2.0
 
 
+class TestReconnectAttemptsCleanReturn:
+    """Clean-return reconnect cycles (stream.run() returns while _running is True)
+    must also be counted; otherwise flapping connections silently undercount."""
+
+    @pytest.mark.asyncio()
+    async def test_clean_return_while_running_increments_counter(
+        self, stream: AlpacaMarketDataStream, reconnect_counter: Counter
+    ) -> None:
+        assert _counter_value(reconnect_counter) == 0.0
+
+        call_count = {"n": 0}
+
+        def fake_run() -> None:
+            call_count["n"] += 1
+            # First two cycles: return normally (clean close). After that, raise
+            # to let the ConnectionError bail us out of the retry loop.
+            if call_count["n"] >= 3:
+                raise RuntimeError("stop")
+            # Return normally with _running still True -> flapping reconnect.
+
+        stream.stream.run = fake_run
+        stream._max_reconnect_attempts = 1  # first exception will bail
+
+        with patch("libs.data.market_data.alpaca_stream.asyncio.sleep", new=AsyncMock()):
+            from libs.data.market_data.exceptions import ConnectionError as MDConnErr
+
+            with pytest.raises(MDConnErr):
+                await stream.start()
+
+        # Two clean-return flaps + one exception-path reconnect = 3 increments.
+        assert _counter_value(reconnect_counter) == 3.0
+
+
 class TestPositionSyncsCounter:
     """Each position-sync cycle increments the counter with a status label."""
 
@@ -257,6 +290,57 @@ class TestPositionSyncsCounter:
             await mgr._sync_subscriptions()
 
         assert _counter_value(syncs_counter, status="error") == 1.0
+
+    @pytest.mark.asyncio()
+    async def test_subscribe_failure_increments_error(self, syncs_counter: Counter) -> None:
+        """Inner SubscriptionError on subscribe_symbols must flip status to error."""
+        from libs.data.market_data.exceptions import SubscriptionError
+
+        mock_stream = AsyncMock(spec=AlpacaMarketDataStream)
+        mock_stream.get_subscribed_symbols.return_value = []
+        mock_stream.subscribe_symbols = AsyncMock(side_effect=SubscriptionError("bad"))
+        mock_stream.unsubscribe_symbols = AsyncMock()
+
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+
+        with patch.object(mgr, "_fetch_position_symbols", new=AsyncMock(return_value={"AAPL"})):
+            await mgr._sync_subscriptions()
+
+        assert _counter_value(syncs_counter, status="error") == 1.0
+        assert _counter_value(syncs_counter, status="success") == 0.0
+
+    @pytest.mark.asyncio()
+    async def test_unsubscribe_failure_increments_error(self, syncs_counter: Counter) -> None:
+        """Inner SubscriptionError on unsubscribe_symbols must flip status to error."""
+        from libs.data.market_data.exceptions import SubscriptionError
+
+        mock_stream = AsyncMock(spec=AlpacaMarketDataStream)
+        # Pretend MSFT was previously subscribed so closed_symbols is non-empty.
+        mock_stream.get_subscribed_symbols.return_value = ["MSFT"]
+        mock_stream.subscribe_symbols = AsyncMock()
+        mock_stream.unsubscribe_symbols = AsyncMock(side_effect=SubscriptionError("bad"))
+
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+        # Seed last_position_symbols so MSFT shows up as "closed" this cycle.
+        mgr._last_position_symbols = {"MSFT"}
+
+        with patch.object(mgr, "_fetch_position_symbols", new=AsyncMock(return_value=set())):
+            await mgr._sync_subscriptions()
+
+        assert _counter_value(syncs_counter, status="error") == 1.0
+        assert _counter_value(syncs_counter, status="success") == 0.0
 
     @pytest.mark.asyncio()
     async def test_multiple_syncs_accumulate(

--- a/tests/apps/market_data_service/test_counter_increments.py
+++ b/tests/apps/market_data_service/test_counter_increments.py
@@ -27,11 +27,24 @@ from libs.data.market_data.alpaca_stream import AlpacaMarketDataStream
 
 
 def _counter_value(counter: Counter, **labels: str) -> float:
-    """Return the current value of a Prometheus counter (label-aware)."""
-    if labels:
-        return counter.labels(**labels)._value.get()  # type: ignore[attr-defined]
-    # Unlabelled counters expose the value directly via ``_value``.
-    return counter._value.get()  # type: ignore[attr-defined]
+    """Return the current value of a Prometheus counter via the public API.
+
+    Uses ``Counter.collect()`` (public prometheus_client API) instead of the
+    private ``_value`` attribute so the test isn't coupled to internal
+    implementation details of prometheus_client.
+    """
+    for metric in counter.collect():
+        for sample in metric.samples:
+            # Counter exposes a ``<name>_total`` sample. Filter to that sample
+            # with the requested labels.
+            if not sample.name.endswith("_total"):
+                continue
+            if labels and sample.labels != labels:
+                continue
+            if not labels and sample.labels:
+                continue
+            return float(sample.value)
+    return 0.0
 
 
 @pytest.fixture()
@@ -168,7 +181,7 @@ class TestReconnectAttemptsCounter:
     ) -> None:
         assert _counter_value(reconnect_counter) == 0.0
 
-        # Fail twice, then bail by raising so we exit the retry loop quickly.
+        # Fail every iteration, bail after a few attempts.
         call_count = {"n": 0}
 
         def fake_run() -> None:
@@ -176,7 +189,7 @@ class TestReconnectAttemptsCounter:
             raise RuntimeError("boom")
 
         stream.stream.run = fake_run
-        stream._max_reconnect_attempts = 2  # bail after 2 attempts
+        stream._max_reconnect_attempts = 3  # bail after 3 attempts
 
         # Patch sleep to avoid the exponential backoff in tests.
         with patch("libs.data.market_data.alpaca_stream.asyncio.sleep", new=AsyncMock()):
@@ -185,12 +198,20 @@ class TestReconnectAttemptsCounter:
             with pytest.raises(MDConnErr):
                 await stream.start()
 
+        # Iteration 1 (initial connect) -> no increment (raises, attempts=1).
+        # Iteration 2 (reconnect) -> +1, raises (attempts=2).
+        # Iteration 3 (reconnect) -> +1, raises (attempts=3, bail).
+        # Reconnect attempts counted: 2 (one per reconnect iteration).
         assert _counter_value(reconnect_counter) == 2.0
 
 
 class TestReconnectAttemptsCleanReturn:
     """Clean-return reconnect cycles (stream.run() returns while _running is True)
-    must also be counted; otherwise flapping connections silently undercount."""
+    must also be counted; otherwise flapping connections silently undercount.
+
+    Counter increments are performed exactly once per reconnect iteration
+    (at the start of each loop pass after the first), so a single failed
+    reconnect following a clean close is not double-counted."""
 
     @pytest.mark.asyncio()
     async def test_clean_return_while_running_increments_counter(
@@ -202,14 +223,14 @@ class TestReconnectAttemptsCleanReturn:
 
         def fake_run() -> None:
             call_count["n"] += 1
-            # First two cycles: return normally (clean close). After that, raise
-            # to let the ConnectionError bail us out of the retry loop.
+            # First two cycles: return normally (clean close). Third cycle:
+            # raise to let the ConnectionError bail us out of the retry loop.
             if call_count["n"] >= 3:
                 raise RuntimeError("stop")
             # Return normally with _running still True -> flapping reconnect.
 
         stream.stream.run = fake_run
-        stream._max_reconnect_attempts = 1  # first exception will bail
+        stream._max_reconnect_attempts = 1  # first exception bails
 
         with patch("libs.data.market_data.alpaca_stream.asyncio.sleep", new=AsyncMock()):
             from libs.data.market_data.exceptions import ConnectionError as MDConnErr
@@ -217,8 +238,40 @@ class TestReconnectAttemptsCleanReturn:
             with pytest.raises(MDConnErr):
                 await stream.start()
 
-        # Two clean-return flaps + one exception-path reconnect = 3 increments.
-        assert _counter_value(reconnect_counter) == 3.0
+        # Iteration 1 (initial connect) -> no increment.
+        # Iteration 2 (reconnect after clean close) -> +1.
+        # Iteration 3 (reconnect after clean close, run raises) -> +1.
+        # The raise happens AFTER the top-of-iteration increment, so the same
+        # failed reconnect is not double-counted with the exception path.
+        assert _counter_value(reconnect_counter) == 2.0
+
+    @pytest.mark.asyncio()
+    async def test_clean_return_then_failure_not_double_counted(
+        self, stream: AlpacaMarketDataStream, reconnect_counter: Counter
+    ) -> None:
+        """Regression test: a single failed reconnect following a clean close
+        must be counted exactly once, not twice."""
+        assert _counter_value(reconnect_counter) == 0.0
+
+        call_count = {"n": 0}
+
+        def fake_run() -> None:
+            call_count["n"] += 1
+            # First cycle returns cleanly; second cycle raises (the reconnect).
+            if call_count["n"] >= 2:
+                raise RuntimeError("reconnect-failed")
+
+        stream.stream.run = fake_run
+        stream._max_reconnect_attempts = 1
+
+        with patch("libs.data.market_data.alpaca_stream.asyncio.sleep", new=AsyncMock()):
+            from libs.data.market_data.exceptions import ConnectionError as MDConnErr
+
+            with pytest.raises(MDConnErr):
+                await stream.start()
+
+        # Exactly one reconnect attempt (iteration 2), not two.
+        assert _counter_value(reconnect_counter) == 1.0
 
 
 class TestPositionSyncsCounter:
@@ -341,6 +394,32 @@ class TestPositionSyncsCounter:
 
         assert _counter_value(syncs_counter, status="error") == 1.0
         assert _counter_value(syncs_counter, status="success") == 0.0
+
+    @pytest.mark.asyncio()
+    async def test_cancelled_sync_does_not_increment(
+        self, mock_stream: AsyncMock, syncs_counter: Counter
+    ) -> None:
+        """CancelledError mid-sync (e.g. shutdown) must NOT record the cycle
+        as success — otherwise aborted cycles bias the monitoring signal."""
+        mgr = PositionBasedSubscription(
+            stream=mock_stream,
+            execution_gateway_url="http://gw",
+            sync_interval=1,
+            initial_sync=False,
+            syncs_counter=syncs_counter,
+        )
+
+        with patch.object(
+            mgr,
+            "_fetch_position_symbols",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await mgr._sync_subscriptions()
+
+        # Neither success nor error should have been recorded.
+        assert _counter_value(syncs_counter, status="success") == 0.0
+        assert _counter_value(syncs_counter, status="error") == 0.0
 
     @pytest.mark.asyncio()
     async def test_multiple_syncs_accumulate(


### PR DESCRIPTION
## Summary
- Three Prometheus counters — `market_data_websocket_messages_received_total`, `market_data_reconnect_attempts_total`, `market_data_position_syncs_total` — were defined but never incremented, so Prometheus alerts and Grafana panels built on them were permanently blind.
- Wire `.inc()` at the right lifecycle points via dependency injection (keeps counter ownership in `main.py`, no import cycles):
  - `alpaca_stream._handle_quote` — `messages_received_counter.labels(message_type="quote").inc()`
  - `alpaca_stream.start` reconnect except branch — `reconnect_attempts_counter.inc()`
  - `position_sync._sync_subscriptions` finally block — `syncs_counter.labels(status=...).inc()`
- DI parameters are optional (default `None`) so existing tests/callers remain green.
- Added 9 regression tests covering increment, accumulation, and error paths.

## Test plan
- [x] `pytest tests/apps/market_data_service/ --no-cov` → 206/206 pass
- [x] `ruff format`, `ruff check` clean on changed files
- [ ] CI to confirm

Fixes #169