### PR TITLE
fix(web-console): resolve trade chart black-box state and stabilize dev services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@
 ALPACA_API_KEY_ID=your_key_here
 ALPACA_API_SECRET_KEY=your_secret_here
 ALPACA_BASE_URL=https://paper-api.alpaca.markets/v2
+# Optional market data feed for stock bars/quotes.
+# Options:
+#   iex  - free feed (recommended default for dev)
+#   sip  - consolidated tape (paid entitlement typically required)
+#   otc  - OTC symbols feed
+ALPACA_DATA_FEED=iex
 # Optional: Backfill fills from Alpaca account activities (FILL)
 ALPACA_FILLS_BACKFILL_ENABLED=false
 ALPACA_FILLS_BACKFILL_INITIAL_LOOKBACK_HOURS=24

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ ALPACA_BASE_URL=https://paper-api.alpaca.markets/v2
 #   iex  - free feed (recommended default for dev)
 #   sip  - consolidated tape (paid entitlement typically required)
 #   otc  - OTC symbols feed
+#   boats - Blue Ocean ATS feed
 ALPACA_DATA_FEED=iex
 # Optional: Backfill fills from Alpaca account activities (FILL)
 ALPACA_FILLS_BACKFILL_ENABLED=false

--- a/apps/execution_gateway/config.py
+++ b/apps/execution_gateway/config.py
@@ -29,7 +29,7 @@ from decimal import Decimal, InvalidOperation
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_ALPACA_DATA_FEEDS = ("iex", "sip", "otc")
+SUPPORTED_ALPACA_DATA_FEEDS = ("iex", "sip", "otc", "boats")
 
 
 # ============================================================================

--- a/apps/execution_gateway/config.py
+++ b/apps/execution_gateway/config.py
@@ -361,7 +361,7 @@ def get_config() -> ExecutionGatewayConfig:
         )
         max_slice_pct_of_adv = 0.01
 
-    # Parse Alpaca data feed (supported: iex, sip, otc)
+    # Parse Alpaca data feed (supported: iex, sip, otc, boats)
     alpaca_data_feed = _get_alpaca_data_feed_env()
 
     return ExecutionGatewayConfig(

--- a/apps/execution_gateway/config.py
+++ b/apps/execution_gateway/config.py
@@ -146,7 +146,7 @@ def _get_bool_env_permissive(name: str, default: bool) -> bool:
 def _get_alpaca_data_feed_env(name: str = "ALPACA_DATA_FEED") -> str | None:
     """Parse Alpaca data feed from environment with explicit option validation.
 
-    Supported values: iex, sip, otc.
+    Supported values: iex, sip, otc, boats.
     Empty values are treated as unset (None).
     """
     raw = os.getenv(name, "")

--- a/apps/execution_gateway/config.py
+++ b/apps/execution_gateway/config.py
@@ -29,6 +29,8 @@ from decimal import Decimal, InvalidOperation
 
 logger = logging.getLogger(__name__)
 
+SUPPORTED_ALPACA_DATA_FEEDS = ("iex", "sip", "otc")
+
 
 # ============================================================================
 # Helper Functions
@@ -139,6 +141,28 @@ def _get_bool_env_permissive(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.lower() in ("true", "yes", "on", "1")
+
+
+def _get_alpaca_data_feed_env(name: str = "ALPACA_DATA_FEED") -> str | None:
+    """Parse Alpaca data feed from environment with explicit option validation.
+
+    Supported values: iex, sip, otc.
+    Empty values are treated as unset (None).
+    """
+    raw = os.getenv(name, "")
+    if not raw.strip():
+        return None
+
+    normalized = raw.strip().lower()
+    if normalized not in SUPPORTED_ALPACA_DATA_FEEDS:
+        logger.warning(
+            "Invalid %s=%s; supported options: %s. Ignoring override.",
+            name,
+            raw,
+            ", ".join(SUPPORTED_ALPACA_DATA_FEEDS),
+        )
+        return None
+    return normalized
 
 
 # ============================================================================
@@ -337,8 +361,8 @@ def get_config() -> ExecutionGatewayConfig:
         )
         max_slice_pct_of_adv = 0.01
 
-    # Parse Alpaca data feed (strip whitespace, convert empty to None)
-    alpaca_data_feed = os.getenv("ALPACA_DATA_FEED", "").strip() or None
+    # Parse Alpaca data feed (supported: iex, sip, otc)
+    alpaca_data_feed = _get_alpaca_data_feed_env()
 
     return ExecutionGatewayConfig(
         # Core Settings

--- a/apps/market_data_service/config.py
+++ b/apps/market_data_service/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     alpaca_api_key: str
     alpaca_secret_key: str
     alpaca_base_url: str = "https://paper-api.alpaca.markets"  # Paper trading default
-    alpaca_data_feed: Literal["iex", "sip", "otc"] = "iex"
+    alpaca_data_feed: Literal["iex", "sip", "otc", "boats"] = "iex"
 
     @field_validator("alpaca_data_feed", mode="before")
     @classmethod
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
         - iex: free feed
         - sip: consolidated tape (entitlement required)
         - otc: OTC symbols feed
+        - boats: Blue Ocean ATS feed
         """
         if value is None:
             return "iex"

--- a/apps/market_data_service/config.py
+++ b/apps/market_data_service/config.py
@@ -4,6 +4,9 @@ Market Data Service Configuration
 Settings loaded from environment variables.
 """
 
+from typing import Literal
+
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -19,6 +22,26 @@ class Settings(BaseSettings):
     alpaca_api_key: str
     alpaca_secret_key: str
     alpaca_base_url: str = "https://paper-api.alpaca.markets"  # Paper trading default
+    alpaca_data_feed: Literal["iex", "sip", "otc"] = "iex"
+
+    @field_validator("alpaca_data_feed", mode="before")
+    @classmethod
+    def normalize_alpaca_data_feed(cls, value: object) -> str:
+        """Normalize ALPACA_DATA_FEED and enforce supported options.
+
+        Supported values:
+        - iex: free feed
+        - sip: consolidated tape (entitlement required)
+        - otc: OTC symbols feed
+        """
+        if value is None:
+            return "iex"
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if not normalized:
+                return "iex"
+            return normalized
+        return str(value).strip().lower()
 
     # Redis Configuration
     redis_host: str = "localhost"

--- a/apps/market_data_service/main.py
+++ b/apps/market_data_service/main.py
@@ -98,6 +98,10 @@ SOURCE_OVERRIDE_AUTH = api_auth(
 SOURCE_OVERRIDE_PREFIX_BY_SERVICE: dict[str, str] = {
     "web_console_ng": "web_console",
 }
+SOURCE_OVERRIDE_SERVICE_BY_PREFIX: dict[str, str] = {
+    source_prefix: service_id
+    for service_id, source_prefix in SOURCE_OVERRIDE_PREFIX_BY_SERVICE.items()
+}
 UNSIGNED_SOURCE_PREFIXES = frozenset(SOURCE_OVERRIDE_PREFIX_BY_SERVICE.values())
 
 
@@ -120,19 +124,24 @@ async def _authorize_source_override(request: Request, normalized_source: str) -
     if normalized_source == "manual":
         return
 
+    source_prefix = normalized_source.split(":", 1)[0].strip().lower()
+    source_service_id = SOURCE_OVERRIDE_SERVICE_BY_PREFIX.get(source_prefix)
+    if source_service_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Unsigned source override is not allowed for prefix '{source_prefix}'",
+        )
+
+    service_key = re.sub(r"[^A-Z0-9_]", "_", source_service_id.upper())
     signed_override_required = bool(
         os.getenv("INTERNAL_TOKEN_SECRET", "").strip()
-        or any(
-            key.startswith("INTERNAL_TOKEN_SECRET_") and str(value).strip()
-            for key, value in os.environ.items()
-        )
+        or os.getenv(f"INTERNAL_TOKEN_SECRET_{service_key}", "").strip()
     )
     if not signed_override_required:
-        unsigned_source_prefix = normalized_source.split(":", 1)[0].strip().lower()
-        if unsigned_source_prefix not in UNSIGNED_SOURCE_PREFIXES:
+        if source_prefix not in UNSIGNED_SOURCE_PREFIXES:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Unsigned source override is not allowed for prefix '{unsigned_source_prefix}'",
+                detail=f"Unsigned source override is not allowed for prefix '{source_prefix}'",
             )
         return
 
@@ -156,13 +165,15 @@ async def _authorize_source_override(request: Request, normalized_source: str) -
         )
 
     service_id = auth_context.internal_claims.service_id.strip().lower()
-    source_prefix = SOURCE_OVERRIDE_PREFIX_BY_SERVICE.get(service_id)
-    if source_prefix is None:
+    service_source_prefix = SOURCE_OVERRIDE_PREFIX_BY_SERVICE.get(service_id)
+    if service_source_prefix is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Source override is not allowed for service '{service_id}'",
         )
-    if normalized_source != source_prefix and not normalized_source.startswith(f"{source_prefix}:"):
+    if normalized_source != service_source_prefix and not normalized_source.startswith(
+        f"{service_source_prefix}:"
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Source '{normalized_source}' is not owned by service '{service_id}'",

--- a/apps/market_data_service/main.py
+++ b/apps/market_data_service/main.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -78,6 +79,23 @@ class HealthResponse(BaseModel):
     subscribed_symbols: int
     reconnect_attempts: int
     max_reconnect_attempts: int
+
+
+SOURCE_TAG_PATTERN = re.compile(r"^[A-Za-z0-9:_-]{1,64}$")
+
+
+def _normalize_subscription_source(raw_source: str | None) -> str:
+    """Normalize and validate caller-provided source ownership tags."""
+    normalized_source = (raw_source or "").strip() or "manual"
+    if not SOURCE_TAG_PATTERN.fullmatch(normalized_source):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Invalid source. Allowed characters: letters, numbers, ':', '_', '-' "
+                "with max length 64."
+            ),
+        )
+    return normalized_source
 
 
 @asynccontextmanager
@@ -336,7 +354,7 @@ async def subscribe_symbols(request: SubscribeRequest) -> SubscribeResponse:
             )
 
         try:
-            normalized_source = request.source.strip() or "manual"
+            normalized_source = _normalize_subscription_source(request.source)
             await stream.subscribe_symbols(request.symbols, source=normalized_source)
 
             subscribed = stream.get_subscribed_symbols()
@@ -410,7 +428,7 @@ async def unsubscribe_symbol(
             )
 
         try:
-            normalized_source = source.strip() or "manual"
+            normalized_source = _normalize_subscription_source(source)
             await stream.unsubscribe_symbols([symbol], source=normalized_source)
 
             remaining = stream.get_subscribed_symbols()

--- a/apps/market_data_service/main.py
+++ b/apps/market_data_service/main.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import httpx
 import redis.exceptions
-from fastapi import FastAPI, HTTPException, status
+from fastapi import FastAPI, HTTPException, Query, status
 from prometheus_client import Counter, Gauge, Histogram, make_asgi_app
 from pydantic import BaseModel
 
@@ -44,6 +44,7 @@ class SubscribeRequest(BaseModel):
     """Request to subscribe to symbols."""
 
     symbols: list[str]
+    source: str = "manual"
 
 
 class SubscribeResponse(BaseModel):
@@ -335,14 +336,20 @@ async def subscribe_symbols(request: SubscribeRequest) -> SubscribeResponse:
             )
 
         try:
-            await stream.subscribe_symbols(request.symbols)
+            normalized_source = request.source.strip() or "manual"
+            await stream.subscribe_symbols(request.symbols, source=normalized_source)
 
             subscribed = stream.get_subscribed_symbols()
 
             # Update metrics after successful subscription
             subscribed_symbols_current.set(len(subscribed))
 
-            logger.info(f"Subscribed to {len(request.symbols)} symbols: {request.symbols}")
+            logger.info(
+                "Subscribed to %s symbols (%s): %s",
+                len(request.symbols),
+                normalized_source,
+                request.symbols,
+            )
 
             return SubscribeResponse(
                 message=f"Successfully subscribed to {len(request.symbols)} symbols",
@@ -376,7 +383,10 @@ async def subscribe_symbols(request: SubscribeRequest) -> SubscribeResponse:
 
 
 @app.delete("/api/v1/subscribe/{symbol}", response_model=UnsubscribeResponse)
-async def unsubscribe_symbol(symbol: str) -> UnsubscribeResponse:
+async def unsubscribe_symbol(
+    symbol: str,
+    source: str = Query(default="manual"),
+) -> UnsubscribeResponse:
     """
     Unsubscribe from a symbol.
 
@@ -400,14 +410,15 @@ async def unsubscribe_symbol(symbol: str) -> UnsubscribeResponse:
             )
 
         try:
-            await stream.unsubscribe_symbols([symbol])
+            normalized_source = source.strip() or "manual"
+            await stream.unsubscribe_symbols([symbol], source=normalized_source)
 
             remaining = stream.get_subscribed_symbols()
 
             # Update metrics after successful unsubscription
             subscribed_symbols_current.set(len(remaining))
 
-            logger.info(f"Unsubscribed from {symbol}")
+            logger.info("Unsubscribed from %s (%s)", symbol, normalized_source)
 
             return UnsubscribeResponse(
                 message=f"Successfully unsubscribed from {symbol}",

--- a/apps/market_data_service/main.py
+++ b/apps/market_data_service/main.py
@@ -16,15 +16,18 @@ from typing import Any
 
 import httpx
 import redis.exceptions
-from fastapi import FastAPI, HTTPException, Query, status
+from fastapi import FastAPI, HTTPException, Query, Request, status
 from prometheus_client import Counter, Gauge, Histogram, make_asgi_app
 from pydantic import BaseModel
 
+from apps.market_data_service.api.dependencies import build_market_data_authenticator
 from apps.market_data_service.config import settings
 from apps.market_data_service.position_sync import PositionBasedSubscription
 from apps.market_data_service.routes.market_data import router as market_data_router
+from libs.core.common.api_auth_dependency import APIAuthConfig, api_auth
 from libs.core.redis_client import EventPublisher, RedisClient
 from libs.data.market_data import AlpacaMarketDataStream, SubscriptionError
+from libs.platform.web_console_auth.permissions import Permission
 
 # Configure logging
 logging.basicConfig(
@@ -83,6 +86,18 @@ class HealthResponse(BaseModel):
 
 SOURCE_TAG_PATTERN = re.compile(r"^[A-Za-z0-9:_-]{1,64}$")
 
+SOURCE_OVERRIDE_AUTH = api_auth(
+    APIAuthConfig(
+        action="market_data_source_override",
+        require_role=None,
+        require_permission=Permission.VIEW_MARKET_DATA,
+    ),
+    authenticator_getter=build_market_data_authenticator,
+)
+SOURCE_OVERRIDE_PREFIX_BY_SERVICE: dict[str, str] = {
+    "web_console_ng": "web_console",
+}
+
 
 def _normalize_subscription_source(raw_source: str | None) -> str:
     """Normalize and validate caller-provided source ownership tags."""
@@ -96,6 +111,44 @@ def _normalize_subscription_source(raw_source: str | None) -> str:
             ),
         )
     return normalized_source
+
+
+async def _authorize_source_override(request: Request, normalized_source: str) -> None:
+    """Require authenticated ownership for non-manual source overrides."""
+    if normalized_source == "manual":
+        return
+
+    auth_context = await SOURCE_OVERRIDE_AUTH(
+        request=request,
+        authorization=request.headers.get("Authorization"),
+        x_user_id=request.headers.get("X-User-ID"),
+        x_request_id=request.headers.get("X-Request-ID"),
+        x_session_version=request.headers.get("X-Session-Version"),
+        x_internal_token=request.headers.get("X-Internal-Token"),
+        x_internal_timestamp=request.headers.get("X-Internal-Timestamp"),
+        x_internal_nonce=request.headers.get("X-Internal-Nonce"),
+        x_service_id=request.headers.get("X-Service-ID"),
+        x_strategy_id=request.headers.get("X-Strategy-ID"),
+        x_body_hash=request.headers.get("X-Body-Hash"),
+    )
+    if auth_context.auth_type != "internal_token" or auth_context.internal_claims is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Explicit source override requires authenticated internal service token",
+        )
+
+    service_id = auth_context.internal_claims.service_id.strip().lower()
+    source_prefix = SOURCE_OVERRIDE_PREFIX_BY_SERVICE.get(service_id)
+    if source_prefix is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Source override is not allowed for service '{service_id}'",
+        )
+    if normalized_source != source_prefix and not normalized_source.startswith(f"{source_prefix}:"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Source '{normalized_source}' is not owned by service '{service_id}'",
+        )
 
 
 @asynccontextmanager
@@ -324,7 +377,7 @@ async def health_check() -> HealthResponse:
 
 
 @app.post("/api/v1/subscribe", response_model=SubscribeResponse, status_code=201)
-async def subscribe_symbols(request: SubscribeRequest) -> SubscribeResponse:
+async def subscribe_symbols(request: SubscribeRequest, http_request: Request) -> SubscribeResponse:
     """
     Subscribe to real-time quotes for symbols.
 
@@ -355,6 +408,7 @@ async def subscribe_symbols(request: SubscribeRequest) -> SubscribeResponse:
 
         try:
             normalized_source = _normalize_subscription_source(request.source)
+            await _authorize_source_override(http_request, normalized_source)
             await stream.subscribe_symbols(request.symbols, source=normalized_source)
 
             subscribed = stream.get_subscribed_symbols()
@@ -402,6 +456,7 @@ async def subscribe_symbols(request: SubscribeRequest) -> SubscribeResponse:
 
 @app.delete("/api/v1/subscribe/{symbol}", response_model=UnsubscribeResponse)
 async def unsubscribe_symbol(
+    http_request: Request,
     symbol: str,
     source: str = Query(default="manual"),
 ) -> UnsubscribeResponse:
@@ -429,6 +484,7 @@ async def unsubscribe_symbol(
 
         try:
             normalized_source = _normalize_subscription_source(source)
+            await _authorize_source_override(http_request, normalized_source)
             await stream.unsubscribe_symbols([symbol], source=normalized_source)
 
             remaining = stream.get_subscribed_symbols()

--- a/apps/market_data_service/main.py
+++ b/apps/market_data_service/main.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import time
 from collections.abc import AsyncIterator
@@ -97,6 +98,7 @@ SOURCE_OVERRIDE_AUTH = api_auth(
 SOURCE_OVERRIDE_PREFIX_BY_SERVICE: dict[str, str] = {
     "web_console_ng": "web_console",
 }
+UNSIGNED_SOURCE_PREFIXES = frozenset(SOURCE_OVERRIDE_PREFIX_BY_SERVICE.values())
 
 
 def _normalize_subscription_source(raw_source: str | None) -> str:
@@ -116,6 +118,22 @@ def _normalize_subscription_source(raw_source: str | None) -> str:
 async def _authorize_source_override(request: Request, normalized_source: str) -> None:
     """Require authenticated ownership for non-manual source overrides."""
     if normalized_source == "manual":
+        return
+
+    signed_override_required = bool(
+        os.getenv("INTERNAL_TOKEN_SECRET", "").strip()
+        or any(
+            key.startswith("INTERNAL_TOKEN_SECRET_") and str(value).strip()
+            for key, value in os.environ.items()
+        )
+    )
+    if not signed_override_required:
+        unsigned_source_prefix = normalized_source.split(":", 1)[0].strip().lower()
+        if unsigned_source_prefix not in UNSIGNED_SOURCE_PREFIXES:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Unsigned source override is not allowed for prefix '{unsigned_source_prefix}'",
+            )
         return
 
     auth_context = await SOURCE_OVERRIDE_AUTH(

--- a/apps/market_data_service/routes/market_data.py
+++ b/apps/market_data_service/routes/market_data.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from apps.market_data_service.api.dependencies import build_market_data_authenticator
 from apps.market_data_service.config import settings
-from apps.market_data_service.schemas import ADVResponse
+from apps.market_data_service.schemas import ADVResponse, BarsResponse
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
 from libs.core.common.rate_limit_dependency import RateLimitConfig, rate_limit
 from libs.core.redis_client import RedisClient
@@ -65,6 +65,7 @@ def _get_provider() -> MarketDataProvider:
         _provider = MarketDataProvider(
             api_key=settings.alpaca_api_key,
             secret_key=settings.alpaca_secret_key,
+            data_feed=settings.alpaca_data_feed,
         )
     return _provider
 
@@ -232,4 +233,45 @@ async def get_adv(
         source=adv_data.source,
         cached=False,
         cached_at=cached_at,
+    )
+
+
+@router.get("/api/v1/market-data/{symbol}/bars", response_model=BarsResponse)
+async def get_historical_bars(
+    symbol: str,
+    timeframe: str = "5Min",
+    limit: int = 240,
+    _auth: AuthContext = Depends(market_data_auth),
+    _rl: int = Depends(market_data_rl),
+) -> BarsResponse:
+    """Get historical OHLCV bars for a symbol."""
+    normalized_symbol = symbol.upper()
+    if limit < 1 or limit > 500:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="limit must be between 1 and 500",
+        )
+
+    provider = _get_provider()
+    try:
+        bars = await provider.get_bars(
+            normalized_symbol,
+            timeframe=timeframe,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except MarketDataError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Historical bars unavailable: {exc}",
+        ) from exc
+
+    return BarsResponse(
+        symbol=normalized_symbol,
+        timeframe=timeframe,
+        bars=bars,
     )

--- a/apps/market_data_service/routes/market_data.py
+++ b/apps/market_data_service/routes/market_data.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from apps.market_data_service.api.dependencies import build_market_data_authenticator
 from apps.market_data_service.config import settings
-from apps.market_data_service.schemas import ADVResponse, BarsResponse
+from apps.market_data_service.schemas import ADVResponse, BarPoint, BarsResponse
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
 from libs.core.common.rate_limit_dependency import RateLimitConfig, rate_limit
 from libs.core.redis_client import RedisClient
@@ -273,5 +273,5 @@ async def get_historical_bars(
     return BarsResponse(
         symbol=normalized_symbol,
         timeframe=timeframe,
-        bars=bars,
+        bars=[BarPoint.model_validate(bar) for bar in bars],
     )

--- a/apps/market_data_service/schemas.py
+++ b/apps/market_data_service/schemas.py
@@ -19,3 +19,22 @@ class ADVResponse(BaseModel):
     cached: bool = Field(..., description="Whether response came from cache")
     cached_at: datetime | None = Field(default=None, description="Timestamp when cached (UTC)")
     stale: bool = Field(..., description="True if data_date is >5 trading days old")
+
+
+class BarPoint(BaseModel):
+    """Single OHLCV bar point."""
+
+    timestamp: datetime = Field(..., description="Bar timestamp (UTC)")
+    open: float = Field(..., description="Open price")
+    high: float = Field(..., description="High price")
+    low: float = Field(..., description="Low price")
+    close: float = Field(..., description="Close price")
+    volume: int = Field(..., description="Volume")
+
+
+class BarsResponse(BaseModel):
+    """Historical bars response payload."""
+
+    symbol: str = Field(..., description="Stock symbol")
+    timeframe: str = Field(..., description="Requested timeframe")
+    bars: list[BarPoint] = Field(..., description="Historical bars in ascending time order")

--- a/apps/signal_service/model_registry.py
+++ b/apps/signal_service/model_registry.py
@@ -650,14 +650,15 @@ class ModelRegistry:
             return False
 
         except (FileNotFoundError, OSError) as e:
-            logger.error(
+            log_fn = logger.warning if isinstance(e, FileNotFoundError) else logger.error
+            log_fn(
                 "Failed to reload model due to file error",
                 extra={
                     "strategy": strategy,
                     "error": str(e),
                     "error_type": type(e).__name__,
                 },
-                exc_info=True,
+                exc_info=not isinstance(e, FileNotFoundError),
             )
 
             # Graceful degradation: keep current model if one is loaded

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -1301,7 +1301,7 @@ class OrderEntryContext:
             # Force next sync to recompute if channel ownership changed meanwhile.
             self._last_synced_market_data_symbols = None
         except Exception as exc:
-            logger.warning(f"Failed to request market-data unsubscribe for {symbol}: {exc}")
+            logger.warning("Failed to request market-data unsubscribe for %s: %s", symbol, exc)
 
     async def _on_price_update(self, data: dict[str, Any]) -> None:
         """Handle price update and dispatch to components."""

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -1271,6 +1271,8 @@ class OrderEntryContext:
         """Collect currently owned price-channel symbols in deterministic order."""
         symbols: set[str] = set()
         for channel in list(self._channel_owners):
+            if channel in self._pending_subscribes:
+                continue
             symbol = self._extract_price_channel_symbol(channel)
             if symbol:
                 symbols.add(symbol)

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -2037,7 +2037,9 @@ class OrderEntryContext:
         # Unsubscribe from all channels
         async with self._subscription_lock:
             channels_to_unsubscribe = list(self._subscriptions)
-            market_data_symbols_to_release = self._collect_owned_price_symbols()
+            market_data_symbols_to_release = sorted(
+                set(self._collect_owned_price_symbols()) | self._pending_market_data_unsubscribes
+            )
 
             for _, future in self._pending_subscribes.items():
                 if future and not future.done():

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -24,6 +24,7 @@ Data Flow:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import uuid
@@ -90,6 +91,7 @@ class OrderEntryContext:
     OWNER_CONNECTION = "connection"
     OWNER_LEVEL2 = "level2"
     PRICE_CHANNEL_PREFIX = "price.updated."
+    MARKET_DATA_SOURCE_PREFIX = "web_console"
 
     # Risk limits refresh interval (240s = 4 minutes, well under 5 minute staleness)
     RISK_LIMITS_REFRESH_INTERVAL_S = 240.0
@@ -132,7 +134,7 @@ class OrderEntryContext:
         self._user_id = user_id.strip()
         self._role = role
         self._strategies = strategies
-        self._market_data_source = f"web_console:{self._user_id}:{uuid.uuid4().hex}"
+        self._market_data_source = self._build_market_data_source(self._user_id)
 
         # Subscription tracking
         self._subscriptions: list[str] = []
@@ -200,6 +202,13 @@ class OrderEntryContext:
         from apps.web_console_ng.core.level2_websocket import Level2WebSocketService
 
         self._level2_service = Level2WebSocketService.get()
+
+    @classmethod
+    def _build_market_data_source(cls, user_id: str) -> str:
+        """Build bounded source tag compatible with server-side validation."""
+        user_hash = hashlib.sha256(user_id.strip().encode("utf-8")).hexdigest()[:12]
+        session_suffix = uuid.uuid4().hex[:12]
+        return f"{cls.MARKET_DATA_SOURCE_PREFIX}:{user_hash}:{session_suffix}"
 
     # =========================================================================
     # Component Setters

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -1733,6 +1733,9 @@ class OrderEntryContext:
                         owners_snapshot = self._channel_owners[channel].copy()
                         self._failed_subscriptions[channel] = (owners_snapshot, callback)
 
+        # Force a full backend resubscribe on reconnect even when local symbol
+        # ownership is unchanged because upstream stream state may have been lost.
+        self._last_synced_market_data_symbols = None
         self._schedule_market_data_sync()
 
     async def _retry_failed_subscriptions(self) -> None:

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -96,6 +96,7 @@ class OrderEntryContext:
     RISK_LIMITS_REFRESH_INTERVAL_S = 240.0
     MARKET_DATA_SYNC_RETRY_DELAY_S = 1.0
     MARKET_DATA_UNSUBSCRIBE_RETRY_DELAY_S = 0.1
+    MARKET_DATA_RELEASE_FLUSH_TIMEOUT_S = 1.0
 
     def __init__(
         self,
@@ -1976,6 +1977,29 @@ class OrderEntryContext:
     # Cleanup
     # =========================================================================
 
+    async def _flush_market_data_release_tasks(self) -> None:
+        """Await pending background release tasks before final cleanup."""
+        pending_tasks = tuple(task for task in self._market_data_release_tasks if not task.done())
+        if not pending_tasks:
+            self._market_data_release_tasks.clear()
+            return
+
+        done, pending = await asyncio.wait(
+            pending_tasks,
+            timeout=self.MARKET_DATA_RELEASE_FLUSH_TIMEOUT_S,
+        )
+        for completed in done:
+            if completed.cancelled():
+                continue
+            exc = completed.exception()
+            if exc is not None:
+                logger.warning("market_data_release_task_failed_during_dispose: %s", exc)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._market_data_release_tasks.clear()
+
     async def dispose(self) -> None:
         """Clean up all subscriptions and timers on page unload."""
         if self._disposed:
@@ -1999,10 +2023,6 @@ class OrderEntryContext:
         self._market_data_retry_task = None
         self._market_data_sync_pending = False
         self._market_data_sync_backoff_required = False
-        for release_task in tuple(self._market_data_release_tasks):
-            if not release_task.done():
-                release_task.cancel()
-        self._market_data_release_tasks.clear()
         self._symbol_change_callbacks.clear()
 
         # Unsubscribe from all channels
@@ -2030,6 +2050,7 @@ class OrderEntryContext:
                 await self._release_market_data_streaming(symbol)
             except Exception as exc:
                 logger.warning("Error releasing market-data source for %s: %s", symbol, exc)
+        await self._flush_market_data_release_tasks()
 
         if self._current_l2_symbol:
             await self._level2_service.unsubscribe(self._user_id, self._current_l2_symbol)

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -190,6 +190,7 @@ class OrderEntryContext:
         # Risk limits refresh task tracking
         self._risk_refresh_task: asyncio.Task[None] | None = None
         self._market_data_sync_task: asyncio.Task[None] | None = None
+        self._market_data_sync_pending: bool = False
         self._last_synced_market_data_symbols: tuple[str, ...] | None = None
 
         from apps.web_console_ng.core.level2_websocket import Level2WebSocketService
@@ -1258,17 +1259,26 @@ class OrderEntryContext:
         if self._disposed:
             return
         if self._market_data_sync_task and not self._market_data_sync_task.done():
+            self._market_data_sync_pending = True
             return
 
+        self._market_data_sync_pending = False
         task = asyncio.create_task(self._sync_market_data_streaming())
         self._market_data_sync_task = task
 
         def _on_done(completed: asyncio.Task[None]) -> None:
+            self._market_data_sync_task = None
             if completed.cancelled():
                 return
             exc = completed.exception()
             if exc:
                 logger.warning("market_data_sync_task_failed: %s", exc)
+            if self._disposed:
+                self._market_data_sync_pending = False
+                return
+            if self._market_data_sync_pending:
+                self._market_data_sync_pending = False
+                self._schedule_market_data_sync()
 
         task.add_done_callback(_on_done)
 
@@ -1822,6 +1832,7 @@ class OrderEntryContext:
         if self._market_data_sync_task and not self._market_data_sync_task.done():
             self._market_data_sync_task.cancel()
         self._market_data_sync_task = None
+        self._market_data_sync_pending = False
         self._symbol_change_callbacks.clear()
 
         # Unsubscribe from all channels

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -194,6 +194,8 @@ class OrderEntryContext:
         self._market_data_sync_task: asyncio.Task[None] | None = None
         self._market_data_sync_pending: bool = False
         self._last_synced_market_data_symbols: tuple[str, ...] | None = None
+        self._pending_market_data_unsubscribes: set[str] = set()
+        self._initializing: bool = True
 
         from apps.web_console_ng.core.level2_websocket import Level2WebSocketService
 
@@ -439,6 +441,7 @@ class OrderEntryContext:
         """
         if self._disposed:
             raise RuntimeError("Cannot initialize disposed OrderEntryContext")
+        self._initializing = True
 
         try:
             # Initialize child components with timer tracker for lifecycle management
@@ -486,9 +489,11 @@ class OrderEntryContext:
             # Request backend streaming for all currently owned price channels.
             # Schedule only after full initialization succeeds so init failures
             # cannot orphan per-session market-data sources.
+            self._initializing = False
             self._schedule_market_data_sync()
 
         except Exception as exc:
+            self._initializing = False
             # FAIL-CLOSED: Explicitly disable order ticket on init failure
             logger.error(f"OrderEntryContext initialization failed: {exc}")
 
@@ -1235,10 +1240,25 @@ class OrderEntryContext:
             return
 
         symbols = tuple(self._collect_owned_price_symbols())
-        if not symbols:
-            self._last_synced_market_data_symbols = ()
+        desired_symbols = set(symbols)
+        previous_symbols = set(self._last_synced_market_data_symbols or ())
+        self._pending_market_data_unsubscribes.difference_update(desired_symbols)
+        stale_symbols = sorted(
+            (previous_symbols - desired_symbols) | self._pending_market_data_unsubscribes
+        )
+
+        if symbols == self._last_synced_market_data_symbols and not stale_symbols:
             return
-        if symbols == self._last_synced_market_data_symbols:
+
+        for stale_symbol in stale_symbols:
+            await self._release_market_data_streaming(stale_symbol)
+
+        if not symbols:
+            self._last_synced_market_data_symbols = (
+                ()
+                if not self._pending_market_data_unsubscribes
+                else None
+            )
             return
 
         try:
@@ -1249,6 +1269,16 @@ class OrderEntryContext:
                 strategies=self._strategies,
                 source=self._market_data_source,
             )
+            latest_symbols = tuple(self._collect_owned_price_symbols())
+            if latest_symbols != symbols:
+                # Channel ownership changed during the await; queue stale removals and
+                # run one follow-up sync with a fresh ownership snapshot.
+                self._pending_market_data_unsubscribes.update(
+                    set(symbols) - set(latest_symbols)
+                )
+                self._last_synced_market_data_symbols = None
+                self._market_data_sync_pending = True
+                return
             self._last_synced_market_data_symbols = symbols
         except Exception as exc:
             logger.warning(
@@ -1256,6 +1286,7 @@ class OrderEntryContext:
                 len(symbols),
                 exc,
             )
+            self._last_synced_market_data_symbols = None
 
     def _schedule_market_data_sync(self) -> None:
         """Schedule asynchronous market-data streaming sync (timer-safe)."""
@@ -1287,21 +1318,40 @@ class OrderEntryContext:
 
     async def _release_market_data_streaming(self, symbol: str) -> None:
         """Best-effort request to market-data-service to stop streaming symbol updates."""
+        normalized_symbol = symbol.strip().upper()
+        if not normalized_symbol:
+            return
         unsubscribe = getattr(self._client, "unsubscribe_market_data_symbol", None)
         if unsubscribe is None:
             return
-        try:
-            await unsubscribe(
-                symbol,
-                user_id=self._user_id,
-                role=self._role,
-                strategies=self._strategies,
-                source=self._market_data_source,
-            )
-            # Force next sync to recompute if channel ownership changed meanwhile.
-            self._last_synced_market_data_symbols = None
-        except Exception as exc:
-            logger.warning("Failed to request market-data unsubscribe for %s: %s", symbol, exc)
+        self._pending_market_data_unsubscribes.add(normalized_symbol)
+        last_error: Exception | None = None
+
+        for attempt in range(2):
+            try:
+                await unsubscribe(
+                    normalized_symbol,
+                    user_id=self._user_id,
+                    role=self._role,
+                    strategies=self._strategies,
+                    source=self._market_data_source,
+                )
+                self._pending_market_data_unsubscribes.discard(normalized_symbol)
+                # Force next sync to recompute if channel ownership changed meanwhile.
+                self._last_synced_market_data_symbols = None
+                return
+            except Exception as exc:
+                last_error = exc
+                if attempt == 0:
+                    await asyncio.sleep(0)
+
+        logger.warning(
+            "Failed to request market-data unsubscribe for %s after retry: %s",
+            normalized_symbol,
+            last_error,
+        )
+        # Keep symbol queued for future sync retry.
+        self._last_synced_market_data_symbols = None
 
     async def _on_price_update(self, data: dict[str, Any]) -> None:
         """Handle price update and dispatch to components."""
@@ -1636,7 +1686,11 @@ class OrderEntryContext:
                 else:
                     price_symbol = self._extract_price_channel_symbol(channel)
                     if price_symbol is not None:
-                        self._schedule_market_data_sync()
+                        if self._initializing:
+                            # Defer backend stream sync until initialization completes.
+                            self._last_synced_market_data_symbols = None
+                        else:
+                            self._schedule_market_data_sync()
 
                 if pending_future and not pending_future.done():
                     pending_future.set_result(None)

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -88,6 +88,7 @@ class OrderEntryContext:
     OWNER_CIRCUIT_BREAKER = "circuit_breaker"
     OWNER_CONNECTION = "connection"
     OWNER_LEVEL2 = "level2"
+    PRICE_CHANNEL_PREFIX = "price.updated."
 
     # Risk limits refresh interval (240s = 4 minutes, well under 5 minute staleness)
     RISK_LIMITS_REFRESH_INTERVAL_S = 240.0
@@ -188,6 +189,8 @@ class OrderEntryContext:
 
         # Risk limits refresh task tracking
         self._risk_refresh_task: asyncio.Task[None] | None = None
+        self._market_data_sync_task: asyncio.Task[None] | None = None
+        self._last_synced_market_data_symbols: tuple[str, ...] | None = None
 
         from apps.web_console_ng.core.level2_websocket import Level2WebSocketService
 
@@ -232,6 +235,26 @@ class OrderEntryContext:
     ) -> None:
         """Set optional callback for connection state changes."""
         self._connection_state_callback = callback
+
+    def _apply_connection_state(self, state: str, is_read_only: bool) -> None:
+        """Apply normalized connection state to ticket, callback, and cached safety state."""
+        normalized = str(state or "UNKNOWN").upper()
+        self._last_connection_state = normalized
+        self._cached_connection_state = normalized
+
+        if self._order_ticket:
+            self._order_ticket.set_connection_state(normalized, is_read_only)
+
+        if self._connection_state_callback:
+            try:
+                self._connection_state_callback(normalized, is_read_only)
+            except Exception as callback_exc:
+                logger.warning(
+                    f"Connection callback failed for state {normalized}: {callback_exc}"
+                )
+
+        # Sync to T7 components
+        self._sync_one_click_cached_state()
 
     def dispatch_strategy_model_context(
         self,
@@ -334,7 +357,9 @@ class OrderEntryContext:
         )
         return self._market_context.create()
 
-    def create_price_chart(self, width: int = 600, height: int = 300) -> Any:
+    def create_price_chart(
+        self, width: int = 600, height: int = 300, *, fill_parent: bool = False
+    ) -> Any:
         """Create and configure the PriceChart component.
 
         Creates the component, stores reference, and returns the UI element
@@ -355,7 +380,7 @@ class OrderEntryContext:
             role=self._role,
             strategies=self._strategies,
         )
-        return self._price_chart.create(width=width, height=height)
+        return self._price_chart.create(width=width, height=height, fill_parent=fill_parent)
 
     def create_dom_ladder(self, *, levels: int = 10) -> Any:
         """Create and configure the DOM ladder component."""
@@ -429,11 +454,28 @@ class OrderEntryContext:
             await self._subscribe_to_connection_channel()
             await self._subscribe_to_positions_channel()
 
+            # Request backend streaming for all currently owned price channels.
+            # This heals startup races where market-data-service may not have been
+            # ready during per-symbol acquire calls.
+            self._schedule_market_data_sync()
+
             # CRITICAL: Fetch initial state for safety mechanisms (fail-closed)
             await self._fetch_initial_safety_state()
 
+            # Bootstrap connection state when no connection channel update has arrived yet.
+            # connection:state is optional in some environments, so rely on monitor state
+            # to avoid a permanent UNKNOWN/read-only ticket on startup.
+            if self._cached_connection_state is None:
+                initial_read_only = self._connection_monitor.is_read_only()
+                initial_state = "CONNECTED" if not initial_read_only else "DISCONNECTED"
+                self._apply_connection_state(initial_state, initial_read_only)
+
             # Load initial risk limits for order validation
             await self._load_initial_risk_limits()
+
+            # Auto-select the first watchlist symbol so ticket/chart context is initialized.
+            # This avoids an empty ticket symbol field until the first manual click.
+            await self._ensure_initial_symbol_selection()
 
             # Start periodic refresh timer to prevent staleness
             # Risk limits go stale after 5 min; refresh every 4 min to stay safe
@@ -477,6 +519,23 @@ class OrderEntryContext:
                     True, "Initialization failed - please refresh"
                 )
             raise
+
+    async def _ensure_initial_symbol_selection(self) -> None:
+        """Select the first watchlist symbol when no symbol is currently selected."""
+        if self._selected_symbol is not None or self._watchlist is None:
+            return
+        try:
+            symbols = self._watchlist.get_symbols()
+        except Exception as exc:
+            logger.debug(f"Unable to read watchlist symbols for auto-select: {exc}")
+            return
+        if not symbols:
+            return
+        default_symbol = symbols[0]
+        try:
+            await self.on_symbol_selected(default_symbol)
+        except Exception as exc:
+            logger.warning(f"Failed to auto-select initial symbol {default_symbol}: {exc}")
 
     # =========================================================================
     # Safety State Management
@@ -921,19 +980,8 @@ class OrderEntryContext:
             state = str(data.get("state", "")).upper()
         except Exception as exc:
             logger.warning(f"Invalid connection payload: {exc}, treating as read-only")
-            self._last_connection_state = "UNKNOWN"
-            # CRITICAL: Update cached state for T7 components (FAIL-CLOSED safety)
-            # Without this, OneClickHandler/SafetyGate would use stale state
-            self._cached_connection_state = "UNKNOWN"
-            if self._order_ticket:
-                self._order_ticket.set_connection_state("UNKNOWN", True)
-            if self._connection_state_callback:
-                try:
-                    self._connection_state_callback("UNKNOWN", True)
-                except Exception as callback_exc:
-                    logger.warning(f"Connection callback failed for UNKNOWN state: {callback_exc}")
             # Sync to T7 components so risk-increasing actions fail closed
-            self._sync_one_click_cached_state()
+            self._apply_connection_state("UNKNOWN", True)
             return
 
         # Track previous state for reconnect detection
@@ -954,8 +1002,6 @@ class OrderEntryContext:
         else:
             is_read_only = state not in READ_WRITE_CONNECTION_STATES
 
-        self._last_connection_state = state
-
         # RECONNECT HANDLING: Re-fetch safety state and re-subscribe channels
         # Resubscribe when transitioning TO CONNECTED from uncertain/disconnected states
         # DEGRADED->CONNECTED doesn't need resubscribe since pubsub connection was never lost
@@ -971,19 +1017,7 @@ class OrderEntryContext:
             await self._resubscribe_all_channels()
             await self._retry_failed_subscriptions()
 
-        # Update cached state for T7 components
-        self._cached_connection_state = state
-
-        if self._order_ticket:
-            self._order_ticket.set_connection_state(state, is_read_only)
-        if self._connection_state_callback:
-            try:
-                self._connection_state_callback(state, is_read_only)
-            except Exception as callback_exc:
-                logger.warning(f"Connection callback failed for state {state}: {callback_exc}")
-
-        # Sync to T7 components
-        self._sync_one_click_cached_state()
+        self._apply_connection_state(state, is_read_only)
 
     async def _subscribe_to_positions_channel(self) -> None:
         """Subscribe to position updates - OrderEntryContext owns this."""
@@ -1173,6 +1207,87 @@ class OrderEntryContext:
             qty_unit=qty_unit,
             qty_unit_size=qty_unit_size,
         )
+
+    @classmethod
+    def _extract_price_channel_symbol(cls, channel: str) -> str | None:
+        """Return symbol for price channels, else None."""
+        if not channel.startswith(cls.PRICE_CHANNEL_PREFIX):
+            return None
+        symbol = channel[len(cls.PRICE_CHANNEL_PREFIX) :].strip().upper()
+        return symbol or None
+
+    def _collect_owned_price_symbols(self) -> list[str]:
+        """Collect currently owned price-channel symbols in deterministic order."""
+        symbols: set[str] = set()
+        for channel in list(self._channel_owners):
+            symbol = self._extract_price_channel_symbol(channel)
+            if symbol:
+                symbols.add(symbol)
+        return sorted(symbols)
+
+    async def _sync_market_data_streaming(self) -> None:
+        """Best-effort sync of backend streaming set with currently owned symbols."""
+        subscribe = getattr(self._client, "subscribe_market_data_symbols", None)
+        if subscribe is None:
+            return
+
+        symbols = tuple(self._collect_owned_price_symbols())
+        if not symbols:
+            self._last_synced_market_data_symbols = ()
+            return
+        if symbols == self._last_synced_market_data_symbols:
+            return
+
+        try:
+            await subscribe(
+                list(symbols),
+                user_id=self._user_id,
+                role=self._role,
+                strategies=self._strategies,
+            )
+            self._last_synced_market_data_symbols = symbols
+        except Exception as exc:
+            logger.warning(
+                "Failed to sync market-data subscriptions for %s symbols: %s",
+                len(symbols),
+                exc,
+            )
+
+    def _schedule_market_data_sync(self) -> None:
+        """Schedule asynchronous market-data streaming sync (timer-safe)."""
+        if self._disposed:
+            return
+        if self._market_data_sync_task and not self._market_data_sync_task.done():
+            return
+
+        task = asyncio.create_task(self._sync_market_data_streaming())
+        self._market_data_sync_task = task
+
+        def _on_done(completed: asyncio.Task[None]) -> None:
+            if completed.cancelled():
+                return
+            exc = completed.exception()
+            if exc:
+                logger.warning("market_data_sync_task_failed: %s", exc)
+
+        task.add_done_callback(_on_done)
+
+    async def _release_market_data_streaming(self, symbol: str) -> None:
+        """Best-effort request to market-data-service to stop streaming symbol updates."""
+        unsubscribe = getattr(self._client, "unsubscribe_market_data_symbol", None)
+        if unsubscribe is None:
+            return
+        try:
+            await unsubscribe(
+                symbol,
+                user_id=self._user_id,
+                role=self._role,
+                strategies=self._strategies,
+            )
+            # Force next sync to recompute if channel ownership changed meanwhile.
+            self._last_synced_market_data_symbols = None
+        except Exception as exc:
+            logger.warning(f"Failed to request market-data unsubscribe for {symbol}: {exc}")
 
     async def _on_price_update(self, data: dict[str, Any]) -> None:
         """Handle price update and dispatch to components."""
@@ -1504,6 +1619,10 @@ class OrderEntryContext:
                         await self._realtime.unsubscribe(channel)
                     except Exception as exc:
                         logger.warning(f"Failed to unsubscribe orphan {channel}: {exc}")
+                else:
+                    price_symbol = self._extract_price_channel_symbol(channel)
+                    if price_symbol is not None:
+                        self._schedule_market_data_sync()
 
                 if pending_future and not pending_future.done():
                     pending_future.set_result(None)
@@ -1557,6 +1676,10 @@ class OrderEntryContext:
                 await self._realtime.unsubscribe(channel)
             except Exception as exc:
                 logger.warning(f"Error releasing channel {channel}: {exc}")
+            price_symbol = self._extract_price_channel_symbol(channel)
+            if price_symbol is not None:
+                await self._release_market_data_streaming(price_symbol)
+                self._schedule_market_data_sync()
 
     async def _resubscribe_all_channels(self) -> None:
         """Re-subscribe all owned channels after reconnect."""
@@ -1595,6 +1718,8 @@ class OrderEntryContext:
                     if channel in self._channel_owners:
                         owners_snapshot = self._channel_owners[channel].copy()
                         self._failed_subscriptions[channel] = (owners_snapshot, callback)
+
+        self._schedule_market_data_sync()
 
     async def _retry_failed_subscriptions(self) -> None:
         """Retry subscriptions that previously failed."""
@@ -1653,6 +1778,15 @@ class OrderEntryContext:
         """Get the currently selected symbol."""
         return self._selected_symbol
 
+    def get_watchlist_symbols(self) -> list[str]:
+        """Get watchlist symbols in display order."""
+        if self._watchlist is None:
+            return []
+        try:
+            return self._watchlist.get_symbols()
+        except Exception:
+            return []
+
     def register_symbol_change_callback(self, callback: Callable[[str | None], None]) -> None:
         """Register a synchronous callback invoked whenever selected symbol changes."""
         if callback not in self._symbol_change_callbacks:
@@ -1685,6 +1819,9 @@ class OrderEntryContext:
         if self._risk_refresh_task and not self._risk_refresh_task.done():
             self._risk_refresh_task.cancel()
         self._risk_refresh_task = None
+        if self._market_data_sync_task and not self._market_data_sync_task.done():
+            self._market_data_sync_task.cancel()
+        self._market_data_sync_task = None
         self._symbol_change_callbacks.clear()
 
         # Unsubscribe from all channels

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import uuid
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
@@ -131,6 +132,7 @@ class OrderEntryContext:
         self._user_id = user_id.strip()
         self._role = role
         self._strategies = strategies
+        self._market_data_source = f"web_console:{self._user_id}:{uuid.uuid4().hex}"
 
         # Subscription tracking
         self._subscriptions: list[str] = []
@@ -1245,6 +1247,7 @@ class OrderEntryContext:
                 user_id=self._user_id,
                 role=self._role,
                 strategies=self._strategies,
+                source=self._market_data_source,
             )
             self._last_synced_market_data_symbols = symbols
         except Exception as exc:
@@ -1293,6 +1296,7 @@ class OrderEntryContext:
                 user_id=self._user_id,
                 role=self._role,
                 strategies=self._strategies,
+                source=self._market_data_source,
             )
             # Force next sync to recompute if channel ownership changed meanwhile.
             self._last_synced_market_data_symbols = None

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -1842,6 +1842,7 @@ class OrderEntryContext:
         # Unsubscribe from all channels
         async with self._subscription_lock:
             channels_to_unsubscribe = list(self._subscriptions)
+            market_data_symbols_to_release = self._collect_owned_price_symbols()
 
             for _, future in self._pending_subscribes.items():
                 if future and not future.done():
@@ -1858,6 +1859,11 @@ class OrderEntryContext:
                 await self._realtime.unsubscribe(channel)
             except Exception as exc:
                 logger.warning(f"Error unsubscribing from {channel}: {exc}")
+        for symbol in market_data_symbols_to_release:
+            try:
+                await self._release_market_data_streaming(symbol)
+            except Exception as exc:
+                logger.warning("Error releasing market-data source for %s: %s", symbol, exc)
 
         if self._current_l2_symbol:
             await self._level2_service.unsubscribe(self._user_id, self._current_l2_symbol)

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -1297,7 +1297,16 @@ class OrderEntryContext:
             return
 
         for stale_symbol in stale_symbols:
-            await self._release_market_data_streaming(stale_symbol)
+            try:
+                await self._release_market_data_streaming(stale_symbol)
+            except Exception as exc:
+                logger.warning(
+                    "market_data_stale_release_failed for %s: %s",
+                    stale_symbol,
+                    exc,
+                )
+                self._market_data_sync_pending = True
+                self._market_data_sync_backoff_required = True
 
         if not symbols:
             unresolved_unsubscribes = bool(self._pending_market_data_unsubscribes)

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -95,6 +95,7 @@ class OrderEntryContext:
 
     # Risk limits refresh interval (240s = 4 minutes, well under 5 minute staleness)
     RISK_LIMITS_REFRESH_INTERVAL_S = 240.0
+    MARKET_DATA_SYNC_RETRY_DELAY_S = 1.0
 
     def __init__(
         self,
@@ -194,7 +195,9 @@ class OrderEntryContext:
         # Risk limits refresh task tracking
         self._risk_refresh_task: asyncio.Task[None] | None = None
         self._market_data_sync_task: asyncio.Task[None] | None = None
+        self._market_data_retry_task: asyncio.Task[None] | None = None
         self._market_data_sync_pending: bool = False
+        self._market_data_sync_backoff_required: bool = False
         self._last_synced_market_data_symbols: tuple[str, ...] | None = None
         self._pending_market_data_unsubscribes: set[str] = set()
         self._initializing: bool = True
@@ -556,7 +559,8 @@ class OrderEntryContext:
         if restored_symbol:
             try:
                 await self.on_symbol_selected(restored_symbol)
-                return
+                if self._selected_symbol == restored_symbol:
+                    return
             except Exception as exc:
                 logger.warning(
                     f"Failed to restore initial symbol selection {restored_symbol}: {exc}"
@@ -1288,6 +1292,9 @@ class OrderEntryContext:
             self._last_synced_market_data_symbols = () if not unresolved_unsubscribes else None
             if unresolved_unsubscribes:
                 self._market_data_sync_pending = True
+                self._market_data_sync_backoff_required = True
+            else:
+                self._market_data_sync_backoff_required = False
             return
 
         try:
@@ -1307,10 +1314,14 @@ class OrderEntryContext:
                 )
                 self._last_synced_market_data_symbols = None
                 self._market_data_sync_pending = True
+                self._market_data_sync_backoff_required = False
                 return
             self._last_synced_market_data_symbols = symbols
             if self._pending_market_data_unsubscribes:
                 self._market_data_sync_pending = True
+                self._market_data_sync_backoff_required = True
+            else:
+                self._market_data_sync_backoff_required = False
         except Exception as exc:
             logger.warning(
                 "Failed to sync market-data subscriptions for %s symbols: %s",
@@ -1319,6 +1330,7 @@ class OrderEntryContext:
             )
             self._last_synced_market_data_symbols = None
             self._market_data_sync_pending = True
+            self._market_data_sync_backoff_required = True
 
     def _schedule_market_data_sync(self) -> None:
         """Schedule asynchronous market-data streaming sync (timer-safe)."""
@@ -1327,6 +1339,10 @@ class OrderEntryContext:
         if self._market_data_sync_task and not self._market_data_sync_task.done():
             self._market_data_sync_pending = True
             return
+
+        if self._market_data_retry_task and not self._market_data_retry_task.done():
+            self._market_data_retry_task.cancel()
+            self._market_data_retry_task = None
 
         self._market_data_sync_pending = False
         task = asyncio.create_task(self._sync_market_data_streaming())
@@ -1344,9 +1360,25 @@ class OrderEntryContext:
                 return
             if self._market_data_sync_pending:
                 self._market_data_sync_pending = False
-                self._schedule_market_data_sync()
+                if self._market_data_sync_backoff_required:
+                    if self._market_data_retry_task is None or self._market_data_retry_task.done():
+                        self._market_data_retry_task = asyncio.create_task(
+                            self._retry_market_data_sync_after_backoff()
+                        )
+                else:
+                    self._schedule_market_data_sync()
 
         task.add_done_callback(_on_done)
+
+    async def _retry_market_data_sync_after_backoff(self) -> None:
+        """Retry market-data sync after brief delay to avoid hot retry loops."""
+        try:
+            await asyncio.sleep(self.MARKET_DATA_SYNC_RETRY_DELAY_S)
+        finally:
+            self._market_data_retry_task = None
+        if self._disposed:
+            return
+        self._schedule_market_data_sync()
 
     async def _release_market_data_streaming(self, symbol: str) -> None:
         """Best-effort request to market-data-service to stop streaming symbol updates."""
@@ -1371,9 +1403,12 @@ class OrderEntryContext:
                 self._pending_market_data_unsubscribes.discard(normalized_symbol)
                 # Force next sync to recompute if channel ownership changed meanwhile.
                 self._last_synced_market_data_symbols = None
+                if not self._pending_market_data_unsubscribes:
+                    self._market_data_sync_backoff_required = False
                 return
             except Exception as exc:
                 last_error = exc
+                self._market_data_sync_backoff_required = True
                 if attempt == 0:
                     await asyncio.sleep(0)
 
@@ -1925,7 +1960,11 @@ class OrderEntryContext:
         if self._market_data_sync_task and not self._market_data_sync_task.done():
             self._market_data_sync_task.cancel()
         self._market_data_sync_task = None
+        if self._market_data_retry_task and not self._market_data_retry_task.done():
+            self._market_data_retry_task.cancel()
+        self._market_data_retry_task = None
         self._market_data_sync_pending = False
+        self._market_data_sync_backoff_required = False
         self._symbol_change_callbacks.clear()
 
         # Unsubscribe from all channels

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -203,6 +203,7 @@ class OrderEntryContext:
         self._market_data_sync_backoff_required: bool = False
         self._last_synced_market_data_symbols: tuple[str, ...] | None = None
         self._pending_market_data_unsubscribes: set[str] = set()
+        self._market_data_release_tasks: set[asyncio.Task[None]] = set()
         self._initializing: bool = True
 
         from apps.web_console_ng.core.level2_websocket import Level2WebSocketService
@@ -1821,8 +1822,27 @@ class OrderEntryContext:
                 logger.warning(f"Error releasing channel {channel}: {exc}")
             price_symbol = self._extract_price_channel_symbol(channel)
             if price_symbol is not None:
-                await self._release_market_data_streaming(price_symbol)
-                self._schedule_market_data_sync()
+                self._schedule_market_data_release(price_symbol)
+
+    def _schedule_market_data_release(self, symbol: str) -> None:
+        """Request upstream unsubscribe in background so UI interactions never block."""
+        if self._disposed:
+            return
+        task = asyncio.create_task(self._release_market_data_streaming(symbol))
+        self._market_data_release_tasks.add(task)
+
+        def _on_done(completed: asyncio.Task[None]) -> None:
+            self._market_data_release_tasks.discard(completed)
+            if completed.cancelled():
+                return
+            exc = completed.exception()
+            if exc:
+                logger.warning("market_data_release_task_failed(%s): %s", symbol, exc)
+            if self._disposed:
+                return
+            self._schedule_market_data_sync()
+
+        task.add_done_callback(_on_done)
 
     async def _resubscribe_all_channels(self) -> None:
         """Re-subscribe all owned channels after reconnect."""
@@ -1973,6 +1993,10 @@ class OrderEntryContext:
         self._market_data_retry_task = None
         self._market_data_sync_pending = False
         self._market_data_sync_backoff_required = False
+        for release_task in tuple(self._market_data_release_tasks):
+            if not release_task.done():
+                release_task.cancel()
+        self._market_data_release_tasks.clear()
         self._symbol_change_callbacks.clear()
 
         # Unsubscribe from all channels

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -27,7 +27,6 @@ import asyncio
 import hashlib
 import json
 import logging
-import uuid
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
@@ -96,6 +95,7 @@ class OrderEntryContext:
     # Risk limits refresh interval (240s = 4 minutes, well under 5 minute staleness)
     RISK_LIMITS_REFRESH_INTERVAL_S = 240.0
     MARKET_DATA_SYNC_RETRY_DELAY_S = 1.0
+    MARKET_DATA_UNSUBSCRIBE_RETRY_DELAY_S = 0.1
 
     def __init__(
         self,
@@ -107,6 +107,7 @@ class OrderEntryContext:
         user_id: str,
         role: str,
         strategies: list[str],
+        client_id: str | None = None,
     ) -> None:
         """Initialize OrderEntryContext.
 
@@ -119,6 +120,8 @@ class OrderEntryContext:
             user_id: User ID for API calls and subscriptions.
             role: User role for authorization.
             strategies: Strategies for position filtering.
+            client_id: Stable browser client ID used to build recoverable
+                market-data source ownership tags.
 
         Raises:
             ValueError: If user_id is empty or whitespace-only.
@@ -135,7 +138,7 @@ class OrderEntryContext:
         self._user_id = user_id.strip()
         self._role = role
         self._strategies = strategies
-        self._market_data_source = self._build_market_data_source(self._user_id)
+        self._market_data_source = self._build_market_data_source(self._user_id, client_id)
 
         # Subscription tracking
         self._subscriptions: list[str] = []
@@ -207,11 +210,16 @@ class OrderEntryContext:
         self._level2_service = Level2WebSocketService.get()
 
     @classmethod
-    def _build_market_data_source(cls, user_id: str) -> str:
-        """Build bounded source tag compatible with server-side validation."""
+    def _build_market_data_source(cls, user_id: str, client_id: str | None) -> str:
+        """Build bounded, recoverable source tag for market-data subscription ownership."""
         user_hash = hashlib.sha256(user_id.strip().encode("utf-8")).hexdigest()[:12]
-        session_suffix = uuid.uuid4().hex[:12]
-        return f"{cls.MARKET_DATA_SOURCE_PREFIX}:{user_hash}:{session_suffix}"
+        normalized_client_id = (client_id or "").strip()
+        client_hash = (
+            hashlib.sha256(normalized_client_id.encode("utf-8")).hexdigest()[:12]
+            if normalized_client_id
+            else "global"
+        )
+        return f"{cls.MARKET_DATA_SOURCE_PREFIX}:{user_hash}:{client_hash}"
 
     # =========================================================================
     # Component Setters
@@ -1410,7 +1418,7 @@ class OrderEntryContext:
                 last_error = exc
                 self._market_data_sync_backoff_required = True
                 if attempt == 0:
-                    await asyncio.sleep(0)
+                    await asyncio.sleep(self.MARKET_DATA_UNSUBSCRIBE_RETRY_DELAY_S)
 
         logger.warning(
             "Failed to request market-data unsubscribe for %s after retry: %s",

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -457,11 +457,6 @@ class OrderEntryContext:
             await self._subscribe_to_connection_channel()
             await self._subscribe_to_positions_channel()
 
-            # Request backend streaming for all currently owned price channels.
-            # This heals startup races where market-data-service may not have been
-            # ready during per-symbol acquire calls.
-            self._schedule_market_data_sync()
-
             # CRITICAL: Fetch initial state for safety mechanisms (fail-closed)
             await self._fetch_initial_safety_state()
 
@@ -487,6 +482,11 @@ class OrderEntryContext:
                 callback=self._refresh_risk_limits,
             )
             self._track_timer(risk_refresh_timer)
+
+            # Request backend streaming for all currently owned price channels.
+            # Schedule only after full initialization succeeds so init failures
+            # cannot orphan per-session market-data sources.
+            self._schedule_market_data_sync()
 
         except Exception as exc:
             # FAIL-CLOSED: Explicitly disable order ticket on init failure

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -1342,6 +1342,7 @@ class OrderEntryContext:
             self._last_synced_market_data_symbols = None
             self._market_data_sync_pending = True
             self._market_data_sync_backoff_required = True
+            raise
 
     def _schedule_market_data_sync(self) -> None:
         """Schedule asynchronous market-data streaming sync (timer-safe)."""
@@ -1430,6 +1431,9 @@ class OrderEntryContext:
         )
         # Keep symbol queued for future sync retry.
         self._last_synced_market_data_symbols = None
+        self._market_data_sync_pending = True
+        if last_error is not None:
+            raise last_error
 
     async def _on_price_update(self, data: dict[str, Any]) -> None:
         """Handle price update and dispatch to components."""

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -532,6 +532,27 @@ class OrderEntryContext:
         """Select the first watchlist symbol when no symbol is currently selected."""
         if self._selected_symbol is not None or self._watchlist is None:
             return
+
+        restored_symbol: str | None = None
+        if self._order_ticket is not None:
+            get_current_symbol = getattr(self._order_ticket, "get_current_symbol", None)
+            if callable(get_current_symbol):
+                try:
+                    candidate = get_current_symbol()
+                    if isinstance(candidate, str) and candidate.strip():
+                        restored_symbol = candidate.strip().upper()
+                except Exception as exc:
+                    logger.debug(f"Unable to read restored ticket symbol for auto-select: {exc}")
+
+        if restored_symbol:
+            try:
+                await self.on_symbol_selected(restored_symbol)
+                return
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to restore initial symbol selection {restored_symbol}: {exc}"
+                )
+
         try:
             symbols = self._watchlist.get_symbols()
         except Exception as exc:
@@ -1254,11 +1275,10 @@ class OrderEntryContext:
             await self._release_market_data_streaming(stale_symbol)
 
         if not symbols:
-            self._last_synced_market_data_symbols = (
-                ()
-                if not self._pending_market_data_unsubscribes
-                else None
-            )
+            unresolved_unsubscribes = bool(self._pending_market_data_unsubscribes)
+            self._last_synced_market_data_symbols = () if not unresolved_unsubscribes else None
+            if unresolved_unsubscribes:
+                self._market_data_sync_pending = True
             return
 
         try:
@@ -1280,6 +1300,8 @@ class OrderEntryContext:
                 self._market_data_sync_pending = True
                 return
             self._last_synced_market_data_symbols = symbols
+            if self._pending_market_data_unsubscribes:
+                self._market_data_sync_pending = True
         except Exception as exc:
             logger.warning(
                 "Failed to sync market-data subscriptions for %s symbols: %s",
@@ -1287,6 +1309,7 @@ class OrderEntryContext:
                 exc,
             )
             self._last_synced_market_data_symbols = None
+            self._market_data_sync_pending = True
 
     def _schedule_market_data_sync(self) -> None:
         """Schedule asynchronous market-data streaming sync (timer-safe)."""

--- a/apps/web_console_ng/components/order_ticket.py
+++ b/apps/web_console_ng/components/order_ticket.py
@@ -2485,6 +2485,13 @@ class OrderTicketComponent:
                     continue
         return None
 
+    def get_current_symbol(self) -> str | None:
+        """Return current ticket symbol, including restored pending-form state."""
+        if not self._state.symbol:
+            return None
+        normalized = self._state.symbol.strip().upper()
+        return normalized or None
+
     # ================= Cleanup =================
 
     async def dispose(self) -> None:

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -311,6 +311,8 @@ class PriceChartComponent:
         if candles:
             await self._hide_no_data_overlay()
         else:
+            self._markers = []
+            await self._clear_chart_series()
             await self._show_no_data_overlay(symbol)
 
         # Fetch execution history for markers
@@ -781,6 +783,13 @@ class PriceChartComponent:
         self._candles = []
         self._markers = []
         await self._hide_no_data_overlay()
+
+        await self._clear_chart_series()
+
+    async def _clear_chart_series(self) -> None:
+        """Clear chart series and marker data without mutating overlay state."""
+        if self._disposed:
+            return
 
         try:
             await self._run_javascript(

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -560,6 +560,63 @@ class PriceChartComponent:
 
     # ================= Data Fetching =================
 
+    def _parse_historical_bars(self, raw_bars: Any) -> list[CandleData]:
+        """Normalize historical bars payloads into sorted candle data."""
+        if not isinstance(raw_bars, list):
+            return []
+
+        parsed: list[CandleData] = []
+        for raw_bar in raw_bars:
+            if not isinstance(raw_bar, dict):
+                continue
+
+            timestamp_raw = raw_bar.get("timestamp") or raw_bar.get("t")
+            if timestamp_raw is None:
+                continue
+
+            try:
+                if isinstance(timestamp_raw, int | float):
+                    timestamp = datetime.fromtimestamp(float(timestamp_raw), tz=UTC)
+                else:
+                    timestamp = parse_iso_timestamp(str(timestamp_raw))
+                open_px = float(raw_bar["open"])
+                high_px = float(raw_bar["high"])
+                low_px = float(raw_bar["low"])
+                close_px = float(raw_bar["close"])
+            except (KeyError, TypeError, ValueError):
+                continue
+
+            if (
+                not math.isfinite(open_px)
+                or not math.isfinite(high_px)
+                or not math.isfinite(low_px)
+                or not math.isfinite(close_px)
+                or min(open_px, high_px, low_px, close_px) <= 0
+            ):
+                continue
+
+            volume_raw = raw_bar.get("volume")
+            try:
+                volume = int(volume_raw) if volume_raw is not None else None
+            except (TypeError, ValueError):
+                volume = None
+
+            parsed.append(
+                CandleData(
+                    time=int(timestamp.timestamp()),
+                    open=open_px,
+                    high=high_px,
+                    low=low_px,
+                    close=close_px,
+                    volume=volume,
+                )
+            )
+
+        parsed.sort(key=lambda candle: candle.time)
+        if len(parsed) > self.MAX_CHART_CANDLES:
+            parsed = parsed[-self.MAX_CHART_CANDLES :]
+        return parsed
+
     async def _fetch_candle_data(self, symbol: str) -> list[CandleData]:
         """Fetch historical candle data for the selected symbol."""
         if self._disposed:
@@ -572,62 +629,6 @@ class PriceChartComponent:
         if not self._user_id:
             logger.debug("Historical bars fetch skipped: user_id unavailable")
             return []
-
-        def _parse_bars(raw_bars: Any) -> list[CandleData]:
-            if not isinstance(raw_bars, list):
-                return []
-
-            parsed: list[CandleData] = []
-            for raw_bar in raw_bars:
-                if not isinstance(raw_bar, dict):
-                    continue
-
-                timestamp_raw = raw_bar.get("timestamp") or raw_bar.get("t")
-                if timestamp_raw is None:
-                    continue
-
-                try:
-                    if isinstance(timestamp_raw, int | float):
-                        timestamp = datetime.fromtimestamp(float(timestamp_raw), tz=UTC)
-                    else:
-                        timestamp = parse_iso_timestamp(str(timestamp_raw))
-                    open_px = float(raw_bar["open"])
-                    high_px = float(raw_bar["high"])
-                    low_px = float(raw_bar["low"])
-                    close_px = float(raw_bar["close"])
-                except (KeyError, TypeError, ValueError):
-                    continue
-
-                if (
-                    not math.isfinite(open_px)
-                    or not math.isfinite(high_px)
-                    or not math.isfinite(low_px)
-                    or not math.isfinite(close_px)
-                    or min(open_px, high_px, low_px, close_px) <= 0
-                ):
-                    continue
-
-                volume_raw = raw_bar.get("volume")
-                try:
-                    volume = int(volume_raw) if volume_raw is not None else None
-                except (TypeError, ValueError):
-                    volume = None
-
-                parsed.append(
-                    CandleData(
-                        time=int(timestamp.timestamp()),
-                        open=open_px,
-                        high=high_px,
-                        low=low_px,
-                        close=close_px,
-                        volume=volume,
-                    )
-                )
-
-            parsed.sort(key=lambda candle: candle.time)
-            if len(parsed) > self.MAX_CHART_CANDLES:
-                parsed = parsed[-self.MAX_CHART_CANDLES :]
-            return parsed
 
         for timeframe, limit in self.HISTORICAL_TIMEFRAME_FALLBACKS:
             try:
@@ -664,7 +665,7 @@ class PriceChartComponent:
                 )
                 continue
 
-            candles = _parse_bars(response.get("bars", []))
+            candles = self._parse_historical_bars(response.get("bars", []))
             if candles:
                 return candles
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -20,7 +20,9 @@ from nicegui import ui
 
 from apps.web_console_ng.ui.lightweight_charts import (
     CHART_INIT_JS,
-    LightweightChartsLoader,
+    LIGHTWEIGHT_CHARTS_CDN,
+    LIGHTWEIGHT_CHARTS_LOCAL,
+    LIGHTWEIGHT_CHARTS_SRI,
 )
 from apps.web_console_ng.utils.time import parse_iso_timestamp
 
@@ -68,6 +70,7 @@ class PriceChartComponent:
 
     DEFAULT_TIMEFRAME = "1D"  # 1 day of data
     CANDLE_INTERVAL = "5m"  # 5-minute candles
+    CANDLE_INTERVAL_SECONDS = 300
 
     def __init__(
         self,
@@ -98,6 +101,13 @@ class PriceChartComponent:
         self._height: int = 300  # Default, overridden by create()
         self._disposed: bool = False
         self._staleness_timer: ui.timer | None = None
+        self._chart_initialized: bool = False
+        try:
+            # Bind to originating NiceGUI client so JS calls from background tasks
+            # execute in the correct browser context.
+            self._ui_client = ui.context.client
+        except Exception:
+            self._ui_client = None
 
         # Track pending update tasks for cleanup on dispose (prevent task leaks)
         self._pending_update_tasks: set[asyncio.Task[None]] = set()
@@ -114,25 +124,25 @@ class PriceChartComponent:
         """
         self._timer_tracker = timer_tracker
 
-        # Initialize chart via one-shot timer (tracked)
         async def init_chart() -> None:
             if self._disposed:
                 return
             try:
-                await LightweightChartsLoader.ensure_loaded()
-                await ui.run_javascript(
-                    CHART_INIT_JS.format(
-                        container_id=self._container_id,
-                        chart_id=self._chart_id,
-                        width=self._width,
-                        height=self._height,
-                    ),
-                    timeout=10.0,
-                )
+                await self._ensure_chart_initialized()
             except Exception as exc:
                 logger.warning(f"Failed to initialize chart: {exc}")
 
-        init_timer = ui.timer(0.1, init_chart, once=True)
+        # Initialize chart via one-shot timer (tracked).
+        # Use a synchronous timer callback that spawns a task to avoid depending
+        # on framework-specific async timer callback behavior.
+        def schedule_chart_init() -> None:
+            if self._disposed:
+                return
+            task = asyncio.create_task(init_chart())
+            self._pending_update_tasks.add(task)
+            task.add_done_callback(lambda t: self._pending_update_tasks.discard(t))
+
+        init_timer = ui.timer(0.1, schedule_chart_init, once=True)
         timer_tracker(init_timer)
 
         # Start realtime staleness monitor (tracked via timer_tracker)
@@ -154,6 +164,40 @@ class PriceChartComponent:
         )
 
         return container
+
+    async def _run_javascript(
+        self,
+        code: str,
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        """Run JavaScript in this component's client context."""
+        if self._ui_client is not None:
+            if timeout is not None:
+                return await self._ui_client.run_javascript(code, timeout=timeout)
+            return await self._ui_client.run_javascript(code)
+        if timeout is not None:
+            return await ui.run_javascript(code, timeout=timeout)
+        return await ui.run_javascript(code)
+
+    async def _ensure_chart_initialized(self) -> None:
+        """Initialize chart library and chart instance once for this component."""
+        if self._chart_initialized or self._disposed:
+            return
+
+        await self._run_javascript(
+            CHART_INIT_JS.format(
+                container_id=self._container_id,
+                chart_id=self._chart_id,
+                width=self._width,
+                height=self._height,
+                cdn=LIGHTWEIGHT_CHARTS_CDN,
+                sri=LIGHTWEIGHT_CHARTS_SRI,
+                local=LIGHTWEIGHT_CHARTS_LOCAL,
+            ),
+            timeout=10.0,
+        )
+        self._chart_initialized = True
 
     # ================= Symbol Management =================
 
@@ -183,6 +227,12 @@ class PriceChartComponent:
             await self._clear_chart()
             return
 
+        # Ensure chart exists even when historical bars are unavailable.
+        try:
+            await self._ensure_chart_initialized()
+        except Exception as exc:
+            logger.warning(f"Failed to ensure chart initialized: {exc}")
+
         # Fetch historical data
         candles = await self._fetch_candle_data(symbol)
 
@@ -191,6 +241,10 @@ class PriceChartComponent:
             return  # Stale - symbol changed during fetch
 
         self._candles = candles
+        if candles:
+            await self._hide_no_data_overlay()
+        else:
+            await self._show_no_data_overlay(symbol)
 
         # Fetch execution history for markers
         markers = await self._fetch_execution_markers(symbol)
@@ -255,9 +309,12 @@ class PriceChartComponent:
         # FAIL-CLOSED: REQUIRE SERVER TIMESTAMP - do NOT use datetime.now() as fallback.
         # If timestamp is missing/invalid, set to None and keep/show stale overlay.
         raw_timestamp = data.get("timestamp")
+        tick_time: datetime | None = None
         if raw_timestamp:
             try:
-                self._last_realtime_update = parse_iso_timestamp(str(raw_timestamp))
+                parsed = parse_iso_timestamp(str(raw_timestamp))
+                self._last_realtime_update = parsed
+                tick_time = parsed
             except (ValueError, TypeError):
                 # Invalid timestamp format - FAIL-CLOSED: treat as missing
                 logger.debug(f"PriceChart: unparseable timestamp {raw_timestamp!r}, keeping stale")
@@ -268,42 +325,109 @@ class PriceChartComponent:
             self._last_realtime_update = None
 
         # Process the price update
+        if tick_time is None:
+            tick_time = datetime.now(UTC)
+
         # Track task for cleanup on dispose (avoid task leaks)
-        task = asyncio.create_task(self._handle_price_update(price))
+        task = asyncio.create_task(self._handle_price_update(price, tick_time))
         self._pending_update_tasks.add(task)
         task.add_done_callback(lambda t: self._pending_update_tasks.discard(t))
 
-    async def _handle_price_update(self, price: float) -> None:
+    async def _handle_price_update(self, price: float, tick_time: datetime) -> None:
         """Process incoming price update and update chart."""
-        if self._disposed or not self._candles:
+        if self._disposed:
             return
+
+        # Ensure chart exists even when historical bars are unavailable.
+        if not self._chart_initialized:
+            try:
+                await self._ensure_chart_initialized()
+            except Exception as exc:
+                logger.debug(f"Failed to initialize chart on tick update: {exc}")
+                return
+
+        await self._hide_no_data_overlay()
 
         # Hide stale overlay on valid update
         if self._last_realtime_update:
             await self._hide_stale_overlay()
 
-        # Update the last candle's close (simplified real-time update)
-        last_candle = self._candles[-1]
-        updated_candle = {
-            "time": last_candle.time,
-            "open": last_candle.open,
-            "high": max(last_candle.high, price),
-            "low": min(last_candle.low, price),
-            "close": price,
-        }
+        bucket_start = (
+            int(tick_time.timestamp()) // self.CANDLE_INTERVAL_SECONDS
+        ) * self.CANDLE_INTERVAL_SECONDS
 
-        # Update internal state
-        self._candles[-1] = CandleData(
-            time=last_candle.time,
-            open=last_candle.open,
-            high=max(last_candle.high, price),
-            low=min(last_candle.low, price),
-            close=price,
-            volume=last_candle.volume,
-        )
+        if not self._candles:
+            seeded_candle = CandleData(
+                time=bucket_start,
+                open=price,
+                high=price,
+                low=price,
+                close=price,
+                volume=None,
+            )
+            self._candles = [seeded_candle]
+            try:
+                await self._run_javascript(
+                    f"""
+                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                    if (chartRef) {{
+                        chartRef.candlestickSeries.setData([{json.dumps({
+                            "time": seeded_candle.time,
+                            "open": seeded_candle.open,
+                            "high": seeded_candle.high,
+                            "low": seeded_candle.low,
+                            "close": seeded_candle.close,
+                        })}]);
+                    }}
+                """
+                )
+            except Exception as exc:
+                logger.debug(f"Failed to seed chart from live tick: {exc}")
+            return
+
+        # Update existing candle or start a new bucket candle
+        last_candle = self._candles[-1]
+        if bucket_start > last_candle.time:
+            updated_candle = {
+                "time": bucket_start,
+                "open": last_candle.close,
+                "high": max(last_candle.close, price),
+                "low": min(last_candle.close, price),
+                "close": price,
+            }
+            self._candles.append(
+                CandleData(
+                    time=updated_candle["time"],
+                    open=updated_candle["open"],
+                    high=updated_candle["high"],
+                    low=updated_candle["low"],
+                    close=updated_candle["close"],
+                    volume=None,
+                )
+            )
+        else:
+            updated_candle = {
+                "time": last_candle.time,
+                "open": last_candle.open,
+                "high": max(last_candle.high, price),
+                "low": min(last_candle.low, price),
+                "close": price,
+            }
+            self._candles[-1] = CandleData(
+                time=updated_candle["time"],
+                open=updated_candle["open"],
+                high=updated_candle["high"],
+                low=updated_candle["low"],
+                close=updated_candle["close"],
+                volume=last_candle.volume,
+            )
+
+            # Keep bounded history in UI-only memory.
+            if len(self._candles) > 500:
+                self._candles = self._candles[-500:]
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const chartRef = window.__charts && window.__charts['{self._chart_id}'];
                 if (chartRef) {{
@@ -329,11 +453,8 @@ class PriceChartComponent:
             return []
 
         # TODO: Implement when fetch_historical_bars is available
-        # For now, return empty to trigger fallback UI
-        logger.debug(f"Historical bars API not implemented, showing fallback for {symbol}")
-
-        # Show fallback UI since we can't fetch data
-        await self._show_fallback_chart(symbol)
+        # For now, return empty and keep chart shell visible.
+        logger.debug(f"Historical bars API not implemented, showing empty chart for {symbol}")
         return []
 
     async def _fetch_execution_markers(self, symbol: str) -> list[ExecutionMarker]:
@@ -398,6 +519,8 @@ class PriceChartComponent:
         if self._disposed or not self._candles:
             return
 
+        await self._hide_no_data_overlay()
+
         # Format candle data for JS
         candle_data = [
             {
@@ -423,7 +546,7 @@ class PriceChartComponent:
         ]
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const chartRef = window.__charts && window.__charts['{self._chart_id}'];
                 if (chartRef) {{
@@ -442,9 +565,10 @@ class PriceChartComponent:
 
         self._candles = []
         self._markers = []
+        await self._hide_no_data_overlay()
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const chartRef = window.__charts && window.__charts['{self._chart_id}'];
                 if (chartRef) {{
@@ -470,7 +594,7 @@ class PriceChartComponent:
         line_data = [{"time": d["time"], "value": d["vwap"]} for d in vwap_data]
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const chartRef = window.__charts && window.__charts['{self._chart_id}'];
                 if (chartRef) {{
@@ -504,7 +628,7 @@ class PriceChartComponent:
         line_data = [{"time": d["time"], "value": d["twap"]} for d in twap_data]
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const chartRef = window.__charts && window.__charts['{self._chart_id}'];
                 if (chartRef) {{
@@ -620,7 +744,7 @@ class PriceChartComponent:
             return
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const container = document.getElementById('{self._container_id}');
                 if (!container) return;
@@ -638,13 +762,68 @@ class PriceChartComponent:
         except Exception as exc:
             logger.debug(f"Failed to show stale overlay: {exc}")
 
+    async def _show_no_data_overlay(self, symbol: str) -> None:
+        """Show neutral overlay while waiting for first live candle."""
+        if self._disposed:
+            return
+
+        js_safe_symbol = json.dumps(symbol)
+        try:
+            await self._run_javascript(
+                f"""
+                const container = document.getElementById('{self._container_id}');
+                if (!container) return;
+                let overlay = container.querySelector('.no-data-overlay');
+                if (!overlay) {{
+                    overlay = document.createElement('div');
+                    overlay.className = 'no-data-overlay';
+                    overlay.style.cssText = 'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:none;z-index:120;background:linear-gradient(180deg, rgba(15,23,42,0.08), rgba(15,23,42,0.35));';
+
+                    const card = document.createElement('div');
+                    card.style.cssText = 'padding:10px 14px;border:1px solid rgba(71,85,105,0.65);border-radius:8px;background:rgba(15,23,42,0.82);box-shadow:0 8px 24px rgba(2,6,23,0.35);text-align:center;';
+
+                    const title = document.createElement('div');
+                    title.style.cssText = 'font-size:12px;font-weight:600;color:#e2e8f0;letter-spacing:0.01em;';
+                    title.textContent = 'Awaiting live market data';
+
+                    const subtitle = document.createElement('div');
+                    subtitle.style.cssText = 'margin-top:4px;font-size:11px;color:#94a3b8;';
+                    subtitle.textContent = 'Selected symbol: ' + {js_safe_symbol};
+
+                    card.appendChild(title);
+                    card.appendChild(subtitle);
+                    overlay.appendChild(card);
+                    container.appendChild(overlay);
+                }}
+                overlay.style.display = 'flex';
+            """
+            )
+        except Exception as exc:
+            logger.debug(f"Failed to show no-data overlay: {exc}")
+
+    async def _hide_no_data_overlay(self) -> None:
+        """Hide no-data overlay after candles become available."""
+        if self._disposed:
+            return
+
+        try:
+            await self._run_javascript(
+                f"""
+                const container = document.getElementById('{self._container_id}');
+                const overlay = container?.querySelector('.no-data-overlay');
+                if (overlay) overlay.style.display = 'none';
+            """
+            )
+        except Exception as exc:
+            logger.debug(f"Failed to hide no-data overlay: {exc}")
+
     async def _hide_stale_overlay(self) -> None:
         """Hide stale data warning overlay."""
         if self._disposed:
             return
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const container = document.getElementById('{self._container_id}');
                 const overlay = container?.querySelector('.stale-overlay');
@@ -665,7 +844,7 @@ class PriceChartComponent:
             return
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const container = document.getElementById('{self._container_id}');
                 if (!container) return;
@@ -721,7 +900,7 @@ class PriceChartComponent:
         js_safe_symbol = json.dumps(symbol)
 
         try:
-            await ui.run_javascript(
+            await self._run_javascript(
                 f"""
                 const container = document.getElementById('{self._container_id}');
                 const symbolForDisplay = {js_safe_symbol};
@@ -806,7 +985,7 @@ class PriceChartComponent:
         # Clear chart by removing from DOM if needed
         if self._container_id:
             try:
-                await ui.run_javascript(
+                await self._run_javascript(
                     f"""
                     const container = document.getElementById('{self._container_id}');
                     if (container) {{ container.innerHTML = ''; }}
@@ -822,6 +1001,7 @@ class PriceChartComponent:
         self._current_symbol = None
         self._candles = []
         self._markers = []
+        self._chart_initialized = False
 
 
 __all__ = [

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -13,7 +13,7 @@ import json
 import logging
 import math
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 from nicegui import ui
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 # Staleness thresholds
 REALTIME_STALE_THRESHOLD_S = 60  # Show warning if no updates for 60s
 REALTIME_FALLBACK_THRESHOLD_S = 180  # Show fallback chart after 3 minutes
+MAX_FUTURE_TICK_SKEW_S = 60  # Drop ticks with timestamps too far in the future
 
 
 def _parse_interval_seconds(interval: str) -> int:
@@ -119,6 +120,7 @@ class PriceChartComponent:
         self._ui_client: Any | None = None
         self._missing_ui_client_warned: bool = False
         self._chart_init_lock = asyncio.Lock()
+        self._no_data_overlay_visible: bool = False
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -349,6 +351,14 @@ class PriceChartComponent:
         if raw_timestamp:
             try:
                 parsed = parse_iso_timestamp(str(raw_timestamp))
+                if parsed > datetime.now(UTC) + timedelta(seconds=MAX_FUTURE_TICK_SKEW_S):
+                    logger.warning(
+                        "PriceChart: future-skewed timestamp %s exceeds %ss threshold",
+                        raw_timestamp,
+                        MAX_FUTURE_TICK_SKEW_S,
+                    )
+                    self._last_realtime_update = None
+                    return
                 self._last_realtime_update = parsed
                 tick_time = parsed
             except (ValueError, TypeError):
@@ -444,9 +454,9 @@ class PriceChartComponent:
         if bucket_start > last_candle.time:
             updated_candle = {
                 "time": bucket_start,
-                "open": last_candle.close,
-                "high": max(last_candle.close, price),
-                "low": min(last_candle.close, price),
+                "open": price,
+                "high": price,
+                "low": price,
                 "close": price,
             }
             self._candles.append(
@@ -879,12 +889,13 @@ class PriceChartComponent:
                 overlay.style.display = 'flex';
             """
             )
+            self._no_data_overlay_visible = True
         except Exception as exc:
             logger.debug(f"Failed to show no-data overlay: {exc}")
 
     async def _hide_no_data_overlay(self) -> None:
         """Hide no-data overlay after candles become available."""
-        if self._disposed:
+        if self._disposed or not self._no_data_overlay_visible:
             return
 
         try:
@@ -895,6 +906,7 @@ class PriceChartComponent:
                 if (overlay) overlay.style.display = 'none';
             """
             )
+            self._no_data_overlay_visible = False
         except Exception as exc:
             logger.debug(f"Failed to hide no-data overlay: {exc}")
 
@@ -1082,6 +1094,7 @@ class PriceChartComponent:
         self._current_symbol = None
         self._candles = []
         self._markers = []
+        self._no_data_overlay_visible = False
         self._chart_initialized = False
 
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -102,6 +102,7 @@ class PriceChartComponent:
         self._disposed: bool = False
         self._staleness_timer: ui.timer | None = None
         self._chart_initialized: bool = False
+        self._ui_client: Any | None = None
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -397,7 +398,7 @@ class PriceChartComponent:
             }
             self._candles.append(
                 CandleData(
-                    time=updated_candle["time"],
+                    time=int(updated_candle["time"]),
                     open=updated_candle["open"],
                     high=updated_candle["high"],
                     low=updated_candle["low"],
@@ -414,7 +415,7 @@ class PriceChartComponent:
                 "close": price,
             }
             self._candles[-1] = CandleData(
-                time=updated_candle["time"],
+                time=int(updated_candle["time"]),
                 open=updated_candle["open"],
                 high=updated_candle["high"],
                 low=updated_candle["low"],

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -120,6 +120,7 @@ class PriceChartComponent:
         self._ui_client: Any | None = None
         self._missing_ui_client_warned: bool = False
         self._chart_init_lock = asyncio.Lock()
+        self._price_update_lock = asyncio.Lock()
         self._no_data_overlay_visible: bool = False
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
@@ -390,139 +391,140 @@ class PriceChartComponent:
         symbol: str | None = None,
     ) -> None:
         """Process incoming price update and update chart."""
-        if self._disposed:
-            return
-        if symbol is not None and symbol != self._current_symbol:
-            return
-
-        # Ensure chart exists even when historical bars are unavailable.
-        if not self._chart_initialized:
-            try:
-                await self._ensure_chart_initialized()
-            except Exception as exc:
-                logger.debug(f"Failed to initialize chart on tick update: {exc}")
+        async with self._price_update_lock:
+            if self._disposed:
                 return
-        if self._disposed or (symbol is not None and symbol != self._current_symbol):
-            return
+            if symbol is not None and symbol != self._current_symbol:
+                return
 
-        await self._hide_no_data_overlay()
+            # Ensure chart exists even when historical bars are unavailable.
+            if not self._chart_initialized:
+                try:
+                    await self._ensure_chart_initialized()
+                except Exception as exc:
+                    logger.debug(f"Failed to initialize chart on tick update: {exc}")
+                    return
+            if self._disposed or (symbol is not None and symbol != self._current_symbol):
+                return
 
-        # Hide stale overlay on valid update
-        if self._last_realtime_update:
-            await self._hide_stale_overlay()
-        if self._disposed or (symbol is not None and symbol != self._current_symbol):
-            return
+            await self._hide_no_data_overlay()
 
-        bucket_start = (
-            int(tick_time.timestamp()) // self.CANDLE_INTERVAL_SECONDS
-        ) * self.CANDLE_INTERVAL_SECONDS
+            # Hide stale overlay on valid update
+            if self._last_realtime_update:
+                await self._hide_stale_overlay()
+            if self._disposed or (symbol is not None and symbol != self._current_symbol):
+                return
 
-        if not self._candles:
-            seeded_candle = CandleData(
-                time=bucket_start,
-                open=price,
-                high=price,
-                low=price,
-                close=price,
-                volume=None,
-            )
-            self._candles = [seeded_candle]
-            try:
-                await self._run_javascript(
-                    f"""
-                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
-                    if (chartRef) {{
-                        chartRef.candlestickSeries.setData([{json.dumps({
-                            "time": seeded_candle.time,
-                            "open": seeded_candle.open,
-                            "high": seeded_candle.high,
-                            "low": seeded_candle.low,
-                            "close": seeded_candle.close,
-                        })}]);
-                    }}
-                """
+            bucket_start = (
+                int(tick_time.timestamp()) // self.CANDLE_INTERVAL_SECONDS
+            ) * self.CANDLE_INTERVAL_SECONDS
+
+            if not self._candles:
+                seeded_candle = CandleData(
+                    time=bucket_start,
+                    open=price,
+                    high=price,
+                    low=price,
+                    close=price,
+                    volume=None,
                 )
-            except Exception as exc:
-                logger.debug(f"Failed to seed chart from live tick: {exc}")
-            return
+                self._candles = [seeded_candle]
+                try:
+                    await self._run_javascript(
+                        f"""
+                        const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                        if (chartRef) {{
+                            chartRef.candlestickSeries.setData([{json.dumps({
+                                "time": seeded_candle.time,
+                                "open": seeded_candle.open,
+                                "high": seeded_candle.high,
+                                "low": seeded_candle.low,
+                                "close": seeded_candle.close,
+                            })}]);
+                        }}
+                    """
+                    )
+                except Exception as exc:
+                    logger.debug(f"Failed to seed chart from live tick: {exc}")
+                return
 
-        # Update existing candle or start a new bucket candle
-        last_candle = self._candles[-1]
-        if bucket_start < last_candle.time:
-            # Ignore delayed/out-of-order ticks from older buckets.
-            return
-        if bucket_start > last_candle.time:
-            updated_candle = {
-                "time": bucket_start,
-                "open": price,
-                "high": price,
-                "low": price,
-                "close": price,
-            }
-            self._candles.append(
-                CandleData(
+            # Update existing candle or start a new bucket candle
+            last_candle = self._candles[-1]
+            if bucket_start < last_candle.time:
+                # Ignore delayed/out-of-order ticks from older buckets.
+                return
+            if bucket_start > last_candle.time:
+                updated_candle = {
+                    "time": bucket_start,
+                    "open": price,
+                    "high": price,
+                    "low": price,
+                    "close": price,
+                }
+                self._candles.append(
+                    CandleData(
+                        time=int(updated_candle["time"]),
+                        open=updated_candle["open"],
+                        high=updated_candle["high"],
+                        low=updated_candle["low"],
+                        close=updated_candle["close"],
+                        volume=None,
+                    )
+                )
+            else:
+                updated_candle = {
+                    "time": last_candle.time,
+                    "open": last_candle.open,
+                    "high": max(last_candle.high, price),
+                    "low": min(last_candle.low, price),
+                    "close": price,
+                }
+                self._candles[-1] = CandleData(
                     time=int(updated_candle["time"]),
                     open=updated_candle["open"],
                     high=updated_candle["high"],
                     low=updated_candle["low"],
                     close=updated_candle["close"],
-                    volume=None,
+                    volume=last_candle.volume,
                 )
-            )
-        else:
-            updated_candle = {
-                "time": last_candle.time,
-                "open": last_candle.open,
-                "high": max(last_candle.high, price),
-                "low": min(last_candle.low, price),
-                "close": price,
-            }
-            self._candles[-1] = CandleData(
-                time=int(updated_candle["time"]),
-                open=updated_candle["open"],
-                high=updated_candle["high"],
-                low=updated_candle["low"],
-                close=updated_candle["close"],
-                volume=last_candle.volume,
-            )
 
-        trimmed_history = False
-        # Keep bounded history in UI-only memory.
-        if len(self._candles) > 500:
-            self._candles = self._candles[-500:]
-            trimmed_history = True
+            trimmed_history = False
+            # Keep bounded history in UI-only memory.
+            if len(self._candles) > 500:
+                self._candles = self._candles[-500:]
+                trimmed_history = True
 
-        try:
-            if trimmed_history:
-                candles_payload = [
-                    {
-                        "time": candle.time,
-                        "open": candle.open,
-                        "high": candle.high,
-                        "low": candle.low,
-                        "close": candle.close,
-                    }
-                    for candle in self._candles
-                ]
-                await self._run_javascript(
-                    f"""
-                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
-                    if (chartRef) {{
-                        chartRef.candlestickSeries.setData({json.dumps(candles_payload)});
-                    }}
-                """
-                )
-            else:
-                await self._run_javascript(
-                    f"""
-                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
-                    if (chartRef) {{
-                        chartRef.candlestickSeries.update({json.dumps(updated_candle)});
-                    }}
-                """
-                )
-        except Exception as exc:
-            logger.debug(f"Failed to update chart: {exc}")
+            try:
+                if trimmed_history:
+                    candles_payload = [
+                        {
+                            "time": candle.time,
+                            "open": candle.open,
+                            "high": candle.high,
+                            "low": candle.low,
+                            "close": candle.close,
+                        }
+                        for candle in self._candles
+                    ]
+                    await self._run_javascript(
+                        f"""
+                        const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                        if (chartRef) {{
+                            chartRef.candlestickSeries.setData({json.dumps(candles_payload)});
+                        }}
+                    """
+                    )
+                else:
+                    await self._run_javascript(
+                        f"""
+                        const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                        if (chartRef) {{
+                            chartRef.candlestickSeries.update({json.dumps(updated_candle)});
+                        }}
+                    """
+                    )
+            except Exception as exc:
+                logger.debug(f"Failed to update chart: {exc}")
 
     # ================= Data Fetching =================
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -131,6 +131,8 @@ class PriceChartComponent:
         self._missing_ui_client_warned: bool = False
         self._chart_init_lock: asyncio.Lock | None = None
         self._price_update_lock: asyncio.Lock | None = None
+        self._price_update_task: asyncio.Task[None] | None = None
+        self._pending_price_update: tuple[float, datetime, str | None] | None = None
         self._no_data_overlay_visible: bool = False
         self._stale_overlay_visible: bool = False
         self._fallback_overlay_visible: bool = False
@@ -418,13 +420,53 @@ class PriceChartComponent:
             # FAIL-CLOSED: Do not bucket/update chart without server timestamp
             return
 
-        # Track task for cleanup on dispose (avoid task leaks)
         symbol_snapshot = self._current_symbol
-        task = asyncio.create_task(
-            self._handle_price_update(price, tick_time, symbol_snapshot)
-        )
+        self._schedule_price_update(price, tick_time, symbol_snapshot)
+
+    def _schedule_price_update(
+        self,
+        price: float,
+        tick_time: datetime,
+        symbol: str | None,
+    ) -> None:
+        """Schedule/coalesce realtime updates to avoid unbounded per-tick tasks."""
+        if self._disposed:
+            return
+
+        next_update = (price, tick_time, symbol)
+        if self._price_update_task and not self._price_update_task.done():
+            # Keep only the latest pending update while one is in-flight.
+            self._pending_price_update = next_update
+            return
+
+        async def process_updates(initial_update: tuple[float, datetime, str | None]) -> None:
+            update: tuple[float, datetime, str | None] | None = initial_update
+            while update is not None and not self._disposed:
+                current_price, current_tick_time, current_symbol = update
+                await self._handle_price_update(
+                    current_price,
+                    current_tick_time,
+                    current_symbol,
+                )
+                update = self._pending_price_update
+                self._pending_price_update = None
+
+        task = asyncio.create_task(process_updates(next_update))
+        self._price_update_task = task
         self._pending_update_tasks.add(task)
-        task.add_done_callback(lambda t: self._pending_update_tasks.discard(t))
+
+        def _on_done(completed: asyncio.Task[None]) -> None:
+            self._pending_update_tasks.discard(completed)
+            self._price_update_task = None
+            if self._disposed:
+                self._pending_price_update = None
+                return
+            if self._pending_price_update is not None:
+                pending = self._pending_price_update
+                self._pending_price_update = None
+                self._schedule_price_update(*pending)
+
+        task.add_done_callback(_on_done)
 
     async def _handle_price_update(
         self,
@@ -1230,6 +1272,8 @@ class PriceChartComponent:
                 except asyncio.CancelledError:
                     pass
         self._pending_update_tasks.clear()
+        self._price_update_task = None
+        self._pending_price_update = None
 
         # Clear chart by removing from DOM if needed
         if self._container_id:

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -38,6 +38,20 @@ REALTIME_STALE_THRESHOLD_S = 60  # Show warning if no updates for 60s
 REALTIME_FALLBACK_THRESHOLD_S = 180  # Show fallback chart after 3 minutes
 
 
+def _parse_interval_seconds(interval: str) -> int:
+    """Convert interval strings like '5m' into seconds."""
+    if len(interval) < 2:
+        raise ValueError(f"Invalid interval format: {interval!r}")
+    value_str, unit = interval[:-1], interval[-1].lower()
+    if not value_str.isdigit():
+        raise ValueError(f"Invalid interval value: {interval!r}")
+    value = int(value_str)
+    multiplier = {"s": 1, "m": 60, "h": 3600}.get(unit)
+    if multiplier is None:
+        raise ValueError(f"Unsupported interval unit: {interval!r}")
+    return value * multiplier
+
+
 @dataclass
 class CandleData:
     """Single candle data point."""
@@ -70,7 +84,7 @@ class PriceChartComponent:
 
     DEFAULT_TIMEFRAME = "1D"  # 1 day of data
     CANDLE_INTERVAL = "5m"  # 5-minute candles
-    CANDLE_INTERVAL_SECONDS = 300
+    CANDLE_INTERVAL_SECONDS = _parse_interval_seconds(CANDLE_INTERVAL)
 
     def __init__(
         self,
@@ -103,6 +117,7 @@ class PriceChartComponent:
         self._staleness_timer: ui.timer | None = None
         self._chart_initialized: bool = False
         self._ui_client: Any | None = None
+        self._missing_ui_client_warned: bool = False
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -177,9 +192,10 @@ class PriceChartComponent:
             if timeout is not None:
                 return await self._ui_client.run_javascript(code, timeout=timeout)
             return await self._ui_client.run_javascript(code)
-        if timeout is not None:
-            return await ui.run_javascript(code, timeout=timeout)
-        return await ui.run_javascript(code)
+        if not self._missing_ui_client_warned:
+            logger.warning("PriceChart: No UI client context available for JavaScript execution")
+            self._missing_ui_client_warned = True
+        return None
 
     async def _ensure_chart_initialized(self) -> None:
         """Initialize chart library and chart instance once for this component."""
@@ -198,7 +214,20 @@ class PriceChartComponent:
             ),
             timeout=10.0,
         )
-        self._chart_initialized = True
+        initialized = await self._run_javascript(
+            f"""
+            (() => {{
+                const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                return !!(chartRef && chartRef.chart && chartRef.candlestickSeries);
+            }})()
+        """
+        )
+        if initialized is True or (
+            isinstance(initialized, str) and initialized.strip().lower() == "true"
+        ):
+            self._chart_initialized = True
+            return
+        raise RuntimeError(f"Chart init did not create chart reference for {self._chart_id}")
 
     # ================= Symbol Management =================
 
@@ -327,7 +356,8 @@ class PriceChartComponent:
 
         # Process the price update
         if tick_time is None:
-            tick_time = datetime.now(UTC)
+            # FAIL-CLOSED: Do not bucket/update chart without server timestamp
+            return
 
         # Track task for cleanup on dispose (avoid task leaks)
         task = asyncio.create_task(self._handle_price_update(price, tick_time))
@@ -423,9 +453,9 @@ class PriceChartComponent:
                 volume=last_candle.volume,
             )
 
-            # Keep bounded history in UI-only memory.
-            if len(self._candles) > 500:
-                self._candles = self._candles[-500:]
+        # Keep bounded history in UI-only memory.
+        if len(self._candles) > 500:
+            self._candles = self._candles[-500:]
 
         try:
             await self._run_javascript(

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -86,6 +86,8 @@ class PriceChartComponent:
     DEFAULT_TIMEFRAME = "1D"  # 1 day of data
     CANDLE_INTERVAL = "5m"  # 5-minute candles
     CANDLE_INTERVAL_SECONDS = _parse_interval_seconds(CANDLE_INTERVAL)
+    MAX_CHART_CANDLES = 500
+    CHART_TRIM_HIGH_WATER_MARK = 600
     HISTORICAL_TIMEFRAME_FALLBACKS: tuple[tuple[str, int], ...] = (
         ("5Min", 240),
         ("15Min", 240),
@@ -126,9 +128,11 @@ class PriceChartComponent:
         self._chart_initialized: bool = False
         self._ui_client: Any | None = None
         self._missing_ui_client_warned: bool = False
-        self._chart_init_lock = asyncio.Lock()
-        self._price_update_lock = asyncio.Lock()
+        self._chart_init_lock: asyncio.Lock | None = None
+        self._price_update_lock: asyncio.Lock | None = None
         self._no_data_overlay_visible: bool = False
+        self._stale_overlay_visible: bool = False
+        self._fallback_overlay_visible: bool = False
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -215,12 +219,24 @@ class PriceChartComponent:
             self._missing_ui_client_warned = True
         return None
 
+    def _get_chart_init_lock(self) -> asyncio.Lock:
+        """Lazily create chart-init lock once an event loop is active."""
+        if self._chart_init_lock is None:
+            self._chart_init_lock = asyncio.Lock()
+        return self._chart_init_lock
+
+    def _get_price_update_lock(self) -> asyncio.Lock:
+        """Lazily create update lock once an event loop is active."""
+        if self._price_update_lock is None:
+            self._price_update_lock = asyncio.Lock()
+        return self._price_update_lock
+
     async def _ensure_chart_initialized(self) -> None:
         """Initialize chart library and chart instance once for this component."""
         if self._chart_initialized or self._disposed:
             return
 
-        async with self._chart_init_lock:
+        async with self._get_chart_init_lock():
             if self._chart_initialized or self._disposed:
                 return
             await self._run_javascript(
@@ -405,7 +421,7 @@ class PriceChartComponent:
         symbol: str | None = None,
     ) -> None:
         """Process incoming price update and update chart."""
-        async with self._price_update_lock:
+        async with self._get_price_update_lock():
             if self._disposed:
                 return
             if symbol is not None and symbol != self._current_symbol:
@@ -424,7 +440,9 @@ class PriceChartComponent:
             await self._hide_no_data_overlay()
 
             # Hide stale overlay on valid update
-            if self._last_realtime_update:
+            if self._last_realtime_update and (
+                self._stale_overlay_visible or self._fallback_overlay_visible
+            ):
                 await self._hide_stale_overlay()
             if self._disposed or (symbol is not None and symbol != self._current_symbol):
                 return
@@ -504,8 +522,8 @@ class PriceChartComponent:
 
             trimmed_history = False
             # Keep bounded history in UI-only memory.
-            if len(self._candles) > 500:
-                self._candles = self._candles[-500:]
+            if len(self._candles) > self.CHART_TRIM_HIGH_WATER_MARK:
+                self._candles = self._candles[-self.MAX_CHART_CANDLES :]
                 trimmed_history = True
 
             try:
@@ -607,8 +625,8 @@ class PriceChartComponent:
                 )
 
             parsed.sort(key=lambda candle: candle.time)
-            if len(parsed) > 500:
-                parsed = parsed[-500:]
+            if len(parsed) > self.MAX_CHART_CANDLES:
+                parsed = parsed[-self.MAX_CHART_CANDLES :]
             return parsed
 
         for timeframe, limit in self.HISTORICAL_TIMEFRAME_FALLBACKS:
@@ -955,6 +973,8 @@ class PriceChartComponent:
                 overlay.style.display = 'block';
             """
             )
+            self._stale_overlay_visible = True
+            self._fallback_overlay_visible = False
         except Exception as exc:
             logger.debug(f"Failed to show stale overlay: {exc}")
 
@@ -1022,7 +1042,9 @@ class PriceChartComponent:
 
     async def _hide_stale_overlay(self) -> None:
         """Hide stale data warning overlay."""
-        if self._disposed:
+        if self._disposed or (
+            not self._stale_overlay_visible and not self._fallback_overlay_visible
+        ):
             return
 
         try:
@@ -1035,6 +1057,8 @@ class PriceChartComponent:
                 if (fallback) fallback.style.display = 'none';
             """
             )
+            self._stale_overlay_visible = False
+            self._fallback_overlay_visible = False
         except Exception as exc:
             logger.debug(f"Failed to hide stale overlay: {exc}")
 
@@ -1088,6 +1112,8 @@ class PriceChartComponent:
                 overlay.style.display = 'flex';
             """
             )
+            self._fallback_overlay_visible = True
+            self._stale_overlay_visible = False
         except Exception as exc:
             logger.debug(f"Failed to show fallback overlay: {exc}")
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 REALTIME_STALE_THRESHOLD_S = 60  # Show warning if no updates for 60s
 REALTIME_FALLBACK_THRESHOLD_S = 180  # Show fallback chart after 3 minutes
 MAX_FUTURE_TICK_SKEW_S = 60  # Drop ticks with timestamps too far in the future
+MAX_PAST_TICK_SKEW_S = 15 * 60  # Drop ticks that are too stale for realtime charting
 
 
 def _parse_interval_seconds(interval: str) -> int:
@@ -384,11 +385,20 @@ class PriceChartComponent:
         if raw_timestamp:
             try:
                 parsed = parse_iso_timestamp(str(raw_timestamp))
-                if parsed > datetime.now(UTC) + timedelta(seconds=MAX_FUTURE_TICK_SKEW_S):
+                now = datetime.now(UTC)
+                if parsed > now + timedelta(seconds=MAX_FUTURE_TICK_SKEW_S):
                     logger.warning(
                         "PriceChart: future-skewed timestamp %s exceeds %ss threshold",
                         raw_timestamp,
                         MAX_FUTURE_TICK_SKEW_S,
+                    )
+                    self._last_realtime_update = None
+                    return
+                if parsed < now - timedelta(seconds=MAX_PAST_TICK_SKEW_S):
+                    logger.warning(
+                        "PriceChart: past-skewed timestamp %s exceeds %ss threshold",
+                        raw_timestamp,
+                        MAX_PAST_TICK_SKEW_S,
                     )
                     self._last_realtime_update = None
                     return

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -46,7 +46,7 @@ def _parse_interval_seconds(interval: str) -> int:
     if not value_str.isdigit():
         raise ValueError(f"Invalid interval value: {interval!r}")
     value = int(value_str)
-    multiplier = {"s": 1, "m": 60, "h": 3600}.get(unit)
+    multiplier = {"s": 1, "m": 60, "h": 3600, "d": 86400}.get(unit)
     if multiplier is None:
         raise ValueError(f"Unsupported interval unit: {interval!r}")
     return value * multiplier
@@ -438,6 +438,9 @@ class PriceChartComponent:
 
         # Update existing candle or start a new bucket candle
         last_candle = self._candles[-1]
+        if bucket_start < last_candle.time:
+            # Ignore delayed/out-of-order ticks from older buckets.
+            return
         if bucket_start > last_candle.time:
             updated_candle = {
                 "time": bucket_start,
@@ -457,9 +460,6 @@ class PriceChartComponent:
                 )
             )
         else:
-            if bucket_start < last_candle.time:
-                # Ignore delayed/out-of-order ticks from older buckets.
-                return
             updated_candle = {
                 "time": last_candle.time,
                 "open": last_candle.open,
@@ -476,19 +476,41 @@ class PriceChartComponent:
                 volume=last_candle.volume,
             )
 
+        trimmed_history = False
         # Keep bounded history in UI-only memory.
         if len(self._candles) > 500:
             self._candles = self._candles[-500:]
+            trimmed_history = True
 
         try:
-            await self._run_javascript(
-                f"""
-                const chartRef = window.__charts && window.__charts['{self._chart_id}'];
-                if (chartRef) {{
-                    chartRef.candlestickSeries.update({json.dumps(updated_candle)});
-                }}
-            """
-            )
+            if trimmed_history:
+                candles_payload = [
+                    {
+                        "time": candle.time,
+                        "open": candle.open,
+                        "high": candle.high,
+                        "low": candle.low,
+                        "close": candle.close,
+                    }
+                    for candle in self._candles
+                ]
+                await self._run_javascript(
+                    f"""
+                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                    if (chartRef) {{
+                        chartRef.candlestickSeries.setData({json.dumps(candles_payload)});
+                    }}
+                """
+                )
+            else:
+                await self._run_javascript(
+                    f"""
+                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                    if (chartRef) {{
+                        chartRef.candlestickSeries.update({json.dumps(updated_candle)});
+                    }}
+                """
+                )
         except Exception as exc:
             logger.debug(f"Failed to update chart: {exc}")
 
@@ -841,6 +863,7 @@ class PriceChartComponent:
                     title.textContent = 'Awaiting live market data';
 
                     const subtitle = document.createElement('div');
+                    subtitle.className = 'no-data-overlay-subtitle';
                     subtitle.style.cssText = 'margin-top:4px;font-size:11px;color:#94a3b8;';
                     subtitle.textContent = 'Selected symbol: ' + {js_safe_symbol};
 
@@ -848,6 +871,10 @@ class PriceChartComponent:
                     card.appendChild(subtitle);
                     overlay.appendChild(card);
                     container.appendChild(overlay);
+                }}
+                const subtitle = overlay.querySelector('.no-data-overlay-subtitle');
+                if (subtitle) {{
+                    subtitle.textContent = 'Selected symbol: ' + {js_safe_symbol};
                 }}
                 overlay.style.display = 'flex';
             """

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -86,6 +86,12 @@ class PriceChartComponent:
     DEFAULT_TIMEFRAME = "1D"  # 1 day of data
     CANDLE_INTERVAL = "5m"  # 5-minute candles
     CANDLE_INTERVAL_SECONDS = _parse_interval_seconds(CANDLE_INTERVAL)
+    HISTORICAL_TIMEFRAME_FALLBACKS: tuple[tuple[str, int], ...] = (
+        ("5Min", 240),
+        ("15Min", 240),
+        ("1Hour", 200),
+        ("1Day", 120),
+    )
 
     def __init__(
         self,
@@ -114,6 +120,7 @@ class PriceChartComponent:
         self._symbol_changed_at: datetime | None = None  # Track when symbol changed for staleness
         self._width: int = 600  # Default, overridden by create()
         self._height: int = 300  # Default, overridden by create()
+        self._fill_parent: bool = False
         self._disposed: bool = False
         self._staleness_timer: ui.timer | None = None
         self._chart_initialized: bool = False
@@ -168,19 +175,26 @@ class PriceChartComponent:
         # Start realtime staleness monitor (tracked via timer_tracker)
         self._start_realtime_staleness_monitor(timer_tracker)
 
-    def create(self, width: int = 600, height: int = 300) -> ui.html:
+    def create(self, width: int = 600, height: int = 300, *, fill_parent: bool = False) -> ui.html:
         """Create the chart container.
 
         NOTE: Does NOT start timers. Timer for chart initialization is started
         in initialize() to ensure timer_tracker is available.
         """
         # Store dimensions for initialization
-        self._width = width
-        self._height = height
+        if fill_parent:
+            # When filling parent, avoid hard minimums that can overflow responsive layouts.
+            self._width = 1
+            self._height = 1
+        else:
+            self._width = width
+            self._height = height
+        self._fill_parent = fill_parent
+        height_style = "100%" if fill_parent else f"{height}px"
 
         # Container div
         container = ui.html(
-            f'<div id="{self._container_id}" ' f'style="width:100%;height:{height}px;"></div>'
+            f'<div id="{self._container_id}" ' f'style="width:100%;height:{height_style};"></div>'
         )
 
         return container
@@ -529,20 +543,114 @@ class PriceChartComponent:
     # ================= Data Fetching =================
 
     async def _fetch_candle_data(self, symbol: str) -> list[CandleData]:
-        """Fetch historical candle data.
-
-        NOTE: This is a stub implementation. Full implementation requires
-        adding fetch_historical_bars() to AsyncTradingClient and exposing
-        an endpoint that proxies to Alpaca bars API.
-
-        Returns empty list if API not available, triggering fallback UI.
-        """
+        """Fetch historical candle data for the selected symbol."""
         if self._disposed:
             return []
 
-        # TODO: Implement when fetch_historical_bars is available
-        # For now, return empty and keep chart shell visible.
-        logger.debug(f"Historical bars API not implemented, showing empty chart for {symbol}")
+        fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
+        if fetch_historical_bars is None:
+            logger.debug(f"Historical bars client API unavailable for {symbol}")
+            return []
+        if not self._user_id:
+            logger.debug("Historical bars fetch skipped: user_id unavailable")
+            return []
+
+        def _parse_bars(raw_bars: Any) -> list[CandleData]:
+            if not isinstance(raw_bars, list):
+                return []
+
+            parsed: list[CandleData] = []
+            for raw_bar in raw_bars:
+                if not isinstance(raw_bar, dict):
+                    continue
+
+                timestamp_raw = raw_bar.get("timestamp") or raw_bar.get("t")
+                if timestamp_raw is None:
+                    continue
+
+                try:
+                    if isinstance(timestamp_raw, int | float):
+                        timestamp = datetime.fromtimestamp(float(timestamp_raw), tz=UTC)
+                    else:
+                        timestamp = parse_iso_timestamp(str(timestamp_raw))
+                    open_px = float(raw_bar["open"])
+                    high_px = float(raw_bar["high"])
+                    low_px = float(raw_bar["low"])
+                    close_px = float(raw_bar["close"])
+                except (KeyError, TypeError, ValueError):
+                    continue
+
+                if (
+                    not math.isfinite(open_px)
+                    or not math.isfinite(high_px)
+                    or not math.isfinite(low_px)
+                    or not math.isfinite(close_px)
+                    or min(open_px, high_px, low_px, close_px) <= 0
+                ):
+                    continue
+
+                volume_raw = raw_bar.get("volume")
+                try:
+                    volume = int(volume_raw) if volume_raw is not None else None
+                except (TypeError, ValueError):
+                    volume = None
+
+                parsed.append(
+                    CandleData(
+                        time=int(timestamp.timestamp()),
+                        open=open_px,
+                        high=high_px,
+                        low=low_px,
+                        close=close_px,
+                        volume=volume,
+                    )
+                )
+
+            parsed.sort(key=lambda candle: candle.time)
+            if len(parsed) > 500:
+                parsed = parsed[-500:]
+            return parsed
+
+        for timeframe, limit in self.HISTORICAL_TIMEFRAME_FALLBACKS:
+            try:
+                response = await fetch_historical_bars(
+                    symbol=symbol,
+                    user_id=self._user_id,
+                    role=self._role,
+                    strategies=self._strategies,
+                    timeframe=timeframe,
+                    limit=limit,
+                )
+            except TypeError:
+                # Compatibility with older client/test doubles lacking auth kwargs.
+                try:
+                    response = await fetch_historical_bars(
+                        symbol=symbol,
+                        timeframe=timeframe,
+                        limit=limit,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "Historical bars fetch failed for %s (%s): %s",
+                        symbol,
+                        timeframe,
+                        exc,
+                    )
+                    continue
+            except Exception as exc:
+                logger.debug(
+                    "Historical bars fetch failed for %s (%s): %s",
+                    symbol,
+                    timeframe,
+                    exc,
+                )
+                continue
+
+            candles = _parse_bars(response.get("bars", []))
+            if candles:
+                return candles
+
+        logger.debug("Historical bars unavailable for %s across fallback timeframes", symbol)
         return []
 
     async def _fetch_execution_markers(self, symbol: str) -> list[ExecutionMarker]:

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -9,6 +9,7 @@ Data Flow: Redis → RealtimeUpdater → OrderEntryContext → PriceChart.set_pr
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import math
@@ -684,32 +685,37 @@ class PriceChartComponent:
             logger.debug("Historical bars fetch skipped: user_id unavailable")
             return []
 
+        try:
+            fetch_signature = inspect.signature(fetch_historical_bars)
+            fetch_params = fetch_signature.parameters
+            supports_auth_kwargs = (
+                "user_id" in fetch_params
+                and "role" in fetch_params
+                and "strategies" in fetch_params
+            ) or any(
+                param.kind == inspect.Parameter.VAR_KEYWORD for param in fetch_params.values()
+            )
+        except (TypeError, ValueError):
+            # Some mocks/non-inspectable callables do not expose signatures.
+            supports_auth_kwargs = False
+
         for timeframe, limit in self.HISTORICAL_TIMEFRAME_FALLBACKS:
-            try:
-                response = await fetch_historical_bars(
-                    symbol=symbol,
-                    user_id=self._user_id,
-                    role=self._role,
-                    strategies=self._strategies,
-                    timeframe=timeframe,
-                    limit=limit,
+            request_kwargs: dict[str, Any] = {
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "limit": limit,
+            }
+            if supports_auth_kwargs:
+                request_kwargs.update(
+                    {
+                        "user_id": self._user_id,
+                        "role": self._role,
+                        "strategies": self._strategies,
+                    }
                 )
-            except TypeError:
-                # Compatibility with older client/test doubles lacking auth kwargs.
-                try:
-                    response = await fetch_historical_bars(
-                        symbol=symbol,
-                        timeframe=timeframe,
-                        limit=limit,
-                    )
-                except Exception as exc:
-                    logger.debug(
-                        "Historical bars fetch failed for %s (%s): %s",
-                        symbol,
-                        timeframe,
-                        exc,
-                    )
-                    continue
+
+            try:
+                response = await fetch_historical_bars(**request_kwargs)
             except Exception as exc:
                 logger.debug(
                     "Historical bars fetch failed for %s (%s): %s",

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -118,6 +118,7 @@ class PriceChartComponent:
         self._chart_initialized: bool = False
         self._ui_client: Any | None = None
         self._missing_ui_client_warned: bool = False
+        self._chart_init_lock = asyncio.Lock()
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -202,32 +203,35 @@ class PriceChartComponent:
         if self._chart_initialized or self._disposed:
             return
 
-        await self._run_javascript(
-            CHART_INIT_JS.format(
-                container_id=self._container_id,
-                chart_id=self._chart_id,
-                width=self._width,
-                height=self._height,
-                cdn=LIGHTWEIGHT_CHARTS_CDN,
-                sri=LIGHTWEIGHT_CHARTS_SRI,
-                local=LIGHTWEIGHT_CHARTS_LOCAL,
-            ),
-            timeout=10.0,
-        )
-        initialized = await self._run_javascript(
-            f"""
-            (() => {{
-                const chartRef = window.__charts && window.__charts['{self._chart_id}'];
-                return !!(chartRef && chartRef.chart && chartRef.candlestickSeries);
-            }})()
-        """
-        )
-        if initialized is True or (
-            isinstance(initialized, str) and initialized.strip().lower() == "true"
-        ):
-            self._chart_initialized = True
-            return
-        raise RuntimeError(f"Chart init did not create chart reference for {self._chart_id}")
+        async with self._chart_init_lock:
+            if self._chart_initialized or self._disposed:
+                return
+            await self._run_javascript(
+                CHART_INIT_JS.format(
+                    container_id=self._container_id,
+                    chart_id=self._chart_id,
+                    width=self._width,
+                    height=self._height,
+                    cdn=LIGHTWEIGHT_CHARTS_CDN,
+                    sri=LIGHTWEIGHT_CHARTS_SRI,
+                    local=LIGHTWEIGHT_CHARTS_LOCAL,
+                ),
+                timeout=10.0,
+            )
+            initialized = await self._run_javascript(
+                f"""
+                (() => {{
+                    const chartRef = window.__charts && window.__charts['{self._chart_id}'];
+                    return !!(chartRef && chartRef.chart && chartRef.candlestickSeries);
+                }})()
+            """
+            )
+            if initialized is True or (
+                isinstance(initialized, str) and initialized.strip().lower() == "true"
+            ):
+                self._chart_initialized = True
+                return
+            raise RuntimeError(f"Chart init did not create chart reference for {self._chart_id}")
 
     # ================= Symbol Management =================
 
@@ -312,6 +316,8 @@ class PriceChartComponent:
             return  # Silently ignore malformed data (display-only component)
 
         # Check symbol matches current selection
+        if self._current_symbol is None:
+            return
         data_symbol = data.get("symbol")
         if data_symbol and data_symbol != self._current_symbol:
             return  # Ignore data for different symbol
@@ -360,13 +366,23 @@ class PriceChartComponent:
             return
 
         # Track task for cleanup on dispose (avoid task leaks)
-        task = asyncio.create_task(self._handle_price_update(price, tick_time))
+        symbol_snapshot = self._current_symbol
+        task = asyncio.create_task(
+            self._handle_price_update(price, tick_time, symbol_snapshot)
+        )
         self._pending_update_tasks.add(task)
         task.add_done_callback(lambda t: self._pending_update_tasks.discard(t))
 
-    async def _handle_price_update(self, price: float, tick_time: datetime) -> None:
+    async def _handle_price_update(
+        self,
+        price: float,
+        tick_time: datetime,
+        symbol: str | None = None,
+    ) -> None:
         """Process incoming price update and update chart."""
         if self._disposed:
+            return
+        if symbol is not None and symbol != self._current_symbol:
             return
 
         # Ensure chart exists even when historical bars are unavailable.
@@ -376,12 +392,16 @@ class PriceChartComponent:
             except Exception as exc:
                 logger.debug(f"Failed to initialize chart on tick update: {exc}")
                 return
+        if self._disposed or (symbol is not None and symbol != self._current_symbol):
+            return
 
         await self._hide_no_data_overlay()
 
         # Hide stale overlay on valid update
         if self._last_realtime_update:
             await self._hide_stale_overlay()
+        if self._disposed or (symbol is not None and symbol != self._current_symbol):
+            return
 
         bucket_start = (
             int(tick_time.timestamp()) // self.CANDLE_INTERVAL_SECONDS
@@ -437,6 +457,9 @@ class PriceChartComponent:
                 )
             )
         else:
+            if bucket_start < last_candle.time:
+                # Ignore delayed/out-of-order ticks from older buckets.
+                return
             updated_candle = {
                 "time": last_candle.time,
                 "open": last_candle.open,

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -161,7 +161,7 @@ class PriceChartComponent:
             try:
                 await self._ensure_chart_initialized()
             except Exception as exc:
-                logger.warning(f"Failed to initialize chart: {exc}")
+                logger.warning("Failed to initialize chart: %s", exc)
 
         # Initialize chart via one-shot timer (tracked).
         # Use a synchronous timer callback that spawns a task to avoid depending

--- a/apps/web_console_ng/components/status_bar.py
+++ b/apps/web_console_ng/components/status_bar.py
@@ -29,7 +29,7 @@ class StatusBar:
                 "bg-red-600 text-white",
                 remove="bg-green-600 bg-yellow-500 text-black",
             )
-        elif state == "DISENGAGED":
+        elif state in {"DISENGAGED", "ACTIVE"}:
             self._container.classes(
                 "bg-green-600 text-white",
                 remove="bg-red-600 bg-yellow-500 text-black",
@@ -46,7 +46,7 @@ class StatusBar:
         if self._label:
             if normalized == "ENGAGED":
                 self._label.set_text("TRADING HALTED")
-            elif normalized == "DISENGAGED":
+            elif normalized in {"DISENGAGED", "ACTIVE"}:
                 self._label.set_text("TRADING ACTIVE")
             else:
                 self._label.set_text("TRADING STATUS UNKNOWN")

--- a/apps/web_console_ng/components/watchlist.py
+++ b/apps/web_console_ng/components/watchlist.py
@@ -308,8 +308,15 @@ class WatchlistComponent:
         self._items[symbol] = WatchlistItem(symbol=symbol)
         self._symbol_order.append(symbol)
 
-        # Request subscription
-        await self._request_subscribe(symbol)
+        # Request subscription and roll back on failure to avoid a broken row.
+        try:
+            await self._request_subscribe(symbol)
+        except Exception as exc:
+            logger.warning(f"Failed to subscribe watchlist symbol {symbol}: {exc}")
+            self._symbol_order.remove(symbol)
+            del self._items[symbol]
+            ui.notify(f"Unable to subscribe {symbol}", type="negative")
+            return
 
         # Re-render
         self._render_items()

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -15,8 +15,10 @@ import hmac
 import json
 import os
 import time
+import uuid
 from typing import Any, cast
 from urllib.parse import quote as url_quote
+from urllib.parse import urlencode
 
 import httpx
 
@@ -158,6 +160,96 @@ class AsyncTradingClient:
                 "(INTERNAL_TOKEN_SECRET is set but role is missing)"
             )
 
+        return headers
+
+    def _get_internal_service_secret(self, service_id: str) -> str:
+        """Resolve per-service secret, falling back to global INTERNAL_TOKEN_SECRET."""
+        service_key = "".join(
+            char if char.isalnum() else "_" for char in service_id.upper().strip()
+        )
+        per_service_secret = os.getenv(f"INTERNAL_TOKEN_SECRET_{service_key}", "").strip()
+        if per_service_secret:
+            return per_service_secret
+        return os.getenv("INTERNAL_TOKEN_SECRET", "").strip()
+
+    @staticmethod
+    def _build_query_string(params: list[tuple[str, Any]] | None = None) -> str:
+        """Build deterministic query string used for both request URL and S2S signature."""
+        if not params:
+            return ""
+        normalized: list[tuple[str, str]] = []
+        for key, value in params:
+            if value is None:
+                continue
+            normalized.append((str(key), str(value)))
+        return urlencode(normalized, doseq=True)
+
+    def _get_market_data_auth_headers(
+        self,
+        *,
+        method: str,
+        path: str,
+        query: str,
+        body: bytes | str | None,
+        user_id: str,
+        role: str | None,
+        strategies: list[str] | None,
+    ) -> dict[str, str]:
+        """Build market-data headers with legacy context + optional C6 S2S signature."""
+        headers = self._get_auth_headers(user_id, role, strategies)
+
+        service_id = os.getenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng").strip() or "web_console_ng"
+        secret = self._get_internal_service_secret(service_id)
+        if not secret:
+            return headers
+
+        timestamp = str(int(time.time()))
+        nonce = str(uuid.uuid4())
+
+        if body is None:
+            body_bytes = b""
+        elif isinstance(body, str):
+            body_bytes = body.encode("utf-8")
+        else:
+            body_bytes = body
+        body_hash = hashlib.sha256(body_bytes).hexdigest()
+
+        normalized_user_id = str(user_id).strip() if user_id else ""
+        normalized_strategy_id = ""
+        if strategies:
+            for strategy in sorted(strategies):
+                value = str(strategy).strip()
+                if value:
+                    normalized_strategy_id = value
+                    break
+
+        payload_data = {
+            "service_id": service_id,
+            "method": method.upper(),
+            "path": path,
+            "query": query,
+            "timestamp": timestamp,
+            "nonce": nonce,
+            "user_id": normalized_user_id,
+            "strategy_id": normalized_strategy_id,
+            "body_hash": body_hash,
+        }
+        payload = json.dumps(payload_data, separators=(",", ":"), sort_keys=True)
+        signature = hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+        headers.update(
+            {
+                "X-Internal-Token": signature,
+                "X-Internal-Timestamp": timestamp,
+                "X-Internal-Nonce": nonce,
+                "X-Service-ID": service_id,
+                "X-Body-Hash": body_hash,
+            }
+        )
+        if normalized_user_id and "x-user-id" not in {key.lower() for key in headers}:
+            headers["X-User-ID"] = normalized_user_id
+        if normalized_strategy_id:
+            headers["X-Strategy-ID"] = normalized_strategy_id
         return headers
 
     def _json_dict(self, response: httpx.Response) -> dict[str, Any]:
@@ -319,8 +411,91 @@ class AsyncTradingClient:
         strategies: list[str] | None = None,
     ) -> dict[str, Any]:
         """Fetch 20-day average daily volume (ADV) for a symbol."""
+        safe_symbol = url_quote(symbol.upper(), safe="")
+        path = f"/api/v1/market-data/{safe_symbol}/adv"
+        headers = self._get_market_data_auth_headers(
+            method="GET",
+            path=path,
+            query="",
+            body=None,
+            user_id=user_id,
+            role=role,
+            strategies=strategies,
+        )
+        resp = await self._market_client.get(path, headers=headers)
+        resp.raise_for_status()
+        return self._json_dict(resp)
+
+    @with_retry(max_attempts=3, backoff_base=1.0, method="GET")
+    async def fetch_historical_bars(
+        self,
+        symbol: str,
+        user_id: str,
+        role: str | None = None,
+        strategies: list[str] | None = None,
+        *,
+        timeframe: str = "5Min",
+        limit: int = 240,
+    ) -> dict[str, Any]:
+        """Fetch historical bars for a symbol from market-data-service."""
+        safe_symbol = url_quote(symbol.upper(), safe="")
+        path = f"/api/v1/market-data/{safe_symbol}/bars"
+        query = self._build_query_string(
+            [
+                ("timeframe", timeframe),
+                ("limit", limit),
+            ]
+        )
+        headers = self._get_market_data_auth_headers(
+            method="GET",
+            path=path,
+            query=query,
+            body=None,
+            user_id=user_id,
+            role=role,
+            strategies=strategies,
+        )
+        request_path = f"{path}?{query}" if query else path
+        resp = await self._market_client.get(
+            request_path,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return self._json_dict(resp)
+
+    @with_retry(max_attempts=3, backoff_base=1.0, method="POST")
+    async def subscribe_market_data_symbols(
+        self,
+        symbols: list[str],
+        user_id: str,
+        role: str | None = None,
+        strategies: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Request market-data-service to stream specified symbols."""
         headers = self._get_auth_headers(user_id, role, strategies)
-        resp = await self._market_client.get(f"/api/v1/market-data/{symbol}/adv", headers=headers)
+        resp = await self._market_client.post(
+            "/api/v1/subscribe",
+            headers=headers,
+            json={"symbols": [str(symbol).upper() for symbol in symbols if str(symbol).strip()]},
+        )
+        resp.raise_for_status()
+        return self._json_dict(resp)
+
+    @with_retry(max_attempts=3, backoff_base=1.0, method="DELETE")
+    async def unsubscribe_market_data_symbol(
+        self,
+        symbol: str,
+        user_id: str,
+        role: str | None = None,
+        strategies: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Request market-data-service to stop streaming one symbol."""
+        headers = self._get_auth_headers(user_id, role, strategies)
+        safe_symbol = url_quote(symbol.upper(), safe="")
+        resp = await self._market_client.delete(
+            f"/api/v1/subscribe/{safe_symbol}",
+            headers=headers,
+        )
         resp.raise_for_status()
         return self._json_dict(resp)
 

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -217,11 +217,28 @@ class AsyncTradingClient:
             body_bytes = body
         body_hash = hashlib.sha256(body_bytes).hexdigest()
 
-        normalized_user_id = str(user_id).strip() if user_id else ""
-        normalized_strategy_id = ""
+        resolved_user_header = headers.get("X-User-Id") or headers.get("X-User-ID") or ""
+        normalized_user_id = str(resolved_user_header).strip()
+        if not normalized_user_id and user_id:
+            normalized_user_id = str(user_id).strip()
+
+        resolved_strategies: list[str] = []
+        header_strategies = headers.get("X-User-Strategies", "")
+        if header_strategies:
+            resolved_strategies.extend(
+                strategy.strip()
+                for strategy in str(header_strategies).split(",")
+                if strategy.strip()
+            )
         if strategies:
+            resolved_strategies.extend(
+                str(strategy).strip() for strategy in strategies if str(strategy).strip()
+            )
+
+        normalized_strategy_id = ""
+        if resolved_strategies:
             normalized_strategy_ids = sorted(
-                {str(strategy).strip() for strategy in strategies if str(strategy).strip()}
+                {strategy for strategy in resolved_strategies if strategy}
             )
             if normalized_strategy_ids:
                 # Deterministic fallback for multi-strategy contexts until the S2S

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -274,6 +274,11 @@ class AsyncTradingClient:
             headers["X-Strategy-ID"] = normalized_strategy_id
         return headers
 
+    def _can_use_market_data_source_override(self) -> bool:
+        """Return True when requests can carry authenticated source ownership tags."""
+        service_id = os.getenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng").strip() or "web_console_ng"
+        return bool(self._get_internal_service_secret(service_id))
+
     def _json_dict(self, response: httpx.Response) -> dict[str, Any]:
         payload = response.json()
         if not isinstance(payload, dict):
@@ -500,7 +505,7 @@ class AsyncTradingClient:
             "symbols": [str(symbol).upper() for symbol in symbols if str(symbol).strip()]
         }
         normalized_source = str(source).strip() if source is not None else ""
-        if normalized_source:
+        if normalized_source and self._can_use_market_data_source_override():
             request_payload["source"] = normalized_source
         request_body = json.dumps(request_payload, separators=(",", ":"), sort_keys=True)
         path = "/api/v1/subscribe"
@@ -533,7 +538,12 @@ class AsyncTradingClient:
     ) -> dict[str, Any]:
         """Request market-data-service to stop streaming one symbol."""
         safe_symbol = url_quote(symbol.upper(), safe="")
-        query = self._build_query_string([("source", str(source).strip())]) if source else ""
+        normalized_source = str(source).strip() if source is not None else ""
+        query = (
+            self._build_query_string([("source", normalized_source)])
+            if normalized_source and self._can_use_market_data_source_override()
+            else ""
+        )
         path = f"/api/v1/subscribe/{safe_symbol}"
         headers = self._get_market_data_auth_headers(
             method="DELETE",

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -177,11 +177,14 @@ class AsyncTradingClient:
         """Build deterministic query string used for both request URL and S2S signature."""
         if not params:
             return ""
-        normalized: list[tuple[str, str]] = []
-        for key, value in params:
-            if value is None:
-                continue
-            normalized.append((str(key), str(value)))
+        normalized = sorted(
+            [
+                (str(key), str(value))
+                for key, value in params
+                if value is not None
+            ],
+            key=lambda pair: (pair[0], pair[1]),
+        )
         return urlencode(normalized, doseq=True)
 
     def _get_market_data_auth_headers(

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -274,11 +274,6 @@ class AsyncTradingClient:
             headers["X-Strategy-ID"] = normalized_strategy_id
         return headers
 
-    def _can_use_market_data_source_override(self) -> bool:
-        """Return True when requests can carry authenticated source ownership tags."""
-        service_id = os.getenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng").strip() or "web_console_ng"
-        return bool(self._get_internal_service_secret(service_id))
-
     def _json_dict(self, response: httpx.Response) -> dict[str, Any]:
         payload = response.json()
         if not isinstance(payload, dict):
@@ -505,7 +500,7 @@ class AsyncTradingClient:
             "symbols": [str(symbol).upper() for symbol in symbols if str(symbol).strip()]
         }
         normalized_source = str(source).strip() if source is not None else ""
-        if normalized_source and self._can_use_market_data_source_override():
+        if normalized_source:
             request_payload["source"] = normalized_source
         request_body = json.dumps(request_payload, separators=(",", ":"), sort_keys=True)
         path = "/api/v1/subscribe"
@@ -539,11 +534,7 @@ class AsyncTradingClient:
         """Request market-data-service to stop streaming one symbol."""
         safe_symbol = url_quote(symbol.upper(), safe="")
         normalized_source = str(source).strip() if source is not None else ""
-        query = (
-            self._build_query_string([("source", normalized_source)])
-            if normalized_source and self._can_use_market_data_source_override()
-            else ""
-        )
+        query = self._build_query_string([("source", normalized_source)]) if normalized_source else ""
         path = f"/api/v1/subscribe/{safe_symbol}"
         headers = self._get_market_data_auth_headers(
             method="DELETE",

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -217,8 +217,12 @@ class AsyncTradingClient:
         normalized_user_id = str(user_id).strip() if user_id else ""
         normalized_strategy_id = ""
         if strategies:
-            normalized_strategy_ids = sorted({str(strategy).strip() for strategy in strategies if str(strategy).strip()})
-            if len(normalized_strategy_ids) == 1:
+            normalized_strategy_ids = sorted(
+                {str(strategy).strip() for strategy in strategies if str(strategy).strip()}
+            )
+            if normalized_strategy_ids:
+                # Deterministic fallback for multi-strategy contexts until the S2S
+                # signature schema supports strategy lists.
                 normalized_strategy_id = normalized_strategy_ids[0]
 
         payload_data = {

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -472,17 +472,27 @@ class AsyncTradingClient:
         source: str | None = None,
     ) -> dict[str, Any]:
         """Request market-data-service to stream specified symbols."""
-        headers = self._get_auth_headers(user_id, role, strategies)
         request_payload: dict[str, Any] = {
             "symbols": [str(symbol).upper() for symbol in symbols if str(symbol).strip()]
         }
         normalized_source = str(source).strip() if source is not None else ""
         if normalized_source:
             request_payload["source"] = normalized_source
+        request_body = json.dumps(request_payload, separators=(",", ":"), sort_keys=True)
+        path = "/api/v1/subscribe"
+        headers = self._get_market_data_auth_headers(
+            method="POST",
+            path=path,
+            query="",
+            body=request_body,
+            user_id=user_id,
+            role=role,
+            strategies=strategies,
+        )
         resp = await self._market_client.post(
-            "/api/v1/subscribe",
+            path,
             headers=headers,
-            json=request_payload,
+            content=request_body,
         )
         resp.raise_for_status()
         return self._json_dict(resp)
@@ -498,10 +508,19 @@ class AsyncTradingClient:
         source: str | None = None,
     ) -> dict[str, Any]:
         """Request market-data-service to stop streaming one symbol."""
-        headers = self._get_auth_headers(user_id, role, strategies)
         safe_symbol = url_quote(symbol.upper(), safe="")
         query = self._build_query_string([("source", str(source).strip())]) if source else ""
-        request_path = f"/api/v1/subscribe/{safe_symbol}?{query}" if query else f"/api/v1/subscribe/{safe_symbol}"
+        path = f"/api/v1/subscribe/{safe_symbol}"
+        headers = self._get_market_data_auth_headers(
+            method="DELETE",
+            path=path,
+            query=query,
+            body=None,
+            user_id=user_id,
+            role=role,
+            strategies=strategies,
+        )
+        request_path = f"{path}?{query}" if query else path
         resp = await self._market_client.delete(
             request_path,
             headers=headers,

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -217,11 +217,9 @@ class AsyncTradingClient:
         normalized_user_id = str(user_id).strip() if user_id else ""
         normalized_strategy_id = ""
         if strategies:
-            for strategy in sorted(strategies):
-                value = str(strategy).strip()
-                if value:
-                    normalized_strategy_id = value
-                    break
+            normalized_strategy_ids = sorted({str(strategy).strip() for strategy in strategies if str(strategy).strip()})
+            if len(normalized_strategy_ids) == 1:
+                normalized_strategy_id = normalized_strategy_ids[0]
 
         payload_data = {
             "service_id": service_id,
@@ -470,13 +468,21 @@ class AsyncTradingClient:
         user_id: str,
         role: str | None = None,
         strategies: list[str] | None = None,
+        *,
+        source: str | None = None,
     ) -> dict[str, Any]:
         """Request market-data-service to stream specified symbols."""
         headers = self._get_auth_headers(user_id, role, strategies)
+        request_payload: dict[str, Any] = {
+            "symbols": [str(symbol).upper() for symbol in symbols if str(symbol).strip()]
+        }
+        normalized_source = str(source).strip() if source is not None else ""
+        if normalized_source:
+            request_payload["source"] = normalized_source
         resp = await self._market_client.post(
             "/api/v1/subscribe",
             headers=headers,
-            json={"symbols": [str(symbol).upper() for symbol in symbols if str(symbol).strip()]},
+            json=request_payload,
         )
         resp.raise_for_status()
         return self._json_dict(resp)
@@ -488,12 +494,16 @@ class AsyncTradingClient:
         user_id: str,
         role: str | None = None,
         strategies: list[str] | None = None,
+        *,
+        source: str | None = None,
     ) -> dict[str, Any]:
         """Request market-data-service to stop streaming one symbol."""
         headers = self._get_auth_headers(user_id, role, strategies)
         safe_symbol = url_quote(symbol.upper(), safe="")
+        query = self._build_query_string([("source", str(source).strip())]) if source else ""
+        request_path = f"/api/v1/subscribe/{safe_symbol}?{query}" if query else f"/api/v1/subscribe/{safe_symbol}"
         resp = await self._market_client.delete(
-            f"/api/v1/subscribe/{safe_symbol}",
+            request_path,
             headers=headers,
         )
         resp.raise_for_status()

--- a/apps/web_console_ng/core/connection_events.py
+++ b/apps/web_console_ng/core/connection_events.py
@@ -74,7 +74,11 @@ def setup_connection_handlers() -> None:
     async def on_client_connect(client: Client) -> None:
         lifecycle = ClientLifecycleManager.get()
 
-        client_id = lifecycle.generate_client_id()
+        stored_client_id = client.storage.get("client_id")
+        if isinstance(stored_client_id, str) and stored_client_id.strip():
+            client_id = stored_client_id
+        else:
+            client_id = lifecycle.generate_client_id()
         client.storage["client_id"] = client_id
 
         scope_state = _get_scope_state(client)

--- a/apps/web_console_ng/core/connection_events.py
+++ b/apps/web_console_ng/core/connection_events.py
@@ -74,16 +74,19 @@ def setup_connection_handlers() -> None:
     async def on_client_connect(client: Client) -> None:
         lifecycle = ClientLifecycleManager.get()
 
-        stored_client_id = client.storage.get("client_id")
-        if isinstance(stored_client_id, str) and stored_client_id.strip():
-            client_id = stored_client_id
+        stored_session_client_id = client.storage.get("session_client_id")
+        if isinstance(stored_session_client_id, str) and stored_session_client_id.strip():
+            session_client_id = stored_session_client_id
         else:
-            client_id = lifecycle.generate_client_id()
-        client.storage["client_id"] = client_id
+            session_client_id = lifecycle.generate_client_id()
+        lifecycle_client_id = lifecycle.generate_client_id()
+        client.storage["session_client_id"] = session_client_id
+        client.storage["client_id"] = lifecycle_client_id
 
         scope_state = _get_scope_state(client)
         if scope_state is not None:
             scope_state["handshake_complete"] = True
+            scope_state["lifecycle_client_id"] = lifecycle_client_id
 
             # Copy session_conn_key from scope state (set by admission.py) to client storage
             # This avoids re-parsing the cookie and ensures cleanup key consistency
@@ -91,7 +94,7 @@ def setup_connection_handlers() -> None:
             if session_conn_key:
                 client.storage["session_conn_key"] = session_conn_key
 
-        await lifecycle.register_client(client_id)
+        await lifecycle.register_client(lifecycle_client_id)
 
         count = health.connection_counter.increment()
         metrics = _get_metrics()
@@ -99,7 +102,13 @@ def setup_connection_handlers() -> None:
             metrics.ws_connects_total.labels(pod=config.POD_NAME).inc()
             metrics.ws_connections.labels(pod=config.POD_NAME).set(count)
 
-        logger.info("ws_client_connected", extra={"client_id": client_id})
+        logger.info(
+            "ws_client_connected",
+            extra={
+                "client_id": lifecycle_client_id,
+                "session_client_id": session_client_id,
+            },
+        )
 
     @app.on_disconnect
     async def on_client_disconnect(client: Client) -> None:
@@ -107,12 +116,19 @@ def setup_connection_handlers() -> None:
         client_id = client.storage.get("client_id")
 
         scope_state = _get_scope_state(client)
+        lifecycle_client_id = None
         handshake_complete = False
         if scope_state is not None:
             handshake_complete = bool(scope_state.get("handshake_complete", False))
+            scoped_lifecycle_id = scope_state.get("lifecycle_client_id")
+            if isinstance(scoped_lifecycle_id, str) and scoped_lifecycle_id.strip():
+                lifecycle_client_id = scoped_lifecycle_id
 
-        if isinstance(client_id, str):
-            await lifecycle.cleanup_client(client_id)
+        if lifecycle_client_id is None and isinstance(client_id, str) and client_id.strip():
+            lifecycle_client_id = client_id
+
+        if lifecycle_client_id is not None:
+            await lifecycle.cleanup_client(lifecycle_client_id)
 
         session_conn_key = client.storage.get("session_conn_key")
         if session_conn_key:

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -720,6 +720,7 @@ async def dashboard(client: Client) -> None:
         user_id=user_id,
         role=user_role,
         strategies=user_strategies,
+        client_id=client_id,
     )
 
     # Create OneClickHandler dependencies and wire it up (P6T7)

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -396,7 +396,7 @@ def resolve_workspace_kill_switch_pill(state: str | None) -> tuple[str, str]:
     normalized = str(state or "UNKNOWN").upper()
     if normalized == "ENGAGED":
         return ("KILL ENGAGED", "danger")
-    if normalized == "DISENGAGED":
+    if normalized in {"DISENGAGED", "ACTIVE"}:
         return ("KILL DISARMED", "muted")
     return (f"KILL {normalized}", "warning")
 
@@ -898,7 +898,7 @@ async def dashboard(client: Client) -> None:
         with ui.element("div").classes("workspace-v2-body"):
             with ui.element("div").classes("workspace-v2-zone-b workspace-v2-enter-zone workspace-v2-enter-zone-b"):
                 with ui.element("div").classes("workspace-v2-chart-pane"):
-                    order_context.create_price_chart(width=960, height=420).classes(
+                    order_context.create_price_chart(fill_parent=True).classes(
                         "w-full h-full"
                     )
                 with ui.element("div").classes("workspace-v2-microstructure"):
@@ -1554,7 +1554,7 @@ async def dashboard(client: Client) -> None:
         state = str(state_raw or "").upper()
         if state == "ENGAGED":
             return True
-        if state == "DISENGAGED":
+        if state in {"DISENGAGED", "ACTIVE"}:
             return False
         return None
 
@@ -1617,7 +1617,7 @@ async def dashboard(client: Client) -> None:
             workspace_kill_switch_state = state
             kill_switch_engaged = _parse_kill_switch_state(state)
             _update_workspace_kill_switch_pill()
-            if state != "DISENGAGED":
+            if state not in {"DISENGAGED", "ACTIVE"}:
                 return (False, "Cannot flatten: Kill Switch is not DISENGAGED")
             return (True, "")
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -688,12 +688,18 @@ async def dashboard(client: Client) -> None:
 
     lifecycle = ClientLifecycleManager.get()
 
-    # Get or generate client_id (may not be set yet if WebSocket hasn't connected)
+    # client_id is per-websocket lifecycle key for cleanup tracking.
     client_id = client.storage.get("client_id")
     if not isinstance(client_id, str) or not client_id:
         client_id = lifecycle.generate_client_id()
         client.storage["client_id"] = client_id
         logger.debug("dashboard_generated_client_id", extra={"client_id": client_id})
+
+    # session_client_id is stable across reconnects and used for market-data ownership tags.
+    session_client_id = client.storage.get("session_client_id")
+    if not isinstance(session_client_id, str) or not session_client_id:
+        session_client_id = lifecycle.generate_client_id()
+        client.storage["session_client_id"] = session_client_id
 
     realtime = RealtimeUpdater(client_id, client)
     timers: list[ui.timer] = []
@@ -720,7 +726,7 @@ async def dashboard(client: Client) -> None:
         user_id=user_id,
         role=user_role,
         strategies=user_strategies,
-        client_id=client_id,
+        client_id=session_client_id,
     )
 
     # Create OneClickHandler dependencies and wire it up (P6T7)

--- a/apps/web_console_ng/static/css/custom.css
+++ b/apps/web_console_ng/static/css/custom.css
@@ -502,16 +502,18 @@
 .workspace-v2-chart-pane {
     border: 1px solid var(--workspace-border);
     border-radius: 8px;
-    flex: 1;
+    flex: 0 0 auto;
+    height: clamp(300px, 44vh, 520px);
     min-height: 0;
     overflow: hidden;
 }
 
 .workspace-v2-microstructure {
     display: grid;
+    flex: 1 1 auto;
     gap: 8px;
     grid-template-columns: minmax(0, 1.4fr) minmax(260px, 1fr);
-    min-height: 324px;
+    min-height: 240px;
 }
 
 .workspace-v2-microstructure-dom {
@@ -975,6 +977,10 @@
         grid-template-columns: minmax(0, 1fr);
         grid-template-rows: minmax(180px, 1fr) minmax(156px, 0.92fr);
         min-height: 292px;
+    }
+
+    .workspace-v2-chart-pane {
+        height: clamp(260px, 40vh, 420px);
     }
 
     .workspace-v2-microstructure-side {

--- a/apps/web_console_ng/ui/__init__.py
+++ b/apps/web_console_ng/ui/__init__.py
@@ -2,8 +2,4 @@
 
 from __future__ import annotations
 
-from apps.web_console_ng.ui.lightweight_charts import LightweightChartsLoader
-
-__all__ = [
-    "LightweightChartsLoader",
-]
+__all__: list[str] = []

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -546,7 +546,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
             if state == "ENGAGED":
                 engage_button.disable()
                 disengage_button.enable()
-            elif state == "DISENGAGED":
+            elif state in {"DISENGAGED", "ACTIVE"}:
                 engage_button.enable()
                 disengage_button.disable()
             else:
@@ -703,6 +703,9 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     )
                     state = str(status.get("state", "UNKNOWN")).upper()
                     kill_switch_state = state if state else "UNKNOWN"
+                    display_state = (
+                        "DISENGAGED" if kill_switch_state == "ACTIVE" else kill_switch_state
+                    )
                     try:
                         cb_status = await client.fetch_circuit_breaker_status(
                             user_id, role=user_role, strategies=user_strategies
@@ -726,7 +729,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         )
                         cb_state = "UNKNOWN"
 
-                    if state == "ENGAGED":
+                    if display_state == "ENGAGED":
                         kill_switch_button.set_text("KILL SWITCH: ENGAGED")
                         kill_switch_button.classes(
                             "bg-red-700 text-rose-100",
@@ -734,7 +737,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         )
                         if last_kill_switch_state != "ENGAGED":
                             ui.notify("Kill switch engaged", type="negative")
-                    elif state == "DISENGAGED":
+                    elif display_state == "DISENGAGED":
                         # Keep muted visual weight when disarmed (do not compete with chart/ticket).
                         kill_switch_button.set_text("KILL SWITCH: DISENGAGED")
                         kill_switch_button.classes(
@@ -743,12 +746,12 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         )
                     else:
                         # Unknown/invalid state - show warning
-                        kill_switch_button.set_text(f"KILL SWITCH: {state}")
+                        kill_switch_button.set_text(f"KILL SWITCH: {display_state}")
                         kill_switch_button.classes(
                             "bg-amber-500 text-black",
                             remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                         )
-                    status_bar.update_state(state)
+                    status_bar.update_state(display_state)
 
                     if cb_state == "TRIPPED":
                         circuit_breaker_badge.set_text("CIRCUIT TRIPPED")
@@ -775,8 +778,8 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                             remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                         )
 
-                    last_kill_switch_state = state
-                    set_kill_switch_controls(state)
+                    last_kill_switch_state = display_state
+                    set_kill_switch_controls(display_state)
                     status_success = True
                 except (ValueError, KeyError, TypeError, ConnectionError, httpx.HTTPError) as e:
                     logger.warning(

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -78,21 +78,24 @@ CHART_INIT_JS = """
         window.__lwc_loading_promise = window.__lwc_loading_promise || (async () => {{
             try {{
                 await loadScriptOnce('lwc-script-cdn-v410', '{cdn}', '{sri}');
-            }} catch (e) {{
+            }} catch (cdnError) {{
                 try {{
                     await loadScriptOnce('lwc-script-local-v410', '{local}');
                 }} catch (fallbackError) {{
                     console.warn('LightweightCharts load failed from CDN and local fallback', fallbackError);
+                    throw fallbackError;
                 }}
             }}
         }})();
 
         try {{
             await window.__lwc_loading_promise;
+        }} catch (loadError) {{
+            window.__lwc_loading_promise = null;
+            console.warn('LightweightCharts load promise failed; will retry on next init', loadError);
+            throw loadError;
         }} finally {{
-            if (typeof window.LightweightCharts !== 'undefined') {{
-                window.__lwc_ready = true;
-            }}
+            window.__lwc_ready = typeof window.LightweightCharts !== 'undefined';
         }}
     }}
 

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -235,6 +235,7 @@ class LightweightChartsLoader:
 
                 # Wait for library to be ready
                 ready_timed_out = True
+                last_ready_check_error: Exception | None = None
                 for _ in range(100):  # Max 5 seconds
                     try:
                         ready = await run_js("window.__lwc_ready === true")
@@ -245,8 +246,9 @@ class LightweightChartsLoader:
                             ready_timed_out = False
                             cls._ready = True
                             return
-                    except Exception:
-                        pass  # JavaScript may not be ready yet
+                    except Exception as exc:
+                        # JavaScript may not be ready yet; keep last error for timeout context.
+                        last_ready_check_error = exc
                     await asyncio.sleep(0.05)
             except Exception:
                 cls._loaded = False
@@ -255,6 +257,11 @@ class LightweightChartsLoader:
 
             cls._loaded = False
             if ready_timed_out:
+                if last_ready_check_error is not None:
+                    raise RuntimeError(
+                        "Timed out waiting for Lightweight Charts readiness flag "
+                        f"(last readiness check error: {last_ready_check_error})"
+                    ) from last_ready_check_error
                 raise RuntimeError("Timed out waiting for Lightweight Charts readiness flag")
 
     @classmethod

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -47,14 +47,16 @@ CHART_INIT_JS = """
     const loadScriptOnce = (id, src, integrity = null) => {{
         const existing = document.getElementById(id);
         if (existing) {{
-            return new Promise((resolve, reject) => {{
-                if (existing.dataset.loaded === 'true') {{
-                    resolve();
-                    return;
-                }}
-                existing.addEventListener('load', () => resolve(), {{ once: true }});
-                existing.addEventListener('error', () => reject(new Error(`Failed to load ${{src}}`)), {{ once: true }});
-            }});
+            if (existing.dataset.failed === 'true') {{
+                existing.remove();
+            }} else if (existing.dataset.loaded === 'true') {{
+                return Promise.resolve();
+            }} else {{
+                return new Promise((resolve, reject) => {{
+                    existing.addEventListener('load', () => resolve(), {{ once: true }});
+                    existing.addEventListener('error', () => reject(new Error(`Failed to load ${{src}}`)), {{ once: true }});
+                }});
+            }}
         }}
 
         const script = document.createElement('script');
@@ -67,9 +69,13 @@ CHART_INIT_JS = """
         return new Promise((resolve, reject) => {{
             script.onload = () => {{
                 script.dataset.loaded = 'true';
+                script.dataset.failed = 'false';
                 resolve();
             }};
-            script.onerror = () => reject(new Error(`Failed to load ${{src}}`));
+            script.onerror = () => {{
+                script.dataset.failed = 'true';
+                reject(new Error(`Failed to load ${{src}}`));
+            }};
             document.head.appendChild(script);
         }});
     }};

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -259,7 +259,6 @@ class LightweightChartsLoader:
             cls._loaded = False
             if ready_timed_out:
                 raise RuntimeError("Timed out waiting for Lightweight Charts readiness flag")
-            raise RuntimeError("Failed to load Lightweight Charts library")
 
     @classmethod
     def reset(cls) -> None:

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -10,7 +10,7 @@ Licensing Notes:
 
 Security Notes:
 - CDN assets loaded with SRI (Subresource Integrity) hash
-- CSP allowlist entry required: script-src unpkg.com
+- CSP allowlist entry required: script-src cdn.jsdelivr.net
 - Alternative: Host locally in /static/vendor/ for airgapped deployments
 """
 
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # CDN with SRI hash for supply-chain security
 # Hash generated via: curl -s "$CDN_URL" | openssl dgst -sha384 -binary | openssl base64 -A
 LIGHTWEIGHT_CHARTS_CDN = (
-    "https://unpkg.com/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"
+    "https://cdn.jsdelivr.net/npm/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"
 )
 LIGHTWEIGHT_CHARTS_SRI = "sha384-rcCMiCptH4kTlEbg0euOTUKWe72TESbrjElatnG+9BfbmUIV268UK/Pro5biJdGm"
 

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -16,15 +16,6 @@ Security Notes:
 
 from __future__ import annotations
 
-import asyncio
-import logging
-from collections.abc import Awaitable, Callable
-from typing import Any
-
-from nicegui import ui
-
-logger = logging.getLogger(__name__)
-
 # CDN with SRI hash for supply-chain security
 # Hash generated via: curl -s "$CDN_URL" | openssl dgst -sha384 -binary | openssl base64 -A
 LIGHTWEIGHT_CHARTS_CDN = (
@@ -172,120 +163,9 @@ CHART_INIT_JS = """
 """
 
 
-class LightweightChartsLoader:
-    """Load Lightweight Charts library via CDN with SRI and fallback."""
-
-    _loaded: bool = False
-    _ready: bool = False  # Track if chart API is ready
-    _lock: asyncio.Lock | None = None
-
-    @classmethod
-    def _get_lock(cls) -> asyncio.Lock:
-        """Lazily create a shared async lock for loader coordination."""
-        if cls._lock is None:
-            cls._lock = asyncio.Lock()
-        return cls._lock
-
-    @classmethod
-    async def ensure_loaded(
-        cls,
-        *,
-        run_javascript: Callable[..., Awaitable[Any]] | None = None,
-    ) -> None:
-        """Ensure the library is loaded exactly once with SRI verification."""
-        if cls._ready:
-            return
-
-        run_js = run_javascript or ui.run_javascript
-
-        async with cls._get_lock():
-            if cls._ready:
-                return
-
-            cls._loaded = True
-
-            try:
-                # Load with SRI hash and crossorigin for supply-chain security
-                # Falls back to local copy if CDN fails
-                await run_js(
-                    f"""
-                    (async function() {{
-                        if (typeof window.LightweightCharts !== 'undefined') {{
-                            window.__lwc_ready = true;
-                            return;
-                        }}
-
-                        try {{
-                            const script = document.createElement('script');
-                            script.src = '{LIGHTWEIGHT_CHARTS_CDN}';
-                            script.integrity = '{LIGHTWEIGHT_CHARTS_SRI}';
-                            script.crossOrigin = 'anonymous';
-
-                            await new Promise((resolve, reject) => {{
-                                script.onload = resolve;
-                                script.onerror = reject;
-                                document.head.appendChild(script);
-                            }});
-                            console.log('Lightweight Charts loaded from CDN');
-                        }} catch (e) {{
-                            console.warn('CDN load failed, using local fallback:', e);
-                            const fallback = document.createElement('script');
-                            fallback.src = '{LIGHTWEIGHT_CHARTS_LOCAL}';
-                            await new Promise((resolve, reject) => {{
-                                fallback.onload = resolve;
-                                fallback.onerror = reject;
-                                document.head.appendChild(fallback);
-                            }});
-                            console.log('Lightweight Charts loaded from local fallback');
-                        }}
-                        window.__lwc_ready = true;
-                    }})();
-                """,
-                    timeout=10.0,
-                )
-
-                # Wait for library to be ready
-                ready_timed_out = True
-                last_ready_check_error: Exception | None = None
-                for _ in range(100):  # Max 5 seconds
-                    try:
-                        ready = await run_js("window.__lwc_ready === true")
-                        ready_bool = ready is True or (
-                            isinstance(ready, str) and ready.strip().lower() == "true"
-                        )
-                        if ready_bool:
-                            ready_timed_out = False
-                            cls._ready = True
-                            return
-                    except Exception as exc:
-                        # JavaScript may not be ready yet; keep last error for timeout context.
-                        last_ready_check_error = exc
-                    await asyncio.sleep(0.05)
-            except Exception:
-                cls._loaded = False
-                cls._ready = False
-                raise
-
-            cls._loaded = False
-            if ready_timed_out:
-                if last_ready_check_error is not None:
-                    raise RuntimeError(
-                        "Timed out waiting for Lightweight Charts readiness flag "
-                        f"(last readiness check error: {last_ready_check_error})"
-                    ) from last_ready_check_error
-                raise RuntimeError("Timed out waiting for Lightweight Charts readiness flag")
-
-    @classmethod
-    def reset(cls) -> None:
-        """Reset loader state (for testing)."""
-        cls._loaded = False
-        cls._ready = False
-        cls._lock = None
-
-
 __all__ = [
-    "LightweightChartsLoader",
     "CHART_INIT_JS",
     "LIGHTWEIGHT_CHARTS_CDN",
     "LIGHTWEIGHT_CHARTS_SRI",
+    "LIGHTWEIGHT_CHARTS_LOCAL",
 ]

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -101,10 +101,12 @@ CHART_INIT_JS = """
         return;
     }}
     const lwc = window.LightweightCharts;
+    const MIN_CHART_WIDTH = 320;
+    const MIN_CHART_HEIGHT = 180;
 
     // Create chart
-    const initialWidth = Math.max(container.clientWidth || 0, {width});
-    const initialHeight = Math.max(container.clientHeight || 0, {height});
+    const initialWidth = Math.max(container.clientWidth || 0, {width}, MIN_CHART_WIDTH);
+    const initialHeight = Math.max(container.clientHeight || 0, {height}, MIN_CHART_HEIGHT);
     const chart = lwc.createChart(container, {{
         width: initialWidth,
         height: initialHeight,
@@ -154,8 +156,8 @@ CHART_INIT_JS = """
     // Resize handler
     const resizeObserver = new ResizeObserver(() => {{
         chart.applyOptions({{
-            width: Math.max(container.clientWidth || 0, {width}),
-            height: Math.max(container.clientHeight || 0, {height}),
+            width: Math.max(container.clientWidth || 0, {width}, MIN_CHART_WIDTH),
+            height: Math.max(container.clientHeight || 0, {height}, MIN_CHART_HEIGHT),
         }});
     }});
     resizeObserver.observe(container);

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -106,9 +106,11 @@ CHART_INIT_JS = """
     const lwc = window.LightweightCharts;
 
     // Create chart
+    const initialWidth = Math.max(container.clientWidth || 0, {width});
+    const initialHeight = Math.max(container.clientHeight || 0, {height});
     const chart = lwc.createChart(container, {{
-        width: {width},
-        height: {height},
+        width: initialWidth,
+        height: initialHeight,
         layout: {{
             background: {{ type: 'solid', color: '#0f172a' }},
             textColor: '#94a3b8',
@@ -153,8 +155,11 @@ CHART_INIT_JS = """
     container.appendChild(attribution);
 
     // Resize handler
-    const resizeObserver = new ResizeObserver(entries => {{
-        chart.applyOptions({{ width: container.clientWidth }});
+    const resizeObserver = new ResizeObserver(() => {{
+        chart.applyOptions({{
+            width: Math.max(container.clientWidth || 0, {width}),
+            height: Math.max(container.clientHeight || 0, {height}),
+        }});
     }});
     resizeObserver.observe(container);
 }})();

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -44,28 +44,54 @@ CHART_INIT_JS = """
     const container = document.getElementById('{container_id}');
     if (!container) return;
 
-    if (typeof window.LightweightCharts === 'undefined') {{
-        try {{
-            const script = document.createElement('script');
-            script.src = '{cdn}';
-            script.integrity = '{sri}';
-            script.crossOrigin = 'anonymous';
-            await new Promise((resolve, reject) => {{
-                script.onload = resolve;
-                script.onerror = reject;
-                document.head.appendChild(script);
+    const loadScriptOnce = (id, src, integrity = null) => {{
+        const existing = document.getElementById(id);
+        if (existing) {{
+            return new Promise((resolve, reject) => {{
+                if (existing.dataset.loaded === 'true') {{
+                    resolve();
+                    return;
+                }}
+                existing.addEventListener('load', () => resolve(), {{ once: true }});
+                existing.addEventListener('error', () => reject(new Error(`Failed to load ${{src}}`)), {{ once: true }});
             }});
-        }} catch (e) {{
+        }}
+
+        const script = document.createElement('script');
+        script.id = id;
+        script.src = src;
+        if (integrity) {{
+            script.integrity = integrity;
+            script.crossOrigin = 'anonymous';
+        }}
+        return new Promise((resolve, reject) => {{
+            script.onload = () => {{
+                script.dataset.loaded = 'true';
+                resolve();
+            }};
+            script.onerror = () => reject(new Error(`Failed to load ${{src}}`));
+            document.head.appendChild(script);
+        }});
+    }};
+
+    if (typeof window.LightweightCharts === 'undefined') {{
+        window.__lwc_loading_promise = window.__lwc_loading_promise || (async () => {{
             try {{
-                const fallback = document.createElement('script');
-                fallback.src = '{local}';
-                await new Promise((resolve, reject) => {{
-                    fallback.onload = resolve;
-                    fallback.onerror = reject;
-                    document.head.appendChild(fallback);
-                }});
-            }} catch (fallbackError) {{
-                console.warn('LightweightCharts load failed from CDN and local fallback', fallbackError);
+                await loadScriptOnce('lwc-script-cdn-v410', '{cdn}', '{sri}');
+            }} catch (e) {{
+                try {{
+                    await loadScriptOnce('lwc-script-local-v410', '{local}');
+                }} catch (fallbackError) {{
+                    console.warn('LightweightCharts load failed from CDN and local fallback', fallbackError);
+                }}
+            }}
+        }})();
+
+        try {{
+            await window.__lwc_loading_promise;
+        }} finally {{
+            if (typeof window.LightweightCharts !== 'undefined') {{
+                window.__lwc_ready = true;
             }}
         }}
     }}

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -237,6 +237,7 @@ class LightweightChartsLoader:
                 )
 
                 # Wait for library to be ready
+                ready_timed_out = True
                 for _ in range(100):  # Max 5 seconds
                     try:
                         ready = await run_js("window.__lwc_ready === true")
@@ -244,6 +245,7 @@ class LightweightChartsLoader:
                             isinstance(ready, str) and ready.strip().lower() == "true"
                         )
                         if ready_bool:
+                            ready_timed_out = False
                             cls._ready = True
                             return
                     except Exception:
@@ -255,6 +257,8 @@ class LightweightChartsLoader:
                 raise
 
             cls._loaded = False
+            if ready_timed_out:
+                raise RuntimeError("Timed out waiting for Lightweight Charts readiness flag")
             raise RuntimeError("Failed to load Lightweight Charts library")
 
     @classmethod

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -188,12 +188,6 @@ class LightweightChartsLoader:
             if cls._ready:
                 return
 
-            # Previous attempt may have failed after setting _loaded=True.
-            # Reset so this call can retry instead of permanently failing.
-            if cls._loaded and not cls._ready:
-                logger.warning("Retrying Lightweight Charts load after incomplete prior attempt")
-                cls._loaded = False
-
             cls._loaded = True
 
             try:

--- a/apps/web_console_ng/ui/lightweight_charts.py
+++ b/apps/web_console_ng/ui/lightweight_charts.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from nicegui import ui
 
@@ -38,28 +40,56 @@ LIGHTWEIGHT_CHARTS_LOCAL = "/static/vendor/lightweight-charts.4.1.0.production.j
 
 # Chart initialization JavaScript template
 CHART_INIT_JS = """
-(function() {{
+(async function() {{
     const container = document.getElementById('{container_id}');
     if (!container) return;
-    if (typeof LightweightCharts === 'undefined') {{
+
+    if (typeof window.LightweightCharts === 'undefined') {{
+        try {{
+            const script = document.createElement('script');
+            script.src = '{cdn}';
+            script.integrity = '{sri}';
+            script.crossOrigin = 'anonymous';
+            await new Promise((resolve, reject) => {{
+                script.onload = resolve;
+                script.onerror = reject;
+                document.head.appendChild(script);
+            }});
+        }} catch (e) {{
+            try {{
+                const fallback = document.createElement('script');
+                fallback.src = '{local}';
+                await new Promise((resolve, reject) => {{
+                    fallback.onload = resolve;
+                    fallback.onerror = reject;
+                    document.head.appendChild(fallback);
+                }});
+            }} catch (fallbackError) {{
+                console.warn('LightweightCharts load failed from CDN and local fallback', fallbackError);
+            }}
+        }}
+    }}
+
+    if (typeof window.LightweightCharts === 'undefined') {{
         console.warn('LightweightCharts unavailable; skipping chart init for {chart_id}');
         return;
     }}
+    const lwc = window.LightweightCharts;
 
     // Create chart
-    const chart = LightweightCharts.createChart(container, {{
+    const chart = lwc.createChart(container, {{
         width: {width},
         height: {height},
         layout: {{
-            background: {{ type: 'solid', color: '#1e1e1e' }},
-            textColor: '#d1d4dc',
+            background: {{ type: 'solid', color: '#0f172a' }},
+            textColor: '#94a3b8',
         }},
         grid: {{
-            vertLines: {{ color: '#2B2B43' }},
-            horzLines: {{ color: '#363C4E' }},
+            vertLines: {{ color: '#1e293b' }},
+            horzLines: {{ color: '#334155' }},
         }},
         crosshair: {{
-            mode: LightweightCharts.CrosshairMode.Normal,
+            mode: lwc.CrosshairMode.Normal,
         }},
         timeScale: {{
             timeVisible: true,
@@ -107,78 +137,106 @@ class LightweightChartsLoader:
 
     _loaded: bool = False
     _ready: bool = False  # Track if chart API is ready
+    _lock: asyncio.Lock | None = None
 
     @classmethod
-    async def ensure_loaded(cls) -> None:
+    def _get_lock(cls) -> asyncio.Lock:
+        """Lazily create a shared async lock for loader coordination."""
+        if cls._lock is None:
+            cls._lock = asyncio.Lock()
+        return cls._lock
+
+    @classmethod
+    async def ensure_loaded(
+        cls,
+        *,
+        run_javascript: Callable[..., Awaitable[Any]] | None = None,
+    ) -> None:
         """Ensure the library is loaded exactly once with SRI verification."""
-        if cls._loaded:
-            # Wait for ready state if already loading
-            for _ in range(100):  # Max 5 seconds
-                if cls._ready:
-                    return
-                await asyncio.sleep(0.05)
-            # Still not ready after waiting - raise error (FAIL-CLOSED)
-            raise RuntimeError("Lightweight Charts library failed to load")  # noqa: TRY003
+        if cls._ready:
+            return
 
-        cls._loaded = True
+        run_js = run_javascript or ui.run_javascript
 
-        # Load with SRI hash and crossorigin for supply-chain security
-        # Falls back to local copy if CDN fails
-        await ui.run_javascript(
-            f"""
-            (async function() {{
-                if (typeof LightweightCharts !== 'undefined') {{
-                    window.__lwc_ready = true;
-                    return;
-                }}
+        async with cls._get_lock():
+            if cls._ready:
+                return
 
-                try {{
-                    const script = document.createElement('script');
-                    script.src = '{LIGHTWEIGHT_CHARTS_CDN}';
-                    script.integrity = '{LIGHTWEIGHT_CHARTS_SRI}';
-                    script.crossOrigin = 'anonymous';
+            # Previous attempt may have failed after setting _loaded=True.
+            # Reset so this call can retry instead of permanently failing.
+            if cls._loaded and not cls._ready:
+                logger.warning("Retrying Lightweight Charts load after incomplete prior attempt")
+                cls._loaded = False
 
-                    await new Promise((resolve, reject) => {{
-                        script.onload = resolve;
-                        script.onerror = reject;
-                        document.head.appendChild(script);
-                    }});
-                    console.log('Lightweight Charts loaded from CDN');
-                }} catch (e) {{
-                    console.warn('CDN load failed, using local fallback:', e);
-                    const fallback = document.createElement('script');
-                    fallback.src = '{LIGHTWEIGHT_CHARTS_LOCAL}';
-                    await new Promise((resolve, reject) => {{
-                        fallback.onload = resolve;
-                        fallback.onerror = reject;
-                        document.head.appendChild(fallback);
-                    }});
-                    console.log('Lightweight Charts loaded from local fallback');
-                }}
-                window.__lwc_ready = true;
-            }})();
-        """,
-            timeout=10.0,
-        )
+            cls._loaded = True
 
-        # Wait for library to be ready
-        for _ in range(100):  # Max 5 seconds
             try:
-                ready = await ui.run_javascript("window.__lwc_ready === true")
-                if ready:
-                    cls._ready = True
-                    return
-            except Exception:
-                pass  # JavaScript may not be ready yet
-            await asyncio.sleep(0.05)
+                # Load with SRI hash and crossorigin for supply-chain security
+                # Falls back to local copy if CDN fails
+                await run_js(
+                    f"""
+                    (async function() {{
+                        if (typeof window.LightweightCharts !== 'undefined') {{
+                            window.__lwc_ready = true;
+                            return;
+                        }}
 
-        raise RuntimeError("Failed to load Lightweight Charts library")
+                        try {{
+                            const script = document.createElement('script');
+                            script.src = '{LIGHTWEIGHT_CHARTS_CDN}';
+                            script.integrity = '{LIGHTWEIGHT_CHARTS_SRI}';
+                            script.crossOrigin = 'anonymous';
+
+                            await new Promise((resolve, reject) => {{
+                                script.onload = resolve;
+                                script.onerror = reject;
+                                document.head.appendChild(script);
+                            }});
+                            console.log('Lightweight Charts loaded from CDN');
+                        }} catch (e) {{
+                            console.warn('CDN load failed, using local fallback:', e);
+                            const fallback = document.createElement('script');
+                            fallback.src = '{LIGHTWEIGHT_CHARTS_LOCAL}';
+                            await new Promise((resolve, reject) => {{
+                                fallback.onload = resolve;
+                                fallback.onerror = reject;
+                                document.head.appendChild(fallback);
+                            }});
+                            console.log('Lightweight Charts loaded from local fallback');
+                        }}
+                        window.__lwc_ready = true;
+                    }})();
+                """,
+                    timeout=10.0,
+                )
+
+                # Wait for library to be ready
+                for _ in range(100):  # Max 5 seconds
+                    try:
+                        ready = await run_js("window.__lwc_ready === true")
+                        ready_bool = ready is True or (
+                            isinstance(ready, str) and ready.strip().lower() == "true"
+                        )
+                        if ready_bool:
+                            cls._ready = True
+                            return
+                    except Exception:
+                        pass  # JavaScript may not be ready yet
+                    await asyncio.sleep(0.05)
+            except Exception:
+                cls._loaded = False
+                cls._ready = False
+                raise
+
+            cls._loaded = False
+            raise RuntimeError("Failed to load Lightweight Charts library")
 
     @classmethod
     def reset(cls) -> None:
         """Reset loader state (for testing)."""
         cls._loaded = False
         cls._ready = False
+        cls._lock = None
 
 
 __all__ = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       - ALPACA_API_KEY_ID=${ALPACA_API_KEY_ID:-}
       - ALPACA_API_SECRET_KEY=${ALPACA_API_SECRET_KEY:-}
       - ALPACA_BASE_URL=${ALPACA_BASE_URL:-https://paper-api.alpaca.markets}
-      # For free Alpaca data, use IEX feed (SIP requires a paid subscription).
+      # Alpaca stock feed options: iex (free), sip (paid entitlement), otc.
       - ALPACA_DATA_FEED=${ALPACA_DATA_FEED:-iex}
       - DRY_RUN=${DRY_RUN:-true}
       - STRATEGY_ID=${STRATEGY_ID:-alpha_baseline}
@@ -272,11 +272,18 @@ services:
       - ALPACA_API_KEY=${ALPACA_API_KEY:-${ALPACA_API_KEY_ID:-}}
       - ALPACA_SECRET_KEY=${ALPACA_SECRET_KEY:-${ALPACA_API_SECRET_KEY:-}}
       - ALPACA_BASE_URL=${ALPACA_BASE_URL:-https://paper-api.alpaca.markets}
+      # Alpaca stock feed options: iex (free), sip (paid entitlement), otc.
+      - ALPACA_DATA_FEED=${ALPACA_DATA_FEED:-iex}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_DB=0
       - EXECUTION_GATEWAY_URL=http://execution_gateway:8002
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # C5/C6 auth config for protected market-data routes (e.g. /market-data/{symbol}/bars).
+      - INTERNAL_TOKEN_REQUIRED=${INTERNAL_TOKEN_REQUIRED:-false}
+      - INTERNAL_TOKEN_SECRET=${INTERNAL_TOKEN_SECRET:-}
+      - API_AUTH_MODE=${API_AUTH_MODE:-log_only}
+      - ALLOWED_SERVICE_IDS=${ALLOWED_SERVICE_IDS:-orchestrator,signal_service,execution_gateway,web_console_ng}
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,9 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-trader}:${POSTGRES_PASSWORD:-trader}@postgres:5432/${POSTGRES_DB:-trader}
       - REDIS_URL=redis://redis:6379/0
       - STRATEGY_ID=${STRATEGY_ID:-alpha_baseline}
+      # Local dev default: allow startup without a registered model artifact.
+      # Override with ALLOW_MODELLESS=false when validating fail-closed startup.
+      - ALLOW_MODELLESS=${ALLOW_MODELLESS:-true}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI:-file:./artifacts/mlruns}
     volumes:

--- a/libs/core/common/api_auth_dependency.py
+++ b/libs/core/common/api_auth_dependency.py
@@ -67,7 +67,10 @@ def _get_internal_token_secret() -> str:
 # SECURITY: Service ID whitelist - only allow known internal services
 # Prevents rogue services from authenticating with stolen secrets
 # Note: Normalize by stripping whitespace and lowercasing for robustness
-_raw_service_ids = os.getenv("ALLOWED_SERVICE_IDS", "orchestrator,signal_service,execution_gateway")
+_raw_service_ids = os.getenv(
+    "ALLOWED_SERVICE_IDS",
+    "orchestrator,signal_service,execution_gateway,web_console_ng",
+)
 ALLOWED_SERVICE_IDS = frozenset(s.strip().lower() for s in _raw_service_ids.split(",") if s.strip())
 
 # Explicit permission allowlist per internal service.
@@ -87,6 +90,9 @@ _SERVICE_PERMISSION_ALLOWLIST: dict[str, set[Permission]] = {
         Permission.SUBMIT_ORDER,
         Permission.CANCEL_ORDER,
         Permission.MODIFY_ORDER,
+        Permission.VIEW_MARKET_DATA,
+    },
+    "web_console_ng": {
         Permission.VIEW_MARKET_DATA,
     },
 }

--- a/libs/core/redis_client/event_publisher.py
+++ b/libs/core/redis_client/event_publisher.py
@@ -64,6 +64,7 @@ class EventPublisher:
     CHANNEL_SIGNALS = "signals.generated"
     CHANNEL_ORDERS = "orders.executed"
     CHANNEL_POSITIONS = "positions.updated"
+    HIGH_FREQUENCY_CHANNEL_PREFIXES = ("price.updated.", "level2.")
 
     def __init__(self, redis_client: RedisClient):
         """
@@ -100,10 +101,13 @@ class EventPublisher:
             # Publish to channel
             num_subscribers = self.redis.publish(channel, message)
 
-            logger.info(
-                f"Published {event.event_type} to '{channel}' "  # type: ignore[attr-defined]
-                f"({num_subscribers} subscribers)"
+            event_type = getattr(event, "event_type", channel)
+            log_fn = (
+                logger.debug
+                if channel.startswith(self.HIGH_FREQUENCY_CHANNEL_PREFIXES)
+                else logger.info
             )
+            log_fn("Published %s to '%s' (%s subscribers)", event_type, channel, num_subscribers)
 
             return num_subscribers
 

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -88,8 +88,17 @@ class MarketDataProvider:
         }
         per_day = bars_per_trading_day.get(normalized, 78)
         required_trading_days = max(2, math.ceil(limit / per_day))
-        # Buffer for weekends/holidays and partial sessions.
-        calendar_days = max(5, required_trading_days * 3)
+        # Buffer for weekends/holidays, early closes, and feed-specific gaps.
+        buffer_multiplier: dict[str, int] = {
+            "1min": 4,
+            "5min": 4,
+            "15min": 4,
+            "1hour": 5,
+            "1day": 8,
+        }
+        calendar_days = max(5, required_trading_days * buffer_multiplier.get(normalized, 4))
+        if normalized != "1day":
+            calendar_days = max(calendar_days, 14)
 
         end = datetime.now(UTC)
         start = end - timedelta(days=calendar_days)

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -144,6 +144,8 @@ class MarketDataProvider:
                 "limit": clamped_limit,
                 "start": start,
                 "end": end,
+                # Request newest bars first so `limit` is applied to the most recent window.
+                "sort": "desc",
             }
             if self._data_feed:
                 request_kwargs["feed"] = self._data_feed

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -111,17 +111,27 @@ class MarketDataProvider:
             return parsed.astimezone(UTC)
         return None
 
+    @staticmethod
+    def _extract_bar_list(bars: Any, symbol: str) -> list[Any]:
+        """Extract symbol-scoped bars from Alpaca response payload variants."""
+        if hasattr(bars, "data") and isinstance(bars.data, dict):
+            return list(bars.data.get(symbol, []))
+        if isinstance(bars, dict):
+            return list(bars.get(symbol, []))
+        return []
+
     def _get_bars_sync(self, symbol: str, timeframe: str, limit: int) -> list[dict[str, Any]]:
         symbol = symbol.upper().strip()
         if not symbol:
             return []
         clamped_limit = max(1, min(limit, 500))
         start, end = self._compute_bars_window(timeframe, clamped_limit)
+        resolved_timeframe = self._resolve_timeframe(timeframe)
 
         try:
             request_kwargs: dict[str, Any] = {
                 "symbol_or_symbols": symbol,
-                "timeframe": self._resolve_timeframe(timeframe),
+                "timeframe": resolved_timeframe,
                 "limit": clamped_limit,
                 "start": start,
                 "end": end,
@@ -142,11 +152,7 @@ class MarketDataProvider:
             )
             raise MarketDataError(str(exc)) from exc
 
-        bar_list: list[Any] = []
-        if hasattr(bars, "data"):
-            bar_list = list(getattr(bars, "data", {}).get(symbol, []))
-        elif isinstance(bars, dict):
-            bar_list = list(bars.get(symbol, []))
+        bar_list = self._extract_bar_list(bars, symbol)
 
         normalized: list[dict[str, Any]] = []
         for bar in bar_list:
@@ -169,14 +175,28 @@ class MarketDataProvider:
             if ts is None:
                 continue
 
+            if open_raw is None or high_raw is None or low_raw is None or close_raw is None:
+                continue
+
             try:
+                open_px = float(open_raw)
+                high_px = float(high_raw)
+                low_px = float(low_raw)
+                close_px = float(close_raw)
+                if (
+                    not math.isfinite(open_px)
+                    or not math.isfinite(high_px)
+                    or not math.isfinite(low_px)
+                    or not math.isfinite(close_px)
+                ):
+                    continue
                 normalized.append(
                     {
                         "timestamp": ts.isoformat(),
-                        "open": float(open_raw),
-                        "high": float(high_raw),
-                        "low": float(low_raw),
-                        "close": float(close_raw),
+                        "open": open_px,
+                        "high": high_px,
+                        "low": low_px,
+                        "close": close_px,
                         "volume": int(volume_raw) if volume_raw is not None else 0,
                     }
                 )
@@ -208,11 +228,7 @@ class MarketDataProvider:
             )
             raise MarketDataError(str(exc)) from exc
 
-        bar_list: list[Any] = []
-        if hasattr(bars, "data"):
-            bar_list = list(getattr(bars, "data", {}).get(symbol, []))
-        elif isinstance(bars, dict):
-            bar_list = list(bars.get(symbol, []))
+        bar_list = self._extract_bar_list(bars, symbol)
 
         if not bar_list:
             return None

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+import math
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 try:
     from alpaca.data.historical import StockHistoricalDataClient
     from alpaca.data.requests import StockBarsRequest
-    from alpaca.data.timeframe import TimeFrame
+    from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 
     ALPACA_AVAILABLE = True
 except ImportError:  # pragma: no cover - optional dependency
@@ -18,6 +19,7 @@ except ImportError:  # pragma: no cover - optional dependency
     StockHistoricalDataClient = None  # type: ignore[assignment,misc]
     StockBarsRequest = None  # type: ignore[assignment,misc]
     TimeFrame = None  # type: ignore[assignment,misc]
+    TimeFrameUnit = None  # type: ignore[assignment,misc]
 
 from libs.data.market_data.exceptions import MarketDataError
 from libs.data.market_data.types import ADVData
@@ -37,6 +39,152 @@ class MarketDataProvider:
     async def get_adv(self, symbol: str) -> ADVData | None:
         """Get 20-day Average Daily Volume from the data provider."""
         return await asyncio.to_thread(self._get_adv_sync, symbol)
+
+    async def get_bars(
+        self,
+        symbol: str,
+        *,
+        timeframe: str = "5Min",
+        limit: int = 240,
+    ) -> list[dict[str, Any]]:
+        """Get historical OHLCV bars for a symbol."""
+        return await asyncio.to_thread(
+            self._get_bars_sync,
+            symbol,
+            timeframe,
+            limit,
+        )
+
+    def _resolve_timeframe(self, timeframe: str) -> Any:
+        """Resolve supported timeframe strings to Alpaca TimeFrame."""
+        normalized = timeframe.strip().lower()
+        mapping: dict[str, Any] = {
+            "1min": TimeFrame(1, TimeFrameUnit.Minute),
+            "5min": TimeFrame(5, TimeFrameUnit.Minute),
+            "15min": TimeFrame(15, TimeFrameUnit.Minute),
+            "1hour": TimeFrame(1, TimeFrameUnit.Hour),
+            "1day": TimeFrame.Day,
+        }
+        resolved = mapping.get(normalized)
+        if resolved is None:
+            raise ValueError(f"Unsupported timeframe: {timeframe}")
+        return resolved
+
+    @staticmethod
+    def _compute_bars_window(timeframe: str, limit: int) -> tuple[datetime, datetime]:
+        """Compute a conservative lookback window for intraday/daily bar requests.
+
+        Alpaca can return empty payloads for recent intraday requests without an explicit
+        start/end window. We over-fetch a calendar window and rely on `limit` to trim.
+        """
+        normalized = timeframe.strip().lower()
+        # Approximate bars per trading day by timeframe.
+        bars_per_trading_day: dict[str, int] = {
+            "1min": 390,
+            "5min": 78,
+            "15min": 26,
+            "1hour": 7,
+            "1day": 1,
+        }
+        per_day = bars_per_trading_day.get(normalized, 78)
+        required_trading_days = max(2, math.ceil(limit / per_day))
+        # Buffer for weekends/holidays and partial sessions.
+        calendar_days = max(5, required_trading_days * 3)
+
+        end = datetime.now(UTC)
+        start = end - timedelta(days=calendar_days)
+        return start, end
+
+    def _normalize_bar_timestamp(self, raw_ts: Any) -> datetime | None:
+        """Normalize provider bar timestamp values to UTC-aware datetimes."""
+        if isinstance(raw_ts, datetime):
+            if raw_ts.tzinfo is None:
+                return raw_ts.replace(tzinfo=UTC)
+            return raw_ts.astimezone(UTC)
+        if isinstance(raw_ts, str):
+            try:
+                parsed = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=UTC)
+            return parsed.astimezone(UTC)
+        return None
+
+    def _get_bars_sync(self, symbol: str, timeframe: str, limit: int) -> list[dict[str, Any]]:
+        symbol = symbol.upper().strip()
+        if not symbol:
+            return []
+        clamped_limit = max(1, min(limit, 500))
+        start, end = self._compute_bars_window(timeframe, clamped_limit)
+
+        try:
+            request_kwargs: dict[str, Any] = {
+                "symbol_or_symbols": symbol,
+                "timeframe": self._resolve_timeframe(timeframe),
+                "limit": clamped_limit,
+                "start": start,
+                "end": end,
+            }
+            if self._data_feed:
+                request_kwargs["feed"] = self._data_feed
+            request = StockBarsRequest(**request_kwargs)
+            bars = self._client.get_stock_bars(request)
+        except Exception as exc:  # pragma: no cover - provider errors
+            logger.warning(
+                "bars_provider_error",
+                extra={
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "limit": clamped_limit,
+                    "error": type(exc).__name__,
+                },
+            )
+            raise MarketDataError(str(exc)) from exc
+
+        bar_list: list[Any] = []
+        if hasattr(bars, "data"):
+            bar_list = list(getattr(bars, "data", {}).get(symbol, []))
+        elif isinstance(bars, dict):
+            bar_list = list(bars.get(symbol, []))
+
+        normalized: list[dict[str, Any]] = []
+        for bar in bar_list:
+            if isinstance(bar, dict):
+                ts_raw = bar.get("timestamp") or bar.get("t")
+                open_raw = bar.get("open") or bar.get("o")
+                high_raw = bar.get("high") or bar.get("h")
+                low_raw = bar.get("low") or bar.get("l")
+                close_raw = bar.get("close") or bar.get("c")
+                volume_raw = bar.get("volume") or bar.get("v")
+            else:
+                ts_raw = getattr(bar, "timestamp", None) or getattr(bar, "t", None)
+                open_raw = getattr(bar, "open", None) or getattr(bar, "o", None)
+                high_raw = getattr(bar, "high", None) or getattr(bar, "h", None)
+                low_raw = getattr(bar, "low", None) or getattr(bar, "l", None)
+                close_raw = getattr(bar, "close", None) or getattr(bar, "c", None)
+                volume_raw = getattr(bar, "volume", None) or getattr(bar, "v", None)
+
+            ts = self._normalize_bar_timestamp(ts_raw)
+            if ts is None:
+                continue
+
+            try:
+                normalized.append(
+                    {
+                        "timestamp": ts.isoformat(),
+                        "open": float(open_raw),
+                        "high": float(high_raw),
+                        "low": float(low_raw),
+                        "close": float(close_raw),
+                        "volume": int(volume_raw) if volume_raw is not None else 0,
+                    }
+                )
+            except (TypeError, ValueError):
+                continue
+
+        normalized.sort(key=lambda bar: str(bar["timestamp"]))
+        return normalized
 
     def _get_adv_sync(self, symbol: str) -> ADVData | None:
         symbol = symbol.upper().strip()

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -129,6 +129,52 @@ class MarketDataProvider:
             return list(bars.get(symbol, []))
         return []
 
+    def _normalize_bar(self, bar: Any) -> dict[str, Any] | None:
+        """Normalize one provider bar object into the API response shape."""
+        if isinstance(bar, dict):
+            ts_raw = bar.get("timestamp") or bar.get("t")
+            open_raw = bar.get("open") or bar.get("o")
+            high_raw = bar.get("high") or bar.get("h")
+            low_raw = bar.get("low") or bar.get("l")
+            close_raw = bar.get("close") or bar.get("c")
+            volume_raw = bar.get("volume") or bar.get("v")
+        else:
+            ts_raw = getattr(bar, "timestamp", None) or getattr(bar, "t", None)
+            open_raw = getattr(bar, "open", None) or getattr(bar, "o", None)
+            high_raw = getattr(bar, "high", None) or getattr(bar, "h", None)
+            low_raw = getattr(bar, "low", None) or getattr(bar, "l", None)
+            close_raw = getattr(bar, "close", None) or getattr(bar, "c", None)
+            volume_raw = getattr(bar, "volume", None) or getattr(bar, "v", None)
+
+        ts = self._normalize_bar_timestamp(ts_raw)
+        if ts is None:
+            return None
+        if open_raw is None or high_raw is None or low_raw is None or close_raw is None:
+            return None
+
+        try:
+            open_px = float(open_raw)
+            high_px = float(high_raw)
+            low_px = float(low_raw)
+            close_px = float(close_raw)
+            if (
+                not math.isfinite(open_px)
+                or not math.isfinite(high_px)
+                or not math.isfinite(low_px)
+                or not math.isfinite(close_px)
+            ):
+                return None
+            return {
+                "timestamp": ts.isoformat(),
+                "open": open_px,
+                "high": high_px,
+                "low": low_px,
+                "close": close_px,
+                "volume": int(volume_raw) if volume_raw is not None else 0,
+            }
+        except (TypeError, ValueError):
+            return None
+
     def _get_bars_sync(self, symbol: str, timeframe: str, limit: int) -> list[dict[str, Any]]:
         symbol = symbol.upper().strip()
         if not symbol:
@@ -167,52 +213,9 @@ class MarketDataProvider:
 
         normalized: list[dict[str, Any]] = []
         for bar in bar_list:
-            if isinstance(bar, dict):
-                ts_raw = bar.get("timestamp") or bar.get("t")
-                open_raw = bar.get("open") or bar.get("o")
-                high_raw = bar.get("high") or bar.get("h")
-                low_raw = bar.get("low") or bar.get("l")
-                close_raw = bar.get("close") or bar.get("c")
-                volume_raw = bar.get("volume") or bar.get("v")
-            else:
-                ts_raw = getattr(bar, "timestamp", None) or getattr(bar, "t", None)
-                open_raw = getattr(bar, "open", None) or getattr(bar, "o", None)
-                high_raw = getattr(bar, "high", None) or getattr(bar, "h", None)
-                low_raw = getattr(bar, "low", None) or getattr(bar, "l", None)
-                close_raw = getattr(bar, "close", None) or getattr(bar, "c", None)
-                volume_raw = getattr(bar, "volume", None) or getattr(bar, "v", None)
-
-            ts = self._normalize_bar_timestamp(ts_raw)
-            if ts is None:
-                continue
-
-            if open_raw is None or high_raw is None or low_raw is None or close_raw is None:
-                continue
-
-            try:
-                open_px = float(open_raw)
-                high_px = float(high_raw)
-                low_px = float(low_raw)
-                close_px = float(close_raw)
-                if (
-                    not math.isfinite(open_px)
-                    or not math.isfinite(high_px)
-                    or not math.isfinite(low_px)
-                    or not math.isfinite(close_px)
-                ):
-                    continue
-                normalized.append(
-                    {
-                        "timestamp": ts.isoformat(),
-                        "open": open_px,
-                        "high": high_px,
-                        "low": low_px,
-                        "close": close_px,
-                        "volume": int(volume_raw) if volume_raw is not None else 0,
-                    }
-                )
-            except (TypeError, ValueError):
-                continue
+            normalized_bar = self._normalize_bar(bar)
+            if normalized_bar is not None:
+                normalized.append(normalized_bar)
 
         normalized.sort(key=lambda bar: str(bar["timestamp"]))
         return normalized

--- a/tests/apps/execution_gateway/test_config.py
+++ b/tests/apps/execution_gateway/test_config.py
@@ -95,6 +95,13 @@ def test_get_config_valid_alpaca_data_feed(monkeypatch):
     assert cfg.alpaca_data_feed == "sip"
 
 
+def test_get_config_valid_alpaca_data_feed_boats(monkeypatch):
+    _reset_cached_config()
+    monkeypatch.setenv("ALPACA_DATA_FEED", "BoAtS")
+    cfg = config_module.get_config()
+    assert cfg.alpaca_data_feed == "boats"
+
+
 def test_get_config_invalid_alpaca_data_feed_logs_warning(monkeypatch, caplog):
     _reset_cached_config()
     monkeypatch.setenv("ALPACA_DATA_FEED", "not-a-feed")

--- a/tests/apps/execution_gateway/test_config.py
+++ b/tests/apps/execution_gateway/test_config.py
@@ -86,3 +86,21 @@ def test_get_config_cached_returns_singleton(monkeypatch):
 
     assert cfg1 is cfg2
     assert cfg2.strategy_id == "alpha_baseline"
+
+
+def test_get_config_valid_alpaca_data_feed(monkeypatch):
+    _reset_cached_config()
+    monkeypatch.setenv("ALPACA_DATA_FEED", "SIP")
+    cfg = config_module.get_config()
+    assert cfg.alpaca_data_feed == "sip"
+
+
+def test_get_config_invalid_alpaca_data_feed_logs_warning(monkeypatch, caplog):
+    _reset_cached_config()
+    monkeypatch.setenv("ALPACA_DATA_FEED", "not-a-feed")
+
+    with caplog.at_level("WARNING"):
+        cfg = config_module.get_config()
+
+    assert cfg.alpaca_data_feed is None
+    assert "Invalid ALPACA_DATA_FEED" in caplog.text

--- a/tests/apps/market_data_service/test_adv_endpoint.py
+++ b/tests/apps/market_data_service/test_adv_endpoint.py
@@ -45,14 +45,22 @@ class DummyCache:
 
 
 class DummyProvider:
-    def __init__(self, adv_data=None, error=None):
+    def __init__(self, adv_data=None, bars_data=None, error=None):
         self._adv_data = adv_data
+        self._bars_data = bars_data or []
         self._error = error
 
     async def get_adv(self, symbol: str):
         if self._error:
             raise self._error
         return self._adv_data
+
+    async def get_bars(self, symbol: str, *, timeframe: str = "5Min", limit: int = 240):
+        if isinstance(self._error, ValueError):
+            raise self._error
+        if self._error:
+            raise self._error
+        return list(self._bars_data)
 
 
 def test_adv_returns_404_for_unknown_symbol(test_client, monkeypatch):
@@ -139,3 +147,71 @@ def test_adv_staleness_calculation(test_client, monkeypatch):
     assert response.status_code == 200
     body = response.json()
     assert body["stale"] is True
+
+
+def test_bars_returns_historical_payload(test_client, monkeypatch):
+    from apps.market_data_service.routes import market_data
+
+    expected_bars = [
+        {
+            "timestamp": "2026-04-20T13:30:00+00:00",
+            "open": 180.1,
+            "high": 181.0,
+            "low": 179.9,
+            "close": 180.6,
+            "volume": 1200,
+        }
+    ]
+    monkeypatch.setattr(
+        market_data,
+        "_get_provider",
+        lambda: DummyProvider(bars_data=expected_bars),
+    )
+
+    response = test_client.get("/api/v1/market-data/aapl/bars?timeframe=5Min&limit=100")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["symbol"] == "AAPL"
+    assert body["timeframe"] == "5Min"
+    assert len(body["bars"]) == 1
+    assert body["bars"][0]["open"] == expected_bars[0]["open"]
+    assert body["bars"][0]["high"] == expected_bars[0]["high"]
+    assert body["bars"][0]["low"] == expected_bars[0]["low"]
+    assert body["bars"][0]["close"] == expected_bars[0]["close"]
+    assert body["bars"][0]["volume"] == expected_bars[0]["volume"]
+    assert body["bars"][0]["timestamp"] in {
+        "2026-04-20T13:30:00Z",
+        "2026-04-20T13:30:00+00:00",
+    }
+
+
+def test_bars_returns_400_for_invalid_limit(test_client):
+    response = test_client.get("/api/v1/market-data/AAPL/bars?limit=0")
+    assert response.status_code == 400
+
+
+def test_bars_returns_400_for_invalid_timeframe(test_client, monkeypatch):
+    from apps.market_data_service.routes import market_data
+
+    monkeypatch.setattr(
+        market_data,
+        "_get_provider",
+        lambda: DummyProvider(error=ValueError("Unsupported timeframe: 2Min")),
+    )
+
+    response = test_client.get("/api/v1/market-data/AAPL/bars?timeframe=2Min")
+    assert response.status_code == 400
+    assert "Unsupported timeframe" in response.text
+
+
+def test_bars_returns_503_when_provider_unavailable(test_client, monkeypatch):
+    from apps.market_data_service.routes import market_data
+
+    monkeypatch.setattr(
+        market_data,
+        "_get_provider",
+        lambda: DummyProvider(error=MarketDataError("down")),
+    )
+
+    response = test_client.get("/api/v1/market-data/AAPL/bars")
+    assert response.status_code == 503

--- a/tests/apps/market_data_service/test_config.py
+++ b/tests/apps/market_data_service/test_config.py
@@ -235,6 +235,17 @@ class TestEnvironmentOverrides:
 
         assert config.settings.alpaca_data_feed == "sip"
 
+    def test_alpaca_data_feed_boats_override(self, monkeypatch):
+        """Test Alpaca BOATS feed is accepted and normalized."""
+        config = _import_config_module(
+            monkeypatch,
+            ALPACA_API_KEY="key",
+            ALPACA_SECRET_KEY="secret",
+            ALPACA_DATA_FEED="BOATS",
+        )
+
+        assert config.settings.alpaca_data_feed == "boats"
+
     def test_alpaca_data_feed_invalid_value_fails_validation(self, monkeypatch):
         """Test invalid Alpaca data feed values are rejected."""
         with pytest.raises(ValidationError):

--- a/tests/apps/market_data_service/test_config.py
+++ b/tests/apps/market_data_service/test_config.py
@@ -27,6 +27,7 @@ def _import_config_module(monkeypatch, **env):
         "ALPACA_API_KEY",
         "ALPACA_SECRET_KEY",
         "ALPACA_BASE_URL",
+        "ALPACA_DATA_FEED",
         "REDIS_HOST",
         "REDIS_PORT",
         "REDIS_DB",
@@ -72,6 +73,7 @@ class TestSettingsDefaults:
 
         # Alpaca defaults
         assert settings.alpaca_base_url == "https://paper-api.alpaca.markets"
+        assert settings.alpaca_data_feed == "iex"
 
         # Redis defaults
         assert settings.redis_host == "localhost"
@@ -221,6 +223,27 @@ class TestEnvironmentOverrides:
         )
 
         assert config.settings.alpaca_base_url == "https://api.alpaca.markets"
+
+    def test_alpaca_data_feed_override(self, monkeypatch):
+        """Test Alpaca data feed override and normalization."""
+        config = _import_config_module(
+            monkeypatch,
+            ALPACA_API_KEY="key",
+            ALPACA_SECRET_KEY="secret",
+            ALPACA_DATA_FEED="SIP",
+        )
+
+        assert config.settings.alpaca_data_feed == "sip"
+
+    def test_alpaca_data_feed_invalid_value_fails_validation(self, monkeypatch):
+        """Test invalid Alpaca data feed values are rejected."""
+        with pytest.raises(ValidationError):
+            _import_config_module(
+                monkeypatch,
+                ALPACA_API_KEY="key",
+                ALPACA_SECRET_KEY="secret",
+                ALPACA_DATA_FEED="invalid-feed",
+            )
 
     def test_redis_config_overrides(self, monkeypatch):
         """Test Redis configuration overrides."""

--- a/tests/apps/market_data_service/test_main.py
+++ b/tests/apps/market_data_service/test_main.py
@@ -33,6 +33,7 @@ def test_client(monkeypatch):
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("EXECUTION_GATEWAY_URL", "http://localhost:8002")
+    monkeypatch.setenv("API_AUTH_MODE", "enforce")
 
     # Create a mock lifespan that doesn't connect to external services
     @asynccontextmanager
@@ -162,17 +163,35 @@ class TestSubscribeEndpoint:
         # Verify subscribe_symbols was called
         mock_stream.subscribe_symbols.assert_called_once_with(["AAPL", "MSFT"], source="manual")
 
-    def test_subscribe_success_with_explicit_source(self, test_client, mock_stream):
-        """Test successful subscription with explicit source tag."""
-        mock_stream.get_subscribed_symbols.return_value = ["AAPL"]
-
+    def test_subscribe_rejects_explicit_source_without_internal_auth(self, test_client, mock_stream):
+        """Explicit source tags require an authenticated internal token."""
         with patch("apps.market_data_service.main.stream", mock_stream):
             response = test_client.post(
                 "/api/v1/subscribe",
                 json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
             )
 
+        assert response.status_code == 401
+        mock_stream.subscribe_symbols.assert_not_called()
+
+    def test_subscribe_success_with_explicit_source_when_authorized(self, test_client, mock_stream):
+        """Authorized internal requests may use explicit source tags."""
+        mock_stream.get_subscribed_symbols.return_value = ["AAPL"]
+
+        with (
+            patch("apps.market_data_service.main.stream", mock_stream),
+            patch(
+                "apps.market_data_service.main._authorize_source_override",
+                new=AsyncMock(),
+            ) as authorize_source_override,
+        ):
+            response = test_client.post(
+                "/api/v1/subscribe",
+                json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
+            )
+
         assert response.status_code == 201
+        authorize_source_override.assert_awaited_once()
         mock_stream.subscribe_symbols.assert_called_once_with(
             ["AAPL"],
             source="web_console:user-1:abc",
@@ -231,14 +250,29 @@ class TestUnsubscribeEndpoint:
         # Verify unsubscribe_symbols was called
         mock_stream.unsubscribe_symbols.assert_called_once_with(["AAPL"], source="manual")
 
-    def test_unsubscribe_success_with_explicit_source(self, test_client, mock_stream):
-        """Test successful unsubscription with explicit source tag."""
-        mock_stream.get_subscribed_symbols.return_value = []
-
+    def test_unsubscribe_rejects_explicit_source_without_internal_auth(self, test_client, mock_stream):
+        """Explicit source tags require an authenticated internal token."""
         with patch("apps.market_data_service.main.stream", mock_stream):
             response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
 
+        assert response.status_code == 401
+        mock_stream.unsubscribe_symbols.assert_not_called()
+
+    def test_unsubscribe_success_with_explicit_source_when_authorized(self, test_client, mock_stream):
+        """Authorized internal requests may unsubscribe with explicit source tags."""
+        mock_stream.get_subscribed_symbols.return_value = []
+
+        with (
+            patch("apps.market_data_service.main.stream", mock_stream),
+            patch(
+                "apps.market_data_service.main._authorize_source_override",
+                new=AsyncMock(),
+            ) as authorize_source_override,
+        ):
+            response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
+
         assert response.status_code == 200
+        authorize_source_override.assert_awaited_once()
         mock_stream.unsubscribe_symbols.assert_called_once_with(
             ["AAPL"],
             source="web_console:user-1:abc",

--- a/tests/apps/market_data_service/test_main.py
+++ b/tests/apps/market_data_service/test_main.py
@@ -160,7 +160,23 @@ class TestSubscribeEndpoint:
         assert data["total_subscriptions"] == 3
 
         # Verify subscribe_symbols was called
-        mock_stream.subscribe_symbols.assert_called_once_with(["AAPL", "MSFT"])
+        mock_stream.subscribe_symbols.assert_called_once_with(["AAPL", "MSFT"], source="manual")
+
+    def test_subscribe_success_with_explicit_source(self, test_client, mock_stream):
+        """Test successful subscription with explicit source tag."""
+        mock_stream.get_subscribed_symbols.return_value = ["AAPL"]
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.post(
+                "/api/v1/subscribe",
+                json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
+            )
+
+        assert response.status_code == 201
+        mock_stream.subscribe_symbols.assert_called_once_with(
+            ["AAPL"],
+            source="web_console:user-1:abc",
+        )
 
     def test_subscribe_subscription_error(self, test_client, mock_stream):
         """Test subscribe handles SubscriptionError."""
@@ -201,7 +217,20 @@ class TestUnsubscribeEndpoint:
         assert data["remaining_subscriptions"] == 2
 
         # Verify unsubscribe_symbols was called
-        mock_stream.unsubscribe_symbols.assert_called_once_with(["AAPL"])
+        mock_stream.unsubscribe_symbols.assert_called_once_with(["AAPL"], source="manual")
+
+    def test_unsubscribe_success_with_explicit_source(self, test_client, mock_stream):
+        """Test successful unsubscription with explicit source tag."""
+        mock_stream.get_subscribed_symbols.return_value = []
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
+
+        assert response.status_code == 200
+        mock_stream.unsubscribe_symbols.assert_called_once_with(
+            ["AAPL"],
+            source="web_console:user-1:abc",
+        )
 
     def test_unsubscribe_subscription_error(self, test_client, mock_stream):
         """Test unsubscribe handles SubscriptionError."""

--- a/tests/apps/market_data_service/test_main.py
+++ b/tests/apps/market_data_service/test_main.py
@@ -229,6 +229,42 @@ class TestSubscribeEndpoint:
         assert response.status_code == 401
         mock_stream.subscribe_symbols.assert_not_called()
 
+    def test_subscribe_allows_explicit_source_when_only_other_service_secret_configured(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Service-specific secrets for unrelated services must not force signed web_console tags."""
+        _clear_internal_token_secrets(monkeypatch)
+        monkeypatch.setenv("INTERNAL_TOKEN_SECRET_SIGNAL_SERVICE", "s" * 64)
+        mock_stream.get_subscribed_symbols.return_value = ["AAPL"]
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.post(
+                "/api/v1/subscribe",
+                json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
+            )
+
+        assert response.status_code == 201
+        mock_stream.subscribe_symbols.assert_called_once_with(
+            ["AAPL"],
+            source="web_console:user-1:abc",
+        )
+
+    def test_subscribe_rejects_explicit_source_when_owner_service_secret_configured(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When web_console secret is configured, explicit source requires signed auth."""
+        _clear_internal_token_secrets(monkeypatch)
+        monkeypatch.setenv("INTERNAL_TOKEN_SECRET_WEB_CONSOLE_NG", "s" * 64)
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.post(
+                "/api/v1/subscribe",
+                json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
+            )
+
+        assert response.status_code == 401
+        mock_stream.subscribe_symbols.assert_not_called()
+
     def test_subscribe_rejects_invalid_source(self, test_client, mock_stream):
         """Source tags must stay bounded and contain only safe characters."""
         with patch("apps.market_data_service.main.stream", mock_stream):
@@ -323,6 +359,36 @@ class TestUnsubscribeEndpoint:
     ):
         """When internal signing is configured, explicit source requires auth."""
         monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "s" * 64)
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
+
+        assert response.status_code == 401
+        mock_stream.unsubscribe_symbols.assert_not_called()
+
+    def test_unsubscribe_allows_explicit_source_when_only_other_service_secret_configured(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Unrelated service secrets must not block unsigned web_console source unsubscription."""
+        _clear_internal_token_secrets(monkeypatch)
+        monkeypatch.setenv("INTERNAL_TOKEN_SECRET_SIGNAL_SERVICE", "s" * 64)
+        mock_stream.get_subscribed_symbols.return_value = []
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
+
+        assert response.status_code == 200
+        mock_stream.unsubscribe_symbols.assert_called_once_with(
+            ["AAPL"],
+            source="web_console:user-1:abc",
+        )
+
+    def test_unsubscribe_rejects_explicit_source_when_owner_service_secret_configured(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When web_console secret is configured, explicit source requires signed auth."""
+        _clear_internal_token_secrets(monkeypatch)
+        monkeypatch.setenv("INTERNAL_TOKEN_SECRET_WEB_CONSOLE_NG", "s" * 64)
 
         with patch("apps.market_data_service.main.stream", mock_stream):
             response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")

--- a/tests/apps/market_data_service/test_main.py
+++ b/tests/apps/market_data_service/test_main.py
@@ -178,6 +178,18 @@ class TestSubscribeEndpoint:
             source="web_console:user-1:abc",
         )
 
+    def test_subscribe_rejects_invalid_source(self, test_client, mock_stream):
+        """Source tags must stay bounded and contain only safe characters."""
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.post(
+                "/api/v1/subscribe",
+                json={"symbols": ["AAPL"], "source": "bad source with spaces !"},
+            )
+
+        assert response.status_code == 400
+        assert "Invalid source" in response.json()["detail"]
+        mock_stream.subscribe_symbols.assert_not_called()
+
     def test_subscribe_subscription_error(self, test_client, mock_stream):
         """Test subscribe handles SubscriptionError."""
         mock_stream.subscribe_symbols.side_effect = SubscriptionError("WebSocket not connected")
@@ -231,6 +243,15 @@ class TestUnsubscribeEndpoint:
             ["AAPL"],
             source="web_console:user-1:abc",
         )
+
+    def test_unsubscribe_rejects_invalid_source(self, test_client, mock_stream):
+        """Unsubscribe source tags must pass the same validation rules."""
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.delete("/api/v1/subscribe/AAPL?source=bad source !!")
+
+        assert response.status_code == 400
+        assert "Invalid source" in response.json()["detail"]
+        mock_stream.unsubscribe_symbols.assert_not_called()
 
     def test_unsubscribe_subscription_error(self, test_client, mock_stream):
         """Test unsubscribe handles SubscriptionError."""

--- a/tests/apps/market_data_service/test_main.py
+++ b/tests/apps/market_data_service/test_main.py
@@ -13,6 +13,7 @@ Tests cover:
 """
 
 import asyncio
+import os
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -22,6 +23,14 @@ import redis.exceptions
 from fastapi.testclient import TestClient
 
 from libs.data.market_data import SubscriptionError
+
+
+def _clear_internal_token_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear any configured internal-token secrets for deterministic unsigned-mode tests."""
+    monkeypatch.delenv("INTERNAL_TOKEN_SECRET", raising=False)
+    for env_key in tuple(os.environ):
+        if env_key.startswith("INTERNAL_TOKEN_SECRET_"):
+            monkeypatch.delenv(env_key, raising=False)
 
 
 @pytest.fixture()
@@ -163,16 +172,24 @@ class TestSubscribeEndpoint:
         # Verify subscribe_symbols was called
         mock_stream.subscribe_symbols.assert_called_once_with(["AAPL", "MSFT"], source="manual")
 
-    def test_subscribe_rejects_explicit_source_without_internal_auth(self, test_client, mock_stream):
-        """Explicit source tags require an authenticated internal token."""
+    def test_subscribe_success_with_explicit_source(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Unsigned environments should preserve explicit web_console source tags."""
+        _clear_internal_token_secrets(monkeypatch)
+        mock_stream.get_subscribed_symbols.return_value = ["AAPL"]
+
         with patch("apps.market_data_service.main.stream", mock_stream):
             response = test_client.post(
                 "/api/v1/subscribe",
                 json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
             )
 
-        assert response.status_code == 401
-        mock_stream.subscribe_symbols.assert_not_called()
+        assert response.status_code == 201
+        mock_stream.subscribe_symbols.assert_called_once_with(
+            ["AAPL"],
+            source="web_console:user-1:abc",
+        )
 
     def test_subscribe_success_with_explicit_source_when_authorized(self, test_client, mock_stream):
         """Authorized internal requests may use explicit source tags."""
@@ -196,6 +213,21 @@ class TestSubscribeEndpoint:
             ["AAPL"],
             source="web_console:user-1:abc",
         )
+
+    def test_subscribe_rejects_explicit_source_without_internal_auth_when_secret_configured(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When internal signing is configured, explicit source requires auth."""
+        monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "s" * 64)
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.post(
+                "/api/v1/subscribe",
+                json={"symbols": ["AAPL"], "source": "web_console:user-1:abc"},
+            )
+
+        assert response.status_code == 401
+        mock_stream.subscribe_symbols.assert_not_called()
 
     def test_subscribe_rejects_invalid_source(self, test_client, mock_stream):
         """Source tags must stay bounded and contain only safe characters."""
@@ -250,13 +282,21 @@ class TestUnsubscribeEndpoint:
         # Verify unsubscribe_symbols was called
         mock_stream.unsubscribe_symbols.assert_called_once_with(["AAPL"], source="manual")
 
-    def test_unsubscribe_rejects_explicit_source_without_internal_auth(self, test_client, mock_stream):
-        """Explicit source tags require an authenticated internal token."""
+    def test_unsubscribe_success_with_explicit_source(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Unsigned environments should preserve explicit web_console source tags."""
+        _clear_internal_token_secrets(monkeypatch)
+        mock_stream.get_subscribed_symbols.return_value = []
+
         with patch("apps.market_data_service.main.stream", mock_stream):
             response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
 
-        assert response.status_code == 401
-        mock_stream.unsubscribe_symbols.assert_not_called()
+        assert response.status_code == 200
+        mock_stream.unsubscribe_symbols.assert_called_once_with(
+            ["AAPL"],
+            source="web_console:user-1:abc",
+        )
 
     def test_unsubscribe_success_with_explicit_source_when_authorized(self, test_client, mock_stream):
         """Authorized internal requests may unsubscribe with explicit source tags."""
@@ -277,6 +317,18 @@ class TestUnsubscribeEndpoint:
             ["AAPL"],
             source="web_console:user-1:abc",
         )
+
+    def test_unsubscribe_rejects_explicit_source_without_internal_auth_when_secret_configured(
+        self, test_client, mock_stream, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When internal signing is configured, explicit source requires auth."""
+        monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "s" * 64)
+
+        with patch("apps.market_data_service.main.stream", mock_stream):
+            response = test_client.delete("/api/v1/subscribe/AAPL?source=web_console:user-1:abc")
+
+        assert response.status_code == 401
+        mock_stream.unsubscribe_symbols.assert_not_called()
 
     def test_unsubscribe_rejects_invalid_source(self, test_client, mock_stream):
         """Unsubscribe source tags must pass the same validation rules."""

--- a/tests/apps/web_console_ng/components/test_status_bar.py
+++ b/tests/apps/web_console_ng/components/test_status_bar.py
@@ -72,6 +72,13 @@ def test_status_bar_disengaged(dummy_ui: None) -> None:
     assert bar._label.text == "TRADING ACTIVE"
 
 
+def test_status_bar_active_alias(dummy_ui: None) -> None:
+    bar = StatusBar()
+    bar.update_state("ACTIVE")
+    assert bar._label is not None
+    assert bar._label.text == "TRADING ACTIVE"
+
+
 def test_status_bar_unknown(dummy_ui: None) -> None:
     bar = StatusBar()
     bar.update_state("UNKNOWN")

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -194,7 +194,7 @@ def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch)
         body=None,
         user_id="user-1",
         role="trader",
-        strategies=["b", "a"],
+        strategies=["alpha"],
     )
 
     payload_data = {
@@ -205,7 +205,7 @@ def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch)
         "timestamp": "1700000000",
         "nonce": "00000000-0000-0000-0000-000000000001",
         "user_id": "user-1",
-        "strategy_id": "a",
+        "strategy_id": "alpha",
         "body_hash": hashlib.sha256(b"").hexdigest(),
     }
     payload = json.dumps(payload_data, separators=(",", ":"), sort_keys=True)
@@ -217,7 +217,49 @@ def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch)
     assert headers["X-Internal-Token"] == expected_sig
     assert headers["X-Body-Hash"] == hashlib.sha256(b"").hexdigest()
     assert headers["X-User-Id"] == "user-1"
-    assert headers["X-Strategy-ID"] == "a"
+    assert headers["X-Strategy-ID"] == "alpha"
+
+
+def test_get_market_data_auth_headers_omits_strategy_id_for_ambiguous_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not forward arbitrary strategy IDs when multiple strategies are present."""
+    monkeypatch.setattr(config, "DEBUG", True)
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+    monkeypatch.setattr("apps.web_console_ng.core.client.time.time", lambda: 1700000000)
+    monkeypatch.setattr(
+        "apps.web_console_ng.core.client.uuid.uuid4",
+        lambda: "00000000-0000-0000-0000-000000000003",
+    )
+
+    client = AsyncTradingClient.get()
+    headers = client._get_market_data_auth_headers(
+        method="GET",
+        path="/api/v1/market-data/SPY/bars",
+        query="timeframe=5Min&limit=240",
+        body=None,
+        user_id="user-1",
+        role="trader",
+        strategies=["beta", "alpha"],
+    )
+
+    payload_data = {
+        "service_id": "web_console_ng",
+        "method": "GET",
+        "path": "/api/v1/market-data/SPY/bars",
+        "query": "timeframe=5Min&limit=240",
+        "timestamp": "1700000000",
+        "nonce": "00000000-0000-0000-0000-000000000003",
+        "user_id": "user-1",
+        "strategy_id": "",
+        "body_hash": hashlib.sha256(b"").hexdigest(),
+    }
+    payload = json.dumps(payload_data, separators=(",", ":"), sort_keys=True)
+    expected_sig = hmac.new(b"secret", payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    assert headers["X-Internal-Token"] == expected_sig
+    assert "X-Strategy-ID" not in headers
 
 
 @pytest.mark.asyncio()
@@ -278,6 +320,72 @@ async def test_fetch_historical_bars_uses_signed_market_data_headers(
     assert request.headers.get("X-Service-ID") == "web_console_ng"
     assert request.headers.get("X-Internal-Token")
     assert request.headers.get("X-User-ID") == "user-1"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_subscribe_market_data_symbols_includes_source_when_provided() -> None:
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.post("http://market-data.local/api/v1/subscribe").mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "message": "ok",
+                "subscribed_symbols": ["AAPL"],
+                "total_subscriptions": 1,
+            },
+        )
+    )
+
+    try:
+        result = await client.subscribe_market_data_symbols(
+            ["AAPL"],
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            source="web_console:user-1:abc",
+        )
+    finally:
+        await client.shutdown()
+
+    assert result["total_subscriptions"] == 1
+    request = route.calls[0].request
+    payload = json.loads(request.content)
+    assert payload == {"symbols": ["AAPL"], "source": "web_console:user-1:abc"}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_unsubscribe_market_data_symbol_passes_source_query_param() -> None:
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.delete(
+        "http://market-data.local/api/v1/subscribe/AAPL?source=web_console%3Auser-1%3Aabc"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={"message": "ok", "remaining_subscriptions": 0},
+        )
+    )
+
+    try:
+        result = await client.unsubscribe_market_data_symbol(
+            "AAPL",
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            source="web_console:user-1:abc",
+        )
+    finally:
+        await client.shutdown()
+
+    assert result["remaining_subscriptions"] == 0
+    assert route.call_count == 1
 
 
 def test_json_dict_requires_object() -> None:

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -276,6 +276,51 @@ def test_build_query_string_sorts_params_deterministically() -> None:
     assert query == "limit=240&symbol=SPY&timeframe=5Min"
 
 
+def test_get_market_data_auth_headers_uses_resolved_debug_user_and_strategies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "DEBUG", True)
+    monkeypatch.setattr(config, "DEV_USER_ID", "dev-user-42")
+    monkeypatch.setattr(config, "DEV_ROLE", "trader")
+    monkeypatch.setattr(config, "DEV_STRATEGIES", ["beta", "alpha"])
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+    monkeypatch.setattr("apps.web_console_ng.core.client.time.time", lambda: 1700000000)
+    monkeypatch.setattr(
+        "apps.web_console_ng.core.client.uuid.uuid4",
+        lambda: "00000000-0000-0000-0000-000000000099",
+    )
+
+    client = AsyncTradingClient.get()
+    headers = client._get_market_data_auth_headers(
+        method="GET",
+        path="/api/v1/market-data/SPY/bars",
+        query="",
+        body=None,
+        user_id="",
+        role=None,
+        strategies=None,
+    )
+
+    payload_data = {
+        "service_id": "web_console_ng",
+        "method": "GET",
+        "path": "/api/v1/market-data/SPY/bars",
+        "query": "",
+        "timestamp": "1700000000",
+        "nonce": "00000000-0000-0000-0000-000000000099",
+        "user_id": "dev-user-42",
+        "strategy_id": "alpha",
+        "body_hash": hashlib.sha256(b"").hexdigest(),
+    }
+    payload = json.dumps(payload_data, separators=(",", ":"), sort_keys=True)
+    expected_sig = hmac.new(b"secret", payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    assert headers["X-User-Id"] == "dev-user-42"
+    assert headers["X-Internal-Token"] == expected_sig
+    assert headers["X-Strategy-ID"] == "alpha"
+
+
 @pytest.mark.asyncio()
 @respx.mock
 async def test_fetch_kill_switch_status_maps_active(

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -190,7 +190,7 @@ def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch)
     headers = client._get_market_data_auth_headers(
         method="GET",
         path="/api/v1/market-data/SPY/bars",
-        query="timeframe=5Min&limit=240",
+        query="limit=240&timeframe=5Min",
         body=None,
         user_id="user-1",
         role="trader",
@@ -201,7 +201,7 @@ def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch)
         "service_id": "web_console_ng",
         "method": "GET",
         "path": "/api/v1/market-data/SPY/bars",
-        "query": "timeframe=5Min&limit=240",
+        "query": "limit=240&timeframe=5Min",
         "timestamp": "1700000000",
         "nonce": "00000000-0000-0000-0000-000000000001",
         "user_id": "user-1",
@@ -237,7 +237,7 @@ def test_get_market_data_auth_headers_uses_deterministic_strategy_id_for_multi_s
     headers = client._get_market_data_auth_headers(
         method="GET",
         path="/api/v1/market-data/SPY/bars",
-        query="timeframe=5Min&limit=240",
+        query="limit=240&timeframe=5Min",
         body=None,
         user_id="user-1",
         role="trader",
@@ -248,7 +248,7 @@ def test_get_market_data_auth_headers_uses_deterministic_strategy_id_for_multi_s
         "service_id": "web_console_ng",
         "method": "GET",
         "path": "/api/v1/market-data/SPY/bars",
-        "query": "timeframe=5Min&limit=240",
+        "query": "limit=240&timeframe=5Min",
         "timestamp": "1700000000",
         "nonce": "00000000-0000-0000-0000-000000000003",
         "user_id": "user-1",
@@ -260,6 +260,20 @@ def test_get_market_data_auth_headers_uses_deterministic_strategy_id_for_multi_s
 
     assert headers["X-Internal-Token"] == expected_sig
     assert headers["X-Strategy-ID"] == "alpha"
+
+
+def test_build_query_string_sorts_params_deterministically() -> None:
+    client = AsyncTradingClient.get()
+
+    query = client._build_query_string(
+        [
+            ("timeframe", "5Min"),
+            ("limit", 240),
+            ("symbol", "SPY"),
+        ]
+    )
+
+    assert query == "limit=240&symbol=SPY&timeframe=5Min"
 
 
 @pytest.mark.asyncio()
@@ -298,7 +312,7 @@ async def test_fetch_historical_bars_uses_signed_market_data_headers(
     client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
 
     route = respx.get(
-        "http://market-data.local/api/v1/market-data/SPY/bars?timeframe=5Min&limit=240"
+        "http://market-data.local/api/v1/market-data/SPY/bars?limit=240&timeframe=5Min"
     ).mock(return_value=httpx.Response(200, json={"symbol": "SPY", "timeframe": "5Min", "bars": []}))
 
     try:

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -175,6 +175,51 @@ def test_get_auth_headers_signature(monkeypatch: pytest.MonkeyPatch) -> None:
     assert headers["X-User-Signature"] == expected_sig
 
 
+def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Market-data headers include valid C6 internal token fields."""
+    monkeypatch.setattr(config, "DEBUG", True)
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+    monkeypatch.setattr("apps.web_console_ng.core.client.time.time", lambda: 1700000000)
+    monkeypatch.setattr(
+        "apps.web_console_ng.core.client.uuid.uuid4",
+        lambda: "00000000-0000-0000-0000-000000000001",
+    )
+
+    client = AsyncTradingClient.get()
+    headers = client._get_market_data_auth_headers(
+        method="GET",
+        path="/api/v1/market-data/SPY/bars",
+        query="timeframe=5Min&limit=240",
+        body=None,
+        user_id="user-1",
+        role="trader",
+        strategies=["b", "a"],
+    )
+
+    payload_data = {
+        "service_id": "web_console_ng",
+        "method": "GET",
+        "path": "/api/v1/market-data/SPY/bars",
+        "query": "timeframe=5Min&limit=240",
+        "timestamp": "1700000000",
+        "nonce": "00000000-0000-0000-0000-000000000001",
+        "user_id": "user-1",
+        "strategy_id": "a",
+        "body_hash": hashlib.sha256(b"").hexdigest(),
+    }
+    payload = json.dumps(payload_data, separators=(",", ":"), sort_keys=True)
+    expected_sig = hmac.new(b"secret", payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    assert headers["X-Service-ID"] == "web_console_ng"
+    assert headers["X-Internal-Timestamp"] == "1700000000"
+    assert headers["X-Internal-Nonce"] == "00000000-0000-0000-0000-000000000001"
+    assert headers["X-Internal-Token"] == expected_sig
+    assert headers["X-Body-Hash"] == hashlib.sha256(b"").hexdigest()
+    assert headers["X-User-Id"] == "user-1"
+    assert headers["X-Strategy-ID"] == "a"
+
+
 @pytest.mark.asyncio()
 @respx.mock
 async def test_fetch_kill_switch_status_maps_active(
@@ -189,6 +234,50 @@ async def test_fetch_kill_switch_status_maps_active(
 
     assert result["state"] == "DISENGAGED"
     assert route.call_count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_fetch_historical_bars_uses_signed_market_data_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Historical bars request uses market-data URL and C6 S2S headers."""
+    monkeypatch.setattr(config, "DEBUG", True)
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+    monkeypatch.setattr("apps.web_console_ng.core.client.time.time", lambda: 1700000000)
+    monkeypatch.setattr(
+        "apps.web_console_ng.core.client.uuid.uuid4",
+        lambda: "00000000-0000-0000-0000-000000000002",
+    )
+
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.get(
+        "http://market-data.local/api/v1/market-data/SPY/bars?timeframe=5Min&limit=240"
+    ).mock(return_value=httpx.Response(200, json={"symbol": "SPY", "timeframe": "5Min", "bars": []}))
+
+    try:
+        result = await client.fetch_historical_bars(
+            symbol="spy",
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            timeframe="5Min",
+            limit=240,
+        )
+    finally:
+        await client.shutdown()
+
+    assert result["symbol"] == "SPY"
+    assert route.call_count == 1
+
+    request = route.calls[0].request
+    assert request.headers.get("X-Service-ID") == "web_console_ng"
+    assert request.headers.get("X-Internal-Token")
+    assert request.headers.get("X-User-ID") == "user-1"
 
 
 def test_json_dict_requires_object() -> None:

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -383,7 +383,11 @@ async def test_fetch_historical_bars_uses_signed_market_data_headers(
 
 @pytest.mark.asyncio()
 @respx.mock
-async def test_subscribe_market_data_symbols_includes_source_when_provided() -> None:
+async def test_subscribe_market_data_symbols_includes_source_when_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
     client = AsyncTradingClient.get()
     client._http_client = httpx.AsyncClient(base_url="http://testserver")
     client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
@@ -418,7 +422,11 @@ async def test_subscribe_market_data_symbols_includes_source_when_provided() -> 
 
 @pytest.mark.asyncio()
 @respx.mock
-async def test_unsubscribe_market_data_symbol_passes_source_query_param() -> None:
+async def test_unsubscribe_market_data_symbol_passes_source_query_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
     client = AsyncTradingClient.get()
     client._http_client = httpx.AsyncClient(base_url="http://testserver")
     client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
@@ -426,6 +434,80 @@ async def test_unsubscribe_market_data_symbol_passes_source_query_param() -> Non
     route = respx.delete(
         "http://market-data.local/api/v1/subscribe/AAPL?source=web_console%3Auser-1%3Aabc"
     ).mock(
+        return_value=httpx.Response(
+            200,
+            json={"message": "ok", "remaining_subscriptions": 0},
+        )
+    )
+
+    try:
+        result = await client.unsubscribe_market_data_symbol(
+            "AAPL",
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            source="web_console:user-1:abc",
+        )
+    finally:
+        await client.shutdown()
+
+    assert result["remaining_subscriptions"] == 0
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_subscribe_market_data_symbols_omits_source_without_internal_signing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INTERNAL_TOKEN_SECRET", raising=False)
+    monkeypatch.delenv("INTERNAL_TOKEN_SECRET_WEB_CONSOLE_NG", raising=False)
+
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.post("http://market-data.local/api/v1/subscribe").mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "message": "ok",
+                "subscribed_symbols": ["AAPL"],
+                "total_subscriptions": 1,
+            },
+        )
+    )
+
+    try:
+        result = await client.subscribe_market_data_symbols(
+            ["AAPL"],
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            source="web_console:user-1:abc",
+        )
+    finally:
+        await client.shutdown()
+
+    assert result["total_subscriptions"] == 1
+    request = route.calls[0].request
+    payload = json.loads(request.content)
+    assert payload == {"symbols": ["AAPL"]}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_unsubscribe_market_data_symbol_omits_source_without_internal_signing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INTERNAL_TOKEN_SECRET", raising=False)
+    monkeypatch.delenv("INTERNAL_TOKEN_SECRET_WEB_CONSOLE_NG", raising=False)
+
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.delete("http://market-data.local/api/v1/subscribe/AAPL").mock(
         return_value=httpx.Response(
             200,
             json={"message": "ok", "remaining_subscriptions": 0},

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -220,10 +220,10 @@ def test_get_market_data_auth_headers_signature(monkeypatch: pytest.MonkeyPatch)
     assert headers["X-Strategy-ID"] == "alpha"
 
 
-def test_get_market_data_auth_headers_omits_strategy_id_for_ambiguous_context(
+def test_get_market_data_auth_headers_uses_deterministic_strategy_id_for_multi_strategy_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Do not forward arbitrary strategy IDs when multiple strategies are present."""
+    """Use stable strategy-id fallback when multiple strategies are present."""
     monkeypatch.setattr(config, "DEBUG", True)
     monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
     monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
@@ -252,14 +252,14 @@ def test_get_market_data_auth_headers_omits_strategy_id_for_ambiguous_context(
         "timestamp": "1700000000",
         "nonce": "00000000-0000-0000-0000-000000000003",
         "user_id": "user-1",
-        "strategy_id": "",
+        "strategy_id": "alpha",
         "body_hash": hashlib.sha256(b"").hexdigest(),
     }
     payload = json.dumps(payload_data, separators=(",", ":"), sort_keys=True)
     expected_sig = hmac.new(b"secret", payload.encode("utf-8"), hashlib.sha256).hexdigest()
 
     assert headers["X-Internal-Token"] == expected_sig
-    assert "X-Strategy-ID" not in headers
+    assert headers["X-Strategy-ID"] == "alpha"
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -383,11 +383,7 @@ async def test_fetch_historical_bars_uses_signed_market_data_headers(
 
 @pytest.mark.asyncio()
 @respx.mock
-async def test_subscribe_market_data_symbols_includes_source_when_provided(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
-    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+async def test_subscribe_market_data_symbols_includes_source_when_provided() -> None:
     client = AsyncTradingClient.get()
     client._http_client = httpx.AsyncClient(base_url="http://testserver")
     client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
@@ -422,11 +418,7 @@ async def test_subscribe_market_data_symbols_includes_source_when_provided(
 
 @pytest.mark.asyncio()
 @respx.mock
-async def test_unsubscribe_market_data_symbol_passes_source_query_param(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
-    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+async def test_unsubscribe_market_data_symbol_passes_source_query_param() -> None:
     client = AsyncTradingClient.get()
     client._http_client = httpx.AsyncClient(base_url="http://testserver")
     client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
@@ -434,80 +426,6 @@ async def test_unsubscribe_market_data_symbol_passes_source_query_param(
     route = respx.delete(
         "http://market-data.local/api/v1/subscribe/AAPL?source=web_console%3Auser-1%3Aabc"
     ).mock(
-        return_value=httpx.Response(
-            200,
-            json={"message": "ok", "remaining_subscriptions": 0},
-        )
-    )
-
-    try:
-        result = await client.unsubscribe_market_data_symbol(
-            "AAPL",
-            user_id="user-1",
-            role="trader",
-            strategies=["alpha"],
-            source="web_console:user-1:abc",
-        )
-    finally:
-        await client.shutdown()
-
-    assert result["remaining_subscriptions"] == 0
-    assert route.call_count == 1
-
-
-@pytest.mark.asyncio()
-@respx.mock
-async def test_subscribe_market_data_symbols_omits_source_without_internal_signing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("INTERNAL_TOKEN_SECRET", raising=False)
-    monkeypatch.delenv("INTERNAL_TOKEN_SECRET_WEB_CONSOLE_NG", raising=False)
-
-    client = AsyncTradingClient.get()
-    client._http_client = httpx.AsyncClient(base_url="http://testserver")
-    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
-
-    route = respx.post("http://market-data.local/api/v1/subscribe").mock(
-        return_value=httpx.Response(
-            201,
-            json={
-                "message": "ok",
-                "subscribed_symbols": ["AAPL"],
-                "total_subscriptions": 1,
-            },
-        )
-    )
-
-    try:
-        result = await client.subscribe_market_data_symbols(
-            ["AAPL"],
-            user_id="user-1",
-            role="trader",
-            strategies=["alpha"],
-            source="web_console:user-1:abc",
-        )
-    finally:
-        await client.shutdown()
-
-    assert result["total_subscriptions"] == 1
-    request = route.calls[0].request
-    payload = json.loads(request.content)
-    assert payload == {"symbols": ["AAPL"]}
-
-
-@pytest.mark.asyncio()
-@respx.mock
-async def test_unsubscribe_market_data_symbol_omits_source_without_internal_signing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("INTERNAL_TOKEN_SECRET", raising=False)
-    monkeypatch.delenv("INTERNAL_TOKEN_SECRET_WEB_CONSOLE_NG", raising=False)
-
-    client = AsyncTradingClient.get()
-    client._http_client = httpx.AsyncClient(base_url="http://testserver")
-    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
-
-    route = respx.delete("http://market-data.local/api/v1/subscribe/AAPL").mock(
         return_value=httpx.Response(
             200,
             json={"message": "ok", "remaining_subscriptions": 0},

--- a/tests/apps/web_console_ng/core/test_client.py
+++ b/tests/apps/web_console_ng/core/test_client.py
@@ -388,6 +388,82 @@ async def test_unsubscribe_market_data_symbol_passes_source_query_param() -> Non
     assert route.call_count == 1
 
 
+@pytest.mark.asyncio()
+@respx.mock
+async def test_subscribe_market_data_symbols_uses_signed_market_data_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "DEBUG", True)
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+    monkeypatch.setattr("apps.web_console_ng.core.client.time.time", lambda: 1700000100)
+    monkeypatch.setattr(
+        "apps.web_console_ng.core.client.uuid.uuid4",
+        lambda: "00000000-0000-0000-0000-000000000010",
+    )
+
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.post("http://market-data.local/api/v1/subscribe").mock(
+        return_value=httpx.Response(201, json={"message": "ok", "subscribed_symbols": [], "total_subscriptions": 0})
+    )
+
+    try:
+        await client.subscribe_market_data_symbols(
+            ["AAPL"],
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+        )
+    finally:
+        await client.shutdown()
+
+    request = route.calls[0].request
+    assert request.headers.get("X-Service-ID") == "web_console_ng"
+    assert request.headers.get("X-Internal-Token")
+    assert request.headers.get("X-Body-Hash")
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_unsubscribe_market_data_symbol_uses_signed_market_data_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "DEBUG", True)
+    monkeypatch.setenv("INTERNAL_TOKEN_SECRET", "secret")
+    monkeypatch.setenv("WEB_CONSOLE_SERVICE_ID", "web_console_ng")
+    monkeypatch.setattr("apps.web_console_ng.core.client.time.time", lambda: 1700000100)
+    monkeypatch.setattr(
+        "apps.web_console_ng.core.client.uuid.uuid4",
+        lambda: "00000000-0000-0000-0000-000000000011",
+    )
+
+    client = AsyncTradingClient.get()
+    client._http_client = httpx.AsyncClient(base_url="http://testserver")
+    client._market_data_client = httpx.AsyncClient(base_url="http://market-data.local")
+
+    route = respx.delete("http://market-data.local/api/v1/subscribe/AAPL").mock(
+        return_value=httpx.Response(200, json={"message": "ok", "remaining_subscriptions": 0})
+    )
+
+    try:
+        await client.unsubscribe_market_data_symbol(
+            "AAPL",
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+        )
+    finally:
+        await client.shutdown()
+
+    request = route.calls[0].request
+    assert request.headers.get("X-Service-ID") == "web_console_ng"
+    assert request.headers.get("X-Internal-Token")
+    assert request.headers.get("X-Body-Hash") == hashlib.sha256(b"").hexdigest()
+
+
 def test_json_dict_requires_object() -> None:
     client = AsyncTradingClient.get()
     response = httpx.Response(200, json=["not", "a", "dict"])

--- a/tests/apps/web_console_ng/core/test_connection_events.py
+++ b/tests/apps/web_console_ng/core/test_connection_events.py
@@ -75,10 +75,12 @@ class DummyLifecycle:
 
     def __init__(self, client_id: str = "client-123") -> None:
         self.client_id = client_id
+        self.generate_calls = 0
         self.registered: list[str] = []
         self.cleaned: list[str] = []
 
     def generate_client_id(self) -> str:
+        self.generate_calls += 1
         return self.client_id
 
     async def register_client(self, client_id: str) -> None:
@@ -217,6 +219,24 @@ async def test_on_connect_registers_client_and_metrics(handlers) -> None:
     assert metrics.ws_connections.set_values == [1]
     assert metrics.ws_connects_total.label_args == [{"pod": config.POD_NAME}]
     assert metrics.ws_connections.label_args == [{"pod": config.POD_NAME}]
+    assert lifecycle.generate_calls == 1
+
+
+@pytest.mark.asyncio()
+async def test_on_connect_reuses_existing_client_id(handlers) -> None:
+    """Reconnect should preserve a previously assigned client_id."""
+    dummy_app, lifecycle, metrics, _semaphore = handlers
+
+    scope = {"state": {}}
+    client = DummyClient(scope)
+    client.storage["client_id"] = "persisted-client-001"
+
+    await dummy_app.on_connect_handler(client)
+
+    assert client.storage["client_id"] == "persisted-client-001"
+    assert lifecycle.registered == ["persisted-client-001"]
+    assert lifecycle.generate_calls == 0
+    assert metrics.ws_connects_total.inc_count == 1
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/core/test_connection_events.py
+++ b/tests/apps/web_console_ng/core/test_connection_events.py
@@ -211,7 +211,9 @@ async def test_on_connect_registers_client_and_metrics(handlers) -> None:
     await dummy_app.on_connect_handler(client)
 
     assert client.storage["client_id"] == "client-123"
+    assert client.storage["session_client_id"] == "client-123"
     assert client.storage["session_conn_key"] == "session_conns:abc"
+    assert scope["state"]["lifecycle_client_id"] == "client-123"
     assert scope["state"]["handshake_complete"] is True
     assert lifecycle.registered == ["client-123"]
     assert health.connection_counter.value == 1
@@ -219,7 +221,7 @@ async def test_on_connect_registers_client_and_metrics(handlers) -> None:
     assert metrics.ws_connections.set_values == [1]
     assert metrics.ws_connects_total.label_args == [{"pod": config.POD_NAME}]
     assert metrics.ws_connections.label_args == [{"pod": config.POD_NAME}]
-    assert lifecycle.generate_calls == 1
+    assert lifecycle.generate_calls == 2
 
 
 @pytest.mark.asyncio()
@@ -229,13 +231,14 @@ async def test_on_connect_reuses_existing_client_id(handlers) -> None:
 
     scope = {"state": {}}
     client = DummyClient(scope)
-    client.storage["client_id"] = "persisted-client-001"
+    client.storage["session_client_id"] = "persisted-client-001"
 
     await dummy_app.on_connect_handler(client)
 
-    assert client.storage["client_id"] == "persisted-client-001"
-    assert lifecycle.registered == ["persisted-client-001"]
-    assert lifecycle.generate_calls == 0
+    assert client.storage["session_client_id"] == "persisted-client-001"
+    assert client.storage["client_id"] == "client-123"
+    assert lifecycle.registered == ["client-123"]
+    assert lifecycle.generate_calls == 1
     assert metrics.ws_connects_total.inc_count == 1
 
 
@@ -344,6 +347,26 @@ async def test_on_disconnect_cleans_up_and_releases(
     assert metrics.ws_disconnects_total.label_args == [{"pod": config.POD_NAME, "reason": "normal"}]
     assert semaphore.release_count == 1
     assert redis.eval_calls
+
+
+@pytest.mark.asyncio()
+async def test_on_disconnect_prefers_scoped_lifecycle_client_id(
+    handlers, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disconnect must use per-connection lifecycle ID, not mutable storage state."""
+    dummy_app, lifecycle, _metrics, _semaphore = handlers
+
+    redis = DummyRedis()
+    monkeypatch.setattr(connection_events, "get_redis_store", lambda: DummyRedisStore(redis))
+
+    scope = {"state": {"handshake_complete": False, "lifecycle_client_id": "old-connection-id"}}
+    client = DummyClient(scope)
+    # Simulate storage overwritten by a newer socket before stale disconnect arrives.
+    client.storage["client_id"] = "new-connection-id"
+
+    await dummy_app.on_disconnect_handler(client)
+
+    assert lifecycle.cleaned == ["old-connection-id"]
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/pages/test_dashboard_dispatch.py
+++ b/tests/apps/web_console_ng/pages/test_dashboard_dispatch.py
@@ -496,9 +496,11 @@ def test_resolve_workspace_connection_pill_read_only_warning() -> None:
 def test_resolve_workspace_kill_switch_pill_states() -> None:
     engaged = dashboard_module.resolve_workspace_kill_switch_pill("ENGAGED")
     disarmed = dashboard_module.resolve_workspace_kill_switch_pill("DISENGAGED")
+    active = dashboard_module.resolve_workspace_kill_switch_pill("ACTIVE")
     unknown = dashboard_module.resolve_workspace_kill_switch_pill(None)
     assert engaged == ("KILL ENGAGED", "danger")
     assert disarmed == ("KILL DISARMED", "muted")
+    assert active == ("KILL DISARMED", "muted")
     assert unknown == ("KILL UNKNOWN", "warning")
 
 

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -327,7 +327,11 @@ class TestOrderEntryContextInitialize:
         ctx._order_ticket.initialize = AsyncMock()
         ctx._order_ticket.set_connection_state = MagicMock()
         ctx._order_ticket.get_current_symbol.return_value = "TSLA"
-        ctx.on_symbol_selected = AsyncMock()
+
+        async def _select_symbol(symbol: str | None) -> None:
+            ctx._selected_symbol = symbol
+
+        ctx.on_symbol_selected = AsyncMock(side_effect=_select_symbol)
 
         ctx._subscribe_to_kill_switch_channel = AsyncMock()
         ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
@@ -341,6 +345,45 @@ class TestOrderEntryContextInitialize:
             await ctx.initialize()
 
         ctx.on_symbol_selected.assert_awaited_once_with("TSLA")
+
+    @pytest.mark.asyncio()
+    async def test_initialize_falls_back_to_watchlist_when_restored_symbol_noops(self) -> None:
+        """Fallback should run when restored symbol selection silently no-ops."""
+        realtime = MagicMock()
+        connection_monitor = MagicMock()
+        connection_monitor.is_read_only.return_value = False
+
+        ctx = OrderEntryContext(
+            realtime_updater=realtime,
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=connection_monitor,
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+        ctx._watchlist = MagicMock()
+        ctx._watchlist.initialize = AsyncMock()
+        ctx._watchlist.get_symbols.return_value = ["SPY", "QQQ"]
+        ctx._order_ticket = MagicMock()
+        ctx._order_ticket.initialize = AsyncMock()
+        ctx._order_ticket.set_connection_state = MagicMock()
+        ctx._order_ticket.get_current_symbol.return_value = "TSLA"
+        ctx.on_symbol_selected = AsyncMock(side_effect=[None, None])
+
+        ctx._subscribe_to_kill_switch_channel = AsyncMock()
+        ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
+        ctx._subscribe_to_connection_channel = AsyncMock()
+        ctx._subscribe_to_positions_channel = AsyncMock()
+        ctx._fetch_initial_safety_state = AsyncMock()
+        ctx._load_initial_risk_limits = AsyncMock()
+
+        with patch("apps.web_console_ng.components.order_entry_context.ui.timer") as timer_mock:
+            timer_mock.return_value = MagicMock()
+            await ctx.initialize()
+
+        assert ctx.on_symbol_selected.await_args_list == [call("TSLA"), call("SPY")]
 
     @pytest.mark.asyncio()
     async def test_initialize_does_not_schedule_market_data_sync_before_late_failures(self) -> None:
@@ -1462,6 +1505,37 @@ class TestMarketDataSync:
         assert context._market_data_sync_pending is False
 
     @pytest.mark.asyncio()
+    async def test_schedule_market_data_sync_backoff_retries_after_failure(
+        self, context: OrderEntryContext
+    ) -> None:
+        """Failed sync should retry once after backoff instead of hot-looping immediately."""
+        run_count = 0
+        context.MARKET_DATA_SYNC_RETRY_DELAY_S = 0
+
+        async def fake_sync() -> None:
+            nonlocal run_count
+            run_count += 1
+            if run_count == 1:
+                context._market_data_sync_pending = True
+                context._market_data_sync_backoff_required = True
+
+        context._sync_market_data_streaming = fake_sync  # type: ignore[method-assign]
+
+        context._schedule_market_data_sync()
+
+        # First sync completes and schedules delayed retry.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert context._market_data_retry_task is not None
+
+        await context._market_data_retry_task
+        if context._market_data_sync_task is not None:
+            await context._market_data_sync_task
+
+        assert run_count == 2
+        assert context._market_data_sync_pending is False
+
+    @pytest.mark.asyncio()
     async def test_sync_market_data_streaming_tracks_race_during_subscribe(
         self, context: OrderEntryContext
     ) -> None:
@@ -1696,6 +1770,18 @@ class TestDispose:
         assert future.done()
         with pytest.raises(asyncio.CancelledError):
             future.result()
+
+    @pytest.mark.asyncio()
+    async def test_dispose_cancels_market_data_retry_task(self, context: OrderEntryContext) -> None:
+        """dispose() cancels any queued market-data backoff retry task."""
+        retry_task = asyncio.create_task(asyncio.sleep(60))
+        context._market_data_retry_task = retry_task
+
+        await context.dispose()
+        await asyncio.sleep(0)
+
+        assert retry_task.cancelled()
+        assert context._market_data_retry_task is None
 
     @pytest.mark.asyncio()
     async def test_dispose_cancels_risk_refresh_task(self, context: OrderEntryContext) -> None:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1307,6 +1307,39 @@ class TestMarketDataSync:
             strategies=["alpha"],
         )
 
+    @pytest.mark.asyncio()
+    async def test_schedule_market_data_sync_requeues_when_inflight(
+        self, context: OrderEntryContext
+    ) -> None:
+        """A sync request arriving mid-flight should trigger one follow-up sync."""
+        run_count = 0
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def fake_sync() -> None:
+            nonlocal run_count
+            run_count += 1
+            if run_count == 1:
+                first_started.set()
+                await release_first.wait()
+
+        context._sync_market_data_streaming = fake_sync  # type: ignore[method-assign]
+
+        context._schedule_market_data_sync()
+        await first_started.wait()
+        context._schedule_market_data_sync()
+
+        assert context._market_data_sync_pending is True
+        release_first.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        if context._market_data_sync_task is not None:
+            await context._market_data_sync_task
+
+        assert run_count == 2
+        assert context._market_data_sync_pending is False
+
 
 class TestDispose:
     """Tests for dispose/cleanup."""

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1638,6 +1638,32 @@ class TestMarketDataSync:
         assert context._last_synced_market_data_symbols == ()
 
     @pytest.mark.asyncio()
+    async def test_sync_market_data_streaming_continues_after_stale_release_failure(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {"price.updated.MSFT": {"watchlist"}}
+        context._last_synced_market_data_symbols = ("AAPL",)
+        context._client.unsubscribe_market_data_symbol = AsyncMock(
+            side_effect=[RuntimeError("down"), RuntimeError("still-down")]
+        )
+        context._client.subscribe_market_data_symbols = AsyncMock(
+            return_value={"message": "ok", "subscribed_symbols": ["MSFT"], "total_subscriptions": 1}
+        )
+        context.MARKET_DATA_UNSUBSCRIBE_RETRY_DELAY_S = 0
+
+        await context._sync_market_data_streaming()
+
+        context._client.subscribe_market_data_symbols.assert_awaited_once_with(
+            ["MSFT"],
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+            source=context._market_data_source,
+        )
+        assert context._pending_market_data_unsubscribes == {"AAPL"}
+        assert context._market_data_sync_pending is True
+
+    @pytest.mark.asyncio()
     async def test_sync_market_data_streaming_marks_pending_after_subscribe_failure(
         self, context: OrderEntryContext
     ) -> None:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1305,6 +1305,7 @@ class TestMarketDataSync:
             user_id="test-user",
             role="trader",
             strategies=["alpha"],
+            source=context._market_data_source,
         )
 
     @pytest.mark.asyncio()
@@ -1339,6 +1340,23 @@ class TestMarketDataSync:
 
         assert run_count == 2
         assert context._market_data_sync_pending is False
+
+    @pytest.mark.asyncio()
+    async def test_release_market_data_streaming_uses_session_source(
+        self,
+        context: OrderEntryContext,
+    ) -> None:
+        context._client.unsubscribe_market_data_symbol = AsyncMock()
+
+        await context._release_market_data_streaming("AAPL")
+
+        context._client.unsubscribe_market_data_symbol.assert_awaited_once_with(
+            "AAPL",
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+            source=context._market_data_source,
+        )
 
 
 class TestDispose:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1850,6 +1850,7 @@ class TestDispose:
     @pytest.mark.asyncio()
     async def test_dispose_cancels_market_data_release_tasks(self, context: OrderEntryContext) -> None:
         """dispose() cancels in-flight async release tasks."""
+        context.MARKET_DATA_RELEASE_FLUSH_TIMEOUT_S = 0
         release_task = asyncio.create_task(asyncio.sleep(60))
         context._market_data_release_tasks.add(release_task)
 
@@ -1857,6 +1858,32 @@ class TestDispose:
         await asyncio.sleep(0)
 
         assert release_task.cancelled()
+        assert context._market_data_release_tasks == set()
+
+    @pytest.mark.asyncio()
+    async def test_dispose_flushes_completed_market_data_release_tasks(
+        self, context: OrderEntryContext
+    ) -> None:
+        """dispose() should allow already-running release tasks to finish cleanly."""
+        release_started = asyncio.Event()
+        allow_release_complete = asyncio.Event()
+
+        async def slow_release() -> None:
+            release_started.set()
+            await allow_release_complete.wait()
+
+        release_task = asyncio.create_task(slow_release())
+        context._market_data_release_tasks.add(release_task)
+
+        dispose_task = asyncio.create_task(context.dispose())
+        await release_started.wait()
+        assert not dispose_task.done()
+
+        allow_release_complete.set()
+        await dispose_task
+
+        assert release_task.done()
+        assert not release_task.cancelled()
         assert context._market_data_release_tasks == set()
 
     @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -285,6 +285,44 @@ class TestOrderEntryContextInitialize:
 
         ctx.on_symbol_selected.assert_awaited_once_with("SPY")
 
+    @pytest.mark.asyncio()
+    async def test_initialize_does_not_schedule_market_data_sync_before_late_failures(self) -> None:
+        """Initialization failures before completion must not trigger market-data sync."""
+        realtime = MagicMock()
+        connection_monitor = MagicMock()
+        connection_monitor.is_read_only.return_value = False
+
+        ctx = OrderEntryContext(
+            realtime_updater=realtime,
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=connection_monitor,
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+        ctx._order_ticket = MagicMock()
+        ctx._order_ticket.initialize = AsyncMock()
+        ctx._order_ticket.set_connection_state = MagicMock()
+        ctx._order_ticket.set_circuit_breaker_state = MagicMock()
+        ctx._order_ticket.set_kill_switch_state = MagicMock()
+
+        ctx._subscribe_to_kill_switch_channel = AsyncMock()
+        ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
+        ctx._subscribe_to_connection_channel = AsyncMock()
+        ctx._subscribe_to_positions_channel = AsyncMock()
+        ctx._fetch_initial_safety_state = AsyncMock()
+        ctx._load_initial_risk_limits = AsyncMock(side_effect=RuntimeError("boom"))
+        ctx._schedule_market_data_sync = MagicMock()
+
+        with patch("apps.web_console_ng.components.order_entry_context.ui.timer") as timer_mock:
+            timer_mock.return_value = MagicMock()
+            with pytest.raises(RuntimeError, match="boom"):
+                await ctx.initialize()
+
+        ctx._schedule_market_data_sync.assert_not_called()
+
 
 class TestFetchInitialSafetyState:
     """Tests for _fetch_initial_safety_state method."""

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1831,6 +1831,23 @@ class TestDispose:
         )
 
     @pytest.mark.asyncio()
+    async def test_dispose_releases_pending_market_data_unsubscribes(
+        self, context: OrderEntryContext
+    ) -> None:
+        """dispose() should also flush symbols queued for retry unsubscribe."""
+        context._pending_market_data_unsubscribes = {"AAPL"}
+
+        await context.dispose()
+
+        context._client.unsubscribe_market_data_symbol.assert_awaited_once_with(
+            "AAPL",
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+            source=context._market_data_source,
+        )
+
+    @pytest.mark.asyncio()
     async def test_dispose_disposes_components(self, context: OrderEntryContext) -> None:
         """dispose() disposes all child components."""
         await context.dispose()

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -171,6 +171,121 @@ class TestStrategyModelContextDispatch:
         )
 
 
+class TestOrderEntryContextInitialize:
+    """Tests for initialize() startup behavior."""
+
+    @pytest.mark.asyncio()
+    async def test_initialize_bootstraps_connected_state_when_unset(self) -> None:
+        """initialize() seeds CONNECTED state if no connection event arrives."""
+        realtime = MagicMock()
+        connection_monitor = MagicMock()
+        connection_monitor.is_read_only.return_value = False
+
+        ctx = OrderEntryContext(
+            realtime_updater=realtime,
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=connection_monitor,
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+        ctx._order_ticket = MagicMock()
+        ctx._order_ticket.initialize = AsyncMock()
+        ctx._order_ticket.set_connection_state = MagicMock()
+        callback = MagicMock()
+        ctx.set_connection_state_callback(callback)
+
+        ctx._subscribe_to_kill_switch_channel = AsyncMock()
+        ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
+        ctx._subscribe_to_connection_channel = AsyncMock()
+        ctx._subscribe_to_positions_channel = AsyncMock()
+        ctx._fetch_initial_safety_state = AsyncMock()
+        ctx._load_initial_risk_limits = AsyncMock()
+
+        with patch("apps.web_console_ng.components.order_entry_context.ui.timer") as timer_mock:
+            timer_mock.return_value = MagicMock()
+            await ctx.initialize()
+
+        assert ctx._cached_connection_state == "CONNECTED"
+        ctx._order_ticket.set_connection_state.assert_called_with("CONNECTED", False)
+        callback.assert_called_with("CONNECTED", False)
+
+    @pytest.mark.asyncio()
+    async def test_initialize_bootstraps_disconnected_state_when_read_only(self) -> None:
+        """initialize() seeds DISCONNECTED state when monitor is read-only."""
+        realtime = MagicMock()
+        connection_monitor = MagicMock()
+        connection_monitor.is_read_only.return_value = True
+
+        ctx = OrderEntryContext(
+            realtime_updater=realtime,
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=connection_monitor,
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+        ctx._order_ticket = MagicMock()
+        ctx._order_ticket.initialize = AsyncMock()
+        ctx._order_ticket.set_connection_state = MagicMock()
+
+        ctx._subscribe_to_kill_switch_channel = AsyncMock()
+        ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
+        ctx._subscribe_to_connection_channel = AsyncMock()
+        ctx._subscribe_to_positions_channel = AsyncMock()
+        ctx._fetch_initial_safety_state = AsyncMock()
+        ctx._load_initial_risk_limits = AsyncMock()
+
+        with patch("apps.web_console_ng.components.order_entry_context.ui.timer") as timer_mock:
+            timer_mock.return_value = MagicMock()
+            await ctx.initialize()
+
+        assert ctx._cached_connection_state == "DISCONNECTED"
+        ctx._order_ticket.set_connection_state.assert_called_with("DISCONNECTED", True)
+
+    @pytest.mark.asyncio()
+    async def test_initialize_auto_selects_first_watchlist_symbol(self) -> None:
+        """initialize() auto-selects the first watchlist symbol when none selected."""
+        realtime = MagicMock()
+        connection_monitor = MagicMock()
+        connection_monitor.is_read_only.return_value = False
+
+        ctx = OrderEntryContext(
+            realtime_updater=realtime,
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=connection_monitor,
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+        ctx._watchlist = MagicMock()
+        ctx._watchlist.initialize = AsyncMock()
+        ctx._watchlist.get_symbols.return_value = ["SPY", "QQQ"]
+        ctx._order_ticket = MagicMock()
+        ctx._order_ticket.initialize = AsyncMock()
+        ctx._order_ticket.set_connection_state = MagicMock()
+        ctx.on_symbol_selected = AsyncMock()
+
+        ctx._subscribe_to_kill_switch_channel = AsyncMock()
+        ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
+        ctx._subscribe_to_connection_channel = AsyncMock()
+        ctx._subscribe_to_positions_channel = AsyncMock()
+        ctx._fetch_initial_safety_state = AsyncMock()
+        ctx._load_initial_risk_limits = AsyncMock()
+
+        with patch("apps.web_console_ng.components.order_entry_context.ui.timer") as timer_mock:
+            timer_mock.return_value = MagicMock()
+            await ctx.initialize()
+
+        ctx.on_symbol_selected.assert_awaited_once_with("SPY")
+
+
 class TestFetchInitialSafetyState:
     """Tests for _fetch_initial_safety_state method."""
 
@@ -1144,6 +1259,55 @@ class TestChannelOwnership:
         assert "selected" in context._channel_owners["prices:AAPL"]
 
 
+class TestMarketDataSync:
+    """Tests for market-data stream synchronization helpers."""
+
+    @pytest.fixture()
+    def context(self) -> OrderEntryContext:
+        return OrderEntryContext(
+            realtime_updater=AsyncMock(),
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=MagicMock(),
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+
+    def test_collect_owned_price_symbols_filters_and_sorts(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {
+            "price.updated.msft": {"watchlist"},
+            "price.updated.AAPL": {"selected_symbol"},
+            "orders:test-user": {"orders"},
+        }
+
+        symbols = context._collect_owned_price_symbols()
+
+        assert symbols == ["AAPL", "MSFT"]
+
+    @pytest.mark.asyncio()
+    async def test_sync_market_data_streaming_batches_symbols(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {
+            "price.updated.MSFT": {"watchlist"},
+            "price.updated.AAPL": {"watchlist"},
+        }
+        context._client.subscribe_market_data_symbols = AsyncMock()
+
+        await context._sync_market_data_streaming()
+
+        context._client.subscribe_market_data_symbols.assert_awaited_once_with(
+            ["AAPL", "MSFT"],
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+
+
 class TestDispose:
     """Tests for dispose/cleanup."""
 
@@ -1360,7 +1524,11 @@ class TestFactoryMethods:
             context.create_price_chart(width=800, height=400)
 
             assert context._price_chart is mock_instance
-            mock_instance.create.assert_called_once_with(width=800, height=400)
+            mock_instance.create.assert_called_once_with(
+                width=800,
+                height=400,
+                fill_parent=False,
+            )
 
     def test_create_order_ticket_stores_reference(self, context: OrderEntryContext) -> None:
         """create_order_ticket stores component reference."""

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1474,6 +1474,19 @@ class TestMarketDataSync:
 
         assert symbols == ["AAPL", "MSFT"]
 
+    def test_collect_owned_price_symbols_skips_pending_subscriptions(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {
+            "price.updated.msft": {"watchlist"},
+            "price.updated.AAPL": {"selected_symbol"},
+        }
+        context._pending_subscribes = {"price.updated.msft": MagicMock()}
+
+        symbols = context._collect_owned_price_symbols()
+
+        assert symbols == ["AAPL"]
+
     @pytest.mark.asyncio()
     async def test_sync_market_data_streaming_batches_symbols(
         self, context: OrderEntryContext

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1379,6 +1379,33 @@ class TestChannelOwnership:
         context._realtime.unsubscribe.assert_called_once()
 
     @pytest.mark.asyncio()
+    async def test_release_channel_offloads_market_data_release(self, context: OrderEntryContext) -> None:
+        """Price channel release should not block on upstream unsubscribe retries."""
+        callback = AsyncMock()
+        await context._acquire_channel("price.updated.AAPL", "owner1", callback)
+
+        release_started = asyncio.Event()
+        release_continue = asyncio.Event()
+
+        async def fake_release(symbol: str) -> None:
+            assert symbol == "AAPL"
+            release_started.set()
+            await release_continue.wait()
+
+        context._release_market_data_streaming = fake_release  # type: ignore[method-assign]
+        context._schedule_market_data_sync = MagicMock()
+
+        await asyncio.wait_for(context._release_channel("price.updated.AAPL", "owner1"), timeout=0.1)
+        await asyncio.wait_for(release_started.wait(), timeout=0.1)
+
+        # Sync should trigger only after background release completes.
+        context._schedule_market_data_sync.assert_not_called()
+        release_continue.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        context._schedule_market_data_sync.assert_called_once()
+
+    @pytest.mark.asyncio()
     async def test_callback_mismatch_raises(self, context: OrderEntryContext) -> None:
         """Different callback for same channel raises ValueError."""
         callback1 = AsyncMock()
@@ -1803,6 +1830,18 @@ class TestDispose:
 
         assert retry_task.cancelled()
         assert context._market_data_retry_task is None
+
+    @pytest.mark.asyncio()
+    async def test_dispose_cancels_market_data_release_tasks(self, context: OrderEntryContext) -> None:
+        """dispose() cancels in-flight async release tasks."""
+        release_task = asyncio.create_task(asyncio.sleep(60))
+        context._market_data_release_tasks.add(release_task)
+
+        await context.dispose()
+        await asyncio.sleep(0)
+
+        assert release_task.cancelled()
+        assert context._market_data_release_tasks == set()
 
     @pytest.mark.asyncio()
     async def test_dispose_cancels_risk_refresh_task(self, context: OrderEntryContext) -> None:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1347,6 +1347,31 @@ class TestMarketDataSync:
         )
 
     @pytest.mark.asyncio()
+    async def test_acquire_channel_defers_market_data_sync_while_initializing(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._initializing = True
+        context._schedule_market_data_sync = MagicMock()
+        callback = AsyncMock()
+
+        await context._acquire_channel("price.updated.AAPL", "watchlist", callback)
+
+        context._schedule_market_data_sync.assert_not_called()
+        assert context._last_synced_market_data_symbols is None
+
+    @pytest.mark.asyncio()
+    async def test_acquire_channel_schedules_market_data_sync_after_initialize(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._initializing = False
+        context._schedule_market_data_sync = MagicMock()
+        callback = AsyncMock()
+
+        await context._acquire_channel("price.updated.AAPL", "watchlist", callback)
+
+        context._schedule_market_data_sync.assert_called_once()
+
+    @pytest.mark.asyncio()
     async def test_schedule_market_data_sync_requeues_when_inflight(
         self, context: OrderEntryContext
     ) -> None:
@@ -1380,6 +1405,47 @@ class TestMarketDataSync:
         assert context._market_data_sync_pending is False
 
     @pytest.mark.asyncio()
+    async def test_sync_market_data_streaming_tracks_race_during_subscribe(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {"price.updated.AAPL": {"watchlist"}}
+
+        async def fake_subscribe(*args: object, **kwargs: object) -> None:
+            # Simulate symbol ownership changing while subscribe call is in-flight.
+            context._channel_owners = {}
+
+        context._client.subscribe_market_data_symbols = AsyncMock(side_effect=fake_subscribe)
+
+        await context._sync_market_data_streaming()
+
+        assert context._market_data_sync_pending is True
+        assert context._last_synced_market_data_symbols is None
+        assert context._pending_market_data_unsubscribes == {"AAPL"}
+
+    @pytest.mark.asyncio()
+    async def test_sync_market_data_streaming_retries_pending_unsubscribes_when_empty(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {}
+        context._last_synced_market_data_symbols = ("AAPL",)
+        context._pending_market_data_unsubscribes = {"AAPL"}
+        context._client.unsubscribe_market_data_symbol = AsyncMock(
+            return_value={"message": "ok", "remaining_subscriptions": 0}
+        )
+
+        await context._sync_market_data_streaming()
+
+        context._client.unsubscribe_market_data_symbol.assert_awaited_once_with(
+            "AAPL",
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+            source=context._market_data_source,
+        )
+        assert context._pending_market_data_unsubscribes == set()
+        assert context._last_synced_market_data_symbols == ()
+
+    @pytest.mark.asyncio()
     async def test_release_market_data_streaming_uses_session_source(
         self,
         context: OrderEntryContext,
@@ -1395,6 +1461,21 @@ class TestMarketDataSync:
             strategies=["alpha"],
             source=context._market_data_source,
         )
+
+    @pytest.mark.asyncio()
+    async def test_release_market_data_streaming_retries_and_persists_failed_symbol(
+        self,
+        context: OrderEntryContext,
+    ) -> None:
+        context._client.unsubscribe_market_data_symbol = AsyncMock(
+            side_effect=[RuntimeError("network"), RuntimeError("still-down")]
+        )
+
+        await context._release_market_data_streaming("AAPL")
+
+        assert context._client.unsubscribe_market_data_symbol.await_count == 2
+        assert context._pending_market_data_unsubscribes == {"AAPL"}
+        assert context._last_synced_market_data_symbols is None
 
     @pytest.mark.asyncio()
     async def test_resubscribe_forces_market_data_sync_even_with_same_symbols(

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -51,6 +52,23 @@ class TestOrderEntryContextInit:
         assert OrderEntryContext.OWNER_KILL_SWITCH == "kill_switch"
         assert OrderEntryContext.OWNER_CIRCUIT_BREAKER == "circuit_breaker"
         assert OrderEntryContext.OWNER_CONNECTION == "connection"
+
+    def test_market_data_source_tag_is_bounded_and_valid(self) -> None:
+        """Generated source tag must satisfy market-data service validation rules."""
+        ctx = OrderEntryContext(
+            realtime_updater=MagicMock(),
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=MagicMock(),
+            redis=MagicMock(),
+            user_id="oauth|tenant:user@example.com",
+            role="trader",
+            strategies=["alpha"],
+        )
+
+        assert len(ctx._market_data_source) <= 64
+        assert re.fullmatch(r"[A-Za-z0-9:_-]{1,64}", ctx._market_data_source)
+        assert "oauth|tenant:user@example.com" not in ctx._market_data_source
 
 
 class TestOrderEntryContextComponentSetters:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1379,6 +1379,7 @@ class TestDispose:
         ctx._market_context = AsyncMock()
         ctx._price_chart = AsyncMock()
         ctx._watchlist = AsyncMock()
+        ctx._client.unsubscribe_market_data_symbol = AsyncMock()
         return ctx
 
     @pytest.mark.asyncio()
@@ -1422,6 +1423,40 @@ class TestDispose:
         await context.dispose()
 
         assert context._realtime.unsubscribe.call_count == 2
+
+    @pytest.mark.asyncio()
+    async def test_dispose_releases_owned_market_data_sources(
+        self, context: OrderEntryContext
+    ) -> None:
+        """dispose() should release per-session market-data sources for owned symbols."""
+        context._subscriptions = ["price.updated.AAPL", "price.updated.msft"]
+        context._channel_owners = {
+            "price.updated.AAPL": {"watchlist"},
+            "price.updated.msft": {"selected_symbol"},
+            "orders:test-user": {"orders"},
+        }
+
+        await context.dispose()
+
+        context._client.unsubscribe_market_data_symbol.assert_has_awaits(
+            [
+                call(
+                    "AAPL",
+                    user_id="test-user",
+                    role="trader",
+                    strategies=["alpha"],
+                    source=context._market_data_source,
+                ),
+                call(
+                    "MSFT",
+                    user_id="test-user",
+                    role="trader",
+                    strategies=["alpha"],
+                    source=context._market_data_source,
+                ),
+            ],
+            any_order=False,
+        )
 
     @pytest.mark.asyncio()
     async def test_dispose_disposes_components(self, context: OrderEntryContext) -> None:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1646,7 +1646,8 @@ class TestMarketDataSync:
             side_effect=RuntimeError("temporary upstream outage")
         )
 
-        await context._sync_market_data_streaming()
+        with pytest.raises(RuntimeError, match="temporary upstream outage"):
+            await context._sync_market_data_streaming()
 
         assert context._last_synced_market_data_symbols is None
         assert context._market_data_sync_pending is True
@@ -1677,11 +1678,13 @@ class TestMarketDataSync:
             side_effect=[RuntimeError("network"), RuntimeError("still-down")]
         )
 
-        await context._release_market_data_streaming("AAPL")
+        with pytest.raises(RuntimeError, match="still-down"):
+            await context._release_market_data_streaming("AAPL")
 
         assert context._client.unsubscribe_market_data_symbol.await_count == 2
         assert context._pending_market_data_unsubscribes == {"AAPL"}
         assert context._last_synced_market_data_symbols is None
+        assert context._market_data_sync_pending is True
 
     @pytest.mark.asyncio()
     async def test_resubscribe_forces_market_data_sync_even_with_same_symbols(

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -286,6 +286,45 @@ class TestOrderEntryContextInitialize:
         ctx.on_symbol_selected.assert_awaited_once_with("SPY")
 
     @pytest.mark.asyncio()
+    async def test_initialize_preserves_restored_ticket_symbol(self) -> None:
+        """Restored pending-form symbol should override watchlist default auto-select."""
+        realtime = MagicMock()
+        connection_monitor = MagicMock()
+        connection_monitor.is_read_only.return_value = False
+
+        ctx = OrderEntryContext(
+            realtime_updater=realtime,
+            trading_client=MagicMock(),
+            state_manager=MagicMock(),
+            connection_monitor=connection_monitor,
+            redis=AsyncMock(),
+            user_id="test-user",
+            role="trader",
+            strategies=["alpha"],
+        )
+        ctx._watchlist = MagicMock()
+        ctx._watchlist.initialize = AsyncMock()
+        ctx._watchlist.get_symbols.return_value = ["SPY", "QQQ"]
+        ctx._order_ticket = MagicMock()
+        ctx._order_ticket.initialize = AsyncMock()
+        ctx._order_ticket.set_connection_state = MagicMock()
+        ctx._order_ticket.get_current_symbol.return_value = "TSLA"
+        ctx.on_symbol_selected = AsyncMock()
+
+        ctx._subscribe_to_kill_switch_channel = AsyncMock()
+        ctx._subscribe_to_circuit_breaker_channel = AsyncMock()
+        ctx._subscribe_to_connection_channel = AsyncMock()
+        ctx._subscribe_to_positions_channel = AsyncMock()
+        ctx._fetch_initial_safety_state = AsyncMock()
+        ctx._load_initial_risk_limits = AsyncMock()
+
+        with patch("apps.web_console_ng.components.order_entry_context.ui.timer") as timer_mock:
+            timer_mock.return_value = MagicMock()
+            await ctx.initialize()
+
+        ctx.on_symbol_selected.assert_awaited_once_with("TSLA")
+
+    @pytest.mark.asyncio()
     async def test_initialize_does_not_schedule_market_data_sync_before_late_failures(self) -> None:
         """Initialization failures before completion must not trigger market-data sync."""
         realtime = MagicMock()
@@ -1444,6 +1483,20 @@ class TestMarketDataSync:
         )
         assert context._pending_market_data_unsubscribes == set()
         assert context._last_synced_market_data_symbols == ()
+
+    @pytest.mark.asyncio()
+    async def test_sync_market_data_streaming_marks_pending_after_subscribe_failure(
+        self, context: OrderEntryContext
+    ) -> None:
+        context._channel_owners = {"price.updated.AAPL": {"watchlist"}}
+        context._client.subscribe_market_data_symbols = AsyncMock(
+            side_effect=RuntimeError("temporary upstream outage")
+        )
+
+        await context._sync_market_data_streaming()
+
+        assert context._last_synced_market_data_symbols is None
+        assert context._market_data_sync_pending is True
 
     @pytest.mark.asyncio()
     async def test_release_market_data_streaming_uses_session_source(

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -64,11 +64,32 @@ class TestOrderEntryContextInit:
             user_id="oauth|tenant:user@example.com",
             role="trader",
             strategies=["alpha"],
+            client_id="browser-session-123",
         )
 
         assert len(ctx._market_data_source) <= 64
         assert re.fullmatch(r"[A-Za-z0-9:_-]{1,64}", ctx._market_data_source)
         assert "oauth|tenant:user@example.com" not in ctx._market_data_source
+
+    def test_market_data_source_tag_is_recoverable_per_client(self) -> None:
+        """Same user/client must derive the same source tag for orphan cleanup recovery."""
+        common_kwargs = {
+            "realtime_updater": MagicMock(),
+            "trading_client": MagicMock(),
+            "state_manager": MagicMock(),
+            "connection_monitor": MagicMock(),
+            "redis": MagicMock(),
+            "user_id": "test-user",
+            "role": "trader",
+            "strategies": ["alpha"],
+        }
+
+        ctx_a = OrderEntryContext(**common_kwargs, client_id="client-a")
+        ctx_a_repeat = OrderEntryContext(**common_kwargs, client_id="client-a")
+        ctx_b = OrderEntryContext(**common_kwargs, client_id="client-b")
+
+        assert ctx_a._market_data_source == ctx_a_repeat._market_data_source
+        assert ctx_a._market_data_source != ctx_b._market_data_source
 
 
 class TestOrderEntryContextComponentSetters:

--- a/tests/apps/web_console_ng/test_order_entry_context.py
+++ b/tests/apps/web_console_ng/test_order_entry_context.py
@@ -1396,6 +1396,24 @@ class TestMarketDataSync:
             source=context._market_data_source,
         )
 
+    @pytest.mark.asyncio()
+    async def test_resubscribe_forces_market_data_sync_even_with_same_symbols(
+        self,
+        context: OrderEntryContext,
+    ) -> None:
+        callback = AsyncMock()
+        context._subscriptions = ["price.updated.AAPL"]
+        context._channel_owners = {"price.updated.AAPL": {"watchlist"}}
+        context._channel_callbacks = {"price.updated.AAPL": callback}
+        context._last_synced_market_data_symbols = ("AAPL",)
+        context._schedule_market_data_sync = MagicMock()
+
+        await context._resubscribe_all_channels()
+
+        context._realtime.subscribe.assert_awaited_once_with("price.updated.AAPL", callback)
+        assert context._last_synced_market_data_symbols is None
+        context._schedule_market_data_sync.assert_called_once()
+
 
 class TestDispose:
     """Tests for dispose/cleanup."""

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -9,6 +9,7 @@ import pytest
 
 from apps.web_console_ng.components.price_chart import (
     MAX_FUTURE_TICK_SKEW_S,
+    MAX_PAST_TICK_SKEW_S,
     REALTIME_STALE_THRESHOLD_S,
     CandleData,
     ExecutionMarker,
@@ -233,18 +234,19 @@ class TestPriceChartPriceData:
     ) -> None:
         """set_price_data updates timestamp on valid data."""
         component._current_symbol = "AAPL"
+        now = datetime.now(UTC)
 
         with patch("asyncio.create_task"):
             component.set_price_data(
                 {
                     "symbol": "AAPL",
                     "price": 150.0,
-                    "timestamp": "2024-01-01T12:00:00Z",
+                    "timestamp": now.isoformat(),
                 }
             )
 
         assert component._last_realtime_update is not None
-        assert component._last_realtime_update.year == 2024
+        assert abs((component._last_realtime_update - now).total_seconds()) < 1
 
     def test_set_price_data_handles_missing_timestamp(self, component: PriceChartComponent) -> None:
         """set_price_data sets timestamp to None when missing (FAIL-CLOSED)."""
@@ -291,6 +293,23 @@ class TestPriceChartPriceData:
                     "symbol": "AAPL",
                     "price": 150.0,
                     "timestamp": future_ts.isoformat(),
+                }
+            )
+
+        assert component._last_realtime_update is None
+        mock_create_task.assert_not_called()
+
+    def test_set_price_data_rejects_past_skew_timestamp(self, component: PriceChartComponent) -> None:
+        """set_price_data drops stale delayed ticks outside allowed past skew."""
+        component._current_symbol = "AAPL"
+        stale_ts = datetime.now(UTC) - timedelta(seconds=MAX_PAST_TICK_SKEW_S + 5)
+
+        with patch("asyncio.create_task") as mock_create_task:
+            component.set_price_data(
+                {
+                    "symbol": "AAPL",
+                    "price": 150.0,
+                    "timestamp": stale_ts.isoformat(),
                 }
             )
 

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -489,11 +489,13 @@ class TestPriceChartSymbolChange:
             patch.object(component, "_fetch_candle_data", return_value=[]),
             patch.object(component, "_fetch_execution_markers", return_value=[]),
             patch.object(component, "_update_chart_data", new_callable=AsyncMock),
+            patch.object(component, "_clear_chart_series", new_callable=AsyncMock) as mock_clear_series,
             patch.object(component, "_show_no_data_overlay", new_callable=AsyncMock) as mock_show,
             patch.object(component, "_hide_no_data_overlay", new_callable=AsyncMock) as mock_hide,
         ):
             await component.on_symbol_changed("AAPL")
 
+        mock_clear_series.assert_awaited_once()
         mock_show.assert_awaited_once_with("AAPL")
         mock_hide.assert_not_called()
 

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -586,6 +586,69 @@ class TestPriceChartRealtimeUpdates:
         assert len(component._candles) == 1
         assert component._candles[0].close == 101.25
 
+    @pytest.mark.asyncio()
+    async def test_handle_price_update_ignores_out_of_order_tick(self) -> None:
+        """Out-of-order ticks should not mutate the latest candle."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._chart_initialized = True
+        component._candles = [
+            CandleData(time=1200, open=100.0, high=101.0, low=99.5, close=100.5, volume=None),
+        ]
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+        component._hide_no_data_overlay = AsyncMock()  # type: ignore[method-assign]
+        component._hide_stale_overlay = AsyncMock()  # type: ignore[method-assign]
+
+        before = component._candles.copy()
+        await component._handle_price_update(99.0, datetime.fromtimestamp(900, UTC))
+
+        assert component._candles == before
+        component._run_javascript.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_handle_price_update_trim_syncs_chart_data(self) -> None:
+        """When Python history is trimmed, JS chart should be reset with setData."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._chart_initialized = True
+        component._candles = [
+            CandleData(
+                time=300 * i,
+                open=100.0 + i,
+                high=101.0 + i,
+                low=99.0 + i,
+                close=100.5 + i,
+                volume=None,
+            )
+            for i in range(500)
+        ]
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+        component._hide_no_data_overlay = AsyncMock()  # type: ignore[method-assign]
+        component._hide_stale_overlay = AsyncMock()  # type: ignore[method-assign]
+
+        last_time = component._candles[-1].time
+        await component._handle_price_update(900.0, datetime.fromtimestamp(last_time + 300, UTC))
+
+        assert len(component._candles) == 500
+        assert component._candles[-1].close == 900.0
+        component._run_javascript.assert_awaited()
+        js_payload = component._run_javascript.await_args.args[0]
+        assert "setData(" in js_payload
+
+
+class TestPriceChartOverlays:
+    """Tests for chart overlays."""
+
+    @pytest.mark.asyncio()
+    async def test_show_no_data_overlay_updates_symbol_text(self) -> None:
+        """Existing overlay subtitle should be refreshed when symbol changes."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+
+        await component._show_no_data_overlay("AAPL")
+
+        js_payload = component._run_javascript.await_args.args[0]
+        assert ".no-data-overlay-subtitle" in js_payload
+        assert "Selected symbol:" in js_payload
+
 
 class TestPriceChartDispose:
     """Tests for dispose/cleanup."""

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -541,6 +541,85 @@ class TestPriceChartSymbolChange:
         mock_clear.assert_called_once()
 
 
+class TestPriceChartHistoricalBars:
+    """Tests for historical bar fetch integration."""
+
+    @pytest.mark.asyncio()
+    async def test_fetch_candle_data_uses_authenticated_client_signature(self) -> None:
+        client = MagicMock()
+        client.fetch_historical_bars = AsyncMock(
+            return_value={
+                "bars": [
+                    {
+                        "timestamp": "2026-04-20T13:30:00Z",
+                        "open": 180.1,
+                        "high": 181.0,
+                        "low": 179.9,
+                        "close": 180.6,
+                        "volume": 1200,
+                    },
+                    {
+                        "timestamp": "2026-04-20T13:35:00Z",
+                        "open": 180.6,
+                        "high": 181.2,
+                        "low": 180.4,
+                        "close": 181.1,
+                        "volume": 900,
+                    },
+                ]
+            }
+        )
+        component = PriceChartComponent(
+            trading_client=client,
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+        )
+
+        candles = await component._fetch_candle_data("AAPL")
+
+        assert len(candles) == 2
+        assert candles[0].open == 180.1
+        assert candles[1].close == 181.1
+        client.fetch_historical_bars.assert_awaited_once_with(
+            symbol="AAPL",
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            timeframe="5Min",
+            limit=240,
+        )
+
+    @pytest.mark.asyncio()
+    async def test_fetch_candle_data_falls_back_to_legacy_signature(self) -> None:
+        class LegacyClient:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, str, int]] = []
+
+            async def fetch_historical_bars(
+                self, *, symbol: str, timeframe: str, limit: int
+            ) -> dict[str, list[dict[str, object]]]:
+                self.calls.append((symbol, timeframe, limit))
+                return {"bars": []}
+
+        component = PriceChartComponent(
+            trading_client=LegacyClient(),  # type: ignore[arg-type]
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+        )
+
+        candles = await component._fetch_candle_data("MSFT")
+
+        assert candles == []
+        assert component._client.calls == [  # type: ignore[attr-defined]
+            ("MSFT", "5Min", 240),
+            ("MSFT", "15Min", 240),
+            ("MSFT", "1Hour", 200),
+            ("MSFT", "1Day", 120),
+        ]
+
+
 class TestPriceChartExecutionMarkers:
     """Tests for execution-marker fetch compatibility."""
 

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -100,6 +101,8 @@ class TestPriceChartInit:
         assert comp._last_realtime_update is None
         assert comp._chart_init_lock is None
         assert comp._price_update_lock is None
+        assert comp._price_update_task is None
+        assert comp._pending_price_update is None
 
     def test_unique_ids_generated(self) -> None:
         """Each component gets unique chart and container IDs."""
@@ -236,7 +239,7 @@ class TestPriceChartPriceData:
         component._current_symbol = "AAPL"
         now = datetime.now(UTC)
 
-        with patch("asyncio.create_task"):
+        with patch.object(component, "_schedule_price_update") as schedule_update:
             component.set_price_data(
                 {
                     "symbol": "AAPL",
@@ -247,12 +250,13 @@ class TestPriceChartPriceData:
 
         assert component._last_realtime_update is not None
         assert abs((component._last_realtime_update - now).total_seconds()) < 1
+        schedule_update.assert_called_once()
 
     def test_set_price_data_handles_missing_timestamp(self, component: PriceChartComponent) -> None:
         """set_price_data sets timestamp to None when missing (FAIL-CLOSED)."""
         component._current_symbol = "AAPL"
 
-        with patch("asyncio.create_task"):
+        with patch.object(component, "_schedule_price_update") as schedule_update:
             component.set_price_data(
                 {
                     "symbol": "AAPL",
@@ -263,12 +267,13 @@ class TestPriceChartPriceData:
 
         # FAIL-CLOSED: timestamp None when missing
         assert component._last_realtime_update is None
+        schedule_update.assert_not_called()
 
     def test_set_price_data_handles_invalid_timestamp(self, component: PriceChartComponent) -> None:
         """set_price_data sets timestamp to None when invalid (FAIL-CLOSED)."""
         component._current_symbol = "AAPL"
 
-        with patch("asyncio.create_task"):
+        with patch.object(component, "_schedule_price_update") as schedule_update:
             component.set_price_data(
                 {
                     "symbol": "AAPL",
@@ -279,6 +284,7 @@ class TestPriceChartPriceData:
 
         # FAIL-CLOSED: timestamp None when invalid
         assert component._last_realtime_update is None
+        schedule_update.assert_not_called()
 
     def test_set_price_data_rejects_future_skew_timestamp(
         self, component: PriceChartComponent
@@ -287,7 +293,7 @@ class TestPriceChartPriceData:
         component._current_symbol = "AAPL"
         future_ts = datetime.now(UTC) + timedelta(seconds=MAX_FUTURE_TICK_SKEW_S + 5)
 
-        with patch("asyncio.create_task") as mock_create_task:
+        with patch.object(component, "_schedule_price_update") as schedule_update:
             component.set_price_data(
                 {
                     "symbol": "AAPL",
@@ -297,14 +303,14 @@ class TestPriceChartPriceData:
             )
 
         assert component._last_realtime_update is None
-        mock_create_task.assert_not_called()
+        schedule_update.assert_not_called()
 
     def test_set_price_data_rejects_past_skew_timestamp(self, component: PriceChartComponent) -> None:
         """set_price_data drops stale delayed ticks outside allowed past skew."""
         component._current_symbol = "AAPL"
         stale_ts = datetime.now(UTC) - timedelta(seconds=MAX_PAST_TICK_SKEW_S + 5)
 
-        with patch("asyncio.create_task") as mock_create_task:
+        with patch.object(component, "_schedule_price_update") as schedule_update:
             component.set_price_data(
                 {
                     "symbol": "AAPL",
@@ -314,7 +320,7 @@ class TestPriceChartPriceData:
             )
 
         assert component._last_realtime_update is None
-        mock_create_task.assert_not_called()
+        schedule_update.assert_not_called()
 
     def test_set_price_data_ignored_when_disposed(self, component: PriceChartComponent) -> None:
         """set_price_data does nothing when disposed."""
@@ -330,6 +336,56 @@ class TestPriceChartPriceData:
         )
 
         assert component._last_realtime_update is None
+
+    @pytest.mark.asyncio()
+    async def test_set_price_data_coalesces_updates_while_inflight(
+        self, component: PriceChartComponent
+    ) -> None:
+        """Only latest pending tick is kept while one update task is running."""
+        component._current_symbol = "AAPL"
+        started = asyncio.Event()
+        release = asyncio.Event()
+        handled_prices: list[float] = []
+
+        async def fake_handle(price: float, tick_time: datetime, symbol: str | None = None) -> None:
+            handled_prices.append(price)
+            if len(handled_prices) == 1:
+                started.set()
+                await release.wait()
+
+        component._handle_price_update = fake_handle  # type: ignore[method-assign]
+        now = datetime.now(UTC)
+
+        component.set_price_data(
+            {"symbol": "AAPL", "price": 100.0, "timestamp": now.isoformat()}
+        )
+        await started.wait()
+
+        component.set_price_data(
+            {
+                "symbol": "AAPL",
+                "price": 101.0,
+                "timestamp": (now + timedelta(seconds=1)).isoformat(),
+            }
+        )
+        component.set_price_data(
+            {
+                "symbol": "AAPL",
+                "price": 102.0,
+                "timestamp": (now + timedelta(seconds=2)).isoformat(),
+            }
+        )
+
+        assert component._pending_price_update is not None
+        assert component._pending_price_update[0] == 102.0
+
+        release.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        if component._price_update_task is not None:
+            await component._price_update_task
+
+        assert handled_prices == [100.0, 102.0]
 
 
 class TestPriceChartStaleness:

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -97,6 +97,8 @@ class TestPriceChartInit:
         assert comp._markers == []
         assert comp._disposed is False
         assert comp._last_realtime_update is None
+        assert comp._chart_init_lock is None
+        assert comp._price_update_lock is None
 
     def test_unique_ids_generated(self) -> None:
         """Each component gets unique chart and container IDs."""
@@ -717,7 +719,7 @@ class TestPriceChartRealtimeUpdates:
                 close=100.5 + i,
                 volume=None,
             )
-            for i in range(500)
+            for i in range(component.CHART_TRIM_HIGH_WATER_MARK)
         ]
         component._run_javascript = AsyncMock()  # type: ignore[method-assign]
         component._hide_no_data_overlay = AsyncMock()  # type: ignore[method-assign]
@@ -726,7 +728,7 @@ class TestPriceChartRealtimeUpdates:
         last_time = component._candles[-1].time
         await component._handle_price_update(900.0, datetime.fromtimestamp(last_time + 300, UTC))
 
-        assert len(component._candles) == 500
+        assert len(component._candles) == component.MAX_CHART_CANDLES
         assert component._candles[-1].close == 900.0
         component._run_javascript.assert_awaited()
         js_payload = component._run_javascript.await_args.args[0]
@@ -779,6 +781,27 @@ class TestPriceChartOverlays:
         await component._hide_no_data_overlay()
 
         component._run_javascript.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_hide_stale_overlay_skips_when_not_visible(self) -> None:
+        """Hide stale overlay should no-op when nothing is visible."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+
+        await component._hide_stale_overlay()
+
+        component._run_javascript.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_show_stale_overlay_sets_visibility_flag(self) -> None:
+        """Stale overlay flag is tracked for high-frequency update optimization."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+
+        await component._show_stale_overlay(72)
+
+        assert component._stale_overlay_visible is True
+        assert component._fallback_overlay_visible is False
 
 
 class TestPriceChartDispose:

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from apps.web_console_ng.components.price_chart import (
+    MAX_FUTURE_TICK_SKEW_S,
     REALTIME_STALE_THRESHOLD_S,
     CandleData,
     ExecutionMarker,
@@ -274,6 +275,25 @@ class TestPriceChartPriceData:
 
         # FAIL-CLOSED: timestamp None when invalid
         assert component._last_realtime_update is None
+
+    def test_set_price_data_rejects_future_skew_timestamp(
+        self, component: PriceChartComponent
+    ) -> None:
+        """set_price_data drops future-skewed ticks to avoid chart freeze."""
+        component._current_symbol = "AAPL"
+        future_ts = datetime.now(UTC) + timedelta(seconds=MAX_FUTURE_TICK_SKEW_S + 5)
+
+        with patch("asyncio.create_task") as mock_create_task:
+            component.set_price_data(
+                {
+                    "symbol": "AAPL",
+                    "price": 150.0,
+                    "timestamp": future_ts.isoformat(),
+                }
+            )
+
+        assert component._last_realtime_update is None
+        mock_create_task.assert_not_called()
 
     def test_set_price_data_ignored_when_disposed(self, component: PriceChartComponent) -> None:
         """set_price_data does nothing when disposed."""
@@ -633,6 +653,27 @@ class TestPriceChartRealtimeUpdates:
         js_payload = component._run_javascript.await_args.args[0]
         assert "setData(" in js_payload
 
+    @pytest.mark.asyncio()
+    async def test_handle_price_update_new_bucket_uses_tick_as_open(self) -> None:
+        """New candles should use the first tick in the bucket as open/high/low/close."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._chart_initialized = True
+        component._candles = [
+            CandleData(time=1200, open=100.0, high=101.0, low=99.0, close=100.5, volume=None),
+        ]
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+        component._hide_no_data_overlay = AsyncMock()  # type: ignore[method-assign]
+        component._hide_stale_overlay = AsyncMock()  # type: ignore[method-assign]
+
+        await component._handle_price_update(108.0, datetime.fromtimestamp(1500, UTC))
+
+        assert len(component._candles) == 2
+        newest = component._candles[-1]
+        assert newest.open == 108.0
+        assert newest.high == 108.0
+        assert newest.low == 108.0
+        assert newest.close == 108.0
+
 
 class TestPriceChartOverlays:
     """Tests for chart overlays."""
@@ -648,6 +689,17 @@ class TestPriceChartOverlays:
         js_payload = component._run_javascript.await_args.args[0]
         assert ".no-data-overlay-subtitle" in js_payload
         assert "Selected symbol:" in js_payload
+        assert component._no_data_overlay_visible is True
+
+    @pytest.mark.asyncio()
+    async def test_hide_no_data_overlay_skips_when_already_hidden(self) -> None:
+        """Hide should not trigger JS when overlay is already hidden."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+
+        await component._hide_no_data_overlay()
+
+        component._run_javascript.assert_not_awaited()
 
 
 class TestPriceChartDispose:

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -458,6 +458,43 @@ class TestPriceChartSymbolChange:
         assert (datetime.now(UTC) - component._symbol_changed_at).total_seconds() < 1
 
     @pytest.mark.asyncio()
+    async def test_symbol_change_without_candles_shows_no_data_overlay(
+        self, component: PriceChartComponent
+    ) -> None:
+        """No historical candles should show waiting overlay."""
+        with (
+            patch.object(component, "_ensure_chart_initialized", new_callable=AsyncMock),
+            patch.object(component, "_fetch_candle_data", return_value=[]),
+            patch.object(component, "_fetch_execution_markers", return_value=[]),
+            patch.object(component, "_update_chart_data", new_callable=AsyncMock),
+            patch.object(component, "_show_no_data_overlay", new_callable=AsyncMock) as mock_show,
+            patch.object(component, "_hide_no_data_overlay", new_callable=AsyncMock) as mock_hide,
+        ):
+            await component.on_symbol_changed("AAPL")
+
+        mock_show.assert_awaited_once_with("AAPL")
+        mock_hide.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_symbol_change_with_candles_hides_no_data_overlay(
+        self, component: PriceChartComponent
+    ) -> None:
+        """Historical candles should hide waiting overlay."""
+        candles = [CandleData(time=1, open=100, high=100, low=100, close=100, volume=1)]
+        with (
+            patch.object(component, "_ensure_chart_initialized", new_callable=AsyncMock),
+            patch.object(component, "_fetch_candle_data", return_value=candles),
+            patch.object(component, "_fetch_execution_markers", return_value=[]),
+            patch.object(component, "_update_chart_data", new_callable=AsyncMock),
+            patch.object(component, "_show_no_data_overlay", new_callable=AsyncMock) as mock_show,
+            patch.object(component, "_hide_no_data_overlay", new_callable=AsyncMock) as mock_hide,
+        ):
+            await component.on_symbol_changed("AAPL")
+
+        mock_hide.assert_awaited_once()
+        mock_show.assert_not_called()
+
+    @pytest.mark.asyncio()
     async def test_symbol_change_to_none_clears_symbol_changed_at(
         self, component: PriceChartComponent
     ) -> None:
@@ -530,6 +567,24 @@ class TestPriceChartExecutionMarkers:
 
         assert markers == []
         assert client.calls == [100]
+
+
+class TestPriceChartRealtimeUpdates:
+    """Tests for live candle updates."""
+
+    @pytest.mark.asyncio()
+    async def test_handle_price_update_hides_no_data_overlay(self) -> None:
+        """First live tick should hide no-data overlay and seed first candle."""
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._chart_initialized = True
+        component._run_javascript = AsyncMock()  # type: ignore[method-assign]
+        component._hide_no_data_overlay = AsyncMock()  # type: ignore[method-assign]
+
+        await component._handle_price_update(101.25, datetime.now(UTC))
+
+        component._hide_no_data_overlay.assert_awaited_once()
+        assert len(component._candles) == 1
+        assert component._candles[0].close == 101.25
 
 
 class TestPriceChartDispose:

--- a/tests/apps/web_console_ng/test_watchlist.py
+++ b/tests/apps/web_console_ng/test_watchlist.py
@@ -178,6 +178,42 @@ class TestWatchlistInitialize:
             mock_render.assert_called_once()
 
 
+class TestWatchlistAddSymbol:
+    """Tests for add-symbol workflow."""
+
+    @pytest.fixture()
+    def component(self) -> WatchlistComponent:
+        """Create component for add-symbol tests."""
+        client = MagicMock()
+        comp = WatchlistComponent(
+            trading_client=client,
+            on_subscribe_symbol=AsyncMock(),
+        )
+        comp._list_container = MagicMock()
+        comp._add_input = MagicMock()
+        comp._add_input.value = "NVDA"
+        return comp
+
+    @pytest.mark.asyncio()
+    async def test_add_symbol_rolls_back_when_subscribe_fails(
+        self, component: WatchlistComponent
+    ) -> None:
+        """Failed subscribe keeps watchlist unchanged and surfaces an error."""
+        component._on_subscribe_symbol = AsyncMock(side_effect=RuntimeError("subscribe failed"))
+
+        with (
+            patch("apps.web_console_ng.components.watchlist.ui.notify") as notify_mock,
+            patch.object(component, "_render_items") as render_mock,
+        ):
+            await component._add_symbol_from_input()
+
+        assert "NVDA" not in component._items
+        assert "NVDA" not in component._symbol_order
+        assert component._add_input.value == ""
+        render_mock.assert_not_called()
+        notify_mock.assert_called_with("Unable to subscribe NVDA", type="negative")
+
+
 class TestWatchlistPriceData:
     """Tests for price data handling."""
 

--- a/tests/apps/web_console_ng/ui/test_lightweight_charts.py
+++ b/tests/apps/web_console_ng/ui/test_lightweight_charts.py
@@ -25,6 +25,12 @@ def test_chart_init_js_recreates_failed_script_nodes() -> None:
     assert "script.dataset.failed = 'true';" in lightweight_charts.CHART_INIT_JS
 
 
+def test_chart_init_js_uses_minimum_chart_dimensions() -> None:
+    """Initialization should avoid ultra-small 1x1 chart bootstrap sizes."""
+    assert "const MIN_CHART_WIDTH = 320;" in lightweight_charts.CHART_INIT_JS
+    assert "const MIN_CHART_HEIGHT = 180;" in lightweight_charts.CHART_INIT_JS
+
+
 @pytest.mark.asyncio()
 async def test_price_chart_uses_sync_timer_callback_for_init(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/apps/web_console_ng/ui/test_lightweight_charts.py
+++ b/tests/apps/web_console_ng/ui/test_lightweight_charts.py
@@ -67,6 +67,12 @@ async def test_loader_timeout_has_explicit_error(monkeypatch: pytest.MonkeyPatch
         await lightweight_charts.LightweightChartsLoader.ensure_loaded()
 
 
+def test_chart_init_js_resets_loading_promise_after_failure() -> None:
+    """Browser loader should reset promise on failure so later inits can retry."""
+    assert "window.__lwc_loading_promise = null;" in lightweight_charts.CHART_INIT_JS
+    assert "throw loadError;" in lightweight_charts.CHART_INIT_JS
+
+
 @pytest.mark.asyncio()
 async def test_price_chart_uses_sync_timer_callback_for_init(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/apps/web_console_ng/ui/test_lightweight_charts.py
+++ b/tests/apps/web_console_ng/ui/test_lightweight_charts.py
@@ -1,0 +1,86 @@
+"""Tests for Lightweight Charts loading and chart initialization wiring."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apps.web_console_ng.components.price_chart import PriceChartComponent
+from apps.web_console_ng.ui import lightweight_charts
+
+
+@pytest.mark.asyncio()
+async def test_loader_retries_after_failed_first_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loader should recover from a failed first attempt and allow retry."""
+    lightweight_charts.LightweightChartsLoader.reset()
+    load_attempts = 0
+
+    async def fake_run_javascript(script: str, *_args: object, **_kwargs: object) -> object:
+        nonlocal load_attempts
+        if "window.__lwc_ready === true" in script:
+            return True
+        if "document.createElement('script')" in script:
+            load_attempts += 1
+            if load_attempts == 1:
+                raise RuntimeError("first load attempt failed")
+            return None
+        return None
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(lightweight_charts.ui, "run_javascript", fake_run_javascript)
+    monkeypatch.setattr(lightweight_charts.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError, match="first load attempt failed"):
+        await lightweight_charts.LightweightChartsLoader.ensure_loaded()
+
+    assert lightweight_charts.LightweightChartsLoader._loaded is False
+    assert lightweight_charts.LightweightChartsLoader._ready is False
+
+    await lightweight_charts.LightweightChartsLoader.ensure_loaded()
+
+    assert load_attempts == 2
+    assert lightweight_charts.LightweightChartsLoader._ready is True
+
+
+@pytest.mark.asyncio()
+async def test_price_chart_uses_sync_timer_callback_for_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Price chart init timer callback should be sync and schedule async work."""
+    chart = PriceChartComponent(trading_client=MagicMock())
+    callbacks: list[object] = []
+    tracked_timers: list[object] = []
+
+    class _DummyTimer:
+        def cancel(self) -> None:
+            return None
+
+    def fake_timer(_interval: float, callback: object, *, once: bool = False) -> _DummyTimer:
+        assert once is True
+        callbacks.append(callback)
+        return _DummyTimer()
+
+    ensure_chart_initialized = AsyncMock()
+
+    monkeypatch.setattr("apps.web_console_ng.components.price_chart.ui.timer", fake_timer)
+    monkeypatch.setattr(chart, "_ensure_chart_initialized", ensure_chart_initialized)
+    monkeypatch.setattr(chart, "_start_realtime_staleness_monitor", lambda _tracker: None)
+
+    await chart.initialize(timer_tracker=tracked_timers.append)
+
+    assert len(callbacks) == 1
+    assert len(tracked_timers) == 1
+    init_callback = callbacks[0]
+    assert not inspect.iscoroutinefunction(init_callback)
+
+    assert callable(init_callback)
+    init_callback()  # type: ignore[operator]
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    ensure_chart_initialized.assert_awaited_once()

--- a/tests/apps/web_console_ng/ui/test_lightweight_charts.py
+++ b/tests/apps/web_console_ng/ui/test_lightweight_charts.py
@@ -73,6 +73,13 @@ def test_chart_init_js_resets_loading_promise_after_failure() -> None:
     assert "throw loadError;" in lightweight_charts.CHART_INIT_JS
 
 
+def test_chart_init_js_recreates_failed_script_nodes() -> None:
+    """Retry path should remove failed script nodes to avoid hanging listeners."""
+    assert "existing.dataset.failed === 'true'" in lightweight_charts.CHART_INIT_JS
+    assert "existing.remove();" in lightweight_charts.CHART_INIT_JS
+    assert "script.dataset.failed = 'true';" in lightweight_charts.CHART_INIT_JS
+
+
 @pytest.mark.asyncio()
 async def test_price_chart_uses_sync_timer_callback_for_init(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/apps/web_console_ng/ui/test_lightweight_charts.py
+++ b/tests/apps/web_console_ng/ui/test_lightweight_charts.py
@@ -12,61 +12,6 @@ from apps.web_console_ng.components.price_chart import PriceChartComponent
 from apps.web_console_ng.ui import lightweight_charts
 
 
-@pytest.mark.asyncio()
-async def test_loader_retries_after_failed_first_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Loader should recover from a failed first attempt and allow retry."""
-    lightweight_charts.LightweightChartsLoader.reset()
-    load_attempts = 0
-
-    async def fake_run_javascript(script: str, *_args: object, **_kwargs: object) -> object:
-        nonlocal load_attempts
-        if "window.__lwc_ready === true" in script:
-            return True
-        if "document.createElement('script')" in script:
-            load_attempts += 1
-            if load_attempts == 1:
-                raise RuntimeError("first load attempt failed")
-            return None
-        return None
-
-    async def fake_sleep(_delay: float) -> None:
-        return None
-
-    monkeypatch.setattr(lightweight_charts.ui, "run_javascript", fake_run_javascript)
-    monkeypatch.setattr(lightweight_charts.asyncio, "sleep", fake_sleep)
-
-    with pytest.raises(RuntimeError, match="first load attempt failed"):
-        await lightweight_charts.LightweightChartsLoader.ensure_loaded()
-
-    assert lightweight_charts.LightweightChartsLoader._loaded is False
-    assert lightweight_charts.LightweightChartsLoader._ready is False
-
-    await lightweight_charts.LightweightChartsLoader.ensure_loaded()
-
-    assert load_attempts == 2
-    assert lightweight_charts.LightweightChartsLoader._ready is True
-
-
-@pytest.mark.asyncio()
-async def test_loader_timeout_has_explicit_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Loader should raise a timeout-specific error when readiness flag never appears."""
-    lightweight_charts.LightweightChartsLoader.reset()
-
-    async def fake_run_javascript(script: str, *_args: object, **_kwargs: object) -> object:
-        if "window.__lwc_ready === true" in script:
-            return False
-        return None
-
-    async def fake_sleep(_delay: float) -> None:
-        return None
-
-    monkeypatch.setattr(lightweight_charts.ui, "run_javascript", fake_run_javascript)
-    monkeypatch.setattr(lightweight_charts.asyncio, "sleep", fake_sleep)
-
-    with pytest.raises(RuntimeError, match="Timed out waiting for Lightweight Charts readiness flag"):
-        await lightweight_charts.LightweightChartsLoader.ensure_loaded()
-
-
 def test_chart_init_js_resets_loading_promise_after_failure() -> None:
     """Browser loader should reset promise on failure so later inits can retry."""
     assert "window.__lwc_loading_promise = null;" in lightweight_charts.CHART_INIT_JS

--- a/tests/apps/web_console_ng/ui/test_lightweight_charts.py
+++ b/tests/apps/web_console_ng/ui/test_lightweight_charts.py
@@ -48,6 +48,26 @@ async def test_loader_retries_after_failed_first_attempt(monkeypatch: pytest.Mon
 
 
 @pytest.mark.asyncio()
+async def test_loader_timeout_has_explicit_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loader should raise a timeout-specific error when readiness flag never appears."""
+    lightweight_charts.LightweightChartsLoader.reset()
+
+    async def fake_run_javascript(script: str, *_args: object, **_kwargs: object) -> object:
+        if "window.__lwc_ready === true" in script:
+            return False
+        return None
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(lightweight_charts.ui, "run_javascript", fake_run_javascript)
+    monkeypatch.setattr(lightweight_charts.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for Lightweight Charts readiness flag"):
+        await lightweight_charts.LightweightChartsLoader.ensure_loaded()
+
+
+@pytest.mark.asyncio()
 async def test_price_chart_uses_sync_timer_callback_for_init(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/libs/core/redis_client/test_event_publisher.py
+++ b/tests/libs/core/redis_client/test_event_publisher.py
@@ -9,6 +9,7 @@ Tests cover:
 - Error handling
 """
 
+import logging
 from datetime import UTC, datetime
 from unittest.mock import Mock
 
@@ -103,6 +104,47 @@ class TestEventPublisherPublish:
 
         # Should return None on error (graceful degradation)
         assert num_subscribers is None
+
+    def test_publish_price_channel_logs_at_debug(self, mock_publisher, caplog):
+        """High-frequency price channels should log at DEBUG, not INFO."""
+        publisher, mock_redis = mock_publisher
+        mock_redis.publish.return_value = 3
+
+        event = Mock()
+        event.event_type = "price.updated"
+        event.model_dump_json.return_value = '{"event_type":"price.updated"}'
+
+        with caplog.at_level(logging.DEBUG):
+            publisher.publish("price.updated.AAPL", event)
+
+        assert any(
+            rec.levelno == logging.DEBUG and "price.updated.AAPL" in rec.getMessage()
+            for rec in caplog.records
+        )
+        assert not any(
+            rec.levelno == logging.INFO and "price.updated.AAPL" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_publish_signal_channel_logs_at_info(self, mock_publisher, caplog):
+        """Normal control-plane events should continue logging at INFO."""
+        publisher, mock_redis = mock_publisher
+        mock_redis.publish.return_value = 1
+        event = SignalEvent(
+            timestamp=datetime.now(UTC),
+            strategy_id="alpha_baseline",
+            symbols=["AAPL"],
+            num_signals=1,
+            as_of_date="2025-01-17",
+        )
+
+        with caplog.at_level(logging.INFO):
+            publisher.publish("signals.generated", event)
+
+        assert any(
+            rec.levelno == logging.INFO and "signals.generated" in rec.getMessage()
+            for rec in caplog.records
+        )
 
 
 class TestEventPublisherSignalEvents:

--- a/tests/libs/data/market_data/test_provider.py
+++ b/tests/libs/data/market_data/test_provider.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
 from libs.data.market_data.provider import MarketDataProvider
 
 
@@ -24,3 +29,18 @@ def test_compute_bars_window_enforces_minimum_window() -> None:
     assert end > start
     # Small requests still need enough lookback to avoid empty payloads around market closures.
     assert (end - start).days >= 6
+
+
+def test_get_bars_sync_preserves_value_error_for_bad_timeframe() -> None:
+    provider = MarketDataProvider.__new__(MarketDataProvider)
+    provider._data_feed = None
+    provider._client = MagicMock()
+
+    with pytest.raises(ValueError, match="Unsupported timeframe"):
+        provider._get_bars_sync("AAPL", "2Min", 10)
+
+
+def test_extract_bar_list_reads_symbol_from_data_dict() -> None:
+    bars = SimpleNamespace(data={"AAPL": [1, 2], "MSFT": [3]})
+    extracted = MarketDataProvider._extract_bar_list(bars, "AAPL")
+    assert extracted == [1, 2]

--- a/tests/libs/data/market_data/test_provider.py
+++ b/tests/libs/data/market_data/test_provider.py
@@ -44,3 +44,40 @@ def test_extract_bar_list_reads_symbol_from_data_dict() -> None:
     bars = SimpleNamespace(data={"AAPL": [1, 2], "MSFT": [3]})
     extracted = MarketDataProvider._extract_bar_list(bars, "AAPL")
     assert extracted == [1, 2]
+
+
+def test_get_bars_sync_requests_latest_window_with_desc_sort(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = MarketDataProvider.__new__(MarketDataProvider)
+    provider._data_feed = "iex"
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_stock_bars_request(**kwargs: object) -> dict[str, object]:
+        captured_kwargs.update(kwargs)
+        return kwargs
+
+    class FakeClient:
+        def get_stock_bars(self, request: object) -> dict[str, list[dict[str, object]]]:
+            return {
+                "AAPL": [
+                    {
+                        "timestamp": "2026-04-20T15:00:00+00:00",
+                        "open": 1.0,
+                        "high": 2.0,
+                        "low": 0.5,
+                        "close": 1.5,
+                        "volume": 10,
+                    }
+                ]
+            }
+
+    provider._client = FakeClient()
+    monkeypatch.setattr(
+        "libs.data.market_data.provider.StockBarsRequest",
+        fake_stock_bars_request,
+    )
+
+    bars = provider._get_bars_sync("AAPL", "5Min", 10)
+
+    assert captured_kwargs["sort"] == "desc"
+    assert bars[0]["timestamp"] == "2026-04-20T15:00:00+00:00"

--- a/tests/libs/data/market_data/test_provider.py
+++ b/tests/libs/data/market_data/test_provider.py
@@ -1,0 +1,26 @@
+"""Tests for MarketDataProvider helper logic."""
+
+from __future__ import annotations
+
+from libs.data.market_data.provider import MarketDataProvider
+
+
+def test_compute_bars_window_5min_uses_sufficient_lookback() -> None:
+    start, end = MarketDataProvider._compute_bars_window("5Min", 240)
+    assert end > start
+    # 240 x 5-minute bars should request a multi-day window with holiday/weekend buffer.
+    assert (end - start).days >= 12
+
+
+def test_compute_bars_window_daily_scales_for_large_limit() -> None:
+    start, end = MarketDataProvider._compute_bars_window("1Day", 120)
+    assert end > start
+    # 120 daily bars with 3x buffer should cover nearly a year.
+    assert (end - start).days >= 360
+
+
+def test_compute_bars_window_enforces_minimum_window() -> None:
+    start, end = MarketDataProvider._compute_bars_window("1Min", 1)
+    assert end > start
+    # Small requests still need enough lookback to avoid empty payloads around market closures.
+    assert (end - start).days >= 6


### PR DESCRIPTION
## Summary
- fix trade chart rendering path so the terminal no longer appears as a black/empty box
- add clear no-data overlay while waiting for live ticks and improve chart visual contrast
- reduce noisy high-frequency Redis publish logs (`price.updated.*`, `level2.*`) from INFO to DEBUG
- stabilize local dev startup by allowing modelless signal_service startup in docker-compose dev defaults
- downgrade missing-model reload path from ERROR/traceback to WARNING for non-fatal dev behavior

## Validation
- `pytest -q tests/apps/web_console_ng/test_price_chart.py tests/apps/web_console_ng/ui/test_lightweight_charts.py`
- `pytest -q tests/libs/core/redis_client/test_event_publisher.py`
- `pytest -q tests/apps/signal_service/test_model_registry.py`
- visual verification via Playwright against `http://localhost:8080/trade` (chart canvas rendered and overlay visible)
