### PR TITLE
fix(web-console-ng): resolve UI functional regressions and consistency issues

### DIFF
--- a/apps/web_console_ng/components/status_bar.py
+++ b/apps/web_console_ng/components/status_bar.py
@@ -50,6 +50,11 @@ class StatusBar:
                 self._label.set_text("TRADING HALTED (CIRCUIT)")
             self._set_state_classes("ENGAGED")
             return
+        if normalized == "ENGAGED":
+            if self._label:
+                self._label.set_text("TRADING HALTED")
+            self._set_state_classes("ENGAGED")
+            return
         if cb_normalized == "QUIET_PERIOD":
             if self._label:
                 self._label.set_text("TRADING PAUSED (QUIET)")
@@ -57,9 +62,7 @@ class StatusBar:
             return
 
         if self._label:
-            if normalized == "ENGAGED":
-                self._label.set_text("TRADING HALTED")
-            elif normalized in {"DISENGAGED", "ACTIVE"}:
+            if normalized in {"DISENGAGED", "ACTIVE"}:
                 self._label.set_text("TRADING ACTIVE")
             else:
                 self._label.set_text("TRADING STATUS UNKNOWN")

--- a/apps/web_console_ng/components/status_bar.py
+++ b/apps/web_console_ng/components/status_bar.py
@@ -40,9 +40,22 @@ class StatusBar:
                 remove="bg-red-600 bg-green-600 text-white",
             )
 
-    def update_state(self, state: str | None) -> None:
-        """Update status bar text and color based on kill switch state."""
+    def update_state(self, state: str | None, *, circuit_state: str | None = None) -> None:
+        """Update status bar from kill-switch and circuit-breaker state."""
         normalized = (state or "UNKNOWN").upper()
+        cb_normalized = (circuit_state or "UNKNOWN").upper()
+
+        if cb_normalized == "TRIPPED":
+            if self._label:
+                self._label.set_text("TRADING HALTED (CIRCUIT)")
+            self._set_state_classes("ENGAGED")
+            return
+        if cb_normalized == "QUIET_PERIOD":
+            if self._label:
+                self._label.set_text("TRADING PAUSED (QUIET)")
+            self._set_state_classes("UNKNOWN")
+            return
+
         if self._label:
             if normalized == "ENGAGED":
                 self._label.set_text("TRADING HALTED")

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -230,8 +230,20 @@ def build_exposure_rows(
     include_total: bool = True,
 ) -> list[dict[str, Any]]:
     """Build AG Grid rows with per-strategy breakdown + TOTAL row."""
-    # Placeholder payloads should not render synthetic totals.
-    if not exposures and total.is_placeholder:
+    # Do not render synthetic totals before first successful fetch.
+    # Prefer the explicit placeholder marker when present, while still
+    # handling legacy all-zero payloads that omit it.
+    if not exposures and (
+        total.is_placeholder
+        or (
+            total.strategy_count <= 0
+            and total.long_total == 0.0
+            and total.short_total == 0.0
+            and total.gross_total == 0.0
+            and total.net_total == 0.0
+            and total.net_pct == 0.0
+        )
+    ):
         return []
 
     rows = []

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -156,9 +156,11 @@ def render_exposure_unavailable(total: TotalExposureDTO) -> None:
 def render_exposure_grid(
     exposures: list[StrategyExposureDTO],
     total: TotalExposureDTO,
+    *,
+    include_total: bool = True,
 ) -> Any:
     """Render AG Grid with per-strategy exposure breakdown + TOTAL row."""
-    rows = build_exposure_rows(exposures, total)
+    rows = build_exposure_rows(exposures, total, include_total=include_total)
 
     dollar_fmt = "params => params.value != null ? (params.value >= 0 ? '+$' : '-$') + Math.abs(params.value).toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) : '-'"
     pct_fmt = "params => params.value != null ? (params.value >= 0 ? '+' : '') + params.value.toFixed(1) + '%' : '-'"
@@ -224,6 +226,8 @@ def render_exposure_grid(
 def build_exposure_rows(
     exposures: list[StrategyExposureDTO],
     total: TotalExposureDTO,
+    *,
+    include_total: bool = True,
 ) -> list[dict[str, Any]]:
     """Build AG Grid rows with per-strategy breakdown + TOTAL row."""
     # Avoid synthetic "$0 TOTAL" row before first successful fetch.
@@ -252,18 +256,19 @@ def build_exposure_rows(
             }
         )
 
-    # TOTAL row
-    rows.append(
-        {
-            "strategy": "TOTAL",
-            "net": total.net_total,
-            "gross": total.gross_total,
-            "long": total.long_total,
-            "short": total.short_total,
-            "net_pct": total.net_pct,
-            "positions": sum(e.position_count for e in exposures),
-        }
-    )
+    if include_total:
+        # TOTAL row
+        rows.append(
+            {
+                "strategy": "TOTAL",
+                "net": total.net_total,
+                "gross": total.gross_total,
+                "long": total.long_total,
+                "short": total.short_total,
+                "net_pct": total.net_pct,
+                "positions": sum(e.position_count for e in exposures),
+            }
+        )
     return rows
 
 

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -43,12 +43,37 @@ def _metric_card(
 
 def render_exposure_chart(exposures: list[StrategyExposureDTO]) -> None:
     """Render stacked bar chart with Long (green) and Short (red) per strategy."""
+    ui.plotly(build_exposure_chart_figure(exposures)).classes("w-full")
+
+
+def build_exposure_chart_figure(exposures: list[StrategyExposureDTO]) -> go.Figure:
+    """Build stacked bar chart figure for Long/Short by strategy."""
     if not exposures:
-        return
+        fig = go.Figure()
+        fig.update_layout(
+            title="Long vs Short by Strategy",
+            height=320,
+            margin={"l": 10, "r": 10, "t": 40, "b": 20},
+            xaxis={"visible": False},
+            yaxis={"visible": False},
+            annotations=[
+                {
+                    "text": "No exposure data available",
+                    "xref": "paper",
+                    "yref": "paper",
+                    "x": 0.5,
+                    "y": 0.5,
+                    "showarrow": False,
+                    "font": {"size": 13, "color": "#94a3b8"},
+                }
+            ],
+        )
+        return fig
 
     strategies = [e.strategy for e in exposures]
     long_values = [e.long_notional for e in exposures]
     short_values = [-e.short_notional for e in exposures]  # negative for visual stacking
+    bar_width = [0.45 for _ in exposures]
 
     fig = go.Figure(
         data=[
@@ -57,24 +82,27 @@ def render_exposure_chart(exposures: list[StrategyExposureDTO]) -> None:
                 x=strategies,
                 y=long_values,
                 marker_color="#22c55e",
+                width=bar_width,
             ),
             go.Bar(
                 name="Short",
                 x=strategies,
                 y=short_values,
                 marker_color="#ef4444",
+                width=bar_width,
             ),
         ]
     )
     fig.update_layout(
         title="Long vs Short by Strategy",
         barmode="relative",
-        xaxis_title="Strategy",
+        bargap=0.35,
+        xaxis={"title": "Strategy", "type": "category", "categoryorder": "array", "categoryarray": strategies},
         yaxis_title="Notional ($)",
         height=320,
         margin={"l": 10, "r": 10, "t": 40, "b": 20},
     )
-    ui.plotly(fig).classes("w-full")
+    return fig
 
 
 def render_bias_warning(total: TotalExposureDTO) -> None:
@@ -130,32 +158,7 @@ def render_exposure_grid(
     total: TotalExposureDTO,
 ) -> Any:
     """Render AG Grid with per-strategy exposure breakdown + TOTAL row."""
-    rows = []
-    for e in exposures:
-        rows.append(
-            {
-                "strategy": e.strategy,
-                "net": e.net_notional,
-                "gross": e.gross_notional,
-                "long": e.long_notional,
-                "short": e.short_notional,
-                "net_pct": e.net_pct,
-                "positions": e.position_count,
-            }
-        )
-
-    # TOTAL row
-    rows.append(
-        {
-            "strategy": "TOTAL",
-            "net": total.net_total,
-            "gross": total.gross_total,
-            "long": total.long_total,
-            "short": total.short_total,
-            "net_pct": total.net_pct,
-            "positions": sum(e.position_count for e in exposures),
-        }
-    )
+    rows = build_exposure_rows(exposures, total)
 
     dollar_fmt = "params => params.value != null ? (params.value >= 0 ? '+$' : '-$') + Math.abs(params.value).toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) : '-'"
     pct_fmt = "params => params.value != null ? (params.value >= 0 ? '+' : '') + params.value.toFixed(1) + '%' : '-'"
@@ -206,7 +209,8 @@ def render_exposure_grid(
             {
                 "field": "positions",
                 "headerName": "# Pos",
-                "minWidth": 80,
+                "minWidth": 95,
+                "maxWidth": 120,
             },
         ],
         "rowData": rows,
