### PR TITLE
fix(ci): scope staging workflow honestly as image smoke test (#164)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,14 +1,29 @@
-name: Deploy to Staging
+# NOTE (issue #164): Despite the historical filename `deploy-staging.yml`, this
+# workflow does NOT deploy to any real staging environment. It runs entirely on
+# an ephemeral `ubuntu-latest` GitHub runner: it pulls the latest images from
+# GHCR, brings them up with `docker-compose -f docker-compose.staging.yml`, hits
+# the services' /health and /api/v1/config endpoints on localhost, then tears
+# down. The runner is discarded afterward — no remote host is touched.
+#
+# The workflow is useful as a post-build smoke test of the staging image set
+# (catches image-level regressions, broken env wiring, paper-trading mode
+# drift) but it MUST NOT be interpreted as a release to a persistent staging
+# environment. If/when a real staging host exists, add a separate deploy job
+# (ssh / self-hosted runner / kubectl) — do not repurpose this one silently.
+#
+# See: https://github.com/LeeeWayyy/trading_platform_new/issues/164
 
-# CRITICAL SAFETY: This workflow only deploys to staging environment with paper trading
-# Live trading is NEVER enabled in this workflow - use manual deployment for production
+name: Staging Image Smoke Test
+
+# CRITICAL SAFETY: This workflow enforces paper-trading-mode image configuration.
+# It never touches live trading credentials or any real deployment target.
 
 on:
   push:
     branches:
       - main
       - master
-  workflow_dispatch:  # Allow manual staging deployments
+  workflow_dispatch:  # Allow manual re-runs
 
 env:
   REGISTRY: ghcr.io
@@ -73,15 +88,19 @@ jobs:
           echo "- ✅ Live API credentials blocked" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ DRY_RUN mode enforced" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Safe to proceed with staging deployment." >> $GITHUB_STEP_SUMMARY
+          echo "Safe to proceed with image smoke test." >> $GITHUB_STEP_SUMMARY
 
   # ===========================================================================
-  # Job 2: Pull Images and Deploy
+  # Job 2: Bring up staging images on the ephemeral runner and smoke-test them.
+  #
+  # This job does NOT deploy anywhere — it just validates that the freshly
+  # built images start up and enforce paper-trading mode. The compose stack
+  # lives only for the duration of this runner. See file header / issue #164.
   # ===========================================================================
-  deploy-staging:
-    name: Deploy to staging environment
+  smoke-test:
+    name: Smoke test staging images (ephemeral runner)
     runs-on: ubuntu-latest
-    needs: validate-credentials  # Only deploy after credential validation passes
+    needs: validate-credentials  # Only run after credential validation passes
     environment: staging
 
     steps:
@@ -107,14 +126,15 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-orchestrator:latest
           echo "::endgroup::"
 
-      - name: Stop existing services
+      - name: Tear down any prior compose stack on this runner
         run: |
-          echo "::group::Stopping existing services"
-          # Stop services gracefully (if they exist)
+          echo "::group::Stopping any prior stack"
+          # Ephemeral runner — this is essentially a no-op, but kept for safety
+          # in case a previous step left containers behind.
           docker-compose -f docker-compose.staging.yml down || true
           echo "::endgroup::"
 
-      - name: Start services with latest images
+      - name: Bring up compose stack on the runner
         env:
           # Paper trading credentials (from GitHub Environments secrets)
           ALPACA_API_KEY_ID: ${{ secrets.ALPACA_PAPER_API_KEY }}
@@ -129,7 +149,7 @@ jobs:
           ENVIRONMENT: "staging"
           LOG_LEVEL: "INFO"
         run: |
-          echo "::group::Starting services"
+          echo "::group::Starting services on runner"
           docker-compose -f docker-compose.staging.yml up -d
           echo "::endgroup::"
 
@@ -144,7 +164,7 @@ jobs:
       - name: Run smoke tests
         run: |
           echo "::group::Running smoke tests"
-          # Test 1: Health checks
+          # Test 1: Health checks (localhost on the runner)
           curl -f http://localhost:8001/health || exit 1
           curl -f http://localhost:8002/health || exit 1
           curl -f http://localhost:8003/health || exit 1
@@ -156,12 +176,12 @@ jobs:
           ALPACA_PAPER=$(echo $CONFIG | jq -r '.alpaca_paper')
 
           if [ "$DRY_RUN" != "true" ]; then
-            echo "❌ ERROR: DRY_RUN is not true in staging (got: $DRY_RUN)"
+            echo "❌ ERROR: DRY_RUN is not true in staging image (got: $DRY_RUN)"
             exit 1
           fi
 
           if [ "$ALPACA_PAPER" != "true" ]; then
-            echo "❌ ERROR: ALPACA_PAPER is not true in staging (got: $ALPACA_PAPER)"
+            echo "❌ ERROR: ALPACA_PAPER is not true in staging image (got: $ALPACA_PAPER)"
             exit 1
           fi
 
@@ -172,53 +192,57 @@ jobs:
           ALPACA_PAPER=$(echo $CONFIG | jq -r '.alpaca_paper')
 
           if [ "$DRY_RUN" != "true" ]; then
-            echo "❌ ERROR: DRY_RUN is not true in staging (got: $DRY_RUN)"
+            echo "❌ ERROR: DRY_RUN is not true in staging image (got: $DRY_RUN)"
             exit 1
           fi
 
           if [ "$ALPACA_PAPER" != "true" ]; then
-            echo "❌ ERROR: ALPACA_PAPER is not true in staging (got: $ALPACA_PAPER)"
+            echo "❌ ERROR: ALPACA_PAPER is not true in staging image (got: $ALPACA_PAPER)"
             exit 1
           fi
 
           echo "✅ All smoke tests passed (paper trading mode verified)"
           echo "::endgroup::"
 
-      - name: Capture deployment info
+      - name: Capture smoke test info
         if: always()
         run: |
-          echo "::group::Deployment Info"
-          echo "Deployment Time: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "::group::Smoke Test Info"
+          echo "Run Time: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "Commit SHA: ${{ github.sha }}"
-          echo "Deployed by: ${{ github.actor }}"
+          echo "Triggered by: ${{ github.actor }}"
           echo "Docker Images:"
           docker images | grep trading-platform
           echo "::endgroup::"
 
-      - name: Deployment summary
+      - name: Smoke test summary
         if: success()
         run: |
-          echo "## Staging Deployment Successful 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "## Staging Image Smoke Test Passed ✅" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Environment:** staging" >> $GITHUB_STEP_SUMMARY
-          echo "- **Mode:** Paper trading (DRY_RUN=true)" >> $GITHUB_STEP_SUMMARY
+          echo "**Scope:** Post-build smoke test of the staging image set on an" >> $GITHUB_STEP_SUMMARY
+          echo "ephemeral GitHub runner. **This is NOT a deployment to a real** " >> $GITHUB_STEP_SUMMARY
+          echo "**staging environment** — no remote host was touched and the" >> $GITHUB_STEP_SUMMARY
+          echo "compose stack is discarded with the runner. See issue #164." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode verified:** Paper trading (DRY_RUN=true, ALPACA_PAPER=true)" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Deployed by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Time:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Services Deployed" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ signal_service (port 8001)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ execution_gateway (port 8002)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ orchestrator (port 8003)" >> $GITHUB_STEP_SUMMARY
+          echo "### Images smoke-tested" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ signal_service (ephemeral port 8001)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ execution_gateway (ephemeral port 8002)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ orchestrator (ephemeral port 8003)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All smoke tests passed." >> $GITHUB_STEP_SUMMARY
+          echo "All health checks and paper-trading-mode assertions passed." >> $GITHUB_STEP_SUMMARY
 
       - name: Notify on failure
         if: failure()
         run: |
-          echo "::error::Staging deployment failed"
-          echo "## Staging Deployment Failed ❌" >> $GITHUB_STEP_SUMMARY
+          echo "::error::Staging image smoke test failed"
+          echo "## Staging Image Smoke Test Failed ❌" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Check logs above for details." >> $GITHUB_STEP_SUMMARY
           # TODO: Add Slack/email notification here
-          # curl -X POST ${{ secrets.SLACK_WEBHOOK_URL }} -d '{"text":"Staging deployment failed"}'
+          # curl -X POST ${{ secrets.SLACK_WEBHOOK_URL }} -d '{"text":"Staging smoke test failed"}'

--- a/docs/GETTING_STARTED/CI_CD_GUIDE.md
+++ b/docs/GETTING_STARTED/CI_CD_GUIDE.md
@@ -27,7 +27,7 @@ This document describes the CI/CD pipeline for the trading platform, including w
 | **ci-tests-coverage.yml** | PR, push to master | Core test suite + coverage | ~15-20min |
 | **backtest-regression.yml** | Selective paths | Validate backtest parity | ~5-10min |
 | **docker-build.yml** | PR, push to master | Build + push Docker images | ~8-12min |
-| **deploy-staging.yml** | Push to master | Deploy to staging environment | ~6-8min |
+| **deploy-staging.yml** | Push to master | Staging image smoke test on ephemeral runner (NOT a real deploy — see issue #164) | ~6-8min |
 | **markdown-link-check.yml** | Weekly + markdown changes | Validate documentation links | ~2-3min |
 | **pr-auto-review-request.yml** | PR open/sync | Auto-request AI code reviews | <30sec |
 | **repomix-context.yml** | PR | Generate AI review context | ~3-5min |
@@ -160,7 +160,13 @@ matrix:
 
 ---
 
-### 4. deploy-staging.yml (Staging Deployment)
+### 4. deploy-staging.yml (Staging Image Smoke Test)
+
+> **Scope (issue #164):** Despite the filename, this workflow is a smoke test,
+> not a deployment. Both jobs run on an ephemeral `ubuntu-latest` runner; no
+> remote host, self-hosted runner, or cluster is touched. A passing run proves
+> the staging images start cleanly and enforce paper-trading mode — it does
+> not update any persistent environment.
 
 **Trigger:**
 ```yaml
@@ -171,20 +177,20 @@ on:
 ```
 
 **Safety gates:**
-1. **Credential validation job** (runs first):
+1. **Credential validation job** (`validate-credentials`, runs first):
    - Verify `ALPACA_PAPER_API_KEY` exists
    - Verify `ALPACA_PAPER_API_SECRET` exists
    - **Block live API keys:** Fail if `ALPACA_LIVE_API_KEY` found in staging
    - Verify `DRY_RUN=true` flag
 
-2. **Deployment job** (depends on validation):
-   - Pull latest Docker images
-   - Stop existing services
-   - Start services with paper trading credentials
+2. **Smoke test job** (`smoke-test`, depends on validation):
+   - Pull latest Docker images from GHCR
+   - Bring compose stack up on the runner (localhost only)
    - Wait for health checks (max 120 seconds)
    - Run smoke tests:
      - Health endpoints: `/health` for all services
      - Paper trading verification: Check `dry_run=true` and `alpaca_paper=true`
+   - Runner (and compose stack) discarded on job completion
 
 **Environment variables:**
 ```yaml
@@ -813,7 +819,7 @@ jobs:
 │   ├── ci-tests-coverage.yml          # Main test suite
 │   ├── backtest-regression.yml        # Backtest parity validation
 │   ├── docker-build.yml               # Container image builds
-│   ├── deploy-staging.yml             # Staging deployment
+│   ├── deploy-staging.yml             # Staging image smoke test (ephemeral, see #164)
 │   ├── markdown-link-check.yml        # Documentation validation
 │   ├── pr-auto-review-request.yml     # Automated review requests
 │   └── repomix-context.yml            # AI review context generation

--- a/docs/RUNBOOKS/staging-deployment.md
+++ b/docs/RUNBOOKS/staging-deployment.md
@@ -392,9 +392,13 @@ docker pull ghcr.io/YOUR_ORG/trading-platform-signal_service:PREVIOUS_SHA
 docker pull ghcr.io/YOUR_ORG/trading-platform-execution_gateway:PREVIOUS_SHA
 docker pull ghcr.io/YOUR_ORG/trading-platform-orchestrator:PREVIOUS_SHA
 
-# Retag locally as :latest so compose picks them up
+# Retag all three locally as :latest so compose picks them up
 docker tag ghcr.io/YOUR_ORG/trading-platform-signal_service:PREVIOUS_SHA \
   ghcr.io/YOUR_ORG/trading-platform-signal_service:latest
+docker tag ghcr.io/YOUR_ORG/trading-platform-execution_gateway:PREVIOUS_SHA \
+  ghcr.io/YOUR_ORG/trading-platform-execution_gateway:latest
+docker tag ghcr.io/YOUR_ORG/trading-platform-orchestrator:PREVIOUS_SHA \
+  ghcr.io/YOUR_ORG/trading-platform-orchestrator:latest
 
 # Bring the local stack up
 docker compose -f docker-compose.staging.yml up -d

--- a/docs/RUNBOOKS/staging-deployment.md
+++ b/docs/RUNBOOKS/staging-deployment.md
@@ -33,7 +33,7 @@ management for it, and troubleshooting.
   NOT a release to a persistent staging environment.
 - **Trading mode:** Paper trading ONLY (DRY_RUN=true, ALPACA_PAPER=true)
 - **Credentials:** Alpaca paper trading API keys (paper-only; live keys blocked)
-- **Trigger:** Runs via GitHub Actions on merge to main/master, or manually
+- **Trigger:** Runs via GitHub Actions on merge to master, or manually
 - **Runtime:** `ubuntu-latest` ephemeral runner; compose stack discarded on
   runner teardown
 
@@ -102,7 +102,7 @@ Required secrets for staging environment:
 # Settings → Environments → staging → Update secrets
 
 # 2. Trigger smoke test
-# Actions → Staging Image Smoke Test → Run workflow → main branch
+# Actions → Staging Image Smoke Test → Run workflow → master branch
 
 # 3. Verify the run (no persistent host exists — check Actions UI)
 #    Visit: Actions → Staging Image Smoke Test → latest run
@@ -124,7 +124,7 @@ workflow logs on the ephemeral runner.
 ### Automatic Run
 
 Triggered automatically on:
-- Merge to `main` or `master` branch
+- Merge to `master` branch
 - Successful completion of CI tests
 
 Workflow: `.github/workflows/deploy-staging.yml`
@@ -152,7 +152,7 @@ Workflow: `.github/workflows/deploy-staging.yml`
 ```bash
 # GitHub Actions UI is the ONLY place to view smoke-test status.
 # The runner is ephemeral — there is no persistent host to shell into.
-https://github.com/YOUR_ORG/trading_platform/actions/workflows/deploy-staging.yml
+https://github.com/YOUR_ORG/trading-platform/actions/workflows/deploy-staging.yml
 ```
 
 Open the latest workflow run to see:
@@ -189,7 +189,7 @@ docker compose -f docker-compose.staging.yml down
 
 1. Go to: Actions → Staging Image Smoke Test
 2. Click "Run workflow"
-3. Select branch: `main`
+3. Select branch: `master`
 4. Click "Run workflow"
 
 **Manual smoke-test use cases:**
@@ -354,7 +354,7 @@ from reaching the smoke test.**
 
 ```bash
 # Check GitHub Actions history for the last green run
-https://github.com/YOUR_ORG/trading_platform/actions/workflows/deploy-staging.yml
+https://github.com/YOUR_ORG/trading-platform/actions/workflows/deploy-staging.yml
 
 # Note the commit SHA of the last successful smoke-test run.
 ```

--- a/docs/RUNBOOKS/staging-deployment.md
+++ b/docs/RUNBOOKS/staging-deployment.md
@@ -17,10 +17,11 @@ management for it, and troubleshooting.
 ## Table of Contents
 - [Overview](#overview)
 - [Credential Management](#credential-management)
-- [Deployment Process](#deployment-process)
+- [Smoke Test Process](#smoke-test-process)
 - [Smoke Tests](#smoke-tests)
 - [Troubleshooting](#troubleshooting)
-- [Rollback Procedures](#rollback-procedures)
+- [Testing Previous Image Versions](#testing-previous-image-versions)
+- [Monitoring and Alerts](#monitoring-and-alerts)
 
 ---
 
@@ -39,7 +40,7 @@ management for it, and troubleshooting.
 **Safety guarantees:**
 - Live API keys are blocked by GitHub Environments
 - DRY_RUN=true enforced at multiple levels
-- Credential validation runs before deployment
+- Credential validation runs before the smoke test
 - Smoke tests verify paper trading mode active
 
 ---
@@ -75,7 +76,7 @@ Required secrets for staging environment:
 **4. Add protection rules (recommended):**
 
 - ✅ Required reviewers: 1
-- ✅ Wait timer: 0 minutes (staging can deploy immediately)
+- ✅ Wait timer: 0 minutes (smoke tests can run immediately)
 - ❌ Do NOT allow administrators to bypass
 
 **5. CRITICAL: Never add these secrets to staging:**
@@ -90,8 +91,8 @@ Required secrets for staging environment:
 
 1. Generate new paper API keys from Alpaca dashboard
 2. Update `ALPACA_PAPER_API_KEY` and `ALPACA_PAPER_API_SECRET` in staging environment
-3. Trigger manual deployment via GitHub Actions
-4. Verify smoke tests pass
+3. Trigger manual smoke test via GitHub Actions
+4. Verify smoke tests pass on the runner (check workflow logs)
 5. Revoke old API keys in Alpaca dashboard
 
 **Rotation checklist:**
@@ -100,17 +101,21 @@ Required secrets for staging environment:
 # 1. Update secrets in GitHub UI
 # Settings → Environments → staging → Update secrets
 
-# 2. Trigger deployment
+# 2. Trigger smoke test
 # Actions → Staging Image Smoke Test → Run workflow → main branch
 
-# 3. Verify deployment
-curl http://staging.example.com:8001/health
-curl http://staging.example.com:8002/health
-curl http://staging.example.com:8003/health
+# 3. Verify the run (no persistent host exists — check Actions UI)
+#    Visit: Actions → Staging Image Smoke Test → latest run
+#    Confirm `validate-credentials` and `smoke-test` jobs are green.
 
-# 4. Check logs for any authentication errors
-docker compose -f docker-compose.staging.yml logs execution_gateway | grep -i "auth\|key"
+# 4. Inspect authentication in the runner's step logs
+#    In the smoke-test job, open the "Show container logs" / "Collect logs"
+#    step and grep for auth/key errors in the execution_gateway output.
 ```
+
+**Note:** There is no persistent staging host (`staging.example.com` is not a
+real endpoint). Rotation is verified purely through the GitHub Actions
+workflow logs on the ephemeral runner.
 
 ---
 
@@ -142,38 +147,64 @@ Workflow: `.github/workflows/deploy-staging.yml`
 > passing run means "images start and enforce paper mode", not "a persistent
 > staging environment was updated".
 
-**View deployment status:**
+**View smoke-test status (automatic and manual runs):**
 
 ```bash
-# GitHub UI
+# GitHub Actions UI is the ONLY place to view smoke-test status.
+# The runner is ephemeral — there is no persistent host to shell into.
 https://github.com/YOUR_ORG/trading_platform/actions/workflows/deploy-staging.yml
+```
 
-# Check running services
+Open the latest workflow run to see:
+- `validate-credentials` job status
+- `smoke-test` job status, including per-step logs and container output
+  (`docker compose ps`, `docker compose logs`, captured inside the job).
+
+**Local reproduction (optional):**
+
+If you want to reproduce the smoke test on your workstation against the same
+images the workflow pulls, you can run a local compose stack. These commands
+target *your local Docker daemon*, not any remote staging host:
+
+```bash
+# Pull the images the workflow uses
+docker compose -f docker-compose.staging.yml pull
+
+# Bring the stack up locally
+docker compose -f docker-compose.staging.yml up -d
+
+# Check running services on your machine
 docker compose -f docker-compose.staging.yml ps
 
 # View logs
 docker compose -f docker-compose.staging.yml logs -f
+
+# Tear down when done
+docker compose -f docker-compose.staging.yml down
 ```
 
-### Manual Deployment
+### Manual Smoke Test Run
 
-**Trigger manual deployment:**
+**Trigger a manual smoke test:**
 
 1. Go to: Actions → Staging Image Smoke Test
 2. Click "Run workflow"
 3. Select branch: `main`
 4. Click "Run workflow"
 
-**Manual deployment use cases:**
-- Testing configuration changes
-- After credential rotation
-- Rollback to previous version (select commit SHA)
+**Manual smoke-test use cases:**
+- Testing configuration changes before merging
+- After credential rotation (verify keys are valid)
+- Re-testing a previous image version (see
+  [Testing Previous Image Versions](#testing-previous-image-versions))
 
 ---
 
 ## Smoke Tests
 
-Smoke tests run automatically after deployment to verify system health.
+Smoke tests run automatically as part of the workflow's `smoke-test` job,
+against the images pulled onto the ephemeral runner. They are the primary
+signal of image health — there is no separate "post-deploy" phase.
 
 **Test 1: Health Checks**
 
@@ -293,7 +324,8 @@ docker compose -f docker-compose.staging.yml config | grep -A 5 "execution_gatew
 **Symptoms:**
 - Workflow fails with error: "ALPACA_LIVE_API_KEY found in staging environment"
 
-**This is EXPECTED BEHAVIOR - the workflow is preventing unsafe deployment.**
+**This is EXPECTED BEHAVIOR - the workflow is preventing unsafe credentials
+from reaching the smoke test.**
 
 **Solutions:**
 
@@ -309,105 +341,112 @@ docker compose -f docker-compose.staging.yml config | grep -A 5 "execution_gatew
 
 ---
 
-## Rollback Procedures
+## Testing Previous Image Versions
 
-### Quick Rollback (Manual)
+> **No remote rollback exists.** Because the smoke test runs on an ephemeral
+> runner and discards the stack at job end, there is nothing to "roll back" on
+> a remote host. The procedures below describe how to re-run the smoke test
+> against a previous image version, and how to reproduce that locally.
 
-**1. Identify last good deployment:**
+### Re-run Smoke Test Against a Previous Version
+
+**1. Identify the last good image version:**
 
 ```bash
-# Check GitHub Actions history
+# Check GitHub Actions history for the last green run
 https://github.com/YOUR_ORG/trading_platform/actions/workflows/deploy-staging.yml
 
-# Note commit SHA of last successful deployment
+# Note the commit SHA of the last successful smoke-test run.
 ```
 
-**2. Redeploy previous version:**
+**2. Trigger the workflow on that SHA:**
 
-```bash
-# Trigger manual workflow with previous commit
-# Actions → Staging Image Smoke Test → Run workflow → Select commit SHA
+```
+# In GitHub UI: Actions → Staging Image Smoke Test → Run workflow
+# Branch/Ref: select the commit SHA (or a tag) of the last good version.
 ```
 
-**3. Verify rollback:**
+**3. Verify the re-run:**
 
 ```bash
-# Check deployment info
-docker compose -f docker-compose.staging.yml logs | grep "Commit SHA"
-
-# Run smoke tests
-curl -f http://localhost:8001/health
-curl -f http://localhost:8002/health
-curl -f http://localhost:8003/health
+# There is no remote host to curl. Verify in the Actions UI:
+# Open the run → smoke-test job → confirm health check and
+# /api/v1/config assertions pass in the step logs.
 ```
 
-### Emergency Rollback (Stop services)
+### Local Reproduction of a Previous Version
 
-**If deployment causes critical issues:**
+If you need to poke at the previous image set interactively on your
+workstation (e.g., to reproduce a smoke-test failure), you can run it
+locally. None of these commands touch any remote infrastructure:
 
 ```bash
-# Stop all services immediately
+# Stop any stack from a prior local run
 docker compose -f docker-compose.staging.yml down
 
-# Optional: preserve data volumes
-docker compose -f docker-compose.staging.yml down  # volumes preserved by default
+# Optional: wipe local volumes (WARNING: deletes local data)
+docker compose -f docker-compose.staging.yml down -v
 
-# Optional: completely wipe environment
-docker compose -f docker-compose.staging.yml down -v  # WARNING: deletes all data
-```
-
-**Restart with previous images:**
-
-```bash
-# Pull specific version
+# Pull specific image versions by SHA tag
 docker pull ghcr.io/YOUR_ORG/trading-platform-signal_service:PREVIOUS_SHA
 docker pull ghcr.io/YOUR_ORG/trading-platform-execution_gateway:PREVIOUS_SHA
 docker pull ghcr.io/YOUR_ORG/trading-platform-orchestrator:PREVIOUS_SHA
 
-# Tag as latest
+# Retag locally as :latest so compose picks them up
 docker tag ghcr.io/YOUR_ORG/trading-platform-signal_service:PREVIOUS_SHA \
   ghcr.io/YOUR_ORG/trading-platform-signal_service:latest
 
-# Restart services
+# Bring the local stack up
 docker compose -f docker-compose.staging.yml up -d
+
+# Run the same smoke checks the workflow runs
+curl -f http://localhost:8001/health
+curl -f http://localhost:8002/health
+curl -f http://localhost:8003/health
 ```
 
 ---
 
 ## Monitoring and Alerts
 
-### Access Monitoring Dashboards
+> **Scope note:** The smoke-test workflow does not expose a persistent
+> Grafana/Prometheus/Loki stack on a remote host. The URLs below only apply
+> when you run the compose stack locally for reproduction (see
+> [Local Reproduction](#manual-smoke-test-run)). In CI, observability
+> artifacts are limited to the workflow's step logs and any uploaded
+> artifacts.
+
+### Access Monitoring Dashboards (local reproduction only)
+
+When you run `docker compose -f docker-compose.staging.yml up -d` locally:
 
 **Grafana:**
-- URL: http://staging.example.com:3000
+- URL: http://localhost:3000
 - Username: admin
-- Password: (from `GRAFANA_PASSWORD` secret)
+- Password: (from your local `GRAFANA_PASSWORD` env var)
 
 **Prometheus:**
-- URL: http://staging.example.com:9090
+- URL: http://localhost:9090
 
 **Loki (logs):**
 - Access via Grafana → Explore → Loki datasource
 
-### Key Metrics to Monitor
+### Key Signals to Check in CI Logs
+
+Within the `smoke-test` job's step output:
 
 **Service health:**
 - All services respond to `/health` with 200 OK
-- Health check duration < 1 second
+- Health check completes within the 120 s workflow timeout
 
 **Trading safety:**
-- DRY_RUN=true in all logs
-- ALPACA_PAPER=true confirmed
-- No live API calls detected
+- DRY_RUN=true in container env dumps
+- ALPACA_PAPER=true confirmed via `/api/v1/config`
+- No live API calls (validation job blocks live keys)
 
-**Error rates:**
-- ERROR/CRITICAL log count < 10/hour
-- HTTP 5xx responses < 1%
-
-**Resource usage:**
-- CPU < 70%
-- Memory < 80%
-- Disk < 85%
+**Error signals (grep the captured container logs):**
+- Zero ERROR/CRITICAL lines during startup
+- No HTTP 5xx responses during smoke checks
 
 ---
 

--- a/docs/RUNBOOKS/staging-deployment.md
+++ b/docs/RUNBOOKS/staging-deployment.md
@@ -1,6 +1,18 @@
-# Staging Deployment Runbook
+# Staging Image Smoke Test Runbook
 
-This runbook covers staging environment deployment, credential management, and troubleshooting.
+> **Scope note (issue #164):** The workflow `.github/workflows/deploy-staging.yml`
+> (historical filename) is a **post-build image smoke test**, not a real
+> deployment. It runs on an ephemeral `ubuntu-latest` GitHub runner: it pulls
+> the latest images from GHCR, starts them with `docker-compose`, hits
+> `/health` and `/api/v1/config` on `localhost`, then the runner is discarded.
+> No remote host / cluster / self-hosted runner is involved. A real staging
+> deployment would require additional infrastructure (SSH target, self-hosted
+> runner, or `kubectl apply`) and is explicitly out of scope for this workflow.
+> Treat passing runs as "images start cleanly and enforce paper-trading mode",
+> **not** as "release to a persistent staging environment".
+
+This runbook covers the staging-image smoke test workflow, credential
+management for it, and troubleshooting.
 
 ## Table of Contents
 - [Overview](#overview)
@@ -14,12 +26,15 @@ This runbook covers staging environment deployment, credential management, and t
 
 ## Overview
 
-**Staging environment characteristics:**
-- **Purpose:** Pre-production testing with paper trading
+**Workflow characteristics:**
+- **Purpose:** Post-build smoke test of the staging image set on an ephemeral
+  GitHub runner. Catches image-level regressions and paper-trading-mode drift.
+  NOT a release to a persistent staging environment.
 - **Trading mode:** Paper trading ONLY (DRY_RUN=true, ALPACA_PAPER=true)
-- **Credentials:** Alpaca paper trading API keys
-- **Deployment:** Automated via GitHub Actions on merge to main/master
-- **Monitoring:** Full observability stack (Prometheus, Grafana, Loki)
+- **Credentials:** Alpaca paper trading API keys (paper-only; live keys blocked)
+- **Trigger:** Runs via GitHub Actions on merge to main/master, or manually
+- **Runtime:** `ubuntu-latest` ephemeral runner; compose stack discarded on
+  runner teardown
 
 **Safety guarantees:**
 - Live API keys are blocked by GitHub Environments
@@ -86,7 +101,7 @@ Required secrets for staging environment:
 # Settings → Environments → staging → Update secrets
 
 # 2. Trigger deployment
-# Actions → Deploy to Staging → Run workflow → main branch
+# Actions → Staging Image Smoke Test → Run workflow → main branch
 
 # 3. Verify deployment
 curl http://staging.example.com:8001/health
@@ -99,9 +114,9 @@ docker compose -f docker-compose.staging.yml logs execution_gateway | grep -i "a
 
 ---
 
-## Deployment Process
+## Smoke Test Process
 
-### Automatic Deployment
+### Automatic Run
 
 Triggered automatically on:
 - Merge to `main` or `master` branch
@@ -109,20 +124,23 @@ Triggered automatically on:
 
 Workflow: `.github/workflows/deploy-staging.yml`
 
-**Deployment steps:**
+**Steps:**
 
-1. **Credential Validation** (Job 1)
+1. **Credential Validation** (Job 1: `validate-credentials`)
    - Verify paper API credentials exist
    - Block live API keys
    - Validate DRY_RUN=true
 
-2. **Deploy** (Job 2)
+2. **Smoke Test** (Job 2: `smoke-test`)
    - Pull latest Docker images from ghcr.io
-   - Stop existing services gracefully
-   - Start services with new images
+   - Bring compose stack up on the runner
    - Wait for health checks (120s timeout)
-   - Run smoke tests
-   - Capture deployment info
+   - Hit `/health` and `/api/v1/config` on localhost
+   - Capture image info; runner + stack discarded on job end
+
+> **Reminder:** Job 2 runs on the GitHub runner, not on a remote host. A
+> passing run means "images start and enforce paper mode", not "a persistent
+> staging environment was updated".
 
 **View deployment status:**
 
@@ -141,7 +159,7 @@ docker compose -f docker-compose.staging.yml logs -f
 
 **Trigger manual deployment:**
 
-1. Go to: Actions → Deploy to Staging
+1. Go to: Actions → Staging Image Smoke Test
 2. Click "Run workflow"
 3. Select branch: `main`
 4. Click "Run workflow"
@@ -308,7 +326,7 @@ https://github.com/YOUR_ORG/trading_platform/actions/workflows/deploy-staging.ym
 
 ```bash
 # Trigger manual workflow with previous commit
-# Actions → Deploy to Staging → Run workflow → Select commit SHA
+# Actions → Staging Image Smoke Test → Run workflow → Select commit SHA
 ```
 
 **3. Verify rollback:**

--- a/tests/test_staging_deployment.py
+++ b/tests/test_staging_deployment.py
@@ -100,7 +100,7 @@ class TestDeployStagingWorkflow:
         # Check that workflow exits with error if live keys found
         assert "exit 1" in content, "Workflow should exit with error if live API keys detected"
 
-    def test_workflow_deployment_depends_on_validation(self, project_root: Path) -> None:
+    def test_workflow_smoke_test_depends_on_validation(self, project_root: Path) -> None:
         """Test that smoke-test job depends on credential validation.
 
         Historically the second job was named 'deploy-staging' and implied a
@@ -131,7 +131,7 @@ class TestDeployStagingWorkflow:
         ), "smoke-test must depend on validate-credentials (safety check)"
 
     def test_workflow_runs_smoke_tests(self, project_root: Path) -> None:
-        """Test that workflow runs smoke tests after deployment."""
+        """Test that workflow runs smoke tests as part of the smoke-test job."""
         workflow_path = project_root / ".github" / "workflows" / "deploy-staging.yml"
         with open(workflow_path) as f:
             content = f.read()
@@ -335,14 +335,24 @@ class TestStagingDeploymentDocumentation:
             "live" in content.lower() or "production" in content.lower()
         ), "Runbook should warn about live/production credentials"
 
-    def test_runbook_covers_rollback_procedures(self, project_root: Path) -> None:
-        """Test that runbook covers rollback procedures."""
-        runbook_path = project_root / "docs" / "RUNBOOKS" / "staging-deployment.md"
-        content = runbook_path.read_text()
+    def test_runbook_covers_previous_version_testing(self, project_root: Path) -> None:
+        """Test that runbook explains how to test previous image versions.
 
-        # Check for rollback procedures
-        assert "rollback" in content.lower(), "Runbook should cover rollback procedures"
-        assert "emergency" in content.lower(), "Runbook should document emergency procedures"
+        Per issue #164 the workflow is an ephemeral image smoke test with no
+        remote host to roll back, so the runbook describes re-running the
+        smoke test against a previous commit SHA plus local reproduction.
+        """
+        runbook_path = project_root / "docs" / "RUNBOOKS" / "staging-deployment.md"
+        content = runbook_path.read_text().lower()
+
+        # The runbook must explain the (absence of) rollback semantics and
+        # describe how to re-test a previous version.
+        assert "rollback" in content, (
+            "Runbook should explicitly address rollback (even if only to note "
+            "no remote rollback exists)"
+        )
+        assert "previous" in content, "Runbook should describe testing previous image versions"
+        assert "previous_sha" in content, "Runbook should show how to target a previous image SHA"
 
 
 # =============================================================================

--- a/tests/test_staging_deployment.py
+++ b/tests/test_staging_deployment.py
@@ -101,28 +101,34 @@ class TestDeployStagingWorkflow:
         assert "exit 1" in content, "Workflow should exit with error if live API keys detected"
 
     def test_workflow_deployment_depends_on_validation(self, project_root: Path) -> None:
-        """Test that deployment job depends on credential validation."""
+        """Test that smoke-test job depends on credential validation.
+
+        Historically the second job was named 'deploy-staging' and implied a
+        real deployment. Per issue #164 the workflow was honestly scoped as an
+        image smoke test and the job renamed to 'smoke-test'. The safety
+        ordering (credential validation must run first) is preserved.
+        """
         workflow_path = project_root / ".github" / "workflows" / "deploy-staging.yml"
         with open(workflow_path) as f:
             config = yaml.safe_load(f)
 
         jobs = config["jobs"]
 
-        # Check for deploy-staging job
-        assert "deploy-staging" in jobs, "Workflow missing 'deploy-staging' job"
+        # Check for smoke-test job (renamed from deploy-staging in #164)
+        assert "smoke-test" in jobs, "Workflow missing 'smoke-test' job"
 
-        deploy_job = jobs["deploy-staging"]
+        smoke_job = jobs["smoke-test"]
 
-        # Check that deploy-staging depends on validate-credentials
-        assert "needs" in deploy_job, "deploy-staging job must have 'needs' dependency"
+        # Check that smoke-test depends on validate-credentials
+        assert "needs" in smoke_job, "smoke-test job must have 'needs' dependency"
 
-        needs = deploy_job["needs"]
+        needs = smoke_job["needs"]
         if isinstance(needs, str):
             needs = [needs]
 
         assert (
             "validate-credentials" in needs
-        ), "deploy-staging must depend on validate-credentials (safety check)"
+        ), "smoke-test must depend on validate-credentials (safety check)"
 
     def test_workflow_runs_smoke_tests(self, project_root: Path) -> None:
         """Test that workflow runs smoke tests after deployment."""


### PR DESCRIPTION
## Summary
- `deploy-staging.yml` claimed to "Deploy to Staging" but actually only ran `docker-compose up` on the ephemeral GitHub runner and curled `localhost`. No SSH, self-hosted runner, remote docker context, or k8s target exists anywhere in the repo.
- Re-scope the workflow honestly as a post-build smoke test rather than a deployment:
  - Workflow `name:` → "Staging Image Smoke Test"
  - Job `deploy-staging` → `smoke-test`
  - Step/summary text updated to say "smoke test" / "ephemeral runner" instead of "deploy"
  - `validate-credentials` job, live-key blocker, health checks, and paper-trading-mode assertions retained (valid defense-in-depth)
- Runbook (`docs/RUNBOOKS/staging-deployment.md`) and CI/CD guide (`docs/GETTING_STARTED/CI_CD_GUIDE.md`) updated to match.
- Not chosen: wiring a real deploy target. No staging host infrastructure exists to deploy to; a future PR should add one if staging becomes real.

## Test plan
- [x] YAML parses cleanly
- [x] `pytest tests/test_staging_deployment.py -m "not slow and not integration"` → 21/21 pass
- [ ] CI to confirm workflow still runs on push

Fixes #164