@@ -217,9 +221,45 @@ def render_exposure_grid(
     return ui.aggrid(grid_options).classes("w-full ag-theme-alpine-dark")
 
 
+def build_exposure_rows(
+    exposures: list[StrategyExposureDTO],
+    total: TotalExposureDTO,
+) -> list[dict[str, Any]]:
+    """Build AG Grid rows with per-strategy breakdown + TOTAL row."""
+    rows = []
+    for e in exposures:
+        rows.append(
+            {
+                "strategy": e.strategy,
+                "net": e.net_notional,
+                "gross": e.gross_notional,
+                "long": e.long_notional,
+                "short": e.short_notional,
+                "net_pct": e.net_pct,
+                "positions": e.position_count,
+            }
+        )
+
+    # TOTAL row
+    rows.append(
+        {
+            "strategy": "TOTAL",
+            "net": total.net_total,
+            "gross": total.gross_total,
+            "long": total.long_total,
+            "short": total.short_total,
+            "net_pct": total.net_pct,
+            "positions": sum(e.position_count for e in exposures),
+        }
+    )
+    return rows
+
+
 __all__ = [
     "render_exposure_summary_cards",
     "render_exposure_chart",
+    "build_exposure_chart_figure",
+    "build_exposure_rows",
     "render_bias_warning",
     "render_data_quality_warning",
     "render_exposure_unavailable",

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -226,6 +226,18 @@ def build_exposure_rows(
     total: TotalExposureDTO,
 ) -> list[dict[str, Any]]:
     """Build AG Grid rows with per-strategy breakdown + TOTAL row."""
+    # Avoid synthetic "$0 TOTAL" row before first successful fetch.
+    if (
+        not exposures
+        and total.strategy_count <= 0
+        and total.long_total == 0.0
+        and total.short_total == 0.0
+        and total.gross_total == 0.0
+        and total.net_total == 0.0
+        and total.net_pct == 0.0
+    ):
+        return []
+
     rows = []
     for e in exposures:
         rows.append(

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -230,16 +230,8 @@ def build_exposure_rows(
     include_total: bool = True,
 ) -> list[dict[str, Any]]:
     """Build AG Grid rows with per-strategy breakdown + TOTAL row."""
-    # Avoid synthetic "$0 TOTAL" row before first successful fetch.
-    if (
-        not exposures
-        and total.strategy_count <= 0
-        and total.long_total == 0.0
-        and total.short_total == 0.0
-        and total.gross_total == 0.0
-        and total.net_total == 0.0
-        and total.net_pct == 0.0
-    ):
+    # Placeholder payloads should not render synthetic totals.
+    if not exposures and total.is_placeholder:
         return []
 
     rows = []

--- a/apps/web_console_ng/components/tax_harvesting.py
+++ b/apps/web_console_ng/components/tax_harvesting.py
@@ -7,7 +7,11 @@ from typing import Any
 from nicegui import ui
 
 
-def render_harvesting_suggestions(suggestions: Any | None) -> None:
+def render_harvesting_suggestions(
+    suggestions: Any | None,
+    *,
+    price_status: str | None = None,
+) -> None:
     """Render tax-loss harvesting suggestions as ranked cards.
 
     Args:
@@ -17,11 +21,22 @@ def render_harvesting_suggestions(suggestions: Any | None) -> None:
     ui.label("Tax-Loss Harvesting").classes("text-lg font-bold mb-2")
 
     if suggestions is None:
+        status = (price_status or "unavailable").strip().lower()
+        if status == "no_open_lots":
+            primary = "No open tax lots available yet."
+            secondary = "Harvesting suggestions appear after fills create tax lots."
+        elif status == "permission_denied":
+            primary = "Current prices unavailable for harvesting suggestions."
+            secondary = "Price feed access is restricted for this session."
+        elif status == "no_prices":
+            primary = "Current prices unavailable for harvesting suggestions."
+            secondary = "No quotes returned for current symbols."
+        else:
+            primary = "Current prices unavailable for harvesting suggestions."
+            secondary = "Market data service is temporarily unavailable."
         with ui.card().classes("w-full p-3"):
-            ui.label("Current prices unavailable — harvesting suggestions hidden.").classes(
-                "text-gray-500 text-sm"
-            )
-            ui.label("Price data requires VIEW_PNL permission.").classes("text-gray-400 text-xs")
+            ui.label(primary).classes("text-gray-500 text-sm")
+            ui.label(secondary).classes("text-gray-400 text-xs")
         return
 
     opportunities = getattr(suggestions, "opportunities", [])

--- a/apps/web_console_ng/components/tax_lot_table.py
+++ b/apps/web_console_ng/components/tax_lot_table.py
@@ -54,49 +54,58 @@ def render_tax_lot_table(
         )
 
     column_defs: list[dict[str, Any]] = [
-        {"headerName": "Symbol", "field": "symbol", "width": 100, "filter": True},
+        {"headerName": "Symbol", "field": "symbol", "minWidth": 110, "width": 120, "filter": True},
         {
             "headerName": "Quantity",
             "field": "quantity",
-            "width": 100,
+            "minWidth": 100,
+            "width": 110,
             "type": "numericColumn",
             ":valueFormatter": "x => x.value != null ? x.value.toFixed(2) : '-'",
         },
         {
             "headerName": "Cost Basis",
             "field": "cost_basis",
-            "width": 120,
+            "minWidth": 120,
+            "width": 130,
             "type": "numericColumn",
             ":valueFormatter": "x => x.value != null ? '$' + x.value.toFixed(2) : '-'",
         },
         {
             "headerName": "Cost/Share",
             "field": "cost_per_share",
-            "width": 110,
+            "minWidth": 120,
+            "width": 130,
             "type": "numericColumn",
             ":valueFormatter": "x => x.value != null ? '$' + x.value.toFixed(2) : '-'",
         },
-        {"headerName": "Acquired", "field": "acquisition_date", "width": 110},
-        {"headerName": "Strategy", "field": "strategy_id", "width": 120},
-        {"headerName": "Status", "field": "status", "width": 80},
-        {"headerName": "Holding", "field": "holding_period", "width": 100},
+        {"headerName": "Acquired", "field": "acquisition_date", "minWidth": 120, "width": 130},
+        {"headerName": "Strategy", "field": "strategy_id", "minWidth": 140, "flex": 1},
+        {"headerName": "Status", "field": "status", "minWidth": 90, "width": 100},
+        {"headerName": "Holding", "field": "holding_period", "minWidth": 120, "width": 130},
         {
             "headerName": "Wash Sale",
             "field": "wash_sale",
-            "width": 90,
-            "cellStyle": "params.value === 'Yes' ? {'color': 'red', 'fontWeight': 'bold'} : {}",
+            "minWidth": 110,
+            "width": 120,
+            ":cellStyle": "params => params.value === 'Yes' ? {'color': 'red', 'fontWeight': 'bold'} : {}",
         },
     ]
 
     grid_options: dict[str, Any] = {
         "columnDefs": column_defs,
         "rowData": rows,
-        "defaultColDef": {"sortable": True, "resizable": True},
+        "defaultColDef": {
+            "sortable": True,
+            "resizable": True,
+            "minWidth": 100,
+            "suppressSizeToFit": False,
+        },
         "rowSelection": "single" if (on_select or (on_close and can_close)) else None,
-        "domLayout": "autoHeight",
+        "domLayout": "normal",
     }
 
-    grid = ui.aggrid(grid_options).classes("w-full ag-theme-alpine-dark")
+    grid = ui.aggrid(grid_options).classes("w-full h-96 ag-theme-alpine-dark")
 
     if on_select:
 

--- a/apps/web_console_ng/pages/attribution.py
+++ b/apps/web_console_ng/pages/attribution.py
@@ -105,6 +105,24 @@ async def attribution_page(client: Client) -> None:
             ui.label("Factor data directory not configured. Set FF_DATA_DIR in settings.").classes(
                 "text-gray-600"
             )
+            with ui.row().classes("mt-4 gap-2"):
+                ui.button(
+                    "Open Data Hub",
+                    icon="storage",
+                    on_click=lambda: ui.navigate.to(
+                        resolve_rooted_path_from_ui("/data", ui_module=ui)
+                    ),
+                ).props("flat")
+                ui.button(
+                    "Open Setup Guide",
+                    icon="description",
+                    on_click=lambda: ui.navigate.to(
+                        resolve_rooted_path_from_ui(
+                            "/data/sources",
+                            ui_module=ui,
+                        )
+                    ),
+                ).props("flat")
         return
 
     ff_data_path = Path(settings.ff_data_dir)
@@ -115,6 +133,19 @@ async def attribution_page(client: Client) -> None:
                 f"Factor data directory not found: {ff_data_path}. "
                 "Please run the Fama-French sync command."
             ).classes("text-gray-600")
+            ui.separator().classes("my-3")
+            ui.label("Run in terminal:").classes("text-xs text-gray-500")
+            ui.label("python scripts/fama_french_sync.py --sync").classes(
+                "font-mono text-xs bg-slate-100 px-2 py-1 rounded text-slate-800"
+            )
+            with ui.row().classes("mt-3 gap-2"):
+                ui.button(
+                    "Open Data Sources",
+                    icon="cloud_sync",
+                    on_click=lambda: ui.navigate.to(
+                        resolve_rooted_path_from_ui("/data/sources", ui_module=ui)
+                    ),
+                ).props("flat")
         return
 
     # === DATA STATE ===

--- a/apps/web_console_ng/pages/circuit_breaker.py
+++ b/apps/web_console_ng/pages/circuit_breaker.py
@@ -45,8 +45,6 @@ def _parse_utc_datetime(value: Any) -> datetime | None:
     raw = str(value).strip()
     if not raw:
         return None
-    if raw.endswith("Z"):
-        raw = raw[:-1] + "+00:00"
     try:
         parsed = datetime.fromisoformat(raw)
     except ValueError:
@@ -216,14 +214,16 @@ async def circuit_breaker_page() -> None:
             else:
                 ui.label(f"Status: {state}").classes("text-2xl font-bold text-gray-600")
 
-            # Trip count today (prefer local history-derived count).
-            trip_count = _count_trips_today(history_data, now_utc=datetime.now(UTC))
-            if trip_count == 0:
-                backend_count = status_data.get("trip_count_today", 0)
-                if isinstance(backend_count, int | float) and int(backend_count) > 0:
-                    tripped_at = _parse_utc_datetime(status_data.get("tripped_at"))
-                    if tripped_at is not None and tripped_at.date() == datetime.now(UTC).date():
-                        trip_count = int(backend_count)
+            # Trip count today from both sources:
+            # - history payload can be truncated
+            # - backend counter can still be valid when breaker is OPEN.
+            now = datetime.now(UTC)
+            history_count = _count_trips_today(history_data, now_utc=now)
+            backend_count = 0
+            backend_value = status_data.get("trip_count_today", 0)
+            if isinstance(backend_value, int | float) and int(backend_value) > 0:
+                backend_count = int(backend_value)
+            trip_count = max(history_count, backend_count)
             if trip_count > 0:
                 with ui.row().classes("mt-2"):
                     ui.label("Trips Today:").classes("font-medium")

--- a/apps/web_console_ng/pages/circuit_breaker.py
+++ b/apps/web_console_ng/pages/circuit_breaker.py
@@ -18,6 +18,7 @@ PARITY: Mirrors apps/web_console/pages/circuit_breaker.py functionality
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from nicegui import app, run, ui
@@ -35,6 +36,35 @@ if TYPE_CHECKING:
     from libs.web_console_services.cb_service import CircuitBreakerService
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_utc_datetime(value: Any) -> datetime | None:
+    """Parse ISO-ish timestamps to timezone-aware UTC datetime."""
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _count_trips_today(history: list[dict[str, Any]], *, now_utc: datetime) -> int:
+    """Count trip events by tripped_at date from local history payload."""
+    today = now_utc.date()
+    count = 0
+    for entry in history:
+        tripped_at = _parse_utc_datetime(entry.get("tripped_at"))
+        if tripped_at is not None and tripped_at.date() == today:
+            count += 1
+    return count
 
 
 def _get_cb_service() -> CircuitBreakerService | None:
@@ -186,8 +216,14 @@ async def circuit_breaker_page() -> None:
             else:
                 ui.label(f"Status: {state}").classes("text-2xl font-bold text-gray-600")
 
-            # Trip count today
-            trip_count = status_data.get("trip_count_today", 0)
+            # Trip count today (prefer local history-derived count).
+            trip_count = _count_trips_today(history_data, now_utc=datetime.now(UTC))
+            if trip_count == 0:
+                backend_count = status_data.get("trip_count_today", 0)
+                if isinstance(backend_count, int | float) and int(backend_count) > 0:
+                    tripped_at = _parse_utc_datetime(status_data.get("tripped_at"))
+                    if tripped_at is not None and tripped_at.date() == datetime.now(UTC).date():
+                        trip_count = int(backend_count)
             if trip_count > 0:
                 with ui.row().classes("mt-2"):
                     ui.label("Trips Today:").classes("font-medium")

--- a/apps/web_console_ng/pages/circuit_breaker.py
+++ b/apps/web_console_ng/pages/circuit_breaker.py
@@ -48,7 +48,11 @@ def _parse_utc_datetime(value: Any) -> datetime | None:
         return None
     try:
         parsed = datetime.fromisoformat(raw)
-    except ValueError:
+    except ValueError as exc:
+        logger.warning(
+            "circuit_breaker_invalid_timestamp",
+            extra={"value": raw, "error": str(exc)},
+        )
         return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)

--- a/apps/web_console_ng/pages/circuit_breaker.py
+++ b/apps/web_console_ng/pages/circuit_breaker.py
@@ -226,12 +226,10 @@ async def circuit_breaker_page() -> None:
             history_count = _count_trips_today(history_data, now_utc=now)
             backend_count = 0
             backend_value = status_data.get("trip_count_today", 0)
-            if (
-                isinstance(backend_value, int | float)
-                and math.isfinite(backend_value)
-                and int(backend_value) > 0
-            ):
-                backend_count = int(backend_value)
+            if isinstance(backend_value, int | float) and math.isfinite(backend_value):
+                backend_value_int = int(backend_value)
+                if backend_value_int > 0:
+                    backend_count = backend_value_int
             trip_count = max(history_count, backend_count)
             if trip_count > 0:
                 with ui.row().classes("mt-2"):

--- a/apps/web_console_ng/pages/circuit_breaker.py
+++ b/apps/web_console_ng/pages/circuit_breaker.py
@@ -18,6 +18,7 @@ PARITY: Mirrors apps/web_console/pages/circuit_breaker.py functionality
 from __future__ import annotations
 
 import logging
+import math
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -221,7 +222,11 @@ async def circuit_breaker_page() -> None:
             history_count = _count_trips_today(history_data, now_utc=now)
             backend_count = 0
             backend_value = status_data.get("trip_count_today", 0)
-            if isinstance(backend_value, int | float) and int(backend_value) > 0:
+            if (
+                isinstance(backend_value, int | float)
+                and math.isfinite(backend_value)
+                and int(backend_value) > 0
+            ):
                 backend_count = int(backend_value)
             trip_count = max(history_count, backend_count)
             if trip_count > 0:

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -2943,7 +2943,7 @@ def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:
     target = resolve_rooted_path_from_ui("/", ui_module=ui_module)
     try:
         request = ui_module.context.client.request
-    except (AttributeError, RuntimeError, KeyError, TypeError) as exc:
+    except (AttributeError, RuntimeError, KeyError, TypeError, ValueError) as exc:
         logger.debug(
             "trade_alias_request_unavailable",
             extra={"error_type": type(exc).__name__, "error": str(exc)},

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -664,6 +664,11 @@ class MarketPriceCache:
 @main_layout
 async def dashboard(client: Client) -> None:
     """Main trading dashboard with real-time updates."""
+    request = getattr(client, "request", None)
+    if request is not None and str(request.scope.get("path", "")) == "/trade":
+        ui.navigate.to("/")
+        return
+
     trading_client = AsyncTradingClient.get()
     user = get_current_user()
     user_id = str(user.get("user_id") or user.get("username") or "").strip()
@@ -1502,13 +1507,13 @@ async def dashboard(client: Client) -> None:
             return
 
         pnl_card.update(_coerce_float(pnl_data.get("total_unrealized_pl", 0)))
-        positions_card.update(_coerce_int(pnl_data.get("total_positions", 0)))
         realized_card.update(_coerce_float(pnl_data.get("realized_pl_today", 0)))
         buying_power = account_info.get("buying_power")
         if buying_power is None:
             buying_power = pnl_data.get("buying_power", 0)
         bp_card.update(_coerce_float(buying_power))
         positions_snapshot = list(positions.get("positions", []))
+        positions_card.update(len(positions_snapshot))
         orders_snapshot = list(orders.get("orders", []))
         await sparkline_service.record_positions(user_id, positions_snapshot)
 
@@ -2022,7 +2027,7 @@ async def dashboard(client: Client) -> None:
         _evaluate_workspace_mask()
         if "total_unrealized_pl" in data:
             pnl_card.update(_coerce_float(data["total_unrealized_pl"]))
-        if "total_positions" in data:
+        if "total_positions" in data and "positions" not in data:
             positions_card.update(_coerce_int(data["total_positions"]))
         if "realized_pl_today" in data:
             realized_card.update(_coerce_float(data["realized_pl_today"]))
@@ -2030,6 +2035,7 @@ async def dashboard(client: Client) -> None:
             bp_card.update(_coerce_float(data["buying_power"]))
         if "positions" in data:
             positions_snapshot = list(data["positions"])
+            positions_card.update(len(positions_snapshot))
             await sparkline_service.record_positions(user_id, positions_snapshot)
             _update_filter_options()
             if tabbed_panel is not None:

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -12,13 +12,14 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
+from urllib.parse import parse_qsl, urlencode
 
 import httpx
 from nicegui import Client, app, events, ui
 
 from apps.web_console_ng import config
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
-from apps.web_console_ng.auth.redirects import with_root_path
+from apps.web_console_ng.auth.redirects import TRADE_REDIRECT_QUERY_KEYS, with_root_path
 from apps.web_console_ng.components.data_health_widget import render_data_health
 from apps.web_console_ng.components.execution_context import (
     build_execution_context_snapshot,
@@ -2934,7 +2935,30 @@ async def dashboard(client: Client) -> None:
 @requires_auth
 async def dashboard_trade_alias() -> None:
     """Legacy alias route for canonical trade workspace."""
-    ui.navigate.to(resolve_rooted_path_from_ui("/", ui_module=ui))
+    ui.navigate.to(_build_trade_alias_redirect_target(ui_module=ui))
+
+
+def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:
+    """Build canonical trade redirect target while preserving safe query params."""
+    target = resolve_rooted_path_from_ui("/", ui_module=ui_module)
+    try:
+        request = ui_module.context.client.request
+    except Exception:
+        return target
+
+    scope = getattr(request, "scope", None)
+    if not isinstance(scope, dict):
+        return target
+
+    raw_query = scope.get("query_string", b"")
+    query_items = parse_qsl(
+        raw_query.decode("utf-8") if isinstance(raw_query, bytes) else str(raw_query),
+        keep_blank_values=False,
+    )
+    safe_items = [(key, value) for key, value in query_items if key in TRADE_REDIRECT_QUERY_KEYS]
+    if not safe_items:
+        return target
+    return f"{target}?{urlencode(safe_items, doseq=True)}"
 
 
 __all__ = ["dashboard", "dashboard_trade_alias", "MarketPriceCache"]

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -2943,7 +2943,7 @@ def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:
     target = resolve_rooted_path_from_ui("/", ui_module=ui_module)
     try:
         request = ui_module.context.client.request
-    except (AttributeError, RuntimeError, KeyError, TypeError, ValueError) as exc:
+    except (AttributeError, RuntimeError) as exc:
         logger.debug(
             "trade_alias_request_unavailable",
             extra={"error_type": type(exc).__name__, "error": str(exc)},
@@ -2955,10 +2955,18 @@ def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:
         return target
 
     raw_query = scope.get("query_string", b"")
-    query_items = parse_qsl(
-        raw_query.decode("utf-8") if isinstance(raw_query, bytes) else str(raw_query),
-        keep_blank_values=False,
-    )
+    if isinstance(raw_query, bytes):
+        try:
+            raw_query_str = raw_query.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            logger.warning(
+                "trade_alias_query_decode_failed",
+                extra={"error_type": type(exc).__name__, "error": str(exc)},
+            )
+            return target
+    else:
+        raw_query_str = str(raw_query)
+    query_items = parse_qsl(raw_query_str, keep_blank_values=False)
     safe_items = [(key, value) for key, value in query_items if key in TRADE_REDIRECT_QUERY_KEYS]
     if not safe_items:
         return target

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -2943,7 +2943,11 @@ def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:
     target = resolve_rooted_path_from_ui("/", ui_module=ui_module)
     try:
         request = ui_module.context.client.request
-    except Exception:
+    except (AttributeError, RuntimeError, KeyError, TypeError) as exc:
+        logger.debug(
+            "trade_alias_request_unavailable",
+            extra={"error_type": type(exc).__name__, "error": str(exc)},
+        )
         return target
 
     scope = getattr(request, "scope", None)

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -87,6 +87,7 @@ from apps.web_console_ng.core.redis_ha import get_redis_store
 from apps.web_console_ng.core.sparkline_service import SparklineDataService
 from apps.web_console_ng.core.state_manager import UserStateManager
 from apps.web_console_ng.ui.layout import main_layout
+from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
 from apps.web_console_ng.utils.time import validate_and_normalize_symbol
 from libs.core.common.db import acquire_connection
 from libs.data.data_pipeline.health_monitor import get_health_monitor
@@ -659,16 +660,10 @@ class MarketPriceCache:
 
 
 @ui.page("/")
-@ui.page("/trade")
 @requires_auth
 @main_layout
 async def dashboard(client: Client) -> None:
     """Main trading dashboard with real-time updates."""
-    request = getattr(client, "request", None)
-    if request is not None and str(request.scope.get("path", "")) == "/trade":
-        ui.navigate.to("/")
-        return
-
     trading_client = AsyncTradingClient.get()
     user = get_current_user()
     user_id = str(user.get("user_id") or user.get("username") or "").strip()
@@ -2935,4 +2930,11 @@ async def dashboard(client: Client) -> None:
         )
 
 
-__all__ = ["dashboard", "MarketPriceCache"]
+@ui.page("/trade")
+@requires_auth
+async def dashboard_trade_alias() -> None:
+    """Legacy alias route for canonical trade workspace."""
+    ui.navigate.to(resolve_rooted_path_from_ui("/", ui_module=ui))
+
+
+__all__ = ["dashboard", "dashboard_trade_alias", "MarketPriceCache"]

--- a/apps/web_console_ng/pages/data_coverage.py
+++ b/apps/web_console_ng/pages/data_coverage.py
@@ -55,6 +55,7 @@ async def data_coverage_page() -> None:
 
     analyzer = CoverageAnalyzer()
     available_tickers = await asyncio.to_thread(analyzer.get_available_tickers)
+    has_coverage_data = bool(available_tickers)
 
     results_container = ui.column().classes("w-full mt-4")
     export_container = ui.column().classes("w-full")
@@ -129,12 +130,19 @@ async def data_coverage_page() -> None:
                 available_tickers=available_tickers,
                 on_analyze=on_analyze,
             )
+            if not has_coverage_data:
+                ui.button("Analyze Coverage", color="primary").props("disable").classes("mt-4")
 
         with ui.column().classes("flex-1"):
             with results_container:
-                ui.label(
-                    "Configure analysis parameters and click Analyze."
-                ).classes("text-gray-500")
+                if has_coverage_data:
+                    ui.label(
+                        "Configure analysis parameters and click Analyze."
+                    ).classes("text-gray-500")
+                else:
+                    ui.label(
+                        "No adjusted data found yet. Run ETL sync, then return to analyze coverage."
+                    ).classes("text-gray-500")
             with export_container:
                 pass
 

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -116,7 +116,6 @@ def _get_user_id_safe(user: Any) -> str | None:
     return str(val) if val is not None else None
 
 
-@ui.page("/data/management")
 @ui.page("/data")
 @requires_auth
 @main_layout
@@ -1586,3 +1585,10 @@ async def _load_quarantine_preview(entry: Any) -> None:
 
 
 __all__ = ["data_management_page"]
+
+
+@ui.page("/data/management")
+@requires_auth
+async def data_management_alias_page() -> None:
+    """Legacy alias route for Data Hub."""
+    ui.navigate.to("/data")

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -32,6 +32,7 @@ from nicegui import ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.ui.layout import main_layout
+from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from libs.data.data_quality.quality_scorer import (
     compute_quality_scores,
@@ -1591,4 +1592,4 @@ __all__ = ["data_management_page"]
 @requires_auth
 async def data_management_alias_page() -> None:
     """Legacy alias route for Data Hub."""
-    ui.navigate.to("/data")
+    ui.navigate.to(resolve_rooted_path_from_ui("/data", ui_module=ui))

--- a/apps/web_console_ng/pages/data_source_status.py
+++ b/apps/web_console_ng/pages/data_source_status.py
@@ -122,9 +122,6 @@ async def data_source_status_page() -> None:
     can_refresh = has_permission(user, Permission.TRIGGER_DATA_SYNC)
 
     ui.label("Data Source Status").classes("text-2xl font-bold mb-2")
-    ui.label("Preview Data").classes(
-        "inline-block px-3 py-1 rounded bg-amber-100 text-amber-700 text-xs font-semibold mb-3"
-    )
 
     summary_container = ui.column().classes("w-full")
     plot_container = ui.column().classes("w-full")
@@ -147,7 +144,7 @@ async def data_source_status_page() -> None:
             {
                 "field": "status",
                 "headerName": "Status",
-                "cellClass": "params => params.value === 'ok' ? 'text-green-600 font-bold' : params.value === 'stale' ? 'text-amber-600 font-bold' : params.value === 'error' ? 'text-red-600 font-bold' : 'text-gray-400 font-bold'",
+                ":cellClass": "params => params.value === 'ok' ? 'text-green-600 font-bold' : params.value === 'stale' ? 'text-amber-600 font-bold' : params.value === 'error' ? 'text-red-600 font-bold' : 'text-gray-400 font-bold'",
                 "minWidth": 110,
             },
             {"field": "last_update", "headerName": "Last Update", "minWidth": 120},
@@ -155,13 +152,13 @@ async def data_source_status_page() -> None:
                 "field": "age_display",
                 "headerName": "Age",
                 "minWidth": 95,
-                "cellClass": "params => params.data && params.data.status === 'stale' ? 'text-amber-600' : params.data && params.data.status === 'error' ? 'text-red-600' : ''",
+                ":cellClass": "params => params.data && params.data.status === 'stale' ? 'text-amber-600' : params.data && params.data.status === 'error' ? 'text-red-600' : ''",
             },
             {
                 "field": "row_count",
                 "headerName": "Row Count",
                 "minWidth": 130,
-                "valueFormatter": "params => params.value != null ? Number(params.value).toLocaleString() : '-'",
+                ":valueFormatter": "params => params.value != null ? Number(params.value).toLocaleString() : '-'",
             },
             {"field": "error_rate", "headerName": "Error Rate", "minWidth": 110},
             {

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -20,6 +20,7 @@ from apps.web_console_ng.components.strategy_exposure import (
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.core.database import get_db_pool
 from apps.web_console_ng.ui.layout import main_layout
+from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 from libs.web_console_services.exposure_service import ExposureService
@@ -226,4 +227,4 @@ __all__ = ["exposure_page"]
 @requires_auth
 async def exposure_alias_page() -> None:
     """Legacy alias route; keep deep links working with canonical path."""
-    ui.navigate.to("/risk/exposure")
+    ui.navigate.to(resolve_rooted_path_from_ui("/risk/exposure", ui_module=ui))

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -9,9 +9,10 @@ from nicegui import ui
 
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.components.strategy_exposure import (
+    build_exposure_chart_figure,
+    build_exposure_rows,
     render_bias_warning,
     render_data_quality_warning,
-    render_exposure_chart,
     render_exposure_grid,
     render_exposure_summary_cards,
     render_exposure_unavailable,
@@ -22,13 +23,13 @@ from apps.web_console_ng.ui.layout import main_layout
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 from libs.web_console_services.exposure_service import ExposureService
+from libs.web_console_services.schemas.exposure import TotalExposureDTO
 
 logger = logging.getLogger(__name__)
 
 _CLEANUP_OWNER_KEY = "exposure_timers"
 
 
-@ui.page("/exposure")
 @ui.page("/risk/exposure")
 @requires_auth
 @main_layout
@@ -54,13 +55,28 @@ async def exposure_page() -> None:
     grid_container = ui.column().classes("w-full")
     chart_container = ui.column().classes("w-full")
     badge_container = ui.column().classes("w-full")
+    status_container = ui.column().classes("w-full")
+
+    empty_total = TotalExposureDTO(
+        long_total=0.0,
+        short_total=0.0,
+        gross_total=0.0,
+        net_total=0.0,
+        net_pct=0.0,
+        strategy_count=0,
+    )
+    with grid_container:
+        exposure_grid = render_exposure_grid([], empty_total)
+    with chart_container:
+        exposure_chart = ui.plotly(build_exposure_chart_figure([])).classes("w-full")
 
     _refreshing = False
     _error_count = 0
+    _had_success = False
     _timer_ref: list[ui.timer | None] = [None]
 
     async def refresh_exposure() -> None:
-        nonlocal _refreshing, _error_count
+        nonlocal _refreshing, _error_count, _had_success
         if _refreshing:
             return
         _refreshing = True
@@ -78,8 +94,10 @@ async def exposure_page() -> None:
                 timeout=25.0,  # Must complete before next 30s poll
             )
             _error_count = 0  # Reset on success
+            _had_success = True
 
             badge_container.clear()
+            status_container.clear()
             if total.is_placeholder:
                 with badge_container:
                     if total.strategy_count == 0:
@@ -97,10 +115,12 @@ async def exposure_page() -> None:
             if not exposures and total.is_partial:
                 summary_container.clear()
                 warning_container.clear()
-                grid_container.clear()
-                chart_container.clear()
                 with warning_container:
                     render_exposure_unavailable(total)
+                exposure_grid.options["rowData"] = []
+                exposure_grid.update()
+                exposure_chart.figure = build_exposure_chart_figure([])
+                exposure_chart.update()
             else:
                 summary_container.clear()
                 with summary_container:
@@ -111,21 +131,17 @@ async def exposure_page() -> None:
                     render_bias_warning(total)
                     render_data_quality_warning(total)
 
-                grid_container.clear()
-                with grid_container:
-                    render_exposure_grid(exposures, total)
-
-                chart_container.clear()
-                with chart_container:
-                    render_exposure_chart(exposures)
+                exposure_grid.options["rowData"] = build_exposure_rows(exposures, total)
+                exposure_grid.update()
+                exposure_chart.figure = build_exposure_chart_figure(exposures)
+                exposure_chart.update()
 
         except PermissionError as exc:
             for container in (
+                status_container,
                 badge_container,
                 summary_container,
                 warning_container,
-                grid_container,
-                chart_container,
             ):
                 container.clear()
             with warning_container:
@@ -172,6 +188,14 @@ async def exposure_page() -> None:
                         "inline-block px-3 py-1 rounded bg-red-100 "
                         "text-red-700 text-xs font-semibold mb-3"
                     )
+            status_container.clear()
+            with status_container:
+                with ui.card().classes("w-full p-2 bg-amber-50 border border-amber-300"):
+                    ui.label(
+                        "Exposure refresh failed; showing last successful data."
+                        if _had_success
+                        else "Exposure data is currently unavailable."
+                    ).classes("text-xs text-amber-700")
         finally:
             _refreshing = False
 
@@ -192,3 +216,10 @@ async def exposure_page() -> None:
 
 
 __all__ = ["exposure_page"]
+
+
+@ui.page("/exposure")
+@requires_auth
+async def exposure_alias_page() -> None:
+    """Legacy alias route; keep deep links working with canonical path."""
+    ui.navigate.to("/risk/exposure")

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -144,6 +144,10 @@ async def exposure_page() -> None:
                 warning_container,
             ):
                 container.clear()
+            exposure_grid.options["rowData"] = []
+            exposure_grid.update()
+            exposure_chart.figure = build_exposure_chart_figure([])
+            exposure_chart.update()
             with warning_container:
                 ui.label("Access revoked — exposure data cleared.").classes(
                     "text-red-500 text-center"

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -77,7 +77,7 @@ async def exposure_page() -> None:
     _timer_ref: list[ui.timer | None] = [None]
 
     async def refresh_exposure() -> None:
-        nonlocal _refreshing, _error_count, _had_success
+        nonlocal _refreshing, _error_count, _had_success, exposure_grid, exposure_chart
         if _refreshing:
             return
         _refreshing = True
@@ -143,12 +143,14 @@ async def exposure_page() -> None:
                 badge_container,
                 summary_container,
                 warning_container,
+                grid_container,
+                chart_container,
             ):
                 container.clear()
-            exposure_grid.options["rowData"] = []
-            exposure_grid.update()
-            exposure_chart.figure = build_exposure_chart_figure([])
-            exposure_chart.update()
+            with grid_container:
+                exposure_grid = render_exposure_grid([], empty_total, include_total=False)
+            with chart_container:
+                exposure_chart = ui.plotly(build_exposure_chart_figure([])).classes("w-full")
             with warning_container:
                 ui.label("Access revoked — exposure data cleared.").classes(
                     "text-red-500 text-center"

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -67,7 +67,7 @@ async def exposure_page() -> None:
         strategy_count=0,
     )
     with grid_container:
-        exposure_grid = render_exposure_grid([], empty_total)
+        exposure_grid = render_exposure_grid([], empty_total, include_total=False)
     with chart_container:
         exposure_chart = ui.plotly(build_exposure_chart_figure([])).classes("w-full")
 

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -77,7 +77,7 @@ async def exposure_page() -> None:
     _timer_ref: list[ui.timer | None] = [None]
 
     async def refresh_exposure() -> None:
-        nonlocal _refreshing, _error_count, _had_success, exposure_grid, exposure_chart
+        nonlocal _refreshing, _error_count, _had_success
         if _refreshing:
             return
         _refreshing = True
@@ -143,14 +143,12 @@ async def exposure_page() -> None:
                 badge_container,
                 summary_container,
                 warning_container,
-                grid_container,
-                chart_container,
             ):
                 container.clear()
-            with grid_container:
-                exposure_grid = render_exposure_grid([], empty_total, include_total=False)
-            with chart_container:
-                exposure_chart = ui.plotly(build_exposure_chart_figure([])).classes("w-full")
+            exposure_grid.options["rowData"] = []
+            exposure_grid.update()
+            exposure_chart.figure = build_exposure_chart_figure([])
+            exposure_chart.update()
             with warning_container:
                 ui.label("Access revoked — exposure data cleared.").classes(
                     "text-red-500 text-center"

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -37,6 +37,11 @@ _CLEANUP_OWNER_KEY = "feature_browser_cache"
 _CACHE_KEY = "feature_cache"
 
 
+def _notify(message: str, *, type: str = "info") -> None:
+    """Consistent top-right notifications for feature browser."""
+    ui.notify(message, type=type, position="top-right")
+
+
 def _get_alpha158_features(
     *, symbols: list[str], start_date: str, end_date: str
 ) -> pd.DataFrame | None:
@@ -115,7 +120,7 @@ async def feature_browser_page() -> None:
     user = get_current_user()
 
     if not has_permission(user, Permission.VIEW_FEATURES):
-        ui.notify("Permission denied: VIEW_FEATURES required", type="negative")
+        _notify("Permission denied: VIEW_FEATURES required", type="negative")
         with ui.card().classes("w-full p-6"):
             ui.label("Permission denied: VIEW_FEATURES required.").classes(
                 "text-red-500 text-center"
@@ -135,6 +140,7 @@ async def feature_browser_page() -> None:
 
     selected_feature: dict[str, str | None] = {"name": None}
     loading_state = {"feature_data_loading": False, "detail_loading": False}
+    data_state: dict[str, str | None] = {"message": None}
 
     with ui.row().classes("w-full gap-3 mb-3 items-end"):
         category_select = ui.select(
@@ -232,9 +238,10 @@ async def feature_browser_page() -> None:
                     },
                 )
 
+            data_state["message"] = None
             return features_df
         except FileNotFoundError:
-            ui.notify("Feature data not available — run ETL pipeline first", type="warning")
+            data_state["message"] = "Feature data not available — run ETL pipeline first."
             return None
         except RuntimeError as exc:
             if "alpha158 feature dependencies are unavailable" in str(exc):
@@ -242,14 +249,14 @@ async def feature_browser_page() -> None:
                     "feature_dependencies_unavailable",
                     extra={"dependency": "qlib"},
                 )
-                ui.notify("Feature data unavailable: optional qlib dependency missing", type="warning")
+                data_state["message"] = "Feature data unavailable: optional qlib dependency missing."
                 return None
             logger.exception("feature_data_load_failed")
-            ui.notify("Feature data unavailable", type="warning")
+            data_state["message"] = "Feature data unavailable."
             return None
         except Exception:
             logger.exception("feature_data_load_failed")
-            ui.notify("Feature data unavailable", type="warning")
+            data_state["message"] = "Feature data unavailable."
             return None
         finally:
             loading_state["feature_data_loading"] = False
@@ -367,7 +374,8 @@ async def feature_browser_page() -> None:
                 chart_panel.clear()
                 with samples_panel:
                     ui.label(
-                        "No feature data available. Run the ETL pipeline to generate features."
+                        data_state["message"]
+                        or "No feature data available. Run the ETL pipeline to generate features."
                     ).classes("text-gray-500")
                 return
 
@@ -384,7 +392,7 @@ async def feature_browser_page() -> None:
             _render_chart(samples, feature_name)
         except Exception:
             logger.exception("feature_statistics_failed", extra={"feature": feature_name})
-            ui.notify("Feature statistics unavailable", type="warning")
+            _notify("Feature statistics unavailable", type="warning")
         finally:
             loading_state["detail_loading"] = False
 
@@ -404,7 +412,7 @@ async def feature_browser_page() -> None:
     async def _open_selected() -> None:
         selected_rows = await grid.get_selected_rows()
         if not selected_rows:
-            ui.notify("Select a feature first", type="info")
+            _notify("Select a feature first")
             return
         feature_name = str(selected_rows[0].get("name", "")).strip()
         if not feature_name:
@@ -426,13 +434,11 @@ async def feature_browser_page() -> None:
 
     with ui.row().classes("w-full justify-end mb-3"):
         ui.button("Open Selected Feature", on_click=_open_selected)
-
-    with ui.card().classes("w-full p-4"):
-        ui.label("Select a feature row to view metadata, lineage, samples, and statistics.").classes(
-            "text-gray-400"
-        )
-
-    await _load_detail(catalog[0].name)
+    if catalog:
+        await _load_detail(catalog[0].name)
+    else:
+        with ui.card().classes("w-full p-4"):
+            ui.label("No feature definitions available.").classes("text-gray-400")
 
     lifecycle = ClientLifecycleManager.get()
     client_id = get_or_create_client_id()

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from datetime import date, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -37,7 +37,10 @@ _CLEANUP_OWNER_KEY = "feature_browser_cache"
 _CACHE_KEY = "feature_cache"
 
 
-def _notify(message: str, *, type: str = "info") -> None:
+NotifyType = Literal["positive", "negative", "warning", "info", "ongoing"]
+
+
+def _notify(message: str, *, type: NotifyType = "info") -> None:
     """Consistent top-right notifications for feature browser."""
     ui.notify(message, type=type, position="top-right")
 

--- a/apps/web_console_ng/pages/health.py
+++ b/apps/web_console_ng/pages/health.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +34,16 @@ if TYPE_CHECKING:
     from libs.web_console_services.health_service import HealthMonitorService
 
 logger = logging.getLogger(__name__)
+
+
+def _format_latency_ms(value: Any) -> str:
+    """Render finite latency values consistently; hide NaN/inf as '-'."""
+    if not isinstance(value, int | float):
+        return "-"
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        return "-"
+    return f"{numeric:.1f}"
 
 
 def _get_health_service() -> HealthMonitorService:
@@ -339,9 +350,9 @@ async def health_page() -> None:
             rows.append(
                 {
                     "service": service_name,
-                    "p50": f"{p50:.1f}" if p50 else "-",
-                    "p95": f"{p95:.1f}" if p95 else "-",
-                    "p99": f"{p99:.1f}" if p99 else "-",
+                    "p50": _format_latency_ms(p50),
+                    "p95": _format_latency_ms(p95),
+                    "p99": _format_latency_ms(p99),
                 }
             )
 

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -263,9 +263,10 @@ async def risk_dashboard(client: Client) -> None:
                             f"Detected {live_position_count_hint} live position(s), "
                             "but model-derived risk metrics are not ready."
                         ).classes("text-sm text-amber-700")
-                        ui.link("Open Strategy Exposure", "/risk/exposure").classes(
-                            "text-sm text-blue-600 hover:underline mt-1"
-                        )
+                        ui.link(
+                            "Open Strategy Exposure",
+                            resolve_rooted_path_from_ui("/risk/exposure", ui_module=ui),
+                        ).classes("text-sm text-blue-600 hover:underline mt-1")
                 else:
                     ui.label("Risk metrics not available").classes("text-gray-500 p-4")
                 return

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -178,7 +178,7 @@ async def risk_dashboard(client: Client) -> None:
                         extra={"user_id": user_id, "error_type": type(exc).__name__},
                         exc_info=True,
                     )
-                    raise
+                    live_position_count_hint = None
             error_state = None  # Clear error on success
             prev_error_state = None
         except PermissionError as e:

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 from typing import Any
 
+import httpx
 from nicegui import Client, ui
 
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
@@ -165,8 +166,18 @@ async def risk_dashboard(client: Client) -> None:
                     positions_rows = positions_payload.get("positions", [])
                     if isinstance(positions_rows, list):
                         live_position_count_hint = len(positions_rows)
-                except Exception:
-                    logger.debug("risk_live_position_hint_failed", exc_info=True)
+                except (
+                    TimeoutError,
+                    httpx.HTTPError,
+                    RuntimeError,
+                    ValueError,
+                    TypeError,
+                ) as exc:
+                    logger.debug(
+                        "risk_live_position_hint_failed",
+                        extra={"user_id": user_id, "error_type": type(exc).__name__},
+                        exc_info=True,
+                    )
             error_state = None  # Clear error on success
             prev_error_state = None
         except PermissionError as e:

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -173,7 +173,7 @@ async def risk_dashboard(client: Client) -> None:
                     ValueError,
                     TypeError,
                 ) as exc:
-                    logger.debug(
+                    logger.warning(
                         "risk_live_position_hint_failed",
                         extra={"user_id": user_id, "error_type": type(exc).__name__},
                         exc_info=True,

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -178,6 +178,7 @@ async def risk_dashboard(client: Client) -> None:
                         extra={"user_id": user_id, "error_type": type(exc).__name__},
                         exc_info=True,
                     )
+                    raise
             error_state = None  # Clear error on success
             prev_error_state = None
         except PermissionError as e:

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -28,6 +28,7 @@ from apps.web_console_ng.config import (
     RISK_BUDGET_VAR_LIMIT,
     RISK_BUDGET_WARNING_THRESHOLD,
 )
+from apps.web_console_ng.core.client import AsyncTradingClient
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.core.database import get_db_pool
 from apps.web_console_ng.core.redis_ha import get_redis_store
@@ -108,10 +109,11 @@ async def risk_dashboard(client: Client) -> None:
     risk_data: dict[str, Any] = {}
     error_state: str | None = None  # Persistent error message for inline display
     prev_error_state: str | None = None  # Track previous error to avoid notification spam
+    live_position_count_hint: int | None = None
 
     async def load_risk_data() -> None:
         """Fetch risk data via RiskService (same as Streamlit, NOT REST)."""
-        nonlocal risk_data, error_state, prev_error_state
+        nonlocal risk_data, error_state, prev_error_state, live_position_count_hint
 
         def set_error(msg: str) -> None:
             """Set error state and notify only on state transition."""
@@ -151,6 +153,19 @@ async def risk_dashboard(client: Client) -> None:
                     "placeholder_reason": data.placeholder_reason,
                 }
             )
+            live_position_count_hint = None
+            if not data.risk_metrics:
+                try:
+                    positions_payload = await AsyncTradingClient.get().fetch_positions(
+                        str(user_id),
+                        role=str(user_role or ""),
+                        strategies=list(authorized_strategies),
+                    )
+                    positions_rows = positions_payload.get("positions", [])
+                    if isinstance(positions_rows, list):
+                        live_position_count_hint = len(positions_rows)
+                except Exception:
+                    logger.debug("risk_live_position_hint_failed", exc_info=True)
             error_state = None  # Clear error on success
             prev_error_state = None
         except PermissionError as e:
@@ -227,7 +242,20 @@ async def risk_dashboard(client: Client) -> None:
         def risk_overview_section() -> None:
             metrics = risk_data.get("risk_metrics", {})
             if not metrics:
-                ui.label("Risk metrics not available").classes("text-gray-500 p-4")
+                if isinstance(live_position_count_hint, int) and live_position_count_hint > 0:
+                    with ui.card().classes("w-full p-4 bg-amber-50 border border-amber-300"):
+                        ui.label("Risk model metrics unavailable").classes(
+                            "text-amber-700 font-semibold"
+                        )
+                        ui.label(
+                            f"Detected {live_position_count_hint} live position(s), "
+                            "but model-derived risk metrics are not ready."
+                        ).classes("text-sm text-amber-700")
+                        ui.link("Open Strategy Exposure", "/risk/exposure").classes(
+                            "text-sm text-blue-600 hover:underline mt-1"
+                        )
+                else:
+                    ui.label("Risk metrics not available").classes("text-gray-500 p-4")
                 return
 
             ui.label("Risk Overview").classes("text-xl font-semibold mb-4")

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -117,8 +117,9 @@ async def risk_dashboard(client: Client) -> None:
 
         def set_error(msg: str) -> None:
             """Set error state and notify only on state transition."""
-            nonlocal error_state, prev_error_state
+            nonlocal error_state, prev_error_state, live_position_count_hint
             risk_data.clear()  # Clear stale data on error
+            live_position_count_hint = None
             if error_state != msg:  # Only notify on state change (avoid spam)
                 error_state = msg
                 ui.notify(msg, type="negative")

--- a/apps/web_console_ng/pages/scheduled_reports.py
+++ b/apps/web_console_ng/pages/scheduled_reports.py
@@ -65,7 +65,6 @@ def _get_service(db_pool: Any, user: dict[str, Any]) -> Any:
     )
 
 
-@ui.page("/reports/scheduled")
 @ui.page("/reports")
 @requires_auth
 @main_layout
@@ -785,3 +784,10 @@ def _format_dt(value: datetime | None) -> str:
 
 
 __all__ = ["scheduled_reports_page"]
+
+
+@ui.page("/reports/scheduled")
+@requires_auth
+async def scheduled_reports_alias_page() -> None:
+    """Legacy alias route for scheduled reports."""
+    ui.navigate.to("/reports")

--- a/apps/web_console_ng/pages/scheduled_reports.py
+++ b/apps/web_console_ng/pages/scheduled_reports.py
@@ -790,4 +790,4 @@ __all__ = ["scheduled_reports_page"]
 @requires_auth
 async def scheduled_reports_alias_page() -> None:
     """Legacy alias route for scheduled reports."""
-    ui.navigate.to("/reports")
+    ui.navigate.to(resolve_rooted_path_from_ui("/reports", ui_module=ui))

--- a/apps/web_console_ng/pages/shadow_results.py
+++ b/apps/web_console_ng/pages/shadow_results.py
@@ -13,6 +13,7 @@ from nicegui import ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.ui.layout import main_layout
+from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
 from apps.web_console_ng.ui.trading_layout import apply_compact_grid_options
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from apps.web_console_ng.utils.time import format_relative_time
@@ -335,4 +336,4 @@ __all__ = [
 @requires_auth
 async def shadow_results_alias_page() -> None:
     """Legacy alias route for shadow results."""
-    ui.navigate.to("/data/shadow")
+    ui.navigate.to(resolve_rooted_path_from_ui("/data/shadow", ui_module=ui))

--- a/apps/web_console_ng/pages/shadow_results.py
+++ b/apps/web_console_ng/pages/shadow_results.py
@@ -157,7 +157,6 @@ def _format_metric(value: Any, precision: int = 4) -> str:
     return "-"
 
 
-@ui.page("/shadow-results")
 @ui.page("/data/shadow")
 @requires_auth
 @main_layout
@@ -176,13 +175,11 @@ async def shadow_results_page() -> None:
     service = ShadowResultsService()
 
     ui.label("Shadow Mode Results").classes("text-2xl font-bold mb-2")
-    ui.label("Preview Data").classes(
-        "inline-block px-3 py-1 rounded bg-amber-100 text-amber-700 text-xs font-semibold mb-3"
-    )
 
     summary_container = ui.column().classes("w-full")
     trend_container = ui.column().classes("w-full")
     detail_container = ui.column().classes("w-full")
+    status_container = ui.column().classes("w-full")
 
     grid_options = apply_compact_grid_options(
         {
@@ -198,7 +195,7 @@ async def shadow_results_page() -> None:
                     "field": "status",
                     "headerName": "Status",
                     "minWidth": 100,
-                    "cellClass": "params => params.value === 'passed' ? 'text-green-600 font-bold' : 'text-red-600 font-bold'",
+                    ":cellClass": "params => params.value === 'passed' ? 'text-green-600 font-bold' : 'text-red-600 font-bold'",
                 },
                 {"field": "correlation", "headerName": "Correlation", "minWidth": 120},
                 {"field": "divergence", "headerName": "Divergence", "minWidth": 120},
@@ -219,6 +216,7 @@ async def shadow_results_page() -> None:
     grid = ui.aggrid(grid_options).classes("w-full ag-theme-alpine-dark")
 
     _refreshing = False
+    _had_success = False
 
     async def render_selected_detail() -> None:
         selected = await grid.get_selected_rows()
@@ -257,21 +255,24 @@ async def shadow_results_page() -> None:
                     ).classes("text-sm")
 
     async def refresh_shadow_results() -> None:
-        nonlocal _refreshing
+        nonlocal _refreshing, _had_success
         if _refreshing:
             return
         _refreshing = True
         try:
             results = await service.get_recent_results(user)
             trend = await service.get_trend(user)
+            _had_success = True
 
+            status_container.clear()
             if not results:
-                ui.notify(
-                    "No shadow validations recorded. "
-                    "Shadow validation runs automatically during model hot-swap when "
-                    "SHADOW_VALIDATION_ENABLED=true.",
-                    type="info",
-                )
+                with status_container:
+                    with ui.card().classes("w-full p-3 bg-slate-800 border border-slate-600"):
+                        ui.label(
+                            "No shadow validations recorded yet. "
+                            "Runs are produced during model hot-swap when "
+                            "SHADOW_VALIDATION_ENABLED=true."
+                        ).classes("text-xs text-slate-300")
 
             _render_summary_cards(results, summary_container)
             _plot_trend(trend, trend_container)
@@ -288,7 +289,20 @@ async def shadow_results_page() -> None:
                     "user_id": get_user_id(user),
                 },
             )
-            ui.notify("Shadow results unavailable", type="warning")
+            if not _had_success:
+                status_container.clear()
+                with status_container:
+                    with ui.card().classes("w-full p-3 bg-amber-50 border border-amber-300"):
+                        ui.label("Shadow results unavailable").classes(
+                            "text-xs text-amber-700"
+                        )
+            else:
+                status_container.clear()
+                with status_container:
+                    with ui.card().classes("w-full p-3 bg-amber-50 border border-amber-300"):
+                        ui.label(
+                            "Shadow results refresh failed; showing last successful snapshot."
+                        ).classes("text-xs text-amber-700")
         finally:
             _refreshing = False
 
@@ -315,3 +329,10 @@ __all__ = [
     "_CLEANUP_OWNER_KEY",
     "shadow_results_page",
 ]
+
+
+@ui.page("/shadow-results")
+@requires_auth
+async def shadow_results_alias_page() -> None:
+    """Legacy alias route for shadow results."""
+    ui.navigate.to("/data/shadow")

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -99,10 +99,14 @@ async def sql_explorer_page() -> None:
     for warning in warnings:
         logger.warning("sql_explorer_path_warning", extra={"detail": warning})
 
-    queryable_datasets = sorted(
-        [dataset for dataset in DATASET_TABLES if can_query_dataset(user, dataset)]
+    all_datasets = sorted(DATASET_TABLES)
+    allowed_datasets = sorted(
+        [dataset for dataset in all_datasets if can_query_dataset(user, dataset)]
     )
-    allowed_datasets = queryable_datasets
+    unauthorized_count = len(all_datasets) - len(allowed_datasets)
+    missing_local_count = sum(
+        1 for dataset in allowed_datasets if not available_tables_by_dataset.get(dataset)
+    )
 
     if not allowed_datasets:
         with ui.card().classes("w-full p-4"):
@@ -143,6 +147,22 @@ async def sql_explorer_page() -> None:
 
     tables_label = ui.label("").classes("text-sm text-gray-400 mb-1")
     dataset_state_label = ui.label("").classes("text-xs mb-1")
+    if unauthorized_count > 0 and missing_local_count > 0:
+        ui.label(
+            f"Showing {len(allowed_datasets)} authorized dataset(s). "
+            f"{unauthorized_count} hidden by permissions, "
+            f"{missing_local_count} missing local data."
+        ).classes("text-xs text-gray-500 mb-1")
+    elif unauthorized_count > 0:
+        ui.label(
+            f"Showing {len(allowed_datasets)} authorized dataset(s). "
+            f"{unauthorized_count} hidden by permissions."
+        ).classes("text-xs text-gray-500 mb-1")
+    elif missing_local_count > 0:
+        ui.label(
+            f"Showing {len(allowed_datasets)} authorized dataset(s). "
+            f"{missing_local_count} missing local data."
+        ).classes("text-xs text-gray-500 mb-1")
 
     def _update_table_hint() -> None:
         dataset = str(dataset_select.value)

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -271,6 +271,10 @@ async def sql_explorer_page() -> None:
         available_tables = available_tables_by_dataset.get(dataset, set())
         if not available_tables:
             status_label.text = "No local data files found for selected dataset"
+            logger.info(
+                "sql_explorer_dataset_missing_local_data",
+                extra={"dataset": dataset, "user_id": user.get("user_id")},
+            )
             ui.notify(
                 "No local parquet files found for selected dataset. "
                 "Sync data before querying.",

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -171,7 +171,7 @@ async def sql_explorer_page() -> None:
         if tables:
             tables_label.text = f"Available tables: {', '.join(tables)}"
             dataset_state_label.text = ""
-            dataset_state_label.classes("text-amber-600", remove="text-gray-500")
+            dataset_state_label.classes("text-gray-500", remove="text-amber-600")
         else:
             tables_label.text = "Available tables: -"
             dataset_state_label.text = (

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -24,6 +24,7 @@ from libs.web_console_services.sql_explorer_service import (
     SqlExplorerService,
     can_query_dataset,
 )
+from libs.web_console_services.sql_validator import DATASET_TABLES
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,6 @@ async def _get_validated_paths() -> tuple[dict[str, set[str]], list[str]]:
         return result
 
 
-@ui.page("/sql-explorer")
 @ui.page("/data/sql-explorer")
 @requires_auth
 @main_layout
@@ -99,18 +99,24 @@ async def sql_explorer_page() -> None:
     for warning in warnings:
         logger.warning("sql_explorer_path_warning", extra={"detail": warning})
 
-    allowed_datasets = sorted(
-        [
-            dataset
-            for dataset in available_tables_by_dataset
-            if can_query_dataset(user, dataset)
-        ]
+    queryable_datasets = sorted(
+        [dataset for dataset in DATASET_TABLES if can_query_dataset(user, dataset)]
     )
+    allowed_datasets = queryable_datasets
 
     if not allowed_datasets:
         with ui.card().classes("w-full p-4"):
             ui.label("No queryable datasets available for your account.").classes("text-gray-400")
         return
+
+    dataset_options = {
+        dataset: (
+            dataset.upper()
+            if available_tables_by_dataset.get(dataset)
+            else f"{dataset.upper()} (no local data)"
+        )
+        for dataset in allowed_datasets
+    }
 
     history: list[dict[str, Any]] = []
     query_running = False
@@ -119,7 +125,7 @@ async def sql_explorer_page() -> None:
     with ui.row().classes("w-full gap-3 items-end"):
         dataset_select = ui.select(
             label="Dataset",
-            options=allowed_datasets,
+            options=dataset_options,
             value=allowed_datasets[0],
         ).classes("w-56")
         timeout_select = ui.select(
@@ -136,11 +142,21 @@ async def sql_explorer_page() -> None:
         ).classes("w-40")
 
     tables_label = ui.label("").classes("text-sm text-gray-400 mb-1")
+    dataset_state_label = ui.label("").classes("text-xs mb-1")
 
     def _update_table_hint() -> None:
         dataset = str(dataset_select.value)
         tables = sorted(available_tables_by_dataset.get(dataset, set()))
-        tables_label.text = f"Available tables: {', '.join(tables)}" if tables else "Available tables: -"
+        if tables:
+            tables_label.text = f"Available tables: {', '.join(tables)}"
+            dataset_state_label.text = ""
+            dataset_state_label.classes("text-amber-600", remove="text-gray-500")
+        else:
+            tables_label.text = "Available tables: -"
+            dataset_state_label.text = (
+                "No local parquet files discovered for this dataset in the current environment."
+            )
+            dataset_state_label.classes("text-amber-600", remove="text-gray-500")
 
     _update_table_hint()
     dataset_select.on_value_change(lambda _: _update_table_hint())
@@ -231,6 +247,16 @@ async def sql_explorer_page() -> None:
             return
 
         dataset = str(dataset_select.value)
+        available_tables = available_tables_by_dataset.get(dataset, set())
+        if not available_tables:
+            status_label.text = "No local data files found for selected dataset"
+            ui.notify(
+                "No local parquet files found for selected dataset. "
+                "Sync data before querying.",
+                type="warning",
+            )
+            return
+
         timeout = int(str(timeout_select.value))
         max_rows_raw = int(max_rows_input.value or 10_000)
         max_rows = min(max_rows_raw, _MAX_ROWS_LIMIT)
@@ -245,7 +271,7 @@ async def sql_explorer_page() -> None:
                 query=query,
                 timeout_seconds=timeout,
                 max_rows=max_rows,
-                available_tables=available_tables_by_dataset.get(dataset, set()),
+                available_tables=available_tables,
             )
 
             cell_count = len(result.df) * len(result.df.columns)
@@ -336,3 +362,10 @@ async def sql_explorer_page() -> None:
 
 
 __all__ = ["sql_explorer_page"]
+
+
+@ui.page("/sql-explorer")
+@requires_auth
+async def sql_explorer_alias_page() -> None:
+    """Legacy alias route for SQL Explorer."""
+    ui.navigate.to("/data/sql-explorer")

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -13,6 +13,7 @@ from nicegui import ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.redis_ha import get_redis_store
 from apps.web_console_ng.ui.layout import main_layout
+from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
 from apps.web_console_ng.ui.trading_layout import apply_compact_grid_options
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 from libs.platform.web_console_auth.rate_limiter import RateLimiter
@@ -388,4 +389,4 @@ __all__ = ["sql_explorer_page"]
 @requires_auth
 async def sql_explorer_alias_page() -> None:
     """Legacy alias route for SQL Explorer."""
-    ui.navigate.to("/data/sql-explorer")
+    ui.navigate.to(resolve_rooted_path_from_ui("/data/sql-explorer", ui_module=ui))

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -84,6 +84,7 @@ async def tax_lots_page() -> None:
 
     # State
     show_all_users = False
+    price_status = "unavailable"
 
     async def _load_lots() -> list[Any]:
         if show_all_users and is_admin:
@@ -406,6 +407,12 @@ async def _fetch_current_prices_with_status(
             continue
         mid_value = item.get("mid")
         if mid_value is None:
+            continue
+        if not isinstance(mid_value, (int, float, Decimal, str)):
+            logger.warning(
+                "market_prices_invalid_mid_type",
+                extra={"symbol": sym, "mid_type": type(mid_value).__name__},
+            )
             continue
         try:
             prices[sym] = Decimal(str(mid_value))

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -32,6 +32,14 @@ logger = logging.getLogger(__name__)
 _COST_BASIS_METHODS = ["fifo", "lifo", "specific_id"]
 
 
+class MarketPriceFetchError(RuntimeError):
+    """Domain error for market-price fetch failures with UI status mapping."""
+
+    def __init__(self, status: str, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
 @ui.page("/tax-lots")
 @requires_auth
 @main_layout
@@ -88,7 +96,10 @@ async def tax_lots_page() -> None:
     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
 
     # Fetch current prices for harvesting (graceful degradation)
-    current_prices, price_status = await _fetch_current_prices_with_status(lots, user)
+    try:
+        current_prices, price_status = await _fetch_current_prices_with_status(lots, user)
+    except MarketPriceFetchError as exc:
+        current_prices, price_status = ({}, exc.status)
     harvester = TaxLossHarvester(db_pool)  # type: ignore[arg-type]
     suggestions = None
     if current_prices and not show_all_users:
@@ -123,9 +134,12 @@ async def tax_lots_page() -> None:
                 show_all_users = e.value
                 lots = await _load_lots()
                 wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
-                current_prices, price_status = await _fetch_current_prices_with_status(
-                    lots, get_current_user(),
-                )
+                try:
+                    current_prices, price_status = await _fetch_current_prices_with_status(
+                        lots, get_current_user(),
+                    )
+                except MarketPriceFetchError as exc:
+                    current_prices, price_status = ({}, exc.status)
                 suggestions = None
                 if current_prices and not show_all_users:
                     try:
@@ -237,9 +251,12 @@ async def tax_lots_page() -> None:
                     nonlocal lots, wash_sale_lot_ids, current_prices, suggestions, price_status
                     lots = await _load_lots()
                     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
-                    current_prices, price_status = await _fetch_current_prices_with_status(
-                        lots, get_current_user(),
-                    )
+                    try:
+                        current_prices, price_status = await _fetch_current_prices_with_status(
+                            lots, get_current_user(),
+                        )
+                    except MarketPriceFetchError as exc:
+                        current_prices, price_status = ({}, exc.status)
                     suggestions = None
                     if current_prices and not show_all_users:
                         try:
@@ -368,22 +385,35 @@ async def _fetch_current_prices_with_status(
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 403:
             logger.info("market_prices_permission_denied", extra={"role": user.get("role")})
-            return ({}, "permission_denied")
+            raise MarketPriceFetchError("permission_denied", "Market data permission denied") from exc
         logger.warning("market_prices_http_error", extra={"status": exc.response.status_code})
-        return ({}, "unavailable")
+        raise MarketPriceFetchError("unavailable", "Market data service HTTP failure") from exc
     except httpx.HTTPError as exc:
         logger.warning("market_prices_fetch_failed", extra={"error": str(exc)})
-        return ({}, "unavailable")
+        raise MarketPriceFetchError("unavailable", "Market data fetch transport failure") from exc
     except ValueError as exc:
         logger.warning("market_prices_invalid_payload", extra={"error": str(exc)})
-        return ({}, "unavailable")
+        raise MarketPriceFetchError("unavailable", "Market data payload invalid") from exc
     prices: dict[str, Decimal] = {}
     for item in raw:
+        if not isinstance(item, dict):
+            continue
+        symbol_value = item.get("symbol")
+        if symbol_value is None:
+            continue
+        sym = str(symbol_value)
+        if sym not in symbols_needed:
+            continue
+        mid_value = item.get("mid")
+        if mid_value is None:
+            continue
         try:
-            sym = str(item["symbol"])
-            if sym in symbols_needed and item.get("mid") is not None:
-                prices[sym] = Decimal(str(item["mid"]))
-        except (KeyError, TypeError, ValueError, ArithmeticError):
+            prices[sym] = Decimal(str(mid_value))
+        except (ArithmeticError, TypeError, ValueError) as exc:
+            logger.warning(
+                "market_prices_invalid_mid",
+                extra={"symbol": sym, "error": str(exc)},
+            )
             continue
     if not prices:
         return ({}, "no_prices")
@@ -392,8 +422,11 @@ async def _fetch_current_prices_with_status(
 
 async def _fetch_current_prices(lots: list[Any], user: dict[str, Any]) -> dict[str, Decimal]:
     """Backward-compatible helper returning only symbol->price mapping."""
-    prices, _status = await _fetch_current_prices_with_status(lots, user)
-    return prices
+    try:
+        prices, _status = await _fetch_current_prices_with_status(lots, user)
+        return prices
+    except MarketPriceFetchError:
+        return {}
 
 
 async def _render_summary_metrics(

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -408,7 +408,7 @@ async def _fetch_current_prices_with_status(
         mid_value = item.get("mid")
         if mid_value is None:
             continue
-        if not isinstance(mid_value, (int, float, Decimal, str)):
+        if not isinstance(mid_value, int | float | Decimal | str):
             logger.warning(
                 "market_prices_invalid_mid_type",
                 extra={"symbol": sym, "mid_type": type(mid_value).__name__},

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -88,7 +88,7 @@ async def tax_lots_page() -> None:
     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
 
     # Fetch current prices for harvesting (graceful degradation)
-    current_prices = await _fetch_current_prices(lots, user)
+    current_prices, price_status = await _fetch_current_prices_with_status(lots, user)
     harvester = TaxLossHarvester(db_pool)  # type: ignore[arg-type]
     suggestions = None
     if current_prices and not show_all_users:
@@ -103,7 +103,9 @@ async def tax_lots_page() -> None:
     # Summary metrics (refreshable for toggle)
     @ui.refreshable  # type: ignore[arg-type]
     async def summary_section() -> None:
-        await _render_summary_metrics(lots, current_prices, wash_sale_lot_ids, db_pool)
+        await _render_summary_metrics(
+            lots, current_prices, wash_sale_lot_ids, db_pool, price_status=price_status,
+        )
 
     await summary_section()
 
@@ -117,11 +119,13 @@ async def tax_lots_page() -> None:
                 )
                 if not allowed:
                     return
-                nonlocal show_all_users, lots, wash_sale_lot_ids, current_prices, suggestions
+                nonlocal show_all_users, lots, wash_sale_lot_ids, current_prices, suggestions, price_status
                 show_all_users = e.value
                 lots = await _load_lots()
                 wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
-                current_prices = await _fetch_current_prices(lots, get_current_user())
+                current_prices, price_status = await _fetch_current_prices_with_status(
+                    lots, get_current_user(),
+                )
                 suggestions = None
                 if current_prices and not show_all_users:
                     try:
@@ -230,10 +234,12 @@ async def tax_lots_page() -> None:
                         logger.debug("audit_log_lot_close_failed")
                     ui.notify(f"Lot {lot_id[:8]}... closed", type="positive")
                     # Refresh all sections
-                    nonlocal lots, wash_sale_lot_ids, current_prices, suggestions
+                    nonlocal lots, wash_sale_lot_ids, current_prices, suggestions, price_status
                     lots = await _load_lots()
                     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
-                    current_prices = await _fetch_current_prices(lots, get_current_user())
+                    current_prices, price_status = await _fetch_current_prices_with_status(
+                        lots, get_current_user(),
+                    )
                     suggestions = None
                     if current_prices and not show_all_users:
                         try:
@@ -253,6 +259,12 @@ async def tax_lots_page() -> None:
 
             @ui.refreshable
             def lot_grid() -> None:
+                if not lots:
+                    with ui.card().classes("w-full p-3 mb-2 bg-slate-800 border border-slate-600"):
+                        ui.label("No open tax lots found.").classes("text-sm text-slate-200")
+                        ui.label(
+                            "Tax lots populate after fills are reconciled into lot records."
+                        ).classes("text-xs text-slate-400")
                 render_tax_lot_table(
                     lots,
                     wash_sale_lot_ids=wash_sale_lot_ids,
@@ -273,7 +285,7 @@ async def tax_lots_page() -> None:
 
             @ui.refreshable
             def harvesting_section() -> None:
-                render_harvesting_suggestions(suggestions)
+                render_harvesting_suggestions(suggestions, price_status=price_status)
 
             harvesting_section()
 
@@ -330,13 +342,21 @@ async def _fetch_wash_sale_lot_ids(db_pool: Any, lots: list[Any]) -> set[str]:
         return set()
 
 
-async def _fetch_current_prices(lots: list[Any], user: dict[str, Any]) -> dict[str, Decimal]:
+async def _fetch_current_prices_with_status(
+    lots: list[Any], user: dict[str, Any],
+) -> tuple[dict[str, Decimal], str]:
     """Fetch current prices via AsyncTradingClient.
 
-    Graceful degradation: returns empty dict on 403 or any error.
+    Returns:
+        (prices, status) where status is one of:
+        - ``ok``: at least one symbol priced
+        - ``no_open_lots``: no lots to price
+        - ``permission_denied``: backend denied market data access
+        - ``no_prices``: backend returned no usable prices
+        - ``unavailable``: transport/service error
     """
     if not lots:
-        return {}
+        return ({}, "no_open_lots")
     symbols_needed = {lot.symbol for lot in lots}
     client = AsyncTradingClient.get()
     try:
@@ -348,15 +368,15 @@ async def _fetch_current_prices(lots: list[Any], user: dict[str, Any]) -> dict[s
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 403:
             logger.info("market_prices_permission_denied", extra={"role": user.get("role")})
-            return {}
+            return ({}, "permission_denied")
         logger.warning("market_prices_http_error", extra={"status": exc.response.status_code})
-        return {}
+        return ({}, "unavailable")
     except httpx.HTTPError as exc:
         logger.warning("market_prices_fetch_failed", extra={"error": str(exc)})
-        return {}
+        return ({}, "unavailable")
     except ValueError as exc:
         logger.warning("market_prices_invalid_payload", extra={"error": str(exc)})
-        return {}
+        return ({}, "unavailable")
     prices: dict[str, Decimal] = {}
     for item in raw:
         try:
@@ -365,6 +385,14 @@ async def _fetch_current_prices(lots: list[Any], user: dict[str, Any]) -> dict[s
                 prices[sym] = Decimal(str(item["mid"]))
         except (KeyError, TypeError, ValueError, ArithmeticError):
             continue
+    if not prices:
+        return ({}, "no_prices")
+    return (prices, "ok")
+
+
+async def _fetch_current_prices(lots: list[Any], user: dict[str, Any]) -> dict[str, Decimal]:
+    """Backward-compatible helper returning only symbol->price mapping."""
+    prices, _status = await _fetch_current_prices_with_status(lots, user)
     return prices
 
 
@@ -373,6 +401,8 @@ async def _render_summary_metrics(
     current_prices: dict[str, Decimal],
     wash_sale_lot_ids: set[str],
     db_pool: Any,
+    *,
+    price_status: str = "ok",
 ) -> None:
     """Render summary header cards."""
     # Pro-rate cost basis for partially sold lots (remaining < quantity)
@@ -419,6 +449,8 @@ async def _render_summary_metrics(
                 ui.label(label).classes(f"text-xl font-bold {color}")
             else:
                 ui.label("N/A").classes("text-xl font-bold text-gray-400")
+                if price_status in {"permission_denied", "unavailable", "no_prices"}:
+                    ui.label("Live price feed unavailable").classes("text-xs text-amber-600")
         with ui.card().classes("flex-1 p-3"):
             ui.label("Short / Long Term").classes("text-gray-500 text-sm")
             ui.label(f"{len(short_term)} / {len(long_term)}").classes("text-xl font-bold")

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -331,6 +331,10 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     # directly to canonical dashboard path to avoid redirect hops.
                     return "/" if path == "/trade" else path
 
+                def _nav_active_path(path: str) -> str:
+                    # Keep only one active entry for canonical dashboard route.
+                    return path
+
                 current_nav_path = current_path
 
                 for section_label, section_paths in nav_groups:
@@ -348,7 +352,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                     for label, path, icon, _required_role in section_items:
                         rendered_paths.add(path)
-                        is_active = current_nav_path == _nav_target(path)
+                        is_active = current_nav_path == _nav_active_path(path)
                         active_classes = (
                             "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                         )
@@ -367,7 +371,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     if path in rendered_paths or not is_nav_item_visible(path):
                         continue
 
-                    is_active = current_nav_path == _nav_target(path)
+                    is_active = current_nav_path == _nav_active_path(path)
                     active_classes = (
                         "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                     )

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -331,7 +331,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     # directly to canonical dashboard path to avoid redirect hops.
                     return "/" if path == "/trade" else path
 
-                current_nav_path = _nav_target(current_path)
+                current_nav_path = current_path
 
                 for section_label, section_paths in nav_groups:
                     section_items = [

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -326,6 +326,11 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                 rendered_paths: set[str] = set()
 
+                def _nav_target(path: str) -> str:
+                    # Keep /trade alias route for compatibility, but navigate
+                    # directly to canonical dashboard path to avoid redirect hops.
+                    return "/" if path == "/trade" else path
+
                 for section_label, section_paths in nav_groups:
                     section_items = [
                         nav_lookup[path]
@@ -346,7 +351,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                             "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                         )
 
-                        with ui.link(target=path).classes(
+                        with ui.link(target=_nav_target(path)).classes(
                             f"nav-link w-full rounded {active_classes}"
                         ):
                             with ui.row().classes("items-center gap-3 p-2"):
@@ -365,7 +370,9 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                     )
 
-                    with ui.link(target=path).classes(f"nav-link w-full rounded {active_classes}"):
+                    with ui.link(target=_nav_target(path)).classes(
+                        f"nav-link w-full rounded {active_classes}"
+                    ):
                         with ui.row().classes("items-center gap-3 p-2"):
                             ui.icon(icon).classes("text-blue-600" if is_active else "text-gray-600")
                             ui.label(label).classes("text-sm")

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -156,8 +156,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                 ui.label("Navigation").classes("text-gray-500 text-xs uppercase tracking-wide mb-2")
 
                 nav_items = [
-                    ("Dashboard", "/", "dashboard", None),
-                    ("Trade", "/trade", "candlestick_chart", None),
+                    ("Trade", "/", "candlestick_chart", None),
                     ("Research Workspace", "/research", "hub", None),
                     ("Circuit Breaker", "/circuit-breaker", "electric_bolt", None),
                     ("System Health", "/health", "monitor_heart", None),
@@ -192,7 +191,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                 nav_groups: list[tuple[str, list[str]]] = [
                     (
                         "Execute",
-                        ["/", "/trade", "/circuit-breaker"],
+                        ["/", "/circuit-breaker"],
                     ),
                     ("Monitor", ["/health", "/alerts", "/journal", "/performance", "/reports"]),
                     (
@@ -326,17 +325,6 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                 rendered_paths: set[str] = set()
 
-                def _nav_target(path: str) -> str:
-                    # Keep /trade alias route for compatibility, but navigate
-                    # directly to canonical dashboard path to avoid redirect hops.
-                    return "/" if path == "/trade" else path
-
-                def _is_nav_item_active(path: str) -> bool:
-                    # Keep a single active nav item for the canonical trade workspace.
-                    if current_nav_path in {"/", "/trade"}:
-                        return path == "/trade"
-                    return current_nav_path == path
-
                 current_nav_path = current_path
 
                 for section_label, section_paths in nav_groups:
@@ -354,12 +342,12 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                     for label, path, icon, _required_role in section_items:
                         rendered_paths.add(path)
-                        is_active = _is_nav_item_active(path)
+                        is_active = current_nav_path == path
                         active_classes = (
                             "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                         )
 
-                        with ui.link(target=_nav_target(path)).classes(
+                        with ui.link(target=path).classes(
                             f"nav-link w-full rounded {active_classes}"
                         ):
                             with ui.row().classes("items-center gap-3 p-2"):
@@ -373,12 +361,12 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     if path in rendered_paths or not is_nav_item_visible(path):
                         continue
 
-                    is_active = _is_nav_item_active(path)
+                    is_active = current_nav_path == path
                     active_classes = (
                         "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                     )
 
-                    with ui.link(target=_nav_target(path)).classes(
+                    with ui.link(target=path).classes(
                         f"nav-link w-full rounded {active_classes}"
                     ):
                         with ui.row().classes("items-center gap-3 p-2"):

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -331,9 +331,11 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     # directly to canonical dashboard path to avoid redirect hops.
                     return "/" if path == "/trade" else path
 
-                def _nav_active_path(path: str) -> str:
-                    # Keep only one active entry for canonical dashboard route.
-                    return path
+                def _is_nav_item_active(path: str) -> bool:
+                    # Keep a single active nav item for the canonical trade workspace.
+                    if current_nav_path in {"/", "/trade"}:
+                        return path == "/trade"
+                    return current_nav_path == path
 
                 current_nav_path = current_path
 
@@ -352,7 +354,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                     for label, path, icon, _required_role in section_items:
                         rendered_paths.add(path)
-                        is_active = current_nav_path == _nav_active_path(path)
+                        is_active = _is_nav_item_active(path)
                         active_classes = (
                             "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                         )
@@ -371,7 +373,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     if path in rendered_paths or not is_nav_item_visible(path):
                         continue
 
-                    is_active = current_nav_path == _nav_active_path(path)
+                    is_active = _is_nav_item_active(path)
                     active_classes = (
                         "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                     )

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -331,6 +331,8 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     # directly to canonical dashboard path to avoid redirect hops.
                     return "/" if path == "/trade" else path
 
+                current_nav_path = _nav_target(current_path)
+
                 for section_label, section_paths in nav_groups:
                     section_items = [
                         nav_lookup[path]
@@ -346,7 +348,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                     for label, path, icon, _required_role in section_items:
                         rendered_paths.add(path)
-                        is_active = current_path == path
+                        is_active = current_nav_path == _nav_target(path)
                         active_classes = (
                             "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                         )
@@ -365,7 +367,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     if path in rendered_paths or not is_nav_item_visible(path):
                         continue
 
-                    is_active = current_path == path
+                    is_active = current_nav_path == _nav_target(path)
                     active_classes = (
                         "bg-blue-100 text-blue-700" if is_active else "hover:bg-slate-200"
                     )
@@ -381,11 +383,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
         status_bar = StatusBar()
 
         def _update_status_bar(state: str | None, cb_state: str | None = None) -> None:
-            """Call StatusBar with backward-compatible fallback for test doubles."""
-            try:
-                status_bar.update_state(state, circuit_state=cb_state)
-            except TypeError:
-                status_bar.update_state(state)
+            status_bar.update_state(state, circuit_state=cb_state)
 
         with ui.header().classes(
             "bg-slate-900 items-center text-white px-4 h-14 flex-nowrap overflow-x-auto"

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -150,9 +150,9 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
         client = AsyncTradingClient.get()
 
         # Left drawer (sidebar)
-        drawer = ui.left_drawer(value=True).classes("bg-surface-1 w-64")
+        drawer = ui.left_drawer(value=True).classes("bg-surface-1 w-64 h-screen overflow-y-auto")
         with drawer:
-            with ui.column().classes("w-full gap-1 p-3"):
+            with ui.column().classes("w-full gap-1 p-3 min-h-screen pb-4"):
                 ui.label("Navigation").classes("text-gray-500 text-xs uppercase tracking-wide mb-2")
 
                 nav_items = [
@@ -372,6 +372,13 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
         # Header
         status_bar = StatusBar()
+
+        def _update_status_bar(state: str | None, cb_state: str | None = None) -> None:
+            """Call StatusBar with backward-compatible fallback for test doubles."""
+            try:
+                status_bar.update_state(state, circuit_state=cb_state)
+            except TypeError:
+                status_bar.update_state(state)
 
         with ui.header().classes(
             "bg-slate-900 items-center text-white px-4 h-14 flex-nowrap overflow-x-auto"
@@ -751,7 +758,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                             "bg-amber-500 text-black",
                             remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                         )
-                    status_bar.update_state(display_state)
+                    _update_status_bar(display_state, cb_state)
 
                     if cb_state == "TRIPPED":
                         circuit_breaker_badge.set_text("CIRCUIT TRIPPED")
@@ -797,7 +804,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         "bg-amber-500 text-black",
                         remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                     )
-                    status_bar.update_state("UNKNOWN")
+                    _update_status_bar("UNKNOWN", "UNKNOWN")
                     set_kill_switch_controls("UNKNOWN")
                     circuit_breaker_badge.set_text("CIRCUIT: UNKNOWN")
                     circuit_breaker_badge.classes(

--- a/libs/web_console_services/universe_service.py
+++ b/libs/web_console_services/universe_service.py
@@ -71,6 +71,11 @@ _MOCK_FACTOR_EXPOSURE: dict[str, float] = {
     "Volatility": -0.1,
 }
 
+_BUILT_IN_SYMBOL_HINTS: dict[str, int] = {
+    "SP500": 500,
+    "R1000": 1000,
+}
+
 
 def safe_user_id(user: Any) -> str:
     """Extract user ID for logging (never raises).
@@ -212,10 +217,16 @@ class UniverseService:
             symbol_count: int | None = None
             base: str | None = None
             approx = False
+            last_updated: str | None = u.created_at.strftime("%Y-%m-%d") if u.created_at else None
 
             if u.universe_type == "built_in":
                 base = "CRSP"
                 symbol_count = count_map.get(u.id)
+                if symbol_count is None:
+                    symbol_count = _BUILT_IN_SYMBOL_HINTS.get(u.id)
+                    approx = symbol_count is not None
+                if last_updated is None and as_of_date is not None:
+                    last_updated = as_of_date.isoformat()
             else:
                 base = u.base_universe_id or "Manual List"
                 if u.manual_symbols is not None:
@@ -237,9 +248,7 @@ class UniverseService:
                     universe_type=u.universe_type,
                     symbol_count=symbol_count,
                     count_is_approximate=approx,
-                    last_updated=(
-                        u.created_at.strftime("%Y-%m-%d") if u.created_at else None
-                    ),
+                    last_updated=last_updated,
                     base=base,
                 )
             )

--- a/tests/apps/web_console_ng/components/test_status_bar.py
+++ b/tests/apps/web_console_ng/components/test_status_bar.py
@@ -84,3 +84,10 @@ def test_status_bar_unknown(dummy_ui: None) -> None:
     bar.update_state("UNKNOWN")
     assert bar._label is not None
     assert "UNKNOWN" in bar._label.text
+
+
+def test_status_bar_engaged_overrides_quiet_period(dummy_ui: None) -> None:
+    bar = StatusBar()
+    bar.update_state("ENGAGED", circuit_state="QUIET_PERIOD")
+    assert bar._label is not None
+    assert bar._label.text == "TRADING HALTED"

--- a/tests/apps/web_console_ng/components/test_strategy_exposure.py
+++ b/tests/apps/web_console_ng/components/test_strategy_exposure.py
@@ -58,3 +58,33 @@ def test_build_exposure_rows_includes_total_with_strategy_data() -> None:
     assert rows[-1]["strategy"] == "TOTAL"
     assert rows[-1]["positions"] == 5
     assert rows[-1]["net"] == 1300.0
+
+
+def test_build_exposure_rows_can_skip_total_row() -> None:
+    """Allow callers to suppress TOTAL row for initial empty-state rendering."""
+    total = TotalExposureDTO(
+        long_total=1200.0,
+        short_total=100.0,
+        gross_total=1300.0,
+        net_total=1100.0,
+        net_pct=84.6,
+        strategy_count=1,
+    )
+    rows = build_exposure_rows(
+        [
+            StrategyExposureDTO(
+                strategy="alpha_a",
+                long_notional=1200.0,
+                short_notional=100.0,
+                gross_notional=1300.0,
+                net_notional=1100.0,
+                net_pct=84.6,
+                position_count=4,
+            )
+        ],
+        total,
+        include_total=False,
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["strategy"] == "alpha_a"

--- a/tests/apps/web_console_ng/components/test_strategy_exposure.py
+++ b/tests/apps/web_console_ng/components/test_strategy_exposure.py
@@ -1,0 +1,60 @@
+"""Unit tests for strategy exposure table row construction."""
+
+from __future__ import annotations
+
+from apps.web_console_ng.components.strategy_exposure import build_exposure_rows
+from libs.web_console_services.schemas.exposure import StrategyExposureDTO, TotalExposureDTO
+
+
+def test_build_exposure_rows_omits_synthetic_total_before_first_fetch() -> None:
+    """Do not render a synthetic TOTAL row for all-zero initial placeholders."""
+    total = TotalExposureDTO(
+        long_total=0.0,
+        short_total=0.0,
+        gross_total=0.0,
+        net_total=0.0,
+        net_pct=0.0,
+        strategy_count=0,
+    )
+
+    assert build_exposure_rows([], total) == []
+
+
+def test_build_exposure_rows_includes_total_with_strategy_data() -> None:
+    """Render per-strategy rows plus a TOTAL summary row when data exists."""
+    total = TotalExposureDTO(
+        long_total=1600.0,
+        short_total=300.0,
+        gross_total=1900.0,
+        net_total=1300.0,
+        net_pct=68.4,
+        strategy_count=2,
+    )
+    rows = build_exposure_rows(
+        [
+            StrategyExposureDTO(
+                strategy="alpha_a",
+                long_notional=1000.0,
+                short_notional=100.0,
+                gross_notional=1100.0,
+                net_notional=900.0,
+                net_pct=47.4,
+                position_count=3,
+            ),
+            StrategyExposureDTO(
+                strategy="alpha_b",
+                long_notional=600.0,
+                short_notional=200.0,
+                gross_notional=800.0,
+                net_notional=400.0,
+                net_pct=21.0,
+                position_count=2,
+            ),
+        ],
+        total,
+    )
+
+    assert len(rows) == 3
+    assert rows[-1]["strategy"] == "TOTAL"
+    assert rows[-1]["positions"] == 5
+    assert rows[-1]["net"] == 1300.0

--- a/tests/apps/web_console_ng/pages/test_dashboard.py
+++ b/tests/apps/web_console_ng/pages/test_dashboard.py
@@ -110,8 +110,10 @@ async def test_market_price_cache_strategy_isolation(monkeypatch: pytest.MonkeyP
 
 def test_dashboard_has_trade_alias_route() -> None:
     """Dashboard page keeps '/' canonical and exposes '/trade' alias."""
-    source = inspect.getsource(dashboard_module.dashboard)
-    assert '@ui.page("/trade")' in source
+    dashboard_source = inspect.getsource(dashboard_module.dashboard)
+    alias_source = inspect.getsource(dashboard_module.dashboard_trade_alias)
+    assert '@ui.page("/")' in dashboard_source
+    assert '@ui.page("/trade")' in alias_source
 
 
 def test_dashboard_session_expiry_redirects_to_login() -> None:

--- a/tests/apps/web_console_ng/pages/test_dashboard.py
+++ b/tests/apps/web_console_ng/pages/test_dashboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
 
 import pytest
 
@@ -125,3 +126,27 @@ def test_dashboard_handoff_defers_market_data_release_until_replacement_context(
     source = inspect.getsource(dashboard_module.dashboard)
     assert "is_handoff = active_generation_id != order_context_generation_id" in source
     assert 'client.storage["deferred_market_data_release_symbols"]' in source
+
+
+def test_trade_alias_redirect_target_preserves_safe_query_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dummy_ui = SimpleNamespace(
+        context=SimpleNamespace(
+            client=SimpleNamespace(
+                request=SimpleNamespace(
+                    scope={
+                        "query_string": b"symbol=AAPL&qty=5&side=buy&foo=ignored",
+                    }
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(
+        dashboard_module,
+        "resolve_rooted_path_from_ui",
+        lambda _path, *, ui_module: "/console",
+    )
+
+    target = dashboard_module._build_trade_alias_redirect_target(ui_module=dummy_ui)
+    assert target == "/console?symbol=AAPL&qty=5&side=buy"

--- a/tests/apps/web_console_ng/pages/test_data_source_status.py
+++ b/tests/apps/web_console_ng/pages/test_data_source_status.py
@@ -189,7 +189,7 @@ async def test_timer_cleanup_registered_with_owner_key(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio()
-async def test_preview_data_badge_rendered(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_preview_data_badge_removed(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_ui = FakeUI()
     lifecycle = DummyLifecycle()
 
@@ -203,7 +203,8 @@ async def test_preview_data_badge_rendered(monkeypatch: pytest.MonkeyPatch) -> N
     page = _unwrap_page()
     await page()
 
-    assert "Preview Data" in fake_ui.labels
+    assert "Data Source Status" in fake_ui.labels
+    assert "Preview Data" not in fake_ui.labels
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/pages/test_shadow_results.py
+++ b/tests/apps/web_console_ng/pages/test_shadow_results.py
@@ -204,7 +204,7 @@ async def test_timer_cleanup_registered_with_owner_key(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio()
-async def test_preview_data_badge_rendered(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_preview_data_badge_removed(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_ui = FakeUI()
     lifecycle = DummyLifecycle()
 
@@ -218,7 +218,8 @@ async def test_preview_data_badge_rendered(monkeypatch: pytest.MonkeyPatch) -> N
     page = _unwrap_page()
     await page()
 
-    assert "Preview Data" in fake_ui.labels
+    assert "Shadow Mode Results" in fake_ui.labels
+    assert "Preview Data" not in fake_ui.labels
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/test_layout.py
+++ b/tests/apps/web_console_ng/test_layout.py
@@ -199,7 +199,9 @@ async def _run_layout(
         def __init__(self) -> None:
             pass
 
-        def update_state(self, state: str) -> None:
+        def update_state(
+            self, state: str | None, *, circuit_state: str | None = None
+        ) -> None:
             pass
 
     class _DummyHeaderMetrics:

--- a/tests/apps/web_console_ng/test_navigation.py
+++ b/tests/apps/web_console_ng/test_navigation.py
@@ -213,7 +213,9 @@ async def _run_layout(monkeypatch: pytest.MonkeyPatch, current_path: str) -> _Fa
         def __init__(self) -> None:
             pass
 
-        def update_state(self, state: str) -> None:
+        def update_state(
+            self, state: str | None, *, circuit_state: str | None = None
+        ) -> None:
             pass
 
     class _DummyHeaderMetrics:
@@ -409,7 +411,9 @@ async def test_exposure_link_hidden_without_permission(
         def __init__(self) -> None:
             pass
 
-        def update_state(self, state: str) -> None:
+        def update_state(
+            self, state: str | None, *, circuit_state: str | None = None
+        ) -> None:
             pass
 
     class _DummyHeaderMetrics:
@@ -559,7 +563,9 @@ async def test_universes_link_hidden_without_permission(
         def __init__(self) -> None:
             pass
 
-        def update_state(self, state: str) -> None:
+        def update_state(
+            self, state: str | None, *, circuit_state: str | None = None
+        ) -> None:
             pass
 
     class _DummyHeaderMetrics:

--- a/tests/apps/web_console_ng/test_navigation.py
+++ b/tests/apps/web_console_ng/test_navigation.py
@@ -324,8 +324,7 @@ async def _run_layout(monkeypatch: pytest.MonkeyPatch, current_path: str) -> _Fa
 def test_navigation_item_structure() -> None:
     items = _extract_nav_items()
     assert items == [
-        ("Dashboard", "/", "dashboard", None),
-        ("Trade", "/trade", "candlestick_chart", None),
+        ("Trade", "/", "candlestick_chart", None),
         ("Research Workspace", "/research", "hub", None),
         ("Circuit Breaker", "/circuit-breaker", "electric_bolt", None),
         ("System Health", "/health", "monitor_heart", None),

--- a/tests/apps/web_console_ng/ui/test_layout.py
+++ b/tests/apps/web_console_ng/ui/test_layout.py
@@ -119,7 +119,9 @@ class _DummyStatusBar:
     def __init__(self) -> None:
         self.state: str | None = None
 
-    def update_state(self, state: str) -> None:
+    def update_state(
+        self, state: str | None, *, circuit_state: str | None = None
+    ) -> None:
         self.state = state
 
 


### PR DESCRIPTION
## Summary
- fix AG Grid formatter/cellClass wiring in data source status
- stabilize exposure page plot/grid refresh behavior and improve chart grouping
- normalize health latency formatting to suppress literal `nan`
- improve attribution no-data UX with actionable sync guidance
- fix tax-lots pricing/harvesting messaging drift and table truncation
- improve SQL explorer dataset availability handling for admin
- remove contradictory shadow/features/coverage states and stale notifications
- fix status chrome consistency when circuit breaker is tripped/quiet
- correct circuit breaker trips-today display logic
- tighten dashboard/risk consistency for positions vs risk-model availability
- make sidebar scrollable at constrained viewport heights
- add canonical alias redirects for duplicate routes
- remove inconsistent "Preview Data" badges
- add/update targeted tests for changed behavior

## Validation
- `ruff check` on touched modules
- `pytest` targeted suites:
  - tests/apps/web_console_ng/pages/test_health.py
  - tests/apps/web_console_ng/pages/test_circuit_breaker.py
  - tests/apps/web_console_ng/pages/test_shadow_results.py
  - tests/apps/web_console_ng/pages/test_tax_lots.py
  - tests/apps/web_console_ng/pages/test_risk.py
  - tests/apps/web_console_ng/pages/test_dashboard.py
  - tests/apps/web_console_ng/ui/test_layout.py
  - tests/libs/web_console_services/test_universe_service.py
  - tests/apps/web_console_ng/components/test_coverage_heatmap.py
  - tests/apps/web_console_ng/pages/test_data_source_status.py
  - tests/apps/web_console_ng/pages/test_scheduled_reports.py
  - tests/apps/web_console_ng/pages/test_scheduled_reports_coverage.py
  - tests/apps/web_console_ng/pages/test_dashboard_dispatch.py
  - tests/apps/web_console_ng/pages/test_dashboard_coverage.py
