### PR TITLE
fix(web-console-ng): stabilize global status synchronization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 # CI step formatting - reduces duplication in ci-local target
 SEPARATOR := ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Docker Desktop local proxy endpoint that is reachable from build containers on macOS.
+# Some environments enforce egress via this proxy (iptables services1 rules).
+DOCKER_DESKTOP_PROXY ?= http://192.168.65.7:3128
 
 # Usage: $(call ci_step_header,Step X/Y,Description)
 define ci_step_header
@@ -50,7 +53,21 @@ up-dev: ## Start all dev services (rebuild first to avoid stale images)
 	@PYTHON=$$( [ -x .venv/bin/python3 ] && echo .venv/bin/python3 || echo python3 ); \
 	$$PYTHON scripts/ops/ensure_web_console_jwt_keys.py
 	$(MAKE) ensure-requirements
-	docker compose --profile dev --profile workers up -d --build
+	@set -e; \
+	BUILD_CMD="docker compose --profile dev --profile workers build"; \
+	UP_CMD="docker compose --profile dev --profile workers up -d"; \
+	if [ -n "$(DOCKER_DESKTOP_PROXY)" ]; then \
+		PROXY_ENV="http_proxy=$(DOCKER_DESKTOP_PROXY) https_proxy=$(DOCKER_DESKTOP_PROXY) HTTP_PROXY=$(DOCKER_DESKTOP_PROXY) HTTPS_PROXY=$(DOCKER_DESKTOP_PROXY)"; \
+		echo "Building dev services using proxy: $(DOCKER_DESKTOP_PROXY)"; \
+		BUILD_ARGS="--build-arg http_proxy=$(DOCKER_DESKTOP_PROXY) --build-arg https_proxy=$(DOCKER_DESKTOP_PROXY) --build-arg HTTP_PROXY=$(DOCKER_DESKTOP_PROXY) --build-arg HTTPS_PROXY=$(DOCKER_DESKTOP_PROXY)"; \
+		if ! eval "$$PROXY_ENV $$BUILD_CMD $$BUILD_ARGS"; then \
+			echo "Proxy build failed, retrying direct build..."; \
+			$$BUILD_CMD; \
+		fi; \
+	else \
+		$$BUILD_CMD; \
+	fi; \
+	$$UP_CMD
 	@echo "Waiting for services to be healthy..."
 	@sleep 10
 	@docker compose --profile dev ps

--- a/Makefile
+++ b/Makefile
@@ -54,20 +54,25 @@ up-dev: ## Start all dev services (rebuild first to avoid stale images)
 	$$PYTHON scripts/ops/ensure_web_console_jwt_keys.py
 	$(MAKE) ensure-requirements
 	@set -e; \
-	BUILD_CMD="docker compose --profile dev --profile workers build"; \
-	UP_CMD="docker compose --profile dev --profile workers up -d"; \
 	if [ -n "$(DOCKER_DESKTOP_PROXY)" ]; then \
-		PROXY_ENV="http_proxy=$(DOCKER_DESKTOP_PROXY) https_proxy=$(DOCKER_DESKTOP_PROXY) HTTP_PROXY=$(DOCKER_DESKTOP_PROXY) HTTPS_PROXY=$(DOCKER_DESKTOP_PROXY)"; \
 		echo "Building dev services using proxy: $(DOCKER_DESKTOP_PROXY)"; \
-		BUILD_ARGS="--build-arg http_proxy=$(DOCKER_DESKTOP_PROXY) --build-arg https_proxy=$(DOCKER_DESKTOP_PROXY) --build-arg HTTP_PROXY=$(DOCKER_DESKTOP_PROXY) --build-arg HTTPS_PROXY=$(DOCKER_DESKTOP_PROXY)"; \
-		if ! eval "$$PROXY_ENV $$BUILD_CMD $$BUILD_ARGS"; then \
+		if ! env \
+			http_proxy="$(DOCKER_DESKTOP_PROXY)" \
+			https_proxy="$(DOCKER_DESKTOP_PROXY)" \
+			HTTP_PROXY="$(DOCKER_DESKTOP_PROXY)" \
+			HTTPS_PROXY="$(DOCKER_DESKTOP_PROXY)" \
+			docker compose --profile dev --profile workers build \
+				--build-arg http_proxy="$(DOCKER_DESKTOP_PROXY)" \
+				--build-arg https_proxy="$(DOCKER_DESKTOP_PROXY)" \
+				--build-arg HTTP_PROXY="$(DOCKER_DESKTOP_PROXY)" \
+				--build-arg HTTPS_PROXY="$(DOCKER_DESKTOP_PROXY)"; then \
 			echo "Proxy build failed, retrying direct build..."; \
-			$$BUILD_CMD; \
+			docker compose --profile dev --profile workers build; \
 		fi; \
 	else \
-		$$BUILD_CMD; \
+		docker compose --profile dev --profile workers build; \
 	fi; \
-	$$UP_CMD
+	docker compose --profile dev --profile workers up -d
 	@echo "Waiting for services to be healthy..."
 	@sleep 10
 	@docker compose --profile dev ps

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up up-dev up-dev-fast ensure-requirements down down-dev logs fmt fmt-check lint check-doc-freshness check-architecture test test-cov test-watch clean clean-cache clean-all install requirements install-hooks ci-local pre-push
+.PHONY: help up up-dev up-dev-fast ensure-requirements down down-dev logs fmt fmt-check lint check-doc-freshness check-architecture test test-cov test-watch ui-crawl ui-deep clean clean-cache clean-all install requirements install-hooks ci-local pre-push
 
 # CI step formatting - reduces duplication in ci-local target
 SEPARATOR := ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -143,6 +143,12 @@ perf: ## Run performance tests (requires RUN_PERF_TESTS=1)
 
 test-watch: ## Run tests in watch mode
 	poetry run pytest-watch
+
+ui-crawl: ## Run broad Playwright UI crawler (manual E2E diagnostic)
+	PYTHONPATH=. poetry run python tests/e2e/ui_crawl.py
+
+ui-deep: ## Run focused Playwright deep page inspector
+	PYTHONPATH=. poetry run python tests/e2e/ui_deep.py
 
 install-hooks: ## Install git hooks (pre-commit quality checks)
 	@echo "Installing git hooks..."

--- a/apps/alert_worker/Dockerfile
+++ b/apps/alert_worker/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11-slim AS builder
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && apt-get install -y --no-install-recommends gcc libpq-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y --no-install-recommends gcc libpq-dev && rm -rf /var/lib/apt/lists/*
 
 # Install service dependencies
 COPY apps/alert_worker/requirements.txt ./
@@ -16,7 +16,7 @@ FROM python:3.11-slim
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local
 COPY libs /app/libs

--- a/apps/auth_service/Dockerfile
+++ b/apps/auth_service/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y --no-install-recommends \
     gcc \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/backtest_worker/Dockerfile
+++ b/apps/backtest_worker/Dockerfile
@@ -1,13 +1,13 @@
 # Backtest Worker Dockerfile - Multi-stage Build
 FROM python:3.11-slim as builder
 WORKDIR /build
-RUN apt-get update && apt-get install -y --no-install-recommends gcc && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y --no-install-recommends gcc && rm -rf /var/lib/apt/lists/*
 COPY apps/backtest_worker/requirements.txt .
 RUN pip install --no-cache-dir --target=/build/packages -r requirements.txt
 
 FROM python:3.11-slim
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y --no-install-recommends postgresql-client curl && rm -rf /var/lib/apt/lists/*
 RUN groupadd -r appuser && useradd -r -g appuser -u 1000 appuser
 COPY --from=builder /build/packages /usr/local/lib/python3.11/site-packages
 COPY libs /app/libs

--- a/apps/execution_gateway/Dockerfile
+++ b/apps/execution_gateway/Dockerfile
@@ -15,7 +15,7 @@ FROM python:3.11-slim as builder
 ARG BUILD_MODE=local
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     gcc \
     g++ \
     make \
@@ -48,7 +48,7 @@ RUN python -m venv /opt/venv && \
 FROM python:3.11-slim
 
 # Install runtime dependencies only (no build tools)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     libpq5 \
     curl \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/execution_gateway/reconciliation/service.py
+++ b/apps/execution_gateway/reconciliation/service.py
@@ -245,7 +245,7 @@ class ReconciliationService:
                 },
             )
             return False
-        except Exception as exc:
+        except ConnectionError as exc:
             self._state.record_reconciliation_result(
                 {
                     "status": "failed",

--- a/apps/execution_gateway/reconciliation/service.py
+++ b/apps/execution_gateway/reconciliation/service.py
@@ -245,6 +245,25 @@ class ReconciliationService:
                 },
             )
             return False
+        except Exception as exc:
+            self._state.record_reconciliation_result(
+                {
+                    "status": "failed",
+                    "mode": "startup",
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "error": str(exc),
+                }
+            )
+            logger.error(
+                "Startup reconciliation failed: unexpected error",
+                exc_info=True,
+                extra={
+                    "error": str(exc),
+                    "error_type": "unexpected",
+                    "reconciliation_mode": "startup",
+                },
+            )
+            return False
 
     async def run_periodic_loop(self) -> None:
         """Run reconciliation periodically until stopped."""

--- a/apps/market_data_service/Dockerfile
+++ b/apps/market_data_service/Dockerfile
@@ -11,7 +11,7 @@ FROM python:3.11-slim as builder
 ARG BUILD_MODE=local
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     gcc \
     g++ \
     make \
@@ -42,7 +42,7 @@ RUN python -m venv /opt/venv && \
 FROM python:3.11-slim
 
 # Install runtime dependencies only (no build tools)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/model_registry/Dockerfile
+++ b/apps/model_registry/Dockerfile
@@ -11,7 +11,7 @@ FROM python:3.11-slim as builder
 ARG BUILD_MODE=local
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     gcc \
     g++ \
     make \
@@ -42,7 +42,7 @@ RUN python -m venv /opt/venv && \
 FROM python:3.11-slim
 
 # Install runtime dependencies only (no build tools)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/orchestrator/Dockerfile
+++ b/apps/orchestrator/Dockerfile
@@ -15,7 +15,7 @@ FROM python:3.11-slim as builder
 ARG BUILD_MODE=local
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     gcc \
     g++ \
     make \
@@ -48,7 +48,7 @@ RUN python -m venv /opt/venv && \
 FROM python:3.11-slim
 
 # Install runtime dependencies only (no build tools)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     libpq5 \
     curl \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/signal_service/Dockerfile
+++ b/apps/signal_service/Dockerfile
@@ -16,7 +16,7 @@ FROM python:3.11-slim as builder
 ARG BUILD_MODE=local
 
 # Install build dependencies (including those needed for qlib)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     gcc \
     g++ \
     make \
@@ -71,7 +71,7 @@ FROM python:3.11-slim
 ARG BUILD_MODE=local
 
 # Install runtime dependencies only (no build tools)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=6 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::ForceIPv4=true && apt-get install -y \
     libpq5 \
     libgomp1 \
     curl \

--- a/apps/web_console_ng/auth/session_store.py
+++ b/apps/web_console_ng/auth/session_store.py
@@ -762,7 +762,8 @@ class ServerSessionStore:
     def _build_device_info(self, client_ip: str, device_info: dict[str, Any]) -> dict[str, str]:
         user_agent = str(device_info.get("user_agent", ""))
         ua_hash = device_info.get("ua_hash") or hashlib.sha256(user_agent.encode()).hexdigest()
-        ip_subnet = _ip_subnet(client_ip, config.DEVICE_BINDING_SUBNET_MASK)
+        normalized_ip = _normalize_device_binding_ip(client_ip)
+        ip_subnet = _ip_subnet(normalized_ip, config.DEVICE_BINDING_SUBNET_MASK)
         return {"ip_subnet": ip_subnet, "ua_hash": str(ua_hash)}
 
     def _audit_failure(
@@ -836,6 +837,22 @@ def _ip_subnet(client_ip: str, mask_bits: int) -> str:
     mask = max(0, min(mask_bits, max_bits))
     network = ipaddress.ip_network(f"{addr}/{mask}", strict=False)
     return str(network)
+
+
+def _normalize_device_binding_ip(client_ip: str) -> str:
+    """Normalize loopback variants for stable device-binding in local dev.
+
+    Browser requests in Docker/Desktop dev can alternate between IPv4 and IPv6
+    loopback addresses (127.0.0.1 vs ::1). Treat both as a single endpoint to
+    avoid spurious mid-session logouts while keeping non-loopback binding strict.
+    """
+    try:
+        addr = ipaddress.ip_address(client_ip)
+    except ValueError:
+        return client_ip
+    if addr.is_loopback:
+        return "127.0.0.1"
+    return client_ip
 
 
 def _get_user_id(session: dict[str, Any]) -> str | None:

--- a/apps/web_console_ng/components/coverage_heatmap.py
+++ b/apps/web_console_ng/components/coverage_heatmap.py
@@ -39,13 +39,8 @@ def render_coverage_controls(
         available_tickers: Authorized ticker symbols for multi-select.
         on_analyze: Callback(symbols, start_date_iso, end_date_iso, resolution).
     """
-    if not available_tickers:
-        ui.label(
-            "No adjusted data found. Run the ETL pipeline first."
-        ).classes("text-gray-500")
-        return
-
     ui.label("Coverage Analysis").classes("font-bold mb-2")
+    has_data = bool(available_tickers)
 
     symbol_select = ui.select(
         label="Symbols (leave empty for all)",
@@ -53,20 +48,28 @@ def render_coverage_controls(
         multiple=True,
         value=[],
     ).classes("w-64")
+    if not has_data:
+        symbol_select.props("disable")
 
     start_input = ui.input(
         label="Start Date (YYYY-MM-DD)",
         value="",
     ).classes("w-48")
+    if not has_data:
+        start_input.props("disable")
 
     end_input = ui.input(
         label="End Date (YYYY-MM-DD)",
         value="",
     ).classes("w-48")
+    if not has_data:
+        end_input.props("disable")
 
     resolution_toggle = ui.toggle(
         ["Daily", "Weekly", "Monthly"], value="Monthly"
     ).classes("mt-2")
+    if not has_data:
+        resolution_toggle.props("disable")
 
     async def _submit() -> None:
         syms = list(symbol_select.value) if symbol_select.value else None
@@ -75,9 +78,14 @@ def render_coverage_controls(
         res_val = str(resolution_toggle.value).lower()
         await on_analyze(syms, start_val, end_val, res_val)
 
-    ui.button(
+    analyze_button = ui.button(
         "Analyze Coverage", on_click=_submit, color="primary"
     ).classes("mt-4")
+    if not has_data:
+        analyze_button.props("disable")
+        ui.label(
+            "No adjusted data found. Run ETL sync, then click Analyze."
+        ).classes("text-gray-500 text-sm mt-2")
 
 
 def render_coverage_heatmap(matrix: CoverageMatrix) -> None:

--- a/apps/web_console_ng/components/hierarchical_orders.py
+++ b/apps/web_console_ng/components/hierarchical_orders.py
@@ -195,6 +195,17 @@ def transform_to_hierarchy(
             child_id = str(child.get("client_order_id") or "")
             child["is_parent"] = False
             child["is_child"] = True
+            child_parent_id = str(child.get("parent_client_order_id") or "")
+            if child_parent_id and child_parent_id != str(parent_id):
+                logger.debug(
+                    "hierarchy_parent_id_mismatch",
+                    extra={
+                        "child_order_id": child_id,
+                        "child_parent_client_order_id": child_parent_id,
+                        "derived_parent_client_order_id": str(parent_id),
+                    },
+                )
+            child["parent_client_order_id"] = str(parent_id)
             child["hierarchy_path"] = [parent_id, child_id]
             results.append(child)
 
@@ -206,6 +217,7 @@ def transform_to_hierarchy(
             child_id = str(child.get("client_order_id") or "")
             child["is_parent"] = False
             child["is_child"] = True
+            child["parent_client_order_id"] = str(parent_id)
             child["is_orphan"] = True
             child["hierarchy_path"] = [child_id]
             results.append(child)

--- a/apps/web_console_ng/components/orders_table.py
+++ b/apps/web_console_ng/components/orders_table.py
@@ -191,15 +191,27 @@ def create_orders_table() -> ui.aggrid:
 
 
 def create_hierarchical_orders_table(expanded_parent_ids: list[str] | None = None) -> ui.aggrid:
-    """Create AG Grid for hierarchical TWAP orders."""
+    """Create AG Grid for parent/child TWAP orders (community-grid compatible)."""
     column_defs = [
+        {
+            "field": "symbol",
+            "headerName": "Symbol",
+            "width": 180,
+            ":cellRenderer": "window.hierarchicalSymbolRenderer",
+            ":cellStyle": (
+                "params => {"
+                " const row = params.data || {};"
+                " const path = Array.isArray(row.hierarchy_path) ? row.hierarchy_path : [];"
+                " const isParent = Boolean(row.is_parent) || (!row.is_child && path.length === 1 && Number(row.child_count || 0) > 0);"
+                " return isParent ? {fontWeight: 600} : {};"
+                "}"
+            ),
+        },
         {
             "field": "side",
             "headerName": "Side",
             "width": 80,
-            "cellStyle": {
-                "function": "params.value === 'buy' ? {color: 'var(--profit)'} : {color: 'var(--loss)'}"
-            },
+            ":cellStyle": "params => params.value === 'buy' ? {color: 'var(--profit)'} : {color: 'var(--loss)'}",
         },
         {"field": "qty", "headerName": "Qty", "width": 80},
         {
@@ -238,35 +250,48 @@ def create_hierarchical_orders_table(expanded_parent_ids: list[str] | None = Non
             "columnDefs": column_defs,
             "rowData": [],
             "domLayout": "autoHeight",
-            "treeData": True,
-            ":getDataPath": "params => params.data.hierarchy_path",
-            "groupDefaultExpanded": 1,
-            "autoGroupColumnDef": {
-                "headerName": "Symbol",
-                "cellRendererParams": {"suppressCount": True},
-                ":valueGetter": "params => params.data ? params.data.symbol : ''",
-                "width": 130,
-            },
             ":getRowId": "params => params.data.client_order_id",
+            ":isExternalFilterPresent": (
+                "() => window.HierarchicalOrdersGrid"
+                " && window.HierarchicalOrdersGrid.hasCollapsedParents('hierarchical_orders_grid')"
+            ),
+            ":doesExternalFilterPass": (
+                "node => {"
+                " if (!node || !node.data || !window.HierarchicalOrdersGrid) return true;"
+                " return window.HierarchicalOrdersGrid.isRowVisible(node.data, 'hierarchical_orders_grid');"
+                "}"
+            ),
             "asyncTransactionWaitMillis": 50,
             "suppressAnimationFrame": False,
             "animateRows": True,
             ":onGridReady": (
-                "params => { window._hierarchicalOrdersGridApi = params.api;"
+                "params => {"
+                " window._hierarchicalOrdersGridApi = params.api;"
+                " if (window.HierarchicalOrdersGrid) {"
+                "  window.HierarchicalOrdersGrid.register(params.api, 'hierarchical_orders_grid');"
+                "  window.HierarchicalOrdersGrid.restoreExpansion("
+                "   params.api, window._hierarchicalOrdersExpanded || [], 'hierarchical_orders_grid'"
+                "  );"
+                " }"
                 " if (window.GridThrottle) window.GridThrottle.registerAsyncGrid('hierarchical_orders_grid');"
-                " if (window.HierarchicalOrdersGrid) window.HierarchicalOrdersGrid.register(params.api, 'hierarchical_orders_grid');"
-                " if (window.HierarchicalOrdersGrid && window._hierarchicalOrdersExpanded)"
-                " window.HierarchicalOrdersGrid.restoreExpansion(params.api, window._hierarchicalOrdersExpanded); }"
+                "}"
             ),
             ":onAsyncTransactionsFlushed": (
-                "params => { if (window.GridThrottle)"
-                " window.GridThrottle.recordTransactionResult(params.api, 'hierarchical_orders_grid', params.results); }"
+                "params => {"
+                " if (window.HierarchicalOrdersGrid) {"
+                "  window.HierarchicalOrdersGrid.refreshVisibility(params.api, 'hierarchical_orders_grid');"
+                " }"
+                " if (window.GridThrottle)"
+                "  window.GridThrottle.recordTransactionResult(params.api, 'hierarchical_orders_grid', params.results);"
+                "}"
             ),
             ":onRowDataUpdated": (
-                "params => { if (window.GridThrottle)"
-                " window.GridThrottle.recordUpdate(params.api, 'hierarchical_orders_grid');"
-                " if (window.HierarchicalOrdersGrid && window._hierarchicalOrdersExpanded)"
-                " window.HierarchicalOrdersGrid.restoreExpansion(params.api, window._hierarchicalOrdersExpanded); }"
+                "params => {"
+                " if (window.HierarchicalOrdersGrid) {"
+                "  window.HierarchicalOrdersGrid.refreshVisibility(params.api, 'hierarchical_orders_grid');"
+                " }"
+                " if (window.GridThrottle) window.GridThrottle.recordUpdate(params.api, 'hierarchical_orders_grid');"
+                "}"
             ),
         }
     )
@@ -278,7 +303,9 @@ def create_hierarchical_orders_table(expanded_parent_ids: list[str] | None = Non
         ui.run_javascript(
             f"window._hierarchicalOrdersExpanded = {expanded_payload};"
             "if (window.HierarchicalOrdersGrid && window._hierarchicalOrdersGridApi)"
-            " window.HierarchicalOrdersGrid.restoreExpansion(window._hierarchicalOrdersGridApi, window._hierarchicalOrdersExpanded);"
+            " window.HierarchicalOrdersGrid.restoreExpansion("
+            "window._hierarchicalOrdersGridApi, window._hierarchicalOrdersExpanded, 'hierarchical_orders_grid'"
+            ");"
         )
 
     monitor = GridPerformanceMonitor("hierarchical_orders_grid")
@@ -453,7 +480,7 @@ async def update_hierarchical_orders_table(
     client_id: str | None = None,
     all_orders: list[dict[str, Any]] | None = None,
 ) -> tuple[set[str], set[str]]:
-    """Update hierarchical orders grid using tree data rows.
+    """Update parent/child orders grid using hierarchy-transformed rows.
 
     Returns:
         (current_order_ids, current_parent_ids)

--- a/apps/web_console_ng/components/status_bar.py
+++ b/apps/web_console_ng/components/status_bar.py
@@ -16,9 +16,11 @@ class StatusBar:
     def _build_ui(self) -> None:
         self._container = ui.element("div").classes(
             "w-full h-6 flex items-center justify-center text-xs font-semibold tracking-wide"
-        )
+        ).props("id=global-status-banner")
         with self._container:
-            self._label = ui.label("TRADING STATUS UNKNOWN").classes("uppercase")
+            self._label = ui.label("TRADING STATUS UNKNOWN").classes("uppercase").props(
+                "id=global-status-banner-label"
+            )
         self._set_state_classes("UNKNOWN")
 
     def _set_state_classes(self, state: str) -> None:
@@ -54,12 +56,16 @@ class StatusBar:
         if stale:
             if cb_normalized == "TRIPPED" or normalized == "ENGAGED":
                 if self._label:
-                    self._label.set_text("TRADING HALTED (STALE)")
+                    self._label.set_text(
+                        "TRADING HALTED (CIRCUIT)"
+                        if cb_normalized == "TRIPPED"
+                        else "TRADING HALTED"
+                    )
                 self._set_state_classes("ENGAGED")
                 return
             if cb_normalized == "QUIET_PERIOD":
                 if self._label:
-                    self._label.set_text("TRADING PAUSED (STALE)")
+                    self._label.set_text("TRADING PAUSED (QUIET)")
                 self._set_state_classes("UNKNOWN")
                 return
             if self._label:

--- a/apps/web_console_ng/components/status_bar.py
+++ b/apps/web_console_ng/components/status_bar.py
@@ -69,7 +69,10 @@ class StatusBar:
                 self._set_state_classes("UNKNOWN")
                 return
             if self._label:
-                self._label.set_text("TRADING ACTIVE (STALE)")
+                if normalized in {"DISENGAGED", "ACTIVE"}:
+                    self._label.set_text("TRADING ACTIVE (STALE)")
+                else:
+                    self._label.set_text("TRADING STATUS UNKNOWN")
             self._set_state_classes("UNKNOWN")
             return
 

--- a/apps/web_console_ng/components/status_bar.py
+++ b/apps/web_console_ng/components/status_bar.py
@@ -40,10 +40,32 @@ class StatusBar:
                 remove="bg-red-600 bg-green-600 text-white",
             )
 
-    def update_state(self, state: str | None, *, circuit_state: str | None = None) -> None:
+    def update_state(
+        self,
+        state: str | None,
+        *,
+        circuit_state: str | None = None,
+        stale: bool = False,
+    ) -> None:
         """Update status bar from kill-switch and circuit-breaker state."""
         normalized = (state or "UNKNOWN").upper()
         cb_normalized = (circuit_state or "UNKNOWN").upper()
+
+        if stale:
+            if cb_normalized == "TRIPPED" or normalized == "ENGAGED":
+                if self._label:
+                    self._label.set_text("TRADING HALTED (STALE)")
+                self._set_state_classes("ENGAGED")
+                return
+            if cb_normalized == "QUIET_PERIOD":
+                if self._label:
+                    self._label.set_text("TRADING PAUSED (STALE)")
+                self._set_state_classes("UNKNOWN")
+                return
+            if self._label:
+                self._label.set_text("TRADING ACTIVE (STALE)")
+            self._set_state_classes("UNKNOWN")
+            return
 
         if cb_normalized == "TRIPPED":
             if self._label:

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -164,6 +164,28 @@ def render_exposure_grid(
 
     dollar_fmt = "params => params.value != null ? (params.value >= 0 ? '+$' : '-$') + Math.abs(params.value).toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) : '-'"
     pct_fmt = "params => params.value != null ? (params.value >= 0 ? '+' : '') + params.value.toFixed(1) + '%' : '-'"
+    fit_columns_once_js = (
+        "params => { "
+        "const root = params.api.getGui ? params.api.getGui() : null; "
+        "const width = root && root.clientWidth ? root.clientWidth : 0; "
+        "if (width > 0) { params.api.sizeColumnsToFit(); } "
+        "}"
+    )
+    bind_fit_columns_js = (
+        "params => { "
+        "const fit = () => { "
+        "const root = params.api.getGui ? params.api.getGui() : null; "
+        "const width = root && root.clientWidth ? root.clientWidth : 0; "
+        "if (width > 0) { params.api.sizeColumnsToFit(); } "
+        "}; "
+        "requestAnimationFrame(fit); "
+        "setTimeout(fit, 120); "
+        "if (!params.api.__wcExposureFitBound) { "
+        "params.api.__wcExposureFitBound = true; "
+        "params.api.addEventListener('gridSizeChanged', fit); "
+        "} "
+        "}"
+    )
 
     grid_options = {
         "defaultColDef": {
@@ -220,28 +242,18 @@ def render_exposure_grid(
             {
                 "field": "positions",
                 "headerName": "# Pos",
-                "minWidth": 84,
-                "maxWidth": 110,
-                "flex": 0.6,
+                "minWidth": 96,
+                "flex": 0.8,
             },
         ],
         "rowData": rows,
         "domLayout": "normal",
         "animateRows": True,
-        ":onGridReady": (
-            "params => { "
-            "const fit = () => { "
-            "const viewport = params.api?.gridBodyCtrl?.eBodyViewport; "
-            "const width = viewport && viewport.clientWidth ? viewport.clientWidth : 0; "
-            "if (width > 0) { params.api.sizeColumnsToFit(); } "
-            "}; "
-            "requestAnimationFrame(fit); "
-            "params.api.addEventListener('gridSizeChanged', fit); "
-            "}"
-        ),
+        ":onGridReady": bind_fit_columns_js,
+        ":onFirstDataRendered": fit_columns_once_js,
     }
 
-    return ui.aggrid(grid_options).classes("w-full min-w-0 ag-theme-alpine-dark")
+    return ui.aggrid(grid_options).classes("w-full min-w-0 pr-1 ag-theme-alpine-dark")
 
 
 def build_exposure_rows(

--- a/apps/web_console_ng/components/strategy_exposure.py
+++ b/apps/web_console_ng/components/strategy_exposure.py
@@ -166,61 +166,82 @@ def render_exposure_grid(
     pct_fmt = "params => params.value != null ? (params.value >= 0 ? '+' : '') + params.value.toFixed(1) + '%' : '-'"
 
     grid_options = {
+        "defaultColDef": {
+            "resizable": True,
+        },
         "columnDefs": [
             {
                 "field": "strategy",
                 "headerName": "Strategy",
                 "pinned": "left",
-                "minWidth": 160,
+                "minWidth": 150,
+                "flex": 1.6,
                 ":cellClass": "params => params.value === 'TOTAL' ? 'font-bold' : ''",
             },
             {
                 "field": "net",
                 "headerName": "Net ($)",
                 ":valueFormatter": dollar_fmt,
-                "minWidth": 130,
+                "minWidth": 110,
+                "flex": 1.0,
                 ":cellClass": "params => params.value >= 0 ? 'text-green-600' : 'text-red-600'",
             },
             {
                 "field": "gross",
                 "headerName": "Gross ($)",
                 ":valueFormatter": "params => params.value != null ? '$' + params.value.toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) : '-'",
-                "minWidth": 130,
+                "minWidth": 110,
+                "flex": 1.0,
             },
             {
                 "field": "long",
                 "headerName": "Long ($)",
                 ":valueFormatter": "params => params.value != null ? '$' + params.value.toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) : '-'",
-                "minWidth": 120,
+                "minWidth": 105,
+                "flex": 1.0,
                 "cellClass": "text-green-600",
             },
             {
                 "field": "short",
                 "headerName": "Short ($)",
                 ":valueFormatter": "params => params.value != null ? '$' + params.value.toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 0}) : '-'",
-                "minWidth": 120,
+                "minWidth": 105,
+                "flex": 1.0,
                 "cellClass": "text-red-600",
             },
             {
                 "field": "net_pct",
                 "headerName": "Net %",
                 ":valueFormatter": pct_fmt,
-                "minWidth": 100,
+                "minWidth": 95,
+                "flex": 0.8,
                 ":cellClass": "params => params.value >= 0 ? 'text-green-600' : 'text-red-600'",
             },
             {
                 "field": "positions",
                 "headerName": "# Pos",
-                "minWidth": 95,
-                "maxWidth": 120,
+                "minWidth": 84,
+                "maxWidth": 110,
+                "flex": 0.6,
             },
         ],
         "rowData": rows,
         "domLayout": "normal",
         "animateRows": True,
+        ":onGridReady": (
+            "params => { "
+            "const fit = () => { "
+            "const viewport = params.api?.gridBodyCtrl?.eBodyViewport; "
+            "const width = viewport && viewport.clientWidth ? viewport.clientWidth : 0; "
+            "if (width > 0) { params.api.sizeColumnsToFit(); } "
+            "}; "
+            "requestAnimationFrame(fit); "
+            "params.api.addEventListener('gridSizeChanged', fit); "
+            "}"
+        ),
     }
 
-    return ui.aggrid(grid_options).classes("w-full ag-theme-alpine-dark")
+    return ui.aggrid(grid_options).classes("w-full min-w-0 ag-theme-alpine-dark")
 
 
 def build_exposure_rows(

--- a/apps/web_console_ng/pages/circuit_breaker.py
+++ b/apps/web_console_ng/pages/circuit_breaker.py
@@ -230,7 +230,18 @@ async def circuit_breaker_page() -> None:
                 backend_value_int = int(backend_value)
                 if backend_value_int > 0:
                     backend_count = backend_value_int
-            trip_count = max(history_count, backend_count)
+
+            # Some backends report all-time "trip_count_today"; only trust that
+            # value when the active trip itself occurred today. Prefer history
+            # payload whenever it has same-day events.
+            status_trip_dt = _parse_utc_datetime(status_data.get("tripped_at"))
+            status_trip_is_today = status_trip_dt is not None and status_trip_dt.date() == now.date()
+            if history_count > 0:
+                trip_count = history_count
+            elif status_trip_is_today:
+                trip_count = max(1, backend_count)
+            else:
+                trip_count = 0
             if trip_count > 0:
                 with ui.row().classes("mt-2"):
                     ui.label("Trips Today:").classes("font-medium")

--- a/apps/web_console_ng/pages/compare.py
+++ b/apps/web_console_ng/pages/compare.py
@@ -90,7 +90,7 @@ async def strategy_comparison_page() -> None:
     if len(authorized_strategies) < MIN_STRATEGIES:
         with ui.card().classes("w-full p-6"):
             ui.label("You need access to at least two strategies to compare performance.").classes(
-                "text-amber-600 text-center"
+                "text-amber-600 text-center whitespace-normal break-words max-w-2xl mx-auto"
             )
         return
 
@@ -319,7 +319,7 @@ def _render_metrics_table(metrics: dict[str, dict[str, float]]) -> None:
             {"name": "sharpe", "label": "Sharpe", "field": "sharpe", "sortable": True},
             {
                 "name": "max_drawdown",
-                "label": "Max Drawdown %",
+                "label": "Max Drawdown ($)",
                 "field": "max_drawdown",
                 "sortable": True,
             },
@@ -584,14 +584,14 @@ def _render_demo_mode(authorized_strategies: list[str]) -> None:
                 "total_return": "$12,500.00",
                 "volatility": "$850.00",
                 "sharpe": "1.45",
-                "max_drawdown": "-3.20%",
+                "max_drawdown": "-$3,200.00",
             },
             {
                 "strategy": "strategy_b",
                 "total_return": "$8,200.00",
                 "volatility": "$620.00",
                 "sharpe": "1.12",
-                "max_drawdown": "-2.10%",
+                "max_drawdown": "-$2,100.00",
             },
         ]
 
@@ -600,7 +600,7 @@ def _render_demo_mode(authorized_strategies: list[str]) -> None:
             {"name": "total_return", "label": "Total Return", "field": "total_return"},
             {"name": "volatility", "label": "Volatility", "field": "volatility"},
             {"name": "sharpe", "label": "Sharpe", "field": "sharpe"},
-            {"name": "max_drawdown", "label": "Max Drawdown %", "field": "max_drawdown"},
+            {"name": "max_drawdown", "label": "Max Drawdown ($)", "field": "max_drawdown"},
         ]
 
         ui.table(columns=columns, rows=demo_metrics).classes("w-full")

--- a/apps/web_console_ng/pages/compare.py
+++ b/apps/web_console_ng/pages/compare.py
@@ -90,7 +90,7 @@ async def strategy_comparison_page() -> None:
     if len(authorized_strategies) < MIN_STRATEGIES:
         with ui.card().classes("w-full p-6"):
             ui.label("You need access to at least two strategies to compare performance.").classes(
-                "text-amber-600 text-center whitespace-normal break-words max-w-2xl mx-auto"
+                "text-amber-600 text-center whitespace-normal break-words w-full max-w-3xl mx-auto"
             )
         return
 
@@ -209,7 +209,7 @@ async def _render_comparison_tool(
                 loading.delete()
                 ui.label(
                     "You do not have permission to access one or more selected strategies."
-                ).classes("text-red-500 p-4")
+                ).classes("text-red-500 p-4 whitespace-normal break-words w-full")
             except (ConnectionError, OSError) as exc:
                 loading.delete()
                 logger.error(

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -1573,6 +1573,10 @@ async def dashboard(client: Client) -> None:
             return False
         return None
 
+    def _normalize_kill_switch_state(state_raw: Any) -> str:
+        state = str(state_raw or "").upper() or "UNKNOWN"
+        return "DISENGAGED" if state == "ACTIVE" else state
+
     async def check_initial_kill_switch() -> None:
         """Fetch initial kill switch status on page load."""
         nonlocal kill_switch_engaged, workspace_kill_switch_state
@@ -1582,7 +1586,7 @@ async def dashboard(client: Client) -> None:
                 role=user_role,
                 strategies=user_strategies,
             )
-            state = str(ks_status.get("state", "")).upper() or "UNKNOWN"
+            state = _normalize_kill_switch_state(ks_status.get("state", ""))
             workspace_kill_switch_state = state
             kill_switch_engaged = _parse_kill_switch_state(state)
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:
@@ -1590,11 +1594,21 @@ async def dashboard(client: Client) -> None:
                 "kill_switch_initial_check_failed",
                 extra={"user_id": user_id, "error": type(exc).__name__},
             )
-            # Use None (unknown) on API failure to preserve fail-open path in on_close_position
-            # This allows risk-reducing closes during kill switch service outages
+            cached_state = _normalize_kill_switch_state(
+                app.storage.user.get("global_kill_switch_state")
+            )
+            if cached_state != "UNKNOWN":
+                workspace_kill_switch_state = cached_state
+            else:
+                workspace_kill_switch_state = "UNKNOWN"
+            # Preserve fail-open close behavior during kill-switch service outages.
+            # Cached state is only for UI continuity; submission guards use live checks.
             kill_switch_engaged = None
-            workspace_kill_switch_state = "UNKNOWN"
         _update_workspace_kill_switch_pill()
+        app.storage.user["global_kill_switch_state"] = workspace_kill_switch_state
+        dispatch_trading_state_event(
+            client_id, {"killSwitchState": workspace_kill_switch_state}
+        )
 
     await check_initial_kill_switch()
     _set_bulk_action_buttons_enabled(not bulk_action_in_progress)
@@ -1614,8 +1628,13 @@ async def dashboard(client: Client) -> None:
                 "circuit_breaker_initial_check_failed",
                 extra={"user_id": user_id, "error": type(exc).__name__},
             )
-            workspace_circuit_breaker_state = "UNKNOWN"
+            cached_state = str(app.storage.user.get("global_circuit_state", "")).upper()
+            workspace_circuit_breaker_state = cached_state or "UNKNOWN"
         _update_workspace_circuit_breaker_pill()
+        app.storage.user["global_circuit_state"] = workspace_circuit_breaker_state
+        dispatch_trading_state_event(
+            client_id, {"circuitBreakerState": workspace_circuit_breaker_state}
+        )
 
     await check_initial_circuit_breaker()
 
@@ -1632,6 +1651,7 @@ async def dashboard(client: Client) -> None:
             workspace_kill_switch_state = state
             kill_switch_engaged = _parse_kill_switch_state(state)
             _update_workspace_kill_switch_pill()
+            app.storage.user["global_kill_switch_state"] = _normalize_kill_switch_state(state)
             if state not in {"DISENGAGED", "ACTIVE"}:
                 return (False, "Cannot flatten: Kill Switch is not DISENGAGED")
             return (True, "")
@@ -1639,6 +1659,7 @@ async def dashboard(client: Client) -> None:
             workspace_kill_switch_state = "UNKNOWN"
             kill_switch_engaged = None
             _update_workspace_kill_switch_pill()
+            app.storage.user["global_kill_switch_state"] = workspace_kill_switch_state
             logger.warning(
                 "flatten_all_kill_switch_check_failed",
                 extra={"user_id": user_id, "error": type(exc).__name__},
@@ -1648,6 +1669,7 @@ async def dashboard(client: Client) -> None:
             workspace_kill_switch_state = "UNKNOWN"
             kill_switch_engaged = None
             _update_workspace_kill_switch_pill()
+            app.storage.user["global_kill_switch_state"] = workspace_kill_switch_state
             logger.exception(
                 "flatten_all_kill_switch_check_unexpected_error",
                 extra={"user_id": user_id, "error": type(exc).__name__},
@@ -2085,11 +2107,12 @@ async def dashboard(client: Client) -> None:
     async def on_kill_switch_update(data: dict[str, Any]) -> None:
         nonlocal kill_switch_engaged, workspace_kill_switch_state
         logger.info("kill_switch_update", extra={"client_id": client_id, "data": data})
-        state = str(data.get("state", "")).upper()
-        workspace_kill_switch_state = state or "UNKNOWN"
+        state = _normalize_kill_switch_state(data.get("state", ""))
+        workspace_kill_switch_state = state
         # Update cached state for instant UI responses; unknown stays None for fail-open closes
         kill_switch_engaged = _parse_kill_switch_state(state)
         _update_workspace_kill_switch_pill()
+        app.storage.user["global_kill_switch_state"] = workspace_kill_switch_state
         dispatch_trading_state_event(client_id, {"killSwitchState": state})
         await activity_feed.add_item(
             {
@@ -2107,6 +2130,7 @@ async def dashboard(client: Client) -> None:
         state = str(data.get("state", "")).upper()
         workspace_circuit_breaker_state = state or "UNKNOWN"
         _update_workspace_circuit_breaker_pill()
+        app.storage.user["global_circuit_state"] = workspace_circuit_breaker_state
         dispatch_trading_state_event(client_id, {"circuitBreakerState": state})
         await activity_feed.add_item(
             {

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -1167,11 +1167,13 @@ async def dashboard(client: Client) -> None:
     bulk_action_in_progress = False
     cancel_dialog_open = False
     flatten_dialog_open = False
+    bulk_action_handlers_ready = False
 
     def _set_bulk_action_buttons_enabled(enabled: bool) -> None:
         if cancel_symbol_orders_btn is not None:
             cancel_enabled = (
                 enabled
+                and bulk_action_handlers_ready
                 and can_cancel_all_orders(user_role=user_role)
                 and not workspace_connection_read_only
                 and not cancel_dialog_open
@@ -1183,6 +1185,7 @@ async def dashboard(client: Client) -> None:
         if flatten_all_positions_btn is not None:
             flatten_enabled = (
                 enabled
+                and bulk_action_handlers_ready
                 and can_flatten_all_positions(user_role=user_role)
                 and not workspace_connection_read_only
                 and not flatten_dialog_open
@@ -2016,6 +2019,9 @@ async def dashboard(client: Client) -> None:
                 cancel_btn = ui.button("Cancel", on_click=dialog.close)
 
         dialog.open()
+
+    bulk_action_handlers_ready = True
+    _set_bulk_action_buttons_enabled(not bulk_action_in_progress)
 
     async def on_position_update(data: dict[str, Any]) -> None:
         nonlocal position_symbols, positions_snapshot

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
-from urllib.parse import parse_qsl, urlencode
+from urllib.parse import urlencode
 
 import httpx
 from nicegui import Client, app, events, ui
@@ -2983,24 +2983,18 @@ def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:
             extra={"error_type": type(exc).__name__, "error": str(exc)},
         )
         return target
-
-    scope = getattr(request, "scope", None)
-    if not isinstance(scope, dict):
+    if request is None:
         return target
 
-    raw_query = scope.get("query_string", b"")
-    if isinstance(raw_query, bytes):
-        try:
-            raw_query_str = raw_query.decode("utf-8")
-        except UnicodeDecodeError as exc:
-            logger.warning(
-                "trade_alias_query_decode_failed",
-                extra={"error_type": type(exc).__name__, "error": str(exc)},
-            )
-            return target
+    query_params = getattr(request, "query_params", None)
+    if query_params is None:
+        return target
+    multi_items = getattr(query_params, "multi_items", None)
+    if callable(multi_items):
+        query_items = list(multi_items())
     else:
-        raw_query_str = str(raw_query)
-    query_items = parse_qsl(raw_query_str, keep_blank_values=False)
+        items = getattr(query_params, "items", None)
+        query_items = list(items()) if callable(items) else []
     safe_items = [(key, value) for key, value in query_items if key in TRADE_REDIRECT_QUERY_KEYS]
     if not safe_items:
         return target

--- a/apps/web_console_ng/pages/dashboard.py
+++ b/apps/web_console_ng/pages/dashboard.py
@@ -88,7 +88,7 @@ from apps.web_console_ng.core.redis_ha import get_redis_store
 from apps.web_console_ng.core.sparkline_service import SparklineDataService
 from apps.web_console_ng.core.state_manager import UserStateManager
 from apps.web_console_ng.ui.layout import main_layout
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from apps.web_console_ng.utils.time import validate_and_normalize_symbol
 from libs.core.common.db import acquire_connection
 from libs.data.data_pipeline.health_monitor import get_health_monitor
@@ -2941,7 +2941,11 @@ async def dashboard(client: Client) -> None:
 @requires_auth
 async def dashboard_trade_alias() -> None:
     """Legacy alias route for canonical trade workspace."""
-    ui.navigate.to(_build_trade_alias_redirect_target(ui_module=ui))
+    render_client_redirect(
+        _build_trade_alias_redirect_target(ui_module=ui),
+        ui_module=ui,
+        message="Redirecting to Trade workspace...",
+    )
 
 
 def _build_trade_alias_redirect_target(*, ui_module: Any) -> str:

--- a/apps/web_console_ng/pages/data_coverage.py
+++ b/apps/web_console_ng/pages/data_coverage.py
@@ -130,8 +130,6 @@ async def data_coverage_page() -> None:
                 available_tickers=available_tickers,
                 on_analyze=on_analyze,
             )
-            if not has_coverage_data:
-                ui.button("Analyze Coverage", color="primary").props("disable").classes("mt-4")
 
         with ui.column().classes("flex-1"):
             with results_container:

--- a/apps/web_console_ng/pages/data_inspector.py
+++ b/apps/web_console_ng/pages/data_inspector.py
@@ -52,8 +52,34 @@ async def data_inspector_page() -> None:
         )
 
     inspector = PITInspector()
-    available_tickers = await asyncio.to_thread(inspector.get_available_tickers)
-    min_date, max_date = await asyncio.to_thread(inspector.get_date_range)
+    try:
+        available_tickers = await asyncio.wait_for(
+            asyncio.to_thread(inspector.get_available_tickers),
+            timeout=4.0,
+        )
+    except TimeoutError:
+        logger.warning("pit_catalog_timeout", extra={"operation": "get_available_tickers"})
+        available_tickers = []
+    except Exception:
+        logger.exception("pit_catalog_fetch_failed")
+        available_tickers = []
+
+    min_date: date | None = None
+    max_date: date | None = None
+    if available_tickers:
+        try:
+            min_date, max_date = await asyncio.wait_for(
+                asyncio.to_thread(inspector.get_date_range),
+                timeout=4.0,
+            )
+        except TimeoutError:
+            logger.warning("pit_date_range_timeout")
+            min_date = None
+            max_date = None
+        except Exception:
+            logger.exception("pit_date_range_failed")
+            min_date = None
+            max_date = None
 
     results_container = ui.column().classes("w-full mt-4")
 
@@ -99,6 +125,11 @@ async def data_inspector_page() -> None:
                 max_date=max_date.isoformat() if max_date else None,
                 on_submit=on_submit,
             )
+            if not available_tickers:
+                ui.label(
+                    "Ticker catalog unavailable or loading timed out. "
+                    "Retry in a moment after data services settle."
+                ).classes("text-xs text-amber-600 mt-2")
 
         # Right: Results
         with ui.column().classes("flex-1"):

--- a/apps/web_console_ng/pages/data_inspector.py
+++ b/apps/web_console_ng/pages/data_inspector.py
@@ -27,6 +27,38 @@ from libs.platform.web_console_auth.permissions import Permission, has_permissio
 logger = logging.getLogger(__name__)
 
 
+class PITCatalogUnavailableError(RuntimeError):
+    """Raised when PIT catalog metadata cannot be loaded for the page."""
+
+
+async def _load_available_tickers(inspector: PITInspector) -> list[str]:
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(inspector.get_available_tickers),
+            timeout=4.0,
+        )
+    except TimeoutError as exc:
+        logger.warning("pit_catalog_timeout", extra={"operation": "get_available_tickers"})
+        raise PITCatalogUnavailableError("PIT catalog request timed out") from exc
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.exception("pit_catalog_fetch_failed")
+        raise PITCatalogUnavailableError("PIT catalog metadata unavailable") from exc
+
+
+async def _load_date_range(inspector: PITInspector) -> tuple[date | None, date | None]:
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(inspector.get_date_range),
+            timeout=4.0,
+        )
+    except TimeoutError as exc:
+        logger.warning("pit_date_range_timeout")
+        raise PITCatalogUnavailableError("PIT date range request timed out") from exc
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.exception("pit_date_range_failed")
+        raise PITCatalogUnavailableError("PIT date range unavailable") from exc
+
+
 @ui.page("/data/inspector")
 @requires_auth
 @main_layout
@@ -53,31 +85,16 @@ async def data_inspector_page() -> None:
 
     inspector = PITInspector()
     try:
-        available_tickers = await asyncio.wait_for(
-            asyncio.to_thread(inspector.get_available_tickers),
-            timeout=4.0,
-        )
-    except TimeoutError:
-        logger.warning("pit_catalog_timeout", extra={"operation": "get_available_tickers"})
-        available_tickers = []
-    except Exception:
-        logger.exception("pit_catalog_fetch_failed")
+        available_tickers = await _load_available_tickers(inspector)
+    except PITCatalogUnavailableError:
         available_tickers = []
 
     min_date: date | None = None
     max_date: date | None = None
     if available_tickers:
         try:
-            min_date, max_date = await asyncio.wait_for(
-                asyncio.to_thread(inspector.get_date_range),
-                timeout=4.0,
-            )
-        except TimeoutError:
-            logger.warning("pit_date_range_timeout")
-            min_date = None
-            max_date = None
-        except Exception:
-            logger.exception("pit_date_range_failed")
+            min_date, max_date = await _load_date_range(inspector)
+        except PITCatalogUnavailableError:
             min_date = None
             max_date = None
 

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -32,7 +32,7 @@ from nicegui import ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.ui.layout import main_layout
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from libs.data.data_quality.quality_scorer import (
     compute_quality_scores,
@@ -1592,4 +1592,8 @@ __all__ = ["data_management_page"]
 @requires_auth
 async def data_management_alias_page() -> None:
     """Legacy alias route for Data Hub."""
-    ui.navigate.to(resolve_rooted_path_from_ui("/data", ui_module=ui))
+    render_client_redirect(
+        resolve_rooted_path_from_ui("/data", ui_module=ui),
+        ui_module=ui,
+        message="Redirecting to Data Hub...",
+    )

--- a/apps/web_console_ng/pages/exposure.py
+++ b/apps/web_console_ng/pages/exposure.py
@@ -20,7 +20,7 @@ from apps.web_console_ng.components.strategy_exposure import (
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.core.database import get_db_pool
 from apps.web_console_ng.ui.layout import main_layout
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 from libs.web_console_services.exposure_service import ExposureService
@@ -227,4 +227,8 @@ __all__ = ["exposure_page"]
 @requires_auth
 async def exposure_alias_page() -> None:
     """Legacy alias route; keep deep links working with canonical path."""
-    ui.navigate.to(resolve_rooted_path_from_ui("/risk/exposure", ui_module=ui))
+    render_client_redirect(
+        resolve_rooted_path_from_ui("/risk/exposure", ui_module=ui),
+        ui_module=ui,
+        message="Redirecting to Strategy Exposure...",
+    )

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -244,7 +244,7 @@ async def feature_browser_page() -> None:
             data_state["message"] = None
             return features_df
         except FileNotFoundError:
-            data_state["message"] = "Feature data not available — run ETL pipeline first."
+            data_state["message"] = "Feature dataset not mounted. Run ETL sync, then reload this page."
             return None
         except RuntimeError as exc:
             if "alpha158 feature dependencies are unavailable" in str(exc):
@@ -252,14 +252,16 @@ async def feature_browser_page() -> None:
                     "feature_dependencies_unavailable",
                     extra={"dependency": "qlib"},
                 )
-                data_state["message"] = "Feature data unavailable: optional qlib dependency missing."
+                data_state["message"] = (
+                    "Live feature preview requires qlib dependencies in the web-console image."
+                )
                 return None
             logger.exception("feature_data_load_failed")
-            data_state["message"] = "Feature data unavailable."
+            data_state["message"] = "Feature preview temporarily unavailable."
             return None
         except Exception:
             logger.exception("feature_data_load_failed")
-            data_state["message"] = "Feature data unavailable."
+            data_state["message"] = "Feature preview temporarily unavailable."
             return None
         finally:
             loading_state["feature_data_loading"] = False
@@ -376,10 +378,18 @@ async def feature_browser_page() -> None:
                 stats_panel.clear()
                 chart_panel.clear()
                 with samples_panel:
-                    ui.label(
-                        data_state["message"]
-                        or "No feature data available. Run the ETL pipeline to generate features."
-                    ).classes("text-gray-500")
+                    with ui.card().classes("w-full p-4 bg-amber-50 border border-amber-300"):
+                        ui.label(
+                            data_state["message"]
+                            or "No feature data available. Run ETL pipeline to generate features."
+                        ).classes("text-amber-700 text-sm")
+                        with ui.row().classes("gap-3 mt-2"):
+                            ui.link("Open Data Coverage", "/data/coverage").classes(
+                                "text-blue-600 hover:underline text-xs"
+                            )
+                            ui.link("Open Data Sources", "/data/sources").classes(
+                                "text-blue-600 hover:underline text-xs"
+                            )
                 return
 
             stats_list = await asyncio.to_thread(

--- a/apps/web_console_ng/pages/feature_browser.py
+++ b/apps/web_console_ng/pages/feature_browser.py
@@ -257,11 +257,11 @@ async def feature_browser_page() -> None:
                 )
                 return None
             logger.exception("feature_data_load_failed")
-            data_state["message"] = "Feature preview temporarily unavailable."
+            data_state["message"] = "Feature preview is temporarily degraded."
             return None
         except Exception:
             logger.exception("feature_data_load_failed")
-            data_state["message"] = "Feature preview temporarily unavailable."
+            data_state["message"] = "Feature preview is temporarily degraded."
             return None
         finally:
             loading_state["feature_data_loading"] = False
@@ -381,7 +381,7 @@ async def feature_browser_page() -> None:
                     with ui.card().classes("w-full p-4 bg-amber-50 border border-amber-300"):
                         ui.label(
                             data_state["message"]
-                            or "No feature data available. Run ETL pipeline to generate features."
+                            or "Feature preview data is not ready yet. Run ETL pipeline to generate features."
                         ).classes("text-amber-700 text-sm")
                         with ui.row().classes("gap-3 mt-2"):
                             ui.link("Open Data Coverage", "/data/coverage").classes(
@@ -405,7 +405,7 @@ async def feature_browser_page() -> None:
             _render_chart(samples, feature_name)
         except Exception:
             logger.exception("feature_statistics_failed", extra={"feature": feature_name})
-            _notify("Feature statistics unavailable", type="warning")
+            _notify("Feature statistics preview is temporarily degraded", type="warning")
         finally:
             loading_state["detail_loading"] = False
 

--- a/apps/web_console_ng/pages/health.py
+++ b/apps/web_console_ng/pages/health.py
@@ -195,9 +195,6 @@ async def health_page() -> None:
                     extra={"error": str(e), "operation": "fetch_health_data"},
                 )
 
-    # Initial fetch
-    await fetch_health_data()
-
     # Page title
     ui.label("System Health Monitor").classes("text-2xl font-bold mb-4")
 
@@ -365,19 +362,61 @@ async def health_page() -> None:
 
     # Auto-refresh
     async def auto_refresh() -> None:
-        await fetch_health_data()
-        service_grid.refresh()
-        connectivity_section.refresh()
-        latency_section.refresh()
+        try:
+            await fetch_health_data()
+            service_grid.refresh()
+            connectivity_section.refresh()
+            latency_section.refresh()
+        except Exception as exc:
+            logger.warning(
+                "health_auto_refresh_failed",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+
+    def _cancel_timer_handle(timer_handle: Any) -> None:
+        cancel_fn = getattr(timer_handle, "cancel", None)
+        if callable(cancel_fn):
+            cancel_fn()
+            return
+        deactivate_fn = getattr(timer_handle, "deactivate", None)
+        if callable(deactivate_fn):
+            deactivate_fn()
 
     # ⚠️ Rev 19: Timer lifecycle cleanup (see Note #29)
     timer = ui.timer(config.AUTO_REFRESH_INTERVAL, auto_refresh)
+    initial_refresh_timer: Any | None = None
+    # Defer first fetch until after page mount to avoid NiceGUI response timeout
+    try:
+        initial_refresh_timer = ui.timer(0.1, auto_refresh, once=True)
+    except TypeError:
+        # Compatibility path for timer APIs without "once": self-cancel after first run.
+        initial_refresh_started = False
+
+        async def _compat_initial_refresh() -> None:
+            nonlocal initial_refresh_started
+            if initial_refresh_started:
+                return
+            initial_refresh_started = True
+            await auto_refresh()
+            if initial_refresh_timer is not None:
+                _cancel_timer_handle(initial_refresh_timer)
+
+        initial_refresh_timer = ui.timer(0.1, _compat_initial_refresh)
 
     # Register cleanup on client disconnect to prevent timer leaks
     client_id = ui.context.client.storage.get("client_id")
     if client_id:
         lifecycle_mgr = ClientLifecycleManager.get()
-        await lifecycle_mgr.register_cleanup_callback(client_id, lambda: timer.cancel())
+
+        def _cleanup_timers() -> None:
+            _cancel_timer_handle(timer)
+            if initial_refresh_timer is not None:
+                _cancel_timer_handle(initial_refresh_timer)
+
+        await lifecycle_mgr.register_cleanup_callback(
+            client_id,
+            _cleanup_timers,
+        )
 
 
 __all__ = ["health_page"]

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -111,16 +111,18 @@ async def risk_dashboard(client: Client) -> None:
     error_state: str | None = None  # Persistent error message for inline display
     prev_error_state: str | None = None  # Track previous error to avoid notification spam
     live_position_count_hint: int | None = None
+    live_position_snapshot: list[dict[str, Any]] = []
 
     async def load_risk_data() -> None:
         """Fetch risk data via RiskService (same as Streamlit, NOT REST)."""
-        nonlocal risk_data, error_state, prev_error_state, live_position_count_hint
+        nonlocal risk_data, error_state, prev_error_state, live_position_count_hint, live_position_snapshot
 
         def set_error(msg: str) -> None:
             """Set error state and notify only on state transition."""
-            nonlocal error_state, prev_error_state, live_position_count_hint
+            nonlocal error_state, prev_error_state, live_position_count_hint, live_position_snapshot
             risk_data.clear()  # Clear stale data on error
             live_position_count_hint = None
+            live_position_snapshot = []
             if error_state != msg:  # Only notify on state change (avoid spam)
                 error_state = msg
                 ui.notify(msg, type="negative")
@@ -142,7 +144,10 @@ async def risk_dashboard(client: Client) -> None:
                 },
             )
             service = RiskService(scoped_access)
-            data = await service.get_risk_dashboard_data()
+            data = await asyncio.wait_for(
+                service.get_risk_dashboard_data(),
+                timeout=8.0,
+            )
 
             risk_data.clear()
             risk_data.update(
@@ -156,16 +161,22 @@ async def risk_dashboard(client: Client) -> None:
                 }
             )
             live_position_count_hint = None
+            live_position_snapshot = []
             if not data.risk_metrics:
                 try:
-                    positions_payload = await AsyncTradingClient.get().fetch_positions(
-                        str(user_id),
-                        role=str(user_role or ""),
-                        strategies=list(authorized_strategies),
+                    positions_payload = await asyncio.wait_for(
+                        AsyncTradingClient.get().fetch_positions(
+                            str(user_id),
+                            role=str(user_role or ""),
+                            strategies=list(authorized_strategies),
+                        ),
+                        timeout=4.0,
                     )
                     positions_rows = positions_payload.get("positions", [])
                     if isinstance(positions_rows, list):
-                        live_position_count_hint = len(positions_rows)
+                        normalized_rows = [row for row in positions_rows if isinstance(row, dict)]
+                        live_position_snapshot = normalized_rows
+                        live_position_count_hint = len(normalized_rows)
                 except (
                     TimeoutError,
                     httpx.HTTPError,
@@ -179,6 +190,7 @@ async def risk_dashboard(client: Client) -> None:
                         exc_info=True,
                     )
                     live_position_count_hint = None
+                    live_position_snapshot = []
             error_state = None  # Clear error on success
             prev_error_state = None
         except PermissionError as e:
@@ -255,7 +267,56 @@ async def risk_dashboard(client: Client) -> None:
         def risk_overview_section() -> None:
             metrics = risk_data.get("risk_metrics", {})
             if not metrics:
-                if isinstance(live_position_count_hint, int) and live_position_count_hint > 0:
+                if live_position_snapshot:
+                    def _position_market_value(position: dict[str, Any]) -> float:
+                        market_value = safe_float(position.get("market_value"))
+                        if market_value is not None:
+                            return market_value
+                        qty = safe_float(position.get("qty")) or 0.0
+                        px = safe_float(position.get("current_price"))
+                        if px is None:
+                            px = safe_float(position.get("avg_entry_price"))
+                        return qty * px if px is not None else 0.0
+
+                    gross_exposure = 0.0
+                    net_exposure = 0.0
+                    total_unrealized = 0.0
+                    for pos in live_position_snapshot:
+                        mv = _position_market_value(pos)
+                        gross_exposure += abs(mv)
+                        net_exposure += mv
+                        total_unrealized += safe_float(pos.get("unrealized_pl")) or 0.0
+
+                    with ui.card().classes("w-full p-4 bg-amber-50 border border-amber-300 mb-4"):
+                        ui.label("Model-derived risk metrics unavailable").classes(
+                            "text-amber-700 font-semibold"
+                        )
+                        ui.label(
+                            "Showing live exposure proxies until full risk model artifacts refresh."
+                        ).classes("text-sm text-amber-700")
+
+                    with ui.row().classes("gap-8 mb-6"):
+                        _render_risk_metric(
+                            "Open Positions",
+                            str(len(live_position_snapshot)),
+                            "Count of currently open positions",
+                        )
+                        _render_risk_metric(
+                            "Gross Exposure",
+                            f"${gross_exposure:,.0f}",
+                            "Sum of absolute market value across positions",
+                        )
+                        _render_risk_metric(
+                            "Net Exposure",
+                            f"${net_exposure:,.0f}",
+                            "Directional net market value across positions",
+                        )
+                        _render_risk_metric(
+                            "Unrealized P&L",
+                            f"${total_unrealized:+,.2f}",
+                            "Current unrealized profit/loss from live positions",
+                        )
+                elif isinstance(live_position_count_hint, int) and live_position_count_hint > 0:
                     with ui.card().classes("w-full p-4 bg-amber-50 border border-amber-300"):
                         ui.label("Risk model metrics unavailable").classes(
                             "text-amber-700 font-semibold"

--- a/apps/web_console_ng/pages/risk.py
+++ b/apps/web_console_ng/pages/risk.py
@@ -117,6 +117,33 @@ async def risk_dashboard(client: Client) -> None:
         """Fetch risk data via RiskService (same as Streamlit, NOT REST)."""
         nonlocal risk_data, error_state, prev_error_state, live_position_count_hint, live_position_snapshot
 
+        async def load_live_position_snapshot() -> list[dict[str, Any]]:
+            try:
+                positions_payload = await asyncio.wait_for(
+                    AsyncTradingClient.get().fetch_positions(
+                        str(user_id),
+                        role=str(user_role or ""),
+                        strategies=list(authorized_strategies),
+                    ),
+                    timeout=4.0,
+                )
+                positions_rows = positions_payload.get("positions", [])
+                if isinstance(positions_rows, list):
+                    return [row for row in positions_rows if isinstance(row, dict)]
+            except (
+                TimeoutError,
+                httpx.HTTPError,
+                RuntimeError,
+                ValueError,
+                TypeError,
+            ) as exc:
+                logger.warning(
+                    "risk_live_position_hint_failed",
+                    extra={"user_id": user_id, "error_type": type(exc).__name__},
+                    exc_info=True,
+                )
+            return []
+
         def set_error(msg: str) -> None:
             """Set error state and notify only on state transition."""
             nonlocal error_state, prev_error_state, live_position_count_hint, live_position_snapshot
@@ -163,34 +190,8 @@ async def risk_dashboard(client: Client) -> None:
             live_position_count_hint = None
             live_position_snapshot = []
             if not data.risk_metrics:
-                try:
-                    positions_payload = await asyncio.wait_for(
-                        AsyncTradingClient.get().fetch_positions(
-                            str(user_id),
-                            role=str(user_role or ""),
-                            strategies=list(authorized_strategies),
-                        ),
-                        timeout=4.0,
-                    )
-                    positions_rows = positions_payload.get("positions", [])
-                    if isinstance(positions_rows, list):
-                        normalized_rows = [row for row in positions_rows if isinstance(row, dict)]
-                        live_position_snapshot = normalized_rows
-                        live_position_count_hint = len(normalized_rows)
-                except (
-                    TimeoutError,
-                    httpx.HTTPError,
-                    RuntimeError,
-                    ValueError,
-                    TypeError,
-                ) as exc:
-                    logger.warning(
-                        "risk_live_position_hint_failed",
-                        extra={"user_id": user_id, "error_type": type(exc).__name__},
-                        exc_info=True,
-                    )
-                    live_position_count_hint = None
-                    live_position_snapshot = []
+                live_position_snapshot = await load_live_position_snapshot()
+                live_position_count_hint = len(live_position_snapshot)
             error_state = None  # Clear error on success
             prev_error_state = None
         except PermissionError as e:
@@ -198,7 +199,14 @@ async def risk_dashboard(client: Client) -> None:
             set_error("Access denied. Please contact an administrator.")
         except TimeoutError:
             logger.warning("risk_data_timeout", extra={"user_id": user_id})
-            set_error("Request timed out. Please try again.")
+            risk_data.clear()
+            live_position_snapshot = await load_live_position_snapshot()
+            live_position_count_hint = len(live_position_snapshot) if live_position_snapshot else None
+            msg = "Risk model request timed out. Showing live exposure proxies where available."
+            if error_state != msg:
+                ui.notify(msg, type="warning")
+            error_state = msg
+            prev_error_state = msg
         except FileNotFoundError as e:
             logger.error(
                 "Risk data load failed - data files not found",
@@ -268,7 +276,7 @@ async def risk_dashboard(client: Client) -> None:
             metrics = risk_data.get("risk_metrics", {})
             if not metrics:
                 if live_position_snapshot:
-                    def _position_market_value(position: dict[str, Any]) -> float:
+                    def _position_market_value(position: dict[str, Any]) -> float | None:
                         market_value = safe_float(position.get("market_value"))
                         if market_value is not None:
                             return market_value
@@ -276,13 +284,17 @@ async def risk_dashboard(client: Client) -> None:
                         px = safe_float(position.get("current_price"))
                         if px is None:
                             px = safe_float(position.get("avg_entry_price"))
-                        return qty * px if px is not None else 0.0
+                        return qty * px if px is not None else None
 
                     gross_exposure = 0.0
                     net_exposure = 0.0
                     total_unrealized = 0.0
+                    missing_exposure_count = 0
                     for pos in live_position_snapshot:
                         mv = _position_market_value(pos)
+                        if mv is None:
+                            missing_exposure_count += 1
+                            continue
                         gross_exposure += abs(mv)
                         net_exposure += mv
                         total_unrealized += safe_float(pos.get("unrealized_pl")) or 0.0
@@ -294,6 +306,11 @@ async def risk_dashboard(client: Client) -> None:
                         ui.label(
                             "Showing live exposure proxies until full risk model artifacts refresh."
                         ).classes("text-sm text-amber-700")
+                        if missing_exposure_count:
+                            ui.label(
+                                f"Exposure totals exclude {missing_exposure_count} position(s) "
+                                "without market value or price data."
+                            ).classes("text-xs text-amber-700")
 
                     with ui.row().classes("gap-8 mb-6"):
                         _render_risk_metric(

--- a/apps/web_console_ng/pages/scheduled_reports.py
+++ b/apps/web_console_ng/pages/scheduled_reports.py
@@ -27,7 +27,7 @@ from nicegui import run, ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.database import get_db_pool
 from apps.web_console_ng.ui.layout import main_layout
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 
 logger = logging.getLogger(__name__)
@@ -790,4 +790,8 @@ __all__ = ["scheduled_reports_page"]
 @requires_auth
 async def scheduled_reports_alias_page() -> None:
     """Legacy alias route for scheduled reports."""
-    ui.navigate.to(resolve_rooted_path_from_ui("/reports", ui_module=ui))
+    render_client_redirect(
+        resolve_rooted_path_from_ui("/reports", ui_module=ui),
+        ui_module=ui,
+        message="Redirecting to Reports...",
+    )

--- a/apps/web_console_ng/pages/shadow_results.py
+++ b/apps/web_console_ng/pages/shadow_results.py
@@ -13,7 +13,7 @@ from nicegui import ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.ui.layout import main_layout
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from apps.web_console_ng.ui.trading_layout import apply_compact_grid_options
 from apps.web_console_ng.utils.session import get_or_create_client_id
 from apps.web_console_ng.utils.time import format_relative_time
@@ -336,4 +336,8 @@ __all__ = [
 @requires_auth
 async def shadow_results_alias_page() -> None:
     """Legacy alias route for shadow results."""
-    ui.navigate.to(resolve_rooted_path_from_ui("/data/shadow", ui_module=ui))
+    render_client_redirect(
+        resolve_rooted_path_from_ui("/data/shadow", ui_module=ui),
+        ui_module=ui,
+        message="Redirecting to Shadow Validation...",
+    )

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -13,7 +13,7 @@ from nicegui import ui
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.redis_ha import get_redis_store
 from apps.web_console_ng.ui.layout import main_layout
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from apps.web_console_ng.ui.trading_layout import apply_compact_grid_options
 from libs.platform.web_console_auth.permissions import Permission, has_permission
 from libs.platform.web_console_auth.rate_limiter import RateLimiter
@@ -199,62 +199,67 @@ async def sql_explorer_page() -> None:
     )
     grid = ui.aggrid(grid_options).classes("w-full ag-theme-alpine-dark mt-3")
 
-    with ui.right_drawer(value=False).classes("w-96 bg-surface-1 p-3") as history_drawer:
-        ui.label("Query History").classes("text-lg font-bold mb-2")
-        history_container = ui.column().classes("w-full gap-2")
+    with ui.dialog() as history_dialog:
+        with ui.card().classes("w-[48rem] max-w-[96vw] max-h-[80vh] bg-surface-1 p-3"):
+            with ui.row().classes("w-full items-center justify-between mb-2"):
+                ui.label("Query History").classes("text-lg font-bold")
+                ui.button(icon="close", on_click=history_dialog.close).props("flat dense")
 
-        def _render_history() -> None:
-            history_container.clear()
-            with history_container:
-                if not history:
-                    ui.label("No query history yet").classes("text-gray-500 text-sm")
-                    return
-                for item in history:
-                    with ui.card().classes("w-full p-2"):
-                        ui.label(item["fingerprint"]).classes("text-xs font-mono")
-                        ui.label(
-                            f"{item['dataset']} | {item['status']} | {item['rows']} rows"
-                        ).classes("text-xs text-gray-400")
-                        def _replay_query(
-                            original: str = item.get("original_sql", ""),
-                            fp: str = item["fingerprint"],
-                        ) -> None:
-                            query_editor.value = original or fp
-                            if not original and "?" in fp:
-                                ui.notify(
-                                    "Query template loaded — replace ? placeholders with actual values",
-                                    type="info",
-                                )
+            history_container = ui.column().classes("w-full gap-2 overflow-y-auto max-h-[60vh]")
 
-                        ui.button("Use in editor", on_click=_replay_query).props(
-                            "flat dense"
-                        )
+            def _render_history() -> None:
+                history_container.clear()
+                with history_container:
+                    if not history:
+                        ui.label("No query history yet").classes("text-gray-500 text-sm")
+                        return
+                    for item in history:
+                        with ui.card().classes("w-full p-2"):
+                            ui.label(item["fingerprint"]).classes("text-xs font-mono")
+                            ui.label(
+                                f"{item['dataset']} | {item['status']} | {item['rows']} rows"
+                            ).classes("text-xs text-gray-400")
 
-        def _add_history(
-            fingerprint: str, dataset: str, status: str, rows: int, *, original_sql: str = "",
-        ) -> None:
-            history.insert(
-                0,
-                {
-                    "fingerprint": fingerprint,
-                    "original_sql": original_sql,
-                    "dataset": dataset,
-                    "status": status,
-                    "rows": rows,
-                },
-            )
-            if len(history) > 20:
-                del history[20:]
-            _render_history()
+                            def _replay_query(
+                                original: str = item.get("original_sql", ""),
+                                fp: str = item["fingerprint"],
+                            ) -> None:
+                                query_editor.value = original or fp
+                                if not original and "?" in fp:
+                                    ui.notify(
+                                        "Query template loaded — replace ? placeholders with actual values",
+                                        type="info",
+                                    )
+                                history_dialog.close()
 
-        with ui.row().classes("gap-2 mt-2"):
-            def _clear_history() -> None:
-                history.clear()
+                            ui.button("Use in editor", on_click=_replay_query).props("flat dense")
+
+            def _add_history(
+                fingerprint: str, dataset: str, status: str, rows: int, *, original_sql: str = "",
+            ) -> None:
+                history.insert(
+                    0,
+                    {
+                        "fingerprint": fingerprint,
+                        "original_sql": original_sql,
+                        "dataset": dataset,
+                        "status": status,
+                        "rows": rows,
+                    },
+                )
+                if len(history) > 20:
+                    del history[20:]
                 _render_history()
 
-            ui.button("Clear History", on_click=_clear_history).props("flat")
+            with ui.row().classes("gap-2 mt-2"):
 
-        _render_history()
+                def _clear_history() -> None:
+                    history.clear()
+                    _render_history()
+
+                ui.button("Clear History", on_click=_clear_history).props("flat")
+
+            _render_history()
 
     async def run_query() -> None:
         nonlocal query_running, last_result_dataset
@@ -383,7 +388,7 @@ async def sql_explorer_page() -> None:
         ui.button("Run", on_click=run_query, color="primary")
         if has_permission(user, Permission.EXPORT_DATA):
             ui.button("Export CSV", on_click=export_csv)
-        ui.button("History", on_click=history_drawer.toggle).props("flat")
+        ui.button("History", on_click=history_dialog.open).props("flat")
 
 
 __all__ = ["sql_explorer_page"]
@@ -393,4 +398,8 @@ __all__ = ["sql_explorer_page"]
 @requires_auth
 async def sql_explorer_alias_page() -> None:
     """Legacy alias route for SQL Explorer."""
-    ui.navigate.to(resolve_rooted_path_from_ui("/data/sql-explorer", ui_module=ui))
+    render_client_redirect(
+        resolve_rooted_path_from_ui("/data/sql-explorer", ui_module=ui),
+        ui_module=ui,
+        message="Redirecting to SQL Explorer...",
+    )

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -564,11 +564,18 @@ async def _render_summary_metrics(
 
     # Pro-rate cost basis for partially sold lots (remaining < quantity)
     if lots:
-        total_cost = sum(_prorated_cost_basis(lot) for lot in lots)
+        total_cost = sum(
+            (_prorated_cost_basis(lot) for lot in lots),
+            Decimal("0"),
+        )
     else:
         total_cost = sum(
-            abs(_to_decimal(pos.get("qty"))) * _to_decimal(pos.get("avg_entry_price"))
-            for pos in position_fallback
+            (
+                abs(_to_decimal(pos.get("qty")))
+                * _to_decimal(pos.get("avg_entry_price"))
+                for pos in position_fallback
+            ),
+            Decimal("0"),
         )
     total_value = Decimal("0")
     priced_cost = Decimal("0")
@@ -582,12 +589,15 @@ async def _render_summary_metrics(
                 priced_cost += _prorated_cost_basis(lot)
 
     if not lots and position_fallback:
-        total_value = sum(
-            _to_decimal(pos.get("market_value"))
-            if _to_decimal(pos.get("market_value")) != Decimal("0")
-            else abs(_to_decimal(pos.get("qty"))) * _to_decimal(pos.get("current_price"))
-            for pos in position_fallback
-        )
+        total_value = Decimal("0")
+        for pos in position_fallback:
+            market_value = _to_decimal(pos.get("market_value"))
+            if market_value != Decimal("0"):
+                total_value += market_value
+            else:
+                total_value += abs(_to_decimal(pos.get("qty"))) * _to_decimal(
+                    pos.get("current_price")
+                )
         priced_cost = total_cost
 
     all_priced = bool(lots) and has_prices and all(

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -547,7 +547,7 @@ async def _render_summary_metrics(
         quantity = _to_decimal(getattr(lot, "quantity", Decimal("0")))
         remaining = _to_decimal(getattr(lot, "remaining_quantity", Decimal("0")))
         if quantity == Decimal("0"):
-            return cost_basis
+            return Decimal("0")
         return cost_basis * (abs(remaining) / abs(quantity))
 
     def _holding_days(lot: Any, as_of: datetime) -> int:
@@ -621,6 +621,10 @@ async def _render_summary_metrics(
         with ui.card().classes("flex-1 p-3"):
             ui.label("Total Cost Basis").classes("text-gray-500 text-sm")
             ui.label(f"${float(total_cost):,.2f}").classes("text-xl font-bold")
+            if lots and has_prices and not all_priced and priced_cost > 0:
+                ui.label(f"Priced subset: ${float(priced_cost):,.2f}").classes(
+                    "text-xs text-slate-400"
+                )
         with ui.card().classes("flex-1 p-3"):
             ui.label("Unrealized Gain/Loss").classes("text-gray-500 text-sm")
             if not lots and position_fallback:

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -6,8 +6,9 @@ cost basis method management, and Form 8949 export/preview.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -85,6 +86,7 @@ async def tax_lots_page() -> None:
     # State
     show_all_users = False
     price_status = "unavailable"
+    live_positions: list[dict[str, Any]] = []
 
     async def _load_lots() -> list[Any]:
         if show_all_users and is_admin:
@@ -92,6 +94,8 @@ async def tax_lots_page() -> None:
         return await service.list_lots(open_only=True)
 
     lots = await _load_lots()
+    if not lots and not show_all_users:
+        live_positions = await _fetch_live_positions(user)
 
     # Fetch wash sale adjustments for displayed lots
     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
@@ -116,7 +120,12 @@ async def tax_lots_page() -> None:
     @ui.refreshable  # type: ignore[arg-type]
     async def summary_section() -> None:
         await _render_summary_metrics(
-            lots, current_prices, wash_sale_lot_ids, db_pool, price_status=price_status,
+            lots,
+            current_prices,
+            wash_sale_lot_ids,
+            db_pool,
+            price_status=price_status,
+            live_positions=live_positions,
         )
 
     await summary_section()
@@ -131,9 +140,12 @@ async def tax_lots_page() -> None:
                 )
                 if not allowed:
                     return
-                nonlocal show_all_users, lots, wash_sale_lot_ids, current_prices, suggestions, price_status
+                nonlocal show_all_users, lots, wash_sale_lot_ids, current_prices, suggestions, price_status, live_positions
                 show_all_users = e.value
                 lots = await _load_lots()
+                live_positions = []
+                if not lots and not show_all_users:
+                    live_positions = await _fetch_live_positions(get_current_user())
                 wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
                 try:
                     current_prices, price_status = await _fetch_current_prices_with_status(
@@ -249,8 +261,11 @@ async def tax_lots_page() -> None:
                         logger.debug("audit_log_lot_close_failed")
                     ui.notify(f"Lot {lot_id[:8]}... closed", type="positive")
                     # Refresh all sections
-                    nonlocal lots, wash_sale_lot_ids, current_prices, suggestions, price_status
+                    nonlocal lots, wash_sale_lot_ids, current_prices, suggestions, price_status, live_positions
                     lots = await _load_lots()
+                    live_positions = []
+                    if not lots and not show_all_users:
+                        live_positions = await _fetch_live_positions(get_current_user())
                     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
                     try:
                         current_prices, price_status = await _fetch_current_prices_with_status(
@@ -279,10 +294,50 @@ async def tax_lots_page() -> None:
             def lot_grid() -> None:
                 if not lots:
                     with ui.card().classes("w-full p-3 mb-2 bg-slate-800 border border-slate-600"):
-                        ui.label("No open tax lots found.").classes("text-sm text-slate-200")
-                        ui.label(
-                            "Tax lots populate after fills are reconciled into lot records."
-                        ).classes("text-xs text-slate-400")
+                        if live_positions and not show_all_users:
+                            ui.label("Tax-lot records are pending reconciliation.").classes(
+                                "text-sm text-amber-200"
+                            )
+                            ui.label(
+                                f"Detected {len(live_positions)} live broker position(s)."
+                            ).classes("text-xs text-slate-300")
+                        else:
+                            ui.label("No open tax lots found.").classes("text-sm text-slate-200")
+                            ui.label(
+                                "Tax lots populate after fills are reconciled into lot records."
+                            ).classes("text-xs text-slate-400")
+                    if live_positions and not show_all_users:
+                        columns = [
+                            {"name": "symbol", "label": "Symbol", "field": "symbol"},
+                            {"name": "qty", "label": "Qty", "field": "qty"},
+                            {"name": "avg_entry", "label": "Avg Entry", "field": "avg_entry"},
+                            {"name": "current_price", "label": "Last", "field": "current_price"},
+                            {"name": "unrealized", "label": "Unrealized P&L", "field": "unrealized"},
+                        ]
+                        rows = []
+
+                        def _format_money(value: Any, *, signed: bool = False) -> str:
+                            try:
+                                parsed = Decimal(str(value))
+                            except (ArithmeticError, TypeError, ValueError):
+                                return "-"
+                            if signed:
+                                return f"${float(parsed):+,.2f}"
+                            return f"${float(parsed):,.2f}"
+
+                        for pos in live_positions:
+                            rows.append(
+                                {
+                                    "symbol": str(pos.get("symbol", "-")),
+                                    "qty": str(pos.get("qty", "-")),
+                                    "avg_entry": _format_money(pos.get("avg_entry_price")),
+                                    "current_price": _format_money(pos.get("current_price")),
+                                    "unrealized": _format_money(pos.get("unrealized_pl"), signed=True),
+                                }
+                            )
+                        with ui.card().classes("w-full p-3 mb-3"):
+                            ui.label("Live Position Snapshot").classes("font-medium mb-2")
+                            ui.table(columns=columns, rows=rows).classes("w-full")
                 render_tax_lot_table(
                     lots,
                     wash_sale_lot_ids=wash_sale_lot_ids,
@@ -385,6 +440,15 @@ async def _fetch_current_prices_with_status(
         )
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 403:
+            if has_permission(user, Permission.VIEW_PNL):
+                logger.warning(
+                    "market_prices_forbidden_with_view_pnl",
+                    extra={"role": user.get("role")},
+                )
+                raise MarketPriceFetchError(
+                    "unavailable",
+                    "Market data service denied request despite VIEW_PNL permission",
+                ) from exc
             logger.info("market_prices_permission_denied", extra={"role": user.get("role")})
             raise MarketPriceFetchError("permission_denied", "Market data permission denied") from exc
         logger.warning("market_prices_http_error", extra={"status": exc.response.status_code})
@@ -436,6 +500,28 @@ async def _fetch_current_prices(lots: list[Any], user: dict[str, Any]) -> dict[s
         return {}
 
 
+async def _fetch_live_positions(user: dict[str, Any]) -> list[dict[str, Any]]:
+    """Fetch live broker positions for fallback display when tax lots are empty."""
+    client = AsyncTradingClient.get()
+    try:
+        payload = await asyncio.wait_for(
+            client.fetch_positions(
+                user.get("user_id", "unknown"),
+                role=user.get("role"),
+                strategies=user.get("strategies"),
+            ),
+            timeout=4.0,
+        )
+    except (TimeoutError, httpx.HTTPError, ValueError, TypeError, RuntimeError):
+        logger.warning("tax_lots_live_positions_fetch_failed", exc_info=True)
+        return []
+
+    raw_positions = payload.get("positions", [])
+    if not isinstance(raw_positions, list):
+        return []
+    return [row for row in raw_positions if isinstance(row, dict)]
+
+
 async def _render_summary_metrics(
     lots: list[Any],
     current_prices: dict[str, Decimal],
@@ -443,36 +529,74 @@ async def _render_summary_metrics(
     db_pool: Any,
     *,
     price_status: str = "ok",
+    live_positions: list[dict[str, Any]] | None = None,
 ) -> None:
     """Render summary header cards."""
+    position_fallback = list(live_positions or [])
+
+    def _to_decimal(value: Any) -> Decimal:
+        if isinstance(value, Decimal):
+            return value
+        try:
+            return Decimal(str(value))
+        except (ArithmeticError, TypeError, ValueError):
+            return Decimal("0")
+
+    def _prorated_cost_basis(lot: Any) -> Decimal:
+        cost_basis = _to_decimal(getattr(lot, "cost_basis", Decimal("0")))
+        quantity = _to_decimal(getattr(lot, "quantity", Decimal("0")))
+        remaining = _to_decimal(getattr(lot, "remaining_quantity", Decimal("0")))
+        if quantity <= Decimal("0"):
+            return cost_basis
+        return cost_basis * (remaining / quantity)
+
+    def _holding_days(lot: Any, as_of: datetime) -> int:
+        acquired = getattr(lot, "acquired_at", None)
+        if acquired is None:
+            acquired = getattr(lot, "acquisition_date", None)
+        if isinstance(acquired, date) and not isinstance(acquired, datetime):
+            acquired_dt = datetime(acquired.year, acquired.month, acquired.day, tzinfo=UTC)
+        elif isinstance(acquired, datetime):
+            acquired_dt = acquired if acquired.tzinfo is not None else acquired.replace(tzinfo=UTC)
+        else:
+            return 0
+        return max((as_of - acquired_dt).days, 0)
+
     # Pro-rate cost basis for partially sold lots (remaining < quantity)
-    total_cost = sum(
-        lot.cost_basis * (lot.remaining_quantity / lot.quantity) if lot.quantity > 0
-        else lot.cost_basis
-        for lot in lots
-    )
+    if lots:
+        total_cost = sum(_prorated_cost_basis(lot) for lot in lots)
+    else:
+        total_cost = sum(
+            abs(_to_decimal(pos.get("qty"))) * _to_decimal(pos.get("avg_entry_price"))
+            for pos in position_fallback
+        )
     total_value = Decimal("0")
     priced_cost = Decimal("0")
-    has_prices = bool(current_prices)
+    has_prices = bool(current_prices) or bool(position_fallback)
 
-    if has_prices:
+    if lots and current_prices:
         for lot in lots:
             price = current_prices.get(lot.symbol)
             if price is not None:
-                total_value += price * lot.remaining_quantity
-                # Pro-rate cost basis for partially sold lots
-                if lot.quantity > 0:
-                    priced_cost += lot.cost_basis * (lot.remaining_quantity / lot.quantity)
-                else:
-                    priced_cost += lot.cost_basis
+                total_value += _to_decimal(price) * _to_decimal(getattr(lot, "remaining_quantity", 0))
+                priced_cost += _prorated_cost_basis(lot)
 
-    all_priced = has_prices and all(
+    if not lots and position_fallback:
+        total_value = sum(
+            _to_decimal(pos.get("market_value"))
+            if _to_decimal(pos.get("market_value")) != Decimal("0")
+            else abs(_to_decimal(pos.get("qty"))) * _to_decimal(pos.get("current_price"))
+            for pos in position_fallback
+        )
+        priced_cost = total_cost
+
+    all_priced = bool(lots) and has_prices and all(
         current_prices.get(lot.symbol) is not None for lot in lots
     )
 
     now = datetime.now(UTC)
-    short_term = [lot for lot in lots if (now - lot.acquisition_date).days <= 365]
-    long_term = [lot for lot in lots if (now - lot.acquisition_date).days > 365]
+    short_term = [lot for lot in lots if _holding_days(lot, now) <= 365]
+    long_term = [lot for lot in lots if _holding_days(lot, now) > 365]
 
     with ui.row().classes("w-full gap-4 mb-4"):
         with ui.card().classes("flex-1 p-3"):
@@ -480,7 +604,14 @@ async def _render_summary_metrics(
             ui.label(f"${float(total_cost):,.2f}").classes("text-xl font-bold")
         with ui.card().classes("flex-1 p-3"):
             ui.label("Unrealized Gain/Loss").classes("text-gray-500 text-sm")
-            if has_prices and priced_cost > 0:
+            if not lots and position_fallback:
+                fallback_unrealized = sum(
+                    _to_decimal(pos.get("unrealized_pl")) for pos in position_fallback
+                )
+                color = "text-green-500" if fallback_unrealized >= 0 else "text-red-500"
+                ui.label(f"${float(fallback_unrealized):+,.2f}").classes(f"text-xl font-bold {color}")
+                ui.label("Derived from live broker positions").classes("text-xs text-slate-400")
+            elif has_prices and priced_cost > 0:
                 gain = total_value - priced_cost
                 color = "text-green-500" if gain >= 0 else "text-red-500"
                 label = f"${float(gain):+,.2f}"

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -41,6 +41,10 @@ class MarketPriceFetchError(RuntimeError):
         self.status = status
 
 
+class LivePositionsUnavailableError(RuntimeError):
+    """Raised when live broker positions cannot be loaded for fallback display."""
+
+
 @ui.page("/tax-lots")
 @requires_auth
 @main_layout
@@ -95,7 +99,10 @@ async def tax_lots_page() -> None:
 
     lots = await _load_lots()
     if not lots and not show_all_users:
-        live_positions = await _fetch_live_positions(user)
+        try:
+            live_positions = await _fetch_live_positions(user)
+        except LivePositionsUnavailableError:
+            live_positions = []
 
     # Fetch wash sale adjustments for displayed lots
     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
@@ -145,7 +152,10 @@ async def tax_lots_page() -> None:
                 lots = await _load_lots()
                 live_positions = []
                 if not lots and not show_all_users:
-                    live_positions = await _fetch_live_positions(user)
+                    try:
+                        live_positions = await _fetch_live_positions(user)
+                    except LivePositionsUnavailableError:
+                        live_positions = []
                 wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
                 try:
                     current_prices, price_status = await _fetch_current_prices_with_status(
@@ -265,7 +275,10 @@ async def tax_lots_page() -> None:
                     lots = await _load_lots()
                     live_positions = []
                     if not lots and not show_all_users:
-                        live_positions = await _fetch_live_positions(user)
+                        try:
+                            live_positions = await _fetch_live_positions(user)
+                        except LivePositionsUnavailableError:
+                            live_positions = []
                     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
                     try:
                         current_prices, price_status = await _fetch_current_prices_with_status(
@@ -512,9 +525,9 @@ async def _fetch_live_positions(user: dict[str, Any]) -> list[dict[str, Any]]:
             ),
             timeout=4.0,
         )
-    except (TimeoutError, httpx.HTTPError, ValueError, TypeError, RuntimeError):
+    except (TimeoutError, httpx.HTTPError, ValueError, TypeError, RuntimeError) as exc:
         logger.warning("tax_lots_live_positions_fetch_failed", exc_info=True)
-        return []
+        raise LivePositionsUnavailableError("live positions unavailable") from exc
 
     raw_positions = payload.get("positions", [])
     if not isinstance(raw_positions, list):

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -577,7 +577,6 @@ async def _render_summary_metrics(
             ),
             Decimal("0"),
         )
-    total_value = Decimal("0")
     priced_cost = Decimal("0")
     priced_gain = Decimal("0")
     has_prices = bool(current_prices) or bool(position_fallback)
@@ -589,7 +588,6 @@ async def _render_summary_metrics(
                 remaining_quantity = _to_decimal(getattr(lot, "remaining_quantity", 0))
                 market_value = _to_decimal(price) * remaining_quantity
                 prorated_cost = _prorated_cost_basis(lot)
-                total_value += market_value
                 priced_cost += prorated_cost
                 priced_gain += (
                     market_value - prorated_cost
@@ -598,15 +596,6 @@ async def _render_summary_metrics(
                 )
 
     if not lots and position_fallback:
-        total_value = Decimal("0")
-        for pos in position_fallback:
-            market_value = _to_decimal(pos.get("market_value"))
-            if market_value != Decimal("0"):
-                total_value += market_value
-            else:
-                total_value += _to_decimal(pos.get("qty")) * _to_decimal(
-                    pos.get("current_price")
-                )
         priced_cost = total_cost
 
     all_priced = bool(lots) and has_prices and all(

--- a/apps/web_console_ng/pages/tax_lots.py
+++ b/apps/web_console_ng/pages/tax_lots.py
@@ -145,11 +145,11 @@ async def tax_lots_page() -> None:
                 lots = await _load_lots()
                 live_positions = []
                 if not lots and not show_all_users:
-                    live_positions = await _fetch_live_positions(get_current_user())
+                    live_positions = await _fetch_live_positions(user)
                 wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
                 try:
                     current_prices, price_status = await _fetch_current_prices_with_status(
-                        lots, get_current_user(),
+                        lots, user,
                     )
                 except MarketPriceFetchError as exc:
                     current_prices, price_status = ({}, exc.status)
@@ -265,11 +265,11 @@ async def tax_lots_page() -> None:
                     lots = await _load_lots()
                     live_positions = []
                     if not lots and not show_all_users:
-                        live_positions = await _fetch_live_positions(get_current_user())
+                        live_positions = await _fetch_live_positions(user)
                     wash_sale_lot_ids = await _fetch_wash_sale_lot_ids(db_pool, lots)
                     try:
                         current_prices, price_status = await _fetch_current_prices_with_status(
-                            lots, get_current_user(),
+                            lots, user,
                         )
                     except MarketPriceFetchError as exc:
                         current_prices, price_status = ({}, exc.status)
@@ -546,9 +546,9 @@ async def _render_summary_metrics(
         cost_basis = _to_decimal(getattr(lot, "cost_basis", Decimal("0")))
         quantity = _to_decimal(getattr(lot, "quantity", Decimal("0")))
         remaining = _to_decimal(getattr(lot, "remaining_quantity", Decimal("0")))
-        if quantity <= Decimal("0"):
+        if quantity == Decimal("0"):
             return cost_basis
-        return cost_basis * (remaining / quantity)
+        return cost_basis * (abs(remaining) / abs(quantity))
 
     def _holding_days(lot: Any, as_of: datetime) -> int:
         acquired = getattr(lot, "acquired_at", None)
@@ -579,14 +579,23 @@ async def _render_summary_metrics(
         )
     total_value = Decimal("0")
     priced_cost = Decimal("0")
+    priced_gain = Decimal("0")
     has_prices = bool(current_prices) or bool(position_fallback)
 
     if lots and current_prices:
         for lot in lots:
             price = current_prices.get(lot.symbol)
             if price is not None:
-                total_value += _to_decimal(price) * _to_decimal(getattr(lot, "remaining_quantity", 0))
-                priced_cost += _prorated_cost_basis(lot)
+                remaining_quantity = _to_decimal(getattr(lot, "remaining_quantity", 0))
+                market_value = _to_decimal(price) * remaining_quantity
+                prorated_cost = _prorated_cost_basis(lot)
+                total_value += market_value
+                priced_cost += prorated_cost
+                priced_gain += (
+                    market_value - prorated_cost
+                    if remaining_quantity >= Decimal("0")
+                    else prorated_cost + market_value
+                )
 
     if not lots and position_fallback:
         total_value = Decimal("0")
@@ -595,7 +604,7 @@ async def _render_summary_metrics(
             if market_value != Decimal("0"):
                 total_value += market_value
             else:
-                total_value += abs(_to_decimal(pos.get("qty"))) * _to_decimal(
+                total_value += _to_decimal(pos.get("qty")) * _to_decimal(
                     pos.get("current_price")
                 )
         priced_cost = total_cost
@@ -622,7 +631,7 @@ async def _render_summary_metrics(
                 ui.label(f"${float(fallback_unrealized):+,.2f}").classes(f"text-xl font-bold {color}")
                 ui.label("Derived from live broker positions").classes("text-xs text-slate-400")
             elif has_prices and priced_cost > 0:
-                gain = total_value - priced_cost
+                gain = priced_gain
                 color = "text-green-500" if gain >= 0 else "text-red-500"
                 label = f"${float(gain):+,.2f}"
                 if not all_priced:

--- a/apps/web_console_ng/static/js/hierarchical_grid.js
+++ b/apps/web_console_ng/static/js/hierarchical_grid.js
@@ -1,6 +1,10 @@
-// Hierarchical orders grid helpers (tree data + expansion persistence)
+// Hierarchical orders grid helpers (community-grid compatible expansion + persistence)
 
 (function() {
+    const DEFAULT_GRID_ID = 'hierarchical_orders_grid';
+    const expansionByGrid = new Map();
+    const gridStatsByGrid = new Map();
+    const registeredApis = new WeakSet();
     const TERMINAL_STATUSES = new Set([
         'filled',
         'canceled',
@@ -14,30 +18,99 @@
         'blocked_circuit_breaker'
     ]);
 
+    function normalizeId(value) {
+        return String(value || '').trim();
+    }
+
     function isTerminalStatus(status) {
         return TERMINAL_STATUSES.has(String(status || '').toLowerCase());
     }
 
-    function collectExpandedIds(api) {
-        const expanded = [];
-        api.forEachNode(node => {
-            if (!node || !node.expanded) return;
-            if (!node.data || !node.data.is_parent) return;
-            const id = node.data.client_order_id;
-            if (id) expanded.push(String(id));
-        });
-        return expanded;
+    function isChildRow(row) {
+        if (!row) return false;
+        if (row.is_child === true) return true;
+        const path = Array.isArray(row.hierarchy_path) ? row.hierarchy_path : [];
+        return path.length > 1;
     }
 
-    function restoreExpansion(api, expandedIds) {
-        if (!api || !Array.isArray(expandedIds)) return;
-        const idSet = new Set(expandedIds.map(id => String(id)));
+    function isParentRow(row) {
+        if (!row) return false;
+        if (row.is_parent === true) return true;
+        return !isChildRow(row) && Number(row.child_count || 0) > 0;
+    }
+
+    function resolveParentId(row) {
+        if (!row) return '';
+        const explicitParent = normalizeId(row.parent_client_order_id);
+        if (explicitParent) return explicitParent;
+        const path = Array.isArray(row.hierarchy_path) ? row.hierarchy_path : [];
+        if (path.length > 1) return normalizeId(path[0]);
+        const parentOrderId = normalizeId(row.parent_order_id);
+        if (parentOrderId) return parentOrderId;
+        return '';
+    }
+
+    function getExpandedSet(gridId) {
+        const key = normalizeId(gridId) || DEFAULT_GRID_ID;
+        if (!expansionByGrid.has(key)) {
+            expansionByGrid.set(key, new Set());
+        }
+        return expansionByGrid.get(key);
+    }
+
+    function getGridStats(gridId) {
+        const key = normalizeId(gridId) || DEFAULT_GRID_ID;
+        if (!gridStatsByGrid.has(key)) {
+            gridStatsByGrid.set(key, {
+                parentIdsWithChildren: new Set(),
+                childParentIds: new Set(),
+                childrenByParent: new Map()
+            });
+        }
+        return gridStatsByGrid.get(key);
+    }
+
+    function recomputeGridStats(api, gridId) {
+        const stats = getGridStats(gridId);
+        stats.parentIdsWithChildren.clear();
+        stats.childParentIds.clear();
+        stats.childrenByParent.clear();
+        if (!api) return stats;
         api.forEachNode(node => {
-            if (!node || !node.data || !node.data.is_parent) return;
-            const id = String(node.data.client_order_id || '');
-            if (!id) return;
-            node.setExpanded(idSet.has(id));
+            const row = node && node.data ? node.data : null;
+            if (!row) return;
+            if (isParentRow(row) && Number(row.child_count || 0) > 0) {
+                const parentId = normalizeId(row.client_order_id);
+                if (parentId) stats.parentIdsWithChildren.add(parentId);
+                return;
+            }
+            if (!isChildRow(row) || row.is_orphan) return;
+            const parentId = resolveParentId(row);
+            if (!parentId) return;
+            stats.childParentIds.add(parentId);
+            if (!stats.childrenByParent.has(parentId)) {
+                stats.childrenByParent.set(parentId, []);
+            }
+            stats.childrenByParent.get(parentId).push(row);
         });
+        return stats;
+    }
+
+    function setExpandedIds(gridId, expandedIds) {
+        const nextSet = new Set(
+            Array.isArray(expandedIds)
+                ? expandedIds.map(normalizeId).filter(Boolean)
+                : []
+        );
+        const expandedSet = getExpandedSet(gridId);
+        expandedSet.clear();
+        nextSet.forEach(id => expandedSet.add(id));
+        window._hierarchicalOrdersExpanded = Array.from(expandedSet);
+        return expandedSet;
+    }
+
+    function collectExpandedIds(gridId) {
+        return Array.from(getExpandedSet(gridId));
     }
 
     function dispatchExpansion(gridId, expandedIds) {
@@ -49,38 +122,158 @@
         }));
     }
 
-    function register(api, gridId) {
+    function isRowVisible(row, gridId) {
+        if (!row || !isChildRow(row)) return true;
+        if (row.is_orphan) return true;
+        const parentId = resolveParentId(row);
+        if (!parentId) return true;
+        return getExpandedSet(gridId).has(parentId);
+    }
+
+    function hasCollapsedParents(gridId) {
+        const stats = getGridStats(gridId);
+        if (stats.childParentIds.size === 0) return false;
+        const expandedSet = getExpandedSet(gridId);
+        for (const parentId of stats.childParentIds) {
+            if (!expandedSet.has(parentId)) return true;
+        }
+        return false;
+    }
+
+    function getChildrenForParent(gridId, parentId) {
+        const stats = getGridStats(gridId);
+        return stats.childrenByParent.get(parentId) || [];
+    }
+
+    function refreshVisibility(api, gridId = DEFAULT_GRID_ID) {
         if (!api) return;
-        let timer = null;
-        const emit = () => {
-            const expandedIds = collectExpandedIds(api);
-            dispatchExpansion(gridId, expandedIds);
-        };
-        const scheduleEmit = () => {
-            if (timer) window.clearTimeout(timer);
-            timer = window.setTimeout(emit, 150);
-        };
-        api.addEventListener('rowGroupOpened', scheduleEmit);
-        api.addEventListener('rowDataUpdated', scheduleEmit);
+        recomputeGridStats(api, gridId);
+        api.onFilterChanged();
+        api.refreshCells({ force: true, columns: ['symbol'] });
+    }
+
+    function restoreExpansion(api, expandedIds, gridId = DEFAULT_GRID_ID) {
+        setExpandedIds(gridId, expandedIds);
+        refreshVisibility(api, gridId);
+    }
+
+    function register(api, gridId = DEFAULT_GRID_ID) {
+        const seedExpansion = Array.isArray(window._hierarchicalOrdersExpanded)
+            ? window._hierarchicalOrdersExpanded
+            : collectExpandedIds(gridId);
+        setExpandedIds(gridId, seedExpansion);
+        recomputeGridStats(api, gridId);
+        if (!api || registeredApis.has(api)) return;
+        api.addEventListener('rowDataUpdated', function() {
+            recomputeGridStats(api, gridId);
+        });
+        registeredApis.add(api);
+    }
+
+    function toggleParent(api, parentId, gridId = DEFAULT_GRID_ID) {
+        const id = normalizeId(parentId);
+        if (!id) return;
+        const expandedSet = getExpandedSet(gridId);
+        if (expandedSet.has(id)) {
+            expandedSet.delete(id);
+        } else {
+            expandedSet.add(id);
+        }
+        const expandedIds = collectExpandedIds(gridId);
+        window._hierarchicalOrdersExpanded = expandedIds;
+        dispatchExpansion(gridId, expandedIds);
+        if (api) {
+            refreshVisibility(api, gridId);
+        }
+    }
+
+    function isExpanded(parentId, gridId = DEFAULT_GRID_ID) {
+        const id = normalizeId(parentId);
+        if (!id) return false;
+        return getExpandedSet(gridId).has(id);
     }
 
     window.HierarchicalOrdersGrid = {
+        collectExpandedIds,
+        hasCollapsedParents,
+        isExpanded,
+        isRowVisible,
+        refreshVisibility,
         register,
-        restoreExpansion
+        restoreExpansion,
+        toggleParent
+    };
+
+    window.hierarchicalSymbolRenderer = function(params) {
+        if (!params || !params.data) return document.createElement('span');
+
+        const row = params.data;
+        const symbol = String(row.symbol || '');
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flex items-center gap-1';
+
+        if (isParentRow(row)) {
+            const parentId = normalizeId(row.client_order_id);
+            const hasChildren = Number(row.child_count || 0) > 0;
+            if (hasChildren) {
+                const toggle = document.createElement('button');
+                toggle.type = 'button';
+                toggle.className = 'h-4 w-4 text-xs text-gray-300 hover:text-white';
+                toggle.textContent = isExpanded(parentId) ? '▾' : '▸';
+                toggle.onclick = function(event) {
+                    event.stopPropagation();
+                    toggleParent(params.api, parentId);
+                };
+                wrapper.appendChild(toggle);
+            } else {
+                const spacer = document.createElement('span');
+                spacer.className = 'inline-block w-4';
+                spacer.textContent = '';
+                wrapper.appendChild(spacer);
+            }
+            const label = document.createElement('span');
+            label.className = 'font-semibold';
+            label.textContent = symbol;
+            wrapper.appendChild(label);
+            return wrapper;
+        }
+
+        if (isChildRow(row)) {
+            const spacer = document.createElement('span');
+            spacer.className = 'inline-block w-4 text-gray-400';
+            spacer.textContent = '↳';
+            wrapper.appendChild(spacer);
+            const label = document.createElement('span');
+            label.className = 'text-xs';
+            label.textContent = symbol;
+            wrapper.appendChild(label);
+            return wrapper;
+        }
+
+        const label = document.createElement('span');
+        label.textContent = symbol;
+        wrapper.appendChild(label);
+        return wrapper;
     };
 
     window.hierarchicalCancelRenderer = function(params) {
-        if (!params.data) return document.createElement('span');
+        if (!params || !params.data) return document.createElement('span');
 
         const btn = document.createElement('button');
-        const isParent = !!params.data.is_parent;
         const disabledBase = window._tradingState?.readOnly;
+        const row = params.data;
 
-        if (isParent) {
-            const children = (params.node?.childrenAfterFilter || [])
-                .map(node => node?.data)
-                .filter(child => child && !isTerminalStatus(child.status));
-            const cancelable = children.filter(child => !!child.client_order_id);
+        if (isParentRow(row)) {
+            const parentId = normalizeId(row.client_order_id);
+            // Intentionally include collapsed children so Cancel All applies
+            // to the full parent order rather than only currently visible rows.
+            const children = parentId
+                ? getChildrenForParent(DEFAULT_GRID_ID, parentId).filter(
+                    child => child && !isTerminalStatus(child.status)
+                )
+                : [];
+
+            const cancelable = children.filter(child => !!normalizeId(child.client_order_id));
             const disabled = disabledBase || cancelable.length === 0;
             btn.className = disabled
                 ? 'px-2 py-1 text-xs bg-gray-400 text-gray-200 rounded cursor-not-allowed'
@@ -91,8 +284,8 @@
                 btn.onclick = function() {
                     window.dispatchEvent(new CustomEvent('cancel_parent_order', {
                         detail: {
-                            parent_order_id: params.data?.client_order_id || '',
-                            symbol: params.data?.symbol || '',
+                            parent_order_id: parentId,
+                            symbol: row.symbol || '',
                             children: cancelable.map(child => ({
                                 client_order_id: child.client_order_id || '',
                                 status: child.status || '',
@@ -106,7 +299,7 @@
             return btn;
         }
 
-        const disabled = disabledBase || !params.data?.client_order_id || isTerminalStatus(params.data?.status);
+        const disabled = disabledBase || !row.client_order_id || isTerminalStatus(row.status);
         btn.className = disabled
             ? 'px-2 py-1 text-xs bg-gray-400 text-gray-200 rounded cursor-not-allowed'
             : 'px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600';
@@ -116,9 +309,9 @@
             btn.onclick = function() {
                 window.dispatchEvent(new CustomEvent('cancel_order', {
                     detail: {
-                        client_order_id: params.data?.client_order_id || '',
-                        symbol: params.data?.symbol || '',
-                        broker_order_id: params.data?._broker_order_id || ''
+                        client_order_id: row.client_order_id || '',
+                        symbol: row.symbol || '',
+                        broker_order_id: row._broker_order_id || ''
                     }
                 }));
             };

--- a/apps/web_console_ng/static/js/trading_state_listener.js
+++ b/apps/web_console_ng/static/js/trading_state_listener.js
@@ -64,10 +64,17 @@
     const readOnly = detail.readOnly;
     const connectionState = detail.connectionState;
     const hasStatusStale = Object.prototype.hasOwnProperty.call(detail, 'statusStale');
+    const hasFreshTradingState =
+      typeof killSwitchState === 'string' ||
+      typeof killSwitch === 'boolean' ||
+      typeof circuitBreakerState === 'string' ||
+      typeof circuitBreaker === 'boolean';
 
     window._tradingState = window._tradingState || {};
     if (hasStatusStale) {
       window._tradingState.statusStale = detail.statusStale === true;
+    } else if (hasFreshTradingState) {
+      window._tradingState.statusStale = false;
     }
     const statusStale = window._tradingState.statusStale === true;
 

--- a/apps/web_console_ng/static/js/trading_state_listener.js
+++ b/apps/web_console_ng/static/js/trading_state_listener.js
@@ -11,6 +11,7 @@
     const banner = document.getElementById('global-status-banner');
     const label = document.getElementById('global-status-banner-label');
     if (!banner || !label) return;
+    if (window._tradingState && window._tradingState.statusStale) return;
 
     const state = ((window._tradingState && window._tradingState.killSwitchState) || 'UNKNOWN')
       .toUpperCase();
@@ -62,10 +63,14 @@
         : detail.circuitState;
     const readOnly = detail.readOnly;
     const connectionState = detail.connectionState;
+    const statusStale = detail.statusStale === true;
+
+    window._tradingState = window._tradingState || {};
+    window._tradingState.statusStale = statusStale;
 
     // Update kill switch badge
     const ksEl = document.getElementById('kill-switch-badge');
-    if (ksEl) {
+    if (ksEl && !statusStale) {
       if (typeof killSwitchState === 'string') {
         const state = killSwitchState.toUpperCase();
         if (state === 'ENGAGED') {
@@ -96,7 +101,7 @@
 
     // Update circuit breaker badge
     const cbEl = document.getElementById('circuit-breaker-badge');
-    if (cbEl) {
+    if (cbEl && !statusStale) {
       if (typeof circuitBreakerState === 'string') {
         const state = circuitBreakerState.toUpperCase();
         if (state === 'TRIPPED') {
@@ -129,7 +134,6 @@
       }
     }
 
-    window._tradingState = window._tradingState || {};
     if (typeof killSwitchState === 'string') {
       window._tradingState.killSwitchState = killSwitchState;
     } else if (typeof killSwitch === 'boolean') {

--- a/apps/web_console_ng/static/js/trading_state_listener.js
+++ b/apps/web_console_ng/static/js/trading_state_listener.js
@@ -63,10 +63,13 @@
         : detail.circuitState;
     const readOnly = detail.readOnly;
     const connectionState = detail.connectionState;
-    const statusStale = detail.statusStale === true;
+    const hasStatusStale = Object.prototype.hasOwnProperty.call(detail, 'statusStale');
 
     window._tradingState = window._tradingState || {};
-    window._tradingState.statusStale = statusStale;
+    if (hasStatusStale) {
+      window._tradingState.statusStale = detail.statusStale === true;
+    }
+    const statusStale = window._tradingState.statusStale === true;
 
     // Update kill switch badge
     const ksEl = document.getElementById('kill-switch-badge');

--- a/apps/web_console_ng/static/js/trading_state_listener.js
+++ b/apps/web_console_ng/static/js/trading_state_listener.js
@@ -7,12 +7,59 @@
   if (window.__tpTradingStateListenerAdded) return;
   window.__tpTradingStateListenerAdded = true;
 
+  const updateGlobalStatusBanner = () => {
+    const banner = document.getElementById('global-status-banner');
+    const label = document.getElementById('global-status-banner-label');
+    if (!banner || !label) return;
+
+    const state = ((window._tradingState && window._tradingState.killSwitchState) || 'UNKNOWN')
+      .toUpperCase();
+    const circuit = (
+      (window._tradingState && window._tradingState.circuitBreakerState) || 'UNKNOWN'
+    ).toUpperCase();
+
+    if (circuit === 'TRIPPED') {
+      label.textContent = 'TRADING HALTED (CIRCUIT)';
+      banner.classList.add('bg-red-600', 'text-white');
+      banner.classList.remove('bg-green-600', 'bg-yellow-500', 'text-black');
+      return;
+    }
+
+    if (state === 'ENGAGED') {
+      label.textContent = 'TRADING HALTED';
+      banner.classList.add('bg-red-600', 'text-white');
+      banner.classList.remove('bg-green-600', 'bg-yellow-500', 'text-black');
+      return;
+    }
+
+    if (circuit === 'QUIET_PERIOD') {
+      label.textContent = 'TRADING PAUSED (QUIET)';
+      banner.classList.add('bg-yellow-500', 'text-black');
+      banner.classList.remove('bg-red-600', 'bg-green-600', 'text-white');
+      return;
+    }
+
+    if (state === 'DISENGAGED' || state === 'ACTIVE') {
+      label.textContent = 'TRADING ACTIVE';
+      banner.classList.add('bg-green-600', 'text-white');
+      banner.classList.remove('bg-red-600', 'bg-yellow-500', 'text-black');
+      return;
+    }
+
+    label.textContent = 'TRADING STATUS UNKNOWN';
+    banner.classList.add('bg-yellow-500', 'text-black');
+    banner.classList.remove('bg-red-600', 'bg-green-600', 'text-white');
+  };
+
   window.addEventListener('trading_state_change', (event) => {
     const detail = (event && event.detail) || {};
     const killSwitch = detail.killSwitch;
     const killSwitchState = detail.killSwitchState;
     const circuitBreaker = detail.circuitBreaker;
-    const circuitBreakerState = detail.circuitBreakerState;
+    const circuitBreakerState =
+      typeof detail.circuitBreakerState === 'string'
+        ? detail.circuitBreakerState
+        : detail.circuitState;
     const readOnly = detail.readOnly;
     const connectionState = detail.connectionState;
 
@@ -22,27 +69,27 @@
       if (typeof killSwitchState === 'string') {
         const state = killSwitchState.toUpperCase();
         if (state === 'ENGAGED') {
-          ksEl.textContent = 'KILL SWITCH ENGAGED';
+          ksEl.textContent = 'KILL SWITCH: ENGAGED';
           ksEl.classList.add('bg-red-500', 'text-white');
-          ksEl.classList.remove('bg-green-500', 'bg-yellow-500', 'text-black');
+          ksEl.classList.remove('bg-slate-700', 'bg-green-500', 'bg-yellow-500', 'text-black');
         } else if (state === 'DISENGAGED') {
-          ksEl.textContent = 'TRADING ACTIVE';
-          ksEl.classList.add('bg-green-500', 'text-white');
-          ksEl.classList.remove('bg-red-500', 'bg-yellow-500', 'text-black');
+          ksEl.textContent = 'KILL SWITCH: DISENGAGED';
+          ksEl.classList.add('bg-slate-700', 'text-slate-100');
+          ksEl.classList.remove('bg-red-500', 'bg-green-500', 'bg-yellow-500', 'text-white', 'text-black');
         } else {
-          ksEl.textContent = `STATE: ${state || 'UNKNOWN'}`;
+          ksEl.textContent = `KILL SWITCH: ${state || 'UNKNOWN'}`;
           ksEl.classList.add('bg-yellow-500', 'text-black');
-          ksEl.classList.remove('bg-red-500', 'bg-green-500', 'text-white');
+          ksEl.classList.remove('bg-red-500', 'bg-green-500', 'bg-slate-700', 'text-white', 'text-slate-100');
         }
       } else if (typeof killSwitch === 'boolean') {
         if (killSwitch) {
-          ksEl.textContent = 'KILL SWITCH ENGAGED';
+          ksEl.textContent = 'KILL SWITCH: ENGAGED';
           ksEl.classList.add('bg-red-500', 'text-white');
-          ksEl.classList.remove('bg-green-500', 'bg-yellow-500', 'text-black');
+          ksEl.classList.remove('bg-slate-700', 'bg-green-500', 'bg-yellow-500', 'text-black');
         } else {
-          ksEl.textContent = 'TRADING ACTIVE';
-          ksEl.classList.add('bg-green-500', 'text-white');
-          ksEl.classList.remove('bg-red-500', 'bg-yellow-500', 'text-black');
+          ksEl.textContent = 'KILL SWITCH: DISENGAGED';
+          ksEl.classList.add('bg-slate-700', 'text-slate-100');
+          ksEl.classList.remove('bg-red-500', 'bg-green-500', 'bg-yellow-500', 'text-white', 'text-black');
         }
       }
     }
@@ -80,6 +127,18 @@
           cbEl.classList.remove('bg-red-500', 'bg-yellow-500', 'text-black');
         }
       }
+    }
+
+    window._tradingState = window._tradingState || {};
+    if (typeof killSwitchState === 'string') {
+      window._tradingState.killSwitchState = killSwitchState;
+    } else if (typeof killSwitch === 'boolean') {
+      window._tradingState.killSwitchState = killSwitch ? 'ENGAGED' : 'DISENGAGED';
+    }
+    if (typeof circuitBreakerState === 'string') {
+      window._tradingState.circuitBreakerState = circuitBreakerState;
+    } else if (typeof circuitBreaker === 'boolean') {
+      window._tradingState.circuitBreakerState = circuitBreaker ? 'TRIPPED' : 'NORMAL';
     }
 
     if (typeof readOnly === 'boolean') {
@@ -126,5 +185,7 @@
         }
       });
     }
+
+    updateGlobalStatusBanner();
   });
 })();

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -393,12 +393,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
             *,
             stale: bool = False,
         ) -> None:
-            try:
-                status_bar.update_state(state, circuit_state=cb_state, stale=stale)
-            except TypeError:
-                # Compatibility for older test doubles/signatures that do not
-                # yet accept the stale keyword.
-                status_bar.update_state(state, circuit_state=cb_state)
+            status_bar.update_state(state, circuit_state=cb_state, stale=stale)
 
         with ui.header().classes(
             "bg-slate-900 items-center text-white px-4 h-14 flex-nowrap overflow-x-auto"

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -324,8 +324,16 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     return True
 
                 rendered_paths: set[str] = set()
-
                 current_nav_path = current_path
+                alias_map = {
+                    "/trade": "/",
+                    "/exposure": "/risk/exposure",
+                    "/sql-explorer": "/data/sql-explorer",
+                    "/data/management": "/data",
+                    "/reports/scheduled": "/reports",
+                    "/shadow-results": "/data/shadow",
+                }
+                current_nav_path = alias_map.get(current_nav_path, current_nav_path)
 
                 for section_label, section_paths in nav_groups:
                     section_items = [
@@ -376,8 +384,18 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
         # Header
         status_bar = StatusBar()
 
-        def _update_status_bar(state: str | None, cb_state: str | None = None) -> None:
-            status_bar.update_state(state, circuit_state=cb_state)
+        def _update_status_bar(
+            state: str | None,
+            cb_state: str | None = None,
+            *,
+            stale: bool = False,
+        ) -> None:
+            try:
+                status_bar.update_state(state, circuit_state=cb_state, stale=stale)
+            except TypeError:
+                # Compatibility for older test doubles/signatures that do not
+                # yet accept the stale keyword.
+                status_bar.update_state(state, circuit_state=cb_state)
 
         with ui.header().classes(
             "bg-slate-900 items-center text-white px-4 h-14 flex-nowrap overflow-x-auto"
@@ -536,6 +554,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
             await page_func(*args, **kwargs)
 
         last_kill_switch_state: str | None = None
+        last_circuit_state: str | None = None
         kill_switch_state: str | None = None
         kill_switch_action_in_progress = False
         connection_monitor = ConnectionMonitor()
@@ -558,6 +577,69 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
             else:
                 engage_button.enable()
                 disengage_button.enable()
+
+        def _render_kill_switch_state(display_state: str, *, stale: bool = False) -> None:
+            rendered_state = f"{display_state} (STALE)" if stale else display_state
+            if display_state == "ENGAGED":
+                kill_switch_button.set_text(f"KILL SWITCH: {rendered_state}")
+                kill_switch_button.classes(
+                    "bg-red-700 text-rose-100",
+                    remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
+                )
+                if not stale and last_kill_switch_state != "ENGAGED":
+                    ui.notify("Kill switch engaged", type="negative")
+            elif display_state == "DISENGAGED":
+                kill_switch_button.set_text(f"KILL SWITCH: {rendered_state}")
+                if stale:
+                    kill_switch_button.classes(
+                        "bg-amber-500 text-black",
+                        remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                    )
+                else:
+                    kill_switch_button.classes(
+                        "bg-slate-700 text-slate-100",
+                        remove="bg-red-700 bg-amber-500 text-rose-100 text-black",
+                    )
+            else:
+                kill_switch_button.set_text(f"KILL SWITCH: {rendered_state}")
+                kill_switch_button.classes(
+                    "bg-amber-500 text-black",
+                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                )
+
+        def _render_circuit_breaker_state(cb_state: str, *, stale: bool = False) -> None:
+            if stale:
+                circuit_breaker_badge.set_text(f"CIRCUIT: {cb_state} (STALE)")
+                circuit_breaker_badge.classes(
+                    "bg-amber-500 text-black",
+                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                )
+                return
+
+            if cb_state == "TRIPPED":
+                circuit_breaker_badge.set_text("CIRCUIT TRIPPED")
+                circuit_breaker_badge.classes(
+                    "bg-red-700 text-rose-100",
+                    remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
+                )
+            elif cb_state == "OPEN":
+                circuit_breaker_badge.set_text("CIRCUIT OK")
+                circuit_breaker_badge.classes(
+                    "bg-slate-700 text-slate-100",
+                    remove="bg-red-700 bg-amber-500 text-rose-100 text-black",
+                )
+            elif cb_state == "QUIET_PERIOD":
+                circuit_breaker_badge.set_text("CIRCUIT QUIET PERIOD")
+                circuit_breaker_badge.classes(
+                    "bg-amber-500 text-black",
+                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                )
+            else:
+                circuit_breaker_badge.set_text(f"CIRCUIT: {cb_state}")
+                circuit_breaker_badge.classes(
+                    "bg-amber-500 text-black",
+                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                )
 
         async def perform_kill_switch_action(action: str, reason: str) -> None:
             nonlocal kill_switch_action_in_progress
@@ -682,7 +764,7 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                 last_read_only = read_only
 
         async def update_global_status() -> None:
-            nonlocal last_kill_switch_state, kill_switch_state
+            nonlocal last_circuit_state, last_kill_switch_state, kill_switch_state
             if status_poll_lock.locked():
                 return
             async with status_poll_lock:
@@ -735,56 +817,12 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         )
                         cb_state = "UNKNOWN"
 
-                    if display_state == "ENGAGED":
-                        kill_switch_button.set_text("KILL SWITCH: ENGAGED")
-                        kill_switch_button.classes(
-                            "bg-red-700 text-rose-100",
-                            remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
-                        )
-                        if last_kill_switch_state != "ENGAGED":
-                            ui.notify("Kill switch engaged", type="negative")
-                    elif display_state == "DISENGAGED":
-                        # Keep muted visual weight when disarmed (do not compete with chart/ticket).
-                        kill_switch_button.set_text("KILL SWITCH: DISENGAGED")
-                        kill_switch_button.classes(
-                            "bg-slate-700 text-slate-100",
-                            remove="bg-red-700 bg-amber-500 text-rose-100 text-black",
-                        )
-                    else:
-                        # Unknown/invalid state - show warning
-                        kill_switch_button.set_text(f"KILL SWITCH: {display_state}")
-                        kill_switch_button.classes(
-                            "bg-amber-500 text-black",
-                            remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
-                        )
-                    _update_status_bar(display_state, cb_state)
-
-                    if cb_state == "TRIPPED":
-                        circuit_breaker_badge.set_text("CIRCUIT TRIPPED")
-                        circuit_breaker_badge.classes(
-                            "bg-red-700 text-rose-100",
-                            remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
-                        )
-                    elif cb_state == "OPEN":
-                        circuit_breaker_badge.set_text("CIRCUIT OK")
-                        circuit_breaker_badge.classes(
-                            "bg-slate-700 text-slate-100",
-                            remove="bg-red-700 bg-amber-500 text-rose-100 text-black",
-                        )
-                    elif cb_state == "QUIET_PERIOD":
-                        circuit_breaker_badge.set_text("CIRCUIT QUIET PERIOD")
-                        circuit_breaker_badge.classes(
-                            "bg-amber-500 text-black",
-                            remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
-                        )
-                    else:
-                        circuit_breaker_badge.set_text(f"CIRCUIT: {cb_state}")
-                        circuit_breaker_badge.classes(
-                            "bg-amber-500 text-black",
-                            remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
-                        )
+                    _render_kill_switch_state(display_state)
+                    _update_status_bar(display_state, cb_state, stale=False)
+                    _render_circuit_breaker_state(cb_state)
 
                     last_kill_switch_state = display_state
+                    last_circuit_state = cb_state
                     set_kill_switch_controls(display_state)
                     status_success = True
                 except (ValueError, KeyError, TypeError, ConnectionError, httpx.HTTPError) as e:
@@ -797,19 +835,25 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         },
                         exc_info=True,
                     )
-                    kill_switch_state = "UNKNOWN"
-                    kill_switch_button.set_text("STATUS UNKNOWN")
-                    kill_switch_button.classes(
-                        "bg-amber-500 text-black",
-                        remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
-                    )
-                    _update_status_bar("UNKNOWN", "UNKNOWN")
-                    set_kill_switch_controls("UNKNOWN")
-                    circuit_breaker_badge.set_text("CIRCUIT: UNKNOWN")
-                    circuit_breaker_badge.classes(
-                        "bg-amber-500 text-black",
-                        remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
-                    )
+                    # Keep last known-good state on transient failures to avoid dashboard churn.
+                    if last_kill_switch_state is not None:
+                        cached_state = last_kill_switch_state
+                        cached_cb_state = last_circuit_state or "UNKNOWN"
+                        kill_switch_state = cached_state
+                        _render_kill_switch_state(cached_state, stale=True)
+                        _update_status_bar(cached_state, cached_cb_state, stale=True)
+                        _render_circuit_breaker_state(cached_cb_state, stale=True)
+                        set_kill_switch_controls(cached_state)
+                    else:
+                        kill_switch_state = "UNKNOWN"
+                        kill_switch_button.set_text("STATUS UNKNOWN")
+                        kill_switch_button.classes(
+                            "bg-amber-500 text-black",
+                            remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                        )
+                        _update_status_bar("UNKNOWN", "UNKNOWN")
+                        set_kill_switch_controls("UNKNOWN")
+                        _render_circuit_breaker_state("UNKNOWN")
 
                 if status_success:
                     connection_monitor.record_success()

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -579,6 +579,31 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                 cached_circuit_state or "UNKNOWN",
                 stale=True,
             )
+            cached_kill_display = cached_kill_state or "UNKNOWN"
+            cached_cb_display = cached_circuit_state or "UNKNOWN"
+            kill_switch_button.set_text(f"KILL SWITCH: {cached_kill_display} (STALE)")
+            if cached_kill_display == "ENGAGED":
+                kill_switch_button.classes(
+                    "bg-red-700 text-rose-100",
+                    remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
+                )
+            else:
+                kill_switch_button.classes(
+                    "bg-amber-500 text-black",
+                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                )
+            if cached_cb_display == "TRIPPED":
+                circuit_breaker_badge.set_text("CIRCUIT TRIPPED (STALE)")
+                circuit_breaker_badge.classes(
+                    "bg-red-700 text-rose-100",
+                    remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
+                )
+            else:
+                circuit_breaker_badge.set_text(f"CIRCUIT: {cached_cb_display} (STALE)")
+                circuit_breaker_badge.classes(
+                    "bg-amber-500 text-black",
+                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                )
 
         # Main content area
         # Top-level layout elements (e.g. drawers) must be outside header/rows.
@@ -650,11 +675,18 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
         def _render_circuit_breaker_state(cb_state: str, *, stale: bool = False) -> None:
             if stale:
-                circuit_breaker_badge.set_text(f"CIRCUIT: {cb_state} (STALE)")
-                circuit_breaker_badge.classes(
-                    "bg-amber-500 text-black",
-                    remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
-                )
+                if cb_state == "TRIPPED":
+                    circuit_breaker_badge.set_text("CIRCUIT TRIPPED (STALE)")
+                    circuit_breaker_badge.classes(
+                        "bg-red-700 text-rose-100",
+                        remove="bg-slate-700 bg-amber-500 text-slate-100 text-black",
+                    )
+                else:
+                    circuit_breaker_badge.set_text(f"CIRCUIT: {cb_state} (STALE)")
+                    circuit_breaker_badge.classes(
+                        "bg-amber-500 text-black",
+                        remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
+                    )
                 return
 
             if cb_state == "TRIPPED":
@@ -829,6 +861,14 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         )
                     if header_metrics.is_stale():
                         header_metrics.mark_stale()
+                    if last_kill_switch_state is not None or last_circuit_state is not None:
+                        dispatch_trading_state(
+                            {
+                                "killSwitchState": last_kill_switch_state or "UNKNOWN",
+                                "circuitState": last_circuit_state or "UNKNOWN",
+                                "statusStale": True,
+                            }
+                        )
                     sync_connection_state()
                     return
 
@@ -869,6 +909,13 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     _render_kill_switch_state(display_state)
                     _update_status_bar(display_state, cb_state, stale=False)
                     _render_circuit_breaker_state(cb_state)
+                    dispatch_trading_state(
+                        {
+                            "killSwitchState": display_state,
+                            "circuitState": cb_state,
+                            "statusStale": False,
+                        }
+                    )
 
                     last_kill_switch_state = display_state
                     last_circuit_state = cb_state
@@ -894,6 +941,13 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         _render_kill_switch_state(cached_state, stale=True)
                         _update_status_bar(cached_state, cached_cb_state, stale=True)
                         _render_circuit_breaker_state(cached_cb_state, stale=True)
+                        dispatch_trading_state(
+                            {
+                                "killSwitchState": cached_state,
+                                "circuitState": cached_cb_state,
+                                "statusStale": True,
+                            }
+                        )
                         set_kill_switch_controls(cached_state)
                     else:
                         fallback_cb_state = last_circuit_state or "UNKNOWN"
@@ -926,6 +980,13 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         _update_status_bar("UNKNOWN", fallback_cb_state)
                         set_kill_switch_controls("UNKNOWN")
                         _render_circuit_breaker_state(fallback_cb_state)
+                        dispatch_trading_state(
+                            {
+                                "killSwitchState": "UNKNOWN",
+                                "circuitState": fallback_cb_state,
+                                "statusStale": fallback_cb_state != "UNKNOWN",
+                            }
+                        )
 
                 if status_success:
                     connection_monitor.record_success()

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -549,6 +549,37 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     "Logout"
                 )
 
+        def _normalize_cached_kill_state(raw_state: Any) -> str | None:
+            if not isinstance(raw_state, str):
+                return None
+            normalized = raw_state.strip().upper()
+            if not normalized:
+                return None
+            if normalized == "ACTIVE":
+                return "DISENGAGED"
+            return normalized
+
+        def _normalize_cached_circuit_state(raw_state: Any) -> str | None:
+            if not isinstance(raw_state, str):
+                return None
+            normalized = raw_state.strip().upper()
+            return normalized or None
+
+        cached_kill_state = _normalize_cached_kill_state(
+            app.storage.user.get("global_kill_switch_state")
+        )
+        cached_circuit_state = _normalize_cached_circuit_state(
+            app.storage.user.get("global_circuit_state")
+        )
+        if cached_kill_state is not None or cached_circuit_state is not None:
+            # Render stale cached state before heavy pages finish building so the
+            # top banner does not start at UNKNOWN on first paint.
+            _update_status_bar(
+                cached_kill_state or "UNKNOWN",
+                cached_circuit_state or "UNKNOWN",
+                stale=True,
+            )
+
         # Main content area
         # Top-level layout elements (e.g. drawers) must be outside header/rows.
         log_drawer.create_drawer()
@@ -581,20 +612,12 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                 engage_button.enable()
                 disengage_button.enable()
 
-        cached_kill_state = app.storage.user.get("global_kill_switch_state")
-        if isinstance(cached_kill_state, str):
-            normalized_cached_kill = cached_kill_state.strip().upper()
-            if normalized_cached_kill == "ACTIVE":
-                normalized_cached_kill = "DISENGAGED"
-            if normalized_cached_kill:
-                last_kill_switch_state = normalized_cached_kill
-                kill_switch_state = normalized_cached_kill
+        if cached_kill_state is not None:
+            last_kill_switch_state = cached_kill_state
+            kill_switch_state = cached_kill_state
 
-        cached_circuit_state = app.storage.user.get("global_circuit_state")
-        if isinstance(cached_circuit_state, str):
-            normalized_cached_circuit = cached_circuit_state.strip().upper()
-            if normalized_cached_circuit:
-                last_circuit_state = normalized_cached_circuit
+        if cached_circuit_state is not None:
+            last_circuit_state = cached_circuit_state
 
         def _render_kill_switch_state(display_state: str, *, stale: bool = False) -> None:
             rendered_state = f"{display_state} (STALE)" if stale else display_state
@@ -659,12 +682,13 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                 )
 
-        if last_kill_switch_state is not None:
+        if last_kill_switch_state is not None or last_circuit_state is not None:
+            cached_state = last_kill_switch_state or "UNKNOWN"
             cached_cb = last_circuit_state or "UNKNOWN"
-            _render_kill_switch_state(last_kill_switch_state, stale=True)
+            _render_kill_switch_state(cached_state, stale=True)
             _render_circuit_breaker_state(cached_cb, stale=True)
-            _update_status_bar(last_kill_switch_state, cached_cb, stale=True)
-            set_kill_switch_controls(last_kill_switch_state)
+            _update_status_bar(cached_state, cached_cb, stale=True)
+            set_kill_switch_controls(cached_state)
 
         async def perform_kill_switch_action(action: str, reason: str) -> None:
             nonlocal kill_switch_action_in_progress

--- a/apps/web_console_ng/ui/layout.py
+++ b/apps/web_console_ng/ui/layout.py
@@ -61,7 +61,10 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
         ui.add_head_html('<link rel="stylesheet" href="/static/css/density.css">')
         ui.add_head_html('<link rel="stylesheet" href="/static/css/custom.css">')
 
-        degrade_threshold = os.environ.get("GRID_DEGRADE_THRESHOLD", "120")
+        raw_degrade_threshold = os.environ.get("GRID_DEGRADE_THRESHOLD", "120")
+        degrade_threshold = (
+            raw_degrade_threshold if raw_degrade_threshold.isdigit() else "120"
+        )
         debug_mode = os.environ.get("GRID_DEBUG", "false").lower() == "true"
         ui.add_body_html(
             "<script>"
@@ -578,6 +581,21 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                 engage_button.enable()
                 disengage_button.enable()
 
+        cached_kill_state = app.storage.user.get("global_kill_switch_state")
+        if isinstance(cached_kill_state, str):
+            normalized_cached_kill = cached_kill_state.strip().upper()
+            if normalized_cached_kill == "ACTIVE":
+                normalized_cached_kill = "DISENGAGED"
+            if normalized_cached_kill:
+                last_kill_switch_state = normalized_cached_kill
+                kill_switch_state = normalized_cached_kill
+
+        cached_circuit_state = app.storage.user.get("global_circuit_state")
+        if isinstance(cached_circuit_state, str):
+            normalized_cached_circuit = cached_circuit_state.strip().upper()
+            if normalized_cached_circuit:
+                last_circuit_state = normalized_cached_circuit
+
         def _render_kill_switch_state(display_state: str, *, stale: bool = False) -> None:
             rendered_state = f"{display_state} (STALE)" if stale else display_state
             if display_state == "ENGAGED":
@@ -640,6 +658,13 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                     "bg-amber-500 text-black",
                     remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                 )
+
+        if last_kill_switch_state is not None:
+            cached_cb = last_circuit_state or "UNKNOWN"
+            _render_kill_switch_state(last_kill_switch_state, stale=True)
+            _render_circuit_breaker_state(cached_cb, stale=True)
+            _update_status_bar(last_kill_switch_state, cached_cb, stale=True)
+            set_kill_switch_controls(last_kill_switch_state)
 
         async def perform_kill_switch_action(action: str, reason: str) -> None:
             nonlocal kill_switch_action_in_progress
@@ -823,6 +848,8 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
 
                     last_kill_switch_state = display_state
                     last_circuit_state = cb_state
+                    app.storage.user["global_kill_switch_state"] = display_state
+                    app.storage.user["global_circuit_state"] = cb_state
                     set_kill_switch_controls(display_state)
                     status_success = True
                 except (ValueError, KeyError, TypeError, ConnectionError, httpx.HTTPError) as e:
@@ -845,15 +872,36 @@ def main_layout(page_func: AsyncPage) -> AsyncPage:
                         _render_circuit_breaker_state(cached_cb_state, stale=True)
                         set_kill_switch_controls(cached_state)
                     else:
+                        fallback_cb_state = last_circuit_state or "UNKNOWN"
+                        if fallback_cb_state == "UNKNOWN":
+                            try:
+                                # Use a short fallback timeout to avoid compounding status-loop latency
+                                cb_status = await asyncio.wait_for(
+                                    client.fetch_circuit_breaker_status(
+                                        user_id, role=user_role, strategies=user_strategies
+                                    ),
+                                    timeout=1.5,
+                                )
+                                fallback_cb_state = str(cb_status.get("state", "UNKNOWN")).upper()
+                                last_circuit_state = fallback_cb_state
+                                app.storage.user["global_circuit_state"] = fallback_cb_state
+                            except (
+                                TimeoutError,
+                                httpx.HTTPError,
+                                ValueError,
+                                KeyError,
+                                TypeError,
+                            ):
+                                fallback_cb_state = "UNKNOWN"
                         kill_switch_state = "UNKNOWN"
                         kill_switch_button.set_text("STATUS UNKNOWN")
                         kill_switch_button.classes(
                             "bg-amber-500 text-black",
                             remove="bg-red-700 bg-slate-700 text-rose-100 text-slate-100",
                         )
-                        _update_status_bar("UNKNOWN", "UNKNOWN")
+                        _update_status_bar("UNKNOWN", fallback_cb_state)
                         set_kill_switch_controls("UNKNOWN")
-                        _render_circuit_breaker_state("UNKNOWN")
+                        _render_circuit_breaker_state(fallback_cb_state)
 
                 if status_success:
                     connection_monitor.record_success()

--- a/apps/web_console_ng/ui/root_path.py
+++ b/apps/web_console_ng/ui/root_path.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any
 
 from nicegui import ui
 
 from apps.web_console_ng.auth.redirects import with_root_path_once
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_rooted_path_from_ui(path: str, *, ui_module: Any | None = None) -> str:
@@ -26,4 +30,36 @@ def resolve_rooted_path_from_ui(path: str, *, ui_module: Any | None = None) -> s
     return with_root_path_once(path, root_path=root_path)
 
 
-__all__ = ["resolve_rooted_path_from_ui"]
+def render_client_redirect(
+    target: str,
+    *,
+    ui_module: Any | None = None,
+    message: str = "Redirecting to canonical page...",
+) -> None:
+    """Render a deterministic client-side redirect with a visible fallback link."""
+    ui_ref = ui if ui_module is None else ui_module
+
+    # JS replace keeps browser history clean on modern clients.
+    # Link fallback below covers environments where JS is unavailable.
+    target_json = (
+        json.dumps(target)
+        .replace("</", "<\\/")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+    try:
+        ui_ref.run_javascript(f"window.location.replace({target_json});")
+    except Exception:
+        # Fallback link below handles environments where JS execution is delayed.
+        logger.debug(
+            "render_client_redirect_js_unavailable",
+            extra={"target": target},
+            exc_info=True,
+        )
+
+    with ui_ref.column().classes("w-full items-center justify-center gap-2 min-h-[30vh]"):
+        ui_ref.label(message).classes("text-sm text-gray-400")
+        ui_ref.link("Continue", target=target).classes("text-sm text-blue-400")
+
+
+__all__ = ["render_client_redirect", "resolve_rooted_path_from_ui"]

--- a/scripts/dev/start_wc_master.sh
+++ b/scripts/dev/start_wc_master.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Start web_console_ng from host Python against current checkout.
+#
+# Intended fallback for environments where docker web_console image rebuild is
+# temporarily blocked. This script:
+# 1) Stops docker web_console_dev to free port 8080
+# 2) Loads env vars from .env (or provided env file)
+# 3) Rewrites docker service hostnames to localhost host-mapped ports
+# 4) Starts apps.web_console_ng.main in the background and waits for readiness
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="${1:-$ROOT_DIR/.env}"
+VENV_PY="$ROOT_DIR/.venv/bin/python"
+LOG_DIR="${WC_MASTER_LOG_DIR:-/tmp/wc_master_logs}"
+PID_FILE="${WC_MASTER_PID_FILE:-/tmp/wc_master.pid}"
+HOST_PORT="${WC_MASTER_PORT:-8080}"
+
+if [[ ! -x "$VENV_PY" ]]; then
+  echo "Missing python executable: $VENV_PY"
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found: $ENV_FILE"
+  exit 1
+fi
+
+echo "Stopping docker web console (if running) to free port $HOST_PORT..."
+docker stop trading_platform_web_console_dev >/dev/null 2>&1 || true
+
+TMP_ENV_SH="$(mktemp /tmp/wc_master_env.XXXXXX.sh)"
+
+"$VENV_PY" - <<'PY' "$ENV_FILE" "$TMP_ENV_SH"
+import pathlib
+import re
+import shlex
+import sys
+
+env_path = pathlib.Path(sys.argv[1])
+out_path = pathlib.Path(sys.argv[2])
+
+mapping = {
+    "@redis:6379": "@localhost:6379",
+    "//redis:6379": "//localhost:6379",
+    "REDIS_HOST=redis": "REDIS_HOST=localhost",
+    "@postgres:5432": "@localhost:5433",
+    "//postgres:5432": "//localhost:5433",
+    "POSTGRES_HOST=postgres": "POSTGRES_HOST=localhost",
+    "@execution_gateway:8002": "@localhost:8002",
+    "//execution_gateway:8002": "//localhost:8002",
+    "@orchestrator:8003": "@localhost:8003",
+    "//orchestrator:8003": "//localhost:8003",
+    "@market_data_service:8004": "@localhost:8004",
+    "//market_data_service:8004": "//localhost:8004",
+    "@signal_service:8001": "@localhost:8001",
+    "//signal_service:8001": "//localhost:8001",
+    "@model_registry:8005": "@localhost:8005",
+    "//model_registry:8005": "//localhost:8005",
+    "@auth_service:8006": "@localhost:8006",
+    "//auth_service:8006": "//localhost:8006",
+    "//loki:3100": "//localhost:3100",
+    "//prometheus:9090": "//localhost:9090",
+}
+
+def parse_line(raw: str) -> tuple[str, str] | None:
+    stripped = raw.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    match = re.match(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$", stripped)
+    if not match:
+        return None
+    key = match.group(1)
+    value = match.group(2).strip()
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        value = value[1:-1]
+    return key, value
+
+lines = ["#!/bin/bash", "set -a"]
+for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+    parsed = parse_line(raw_line)
+    if parsed is None:
+        continue
+    key, value = parsed
+    merged = f"{key}={value}"
+    for source, replacement in mapping.items():
+        merged = merged.replace(source, replacement)
+    final_key, _, final_value = merged.partition("=")
+    lines.append(f"export {final_key}={shlex.quote(final_value)}")
+lines.append("set +a")
+
+out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+chmod +x "$TMP_ENV_SH"
+# shellcheck disable=SC1090
+source "$TMP_ENV_SH"
+
+export HOST=0.0.0.0
+export PORT="$HOST_PORT"
+export PYTHONPATH="$ROOT_DIR"
+
+mkdir -p "$LOG_DIR"
+echo "Starting web console from host checkout..."
+"$VENV_PY" -m apps.web_console_ng.main >"$LOG_DIR/out.log" 2>&1 &
+PID=$!
+echo "$PID" >"$PID_FILE"
+echo "started pid=$PID (logs: $LOG_DIR/out.log)"
+
+for i in {1..60}; do
+  if curl -s -o /dev/null "http://localhost:$HOST_PORT/login" 2>/dev/null; then
+    echo "ready after ${i}s"
+    rm -f "$TMP_ENV_SH"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Web console did not become ready in 60s; tailing log:"
+tail -30 "$LOG_DIR/out.log" || true
+rm -f "$TMP_ENV_SH"
+exit 1

--- a/scripts/dev/start_wc_master.sh
+++ b/scripts/dev/start_wc_master.sh
@@ -32,6 +32,10 @@ echo "Stopping docker web console (if running) to free port $HOST_PORT..."
 docker stop trading_platform_web_console_dev >/dev/null 2>&1 || true
 
 TMP_ENV_SH="$(mktemp /tmp/wc_master_env.XXXXXX.sh)"
+cleanup() {
+  rm -f "$TMP_ENV_SH"
+}
+trap cleanup EXIT INT TERM
 
 "$VENV_PY" - <<'PY' "$ENV_FILE" "$TMP_ENV_SH"
 import pathlib
@@ -114,7 +118,6 @@ echo "started pid=$PID (logs: $LOG_DIR/out.log)"
 for i in {1..60}; do
   if curl -s -o /dev/null "http://localhost:$HOST_PORT/login" 2>/dev/null; then
     echo "ready after ${i}s"
-    rm -f "$TMP_ENV_SH"
     exit 0
   fi
   sleep 1
@@ -122,5 +125,4 @@ done
 
 echo "Web console did not become ready in 60s; tailing log:"
 tail -30 "$LOG_DIR/out.log" || true
-rm -f "$TMP_ENV_SH"
 exit 1

--- a/tests/apps/execution_gateway/test_reconciliation_service.py
+++ b/tests/apps/execution_gateway/test_reconciliation_service.py
@@ -35,3 +35,22 @@ async def test_periodic_reconciliation_opens_gate():
     assert service.is_startup_complete() is False
     await service.run_reconciliation_once("periodic")
     assert service.is_startup_complete() is True
+
+
+@pytest.mark.asyncio()
+async def test_startup_reconciliation_handles_unexpected_error():
+    service = ReconciliationService(
+        db_client=object(),
+        alpaca_client=object(),
+        redis_client=None,
+        dry_run=False,
+    )
+
+    def _raise(_mode: str) -> None:
+        raise ConnectionError("broker unavailable")
+
+    service._run_reconciliation = _raise  # type: ignore[assignment]
+
+    result = await service.run_startup_reconciliation()
+    assert result is False
+    assert service.is_startup_complete() is False

--- a/tests/apps/web_console_ng/auth/test_session_store.py
+++ b/tests/apps/web_console_ng/auth/test_session_store.py
@@ -17,6 +17,7 @@ from apps.web_console_ng.auth.session_store import (
     SessionValidationError,
     _get_user_id,
     _ip_subnet,
+    _normalize_device_binding_ip,
     _normalize_fernet_key,
     extract_session_id,
     get_session_store,
@@ -805,6 +806,16 @@ def test_ip_subnet_empty_ip() -> None:
     """Test that empty IP returns empty string."""
     result = _ip_subnet("", 24)
     assert result == ""
+
+
+def test_normalize_device_binding_ip_loopback_ipv6() -> None:
+    """IPv6 loopback should normalize to IPv4 loopback."""
+    assert _normalize_device_binding_ip("::1") == "127.0.0.1"
+
+
+def test_normalize_device_binding_ip_preserves_non_loopback() -> None:
+    """Non-loopback IPs should remain unchanged."""
+    assert _normalize_device_binding_ip("192.168.1.10") == "192.168.1.10"
 
 
 def test_get_user_id_valid_session() -> None:

--- a/tests/apps/web_console_ng/components/test_coverage_heatmap.py
+++ b/tests/apps/web_console_ng/components/test_coverage_heatmap.py
@@ -179,7 +179,7 @@ class TestRenderCoverageControls:
             on_analyze=lambda *a: None,
         )
         assert any("No adjusted data" in el.text for el in dummy_ui.labels)
-        assert dummy_ui.buttons == []
+        assert len(dummy_ui.buttons) == 1
 
     def test_creates_form_elements(self, dummy_ui: DummyUI) -> None:
         heatmap_module.render_coverage_controls(

--- a/tests/apps/web_console_ng/components/test_hierarchical_orders.py
+++ b/tests/apps/web_console_ng/components/test_hierarchical_orders.py
@@ -55,6 +55,7 @@ def test_transform_to_hierarchy_builds_tree() -> None:
     child = rows[1]
     assert child["hierarchy_path"] == ["parent-1", "child-1"]
     assert child["is_child"] is True
+    assert child["parent_client_order_id"] == "parent-1"
 
 
 def test_transform_to_hierarchy_orphan_child_flattened() -> None:
@@ -75,6 +76,33 @@ def test_transform_to_hierarchy_orphan_child_flattened() -> None:
     orphan = rows[0]
     assert orphan["hierarchy_path"] == ["child-1"]
     assert orphan["is_orphan"] is True
+    assert orphan["parent_client_order_id"] == "missing-parent"
+
+
+def test_transform_to_hierarchy_overrides_mismatched_parent_client_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    orders = [
+        {"client_order_id": "parent-1", "symbol": "AAPL", "qty": 10},
+        {
+            "client_order_id": "child-1",
+            "parent_order_id": "parent-1",
+            "parent_client_order_id": "unexpected-parent",
+            "slice_num": 1,
+            "symbol": "AAPL",
+            "qty": 5,
+        },
+    ]
+
+    with caplog.at_level("DEBUG"):
+        rows = module.transform_to_hierarchy(orders)
+
+    child = rows[1]
+    assert child["parent_client_order_id"] == "parent-1"
+    assert any(
+        record.message == "hierarchy_parent_id_mismatch"
+        for record in caplog.records
+    )
 
 
 def test_compute_parent_aggregates_uses_children_when_parent_qty_zero() -> None:

--- a/tests/apps/web_console_ng/components/test_status_bar.py
+++ b/tests/apps/web_console_ng/components/test_status_bar.py
@@ -23,6 +23,9 @@ class DummyLabel:
     def classes(self, _add: str | None = None, _remove: str | None = None) -> DummyLabel:
         return self
 
+    def props(self, _value: str) -> DummyLabel:
+        return self
+
 
 class DummyElement:
     """Mock NiceGUI element for testing."""
@@ -37,6 +40,9 @@ class DummyElement:
         if add:
             for cls in add.split():
                 self._classes.add(cls)
+        return self
+
+    def props(self, _value: str) -> DummyElement:
         return self
 
     def __enter__(self) -> DummyElement:
@@ -91,3 +97,10 @@ def test_status_bar_engaged_overrides_quiet_period(dummy_ui: None) -> None:
     bar.update_state("ENGAGED", circuit_state="QUIET_PERIOD")
     assert bar._label is not None
     assert bar._label.text == "TRADING HALTED"
+
+
+def test_status_bar_stale_circuit_trip_is_explicit(dummy_ui: None) -> None:
+    bar = StatusBar()
+    bar.update_state("UNKNOWN", circuit_state="TRIPPED", stale=True)
+    assert bar._label is not None
+    assert bar._label.text == "TRADING HALTED (CIRCUIT)"

--- a/tests/apps/web_console_ng/components/test_status_bar.py
+++ b/tests/apps/web_console_ng/components/test_status_bar.py
@@ -104,3 +104,10 @@ def test_status_bar_stale_circuit_trip_is_explicit(dummy_ui: None) -> None:
     bar.update_state("UNKNOWN", circuit_state="TRIPPED", stale=True)
     assert bar._label is not None
     assert bar._label.text == "TRADING HALTED (CIRCUIT)"
+
+
+def test_status_bar_stale_unknown_does_not_claim_active(dummy_ui: None) -> None:
+    bar = StatusBar()
+    bar.update_state("UNKNOWN", stale=True)
+    assert bar._label is not None
+    assert bar._label.text == "TRADING STATUS UNKNOWN"

--- a/tests/apps/web_console_ng/components/test_strategy_exposure.py
+++ b/tests/apps/web_console_ng/components/test_strategy_exposure.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
+from apps.web_console_ng.components import strategy_exposure as strategy_exposure_module
 from apps.web_console_ng.components.strategy_exposure import build_exposure_rows
 from libs.web_console_services.schemas.exposure import StrategyExposureDTO, TotalExposureDTO
 
@@ -88,3 +93,59 @@ def test_build_exposure_rows_can_skip_total_row() -> None:
 
     assert len(rows) == 1
     assert rows[0]["strategy"] == "alpha_a"
+
+
+class _DummyGridElement:
+    def classes(self, _value: str) -> _DummyGridElement:
+        return self
+
+
+class _DummyUI:
+    def __init__(self) -> None:
+        self.grid_options: dict[str, Any] | None = None
+
+    def aggrid(self, options: dict[str, Any]) -> _DummyGridElement:
+        self.grid_options = options
+        return _DummyGridElement()
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_render_exposure_grid_sets_position_width_and_fit_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dummy_ui = _DummyUI()
+    monkeypatch.setattr(strategy_exposure_module, "ui", dummy_ui)
+
+    total = TotalExposureDTO(
+        long_total=1200.0,
+        short_total=100.0,
+        gross_total=1300.0,
+        net_total=1100.0,
+        net_pct=84.6,
+        strategy_count=1,
+    )
+
+    strategy_exposure_module.render_exposure_grid(
+        exposures=[
+            StrategyExposureDTO(
+                strategy="alpha_a",
+                long_notional=1200.0,
+                short_notional=100.0,
+                gross_notional=1300.0,
+                net_notional=1100.0,
+                net_pct=84.6,
+                position_count=4,
+            )
+        ],
+        total=total,
+    )
+
+    assert dummy_ui.grid_options is not None
+    position_col = next(
+        col for col in dummy_ui.grid_options["columnDefs"] if col.get("field") == "positions"
+    )
+    assert position_col["minWidth"] >= 96
+    assert "maxWidth" not in position_col
+    assert "gridSizeChanged" in str(dummy_ui.grid_options[":onGridReady"])
+    assert "__wcExposureFitBound" in str(dummy_ui.grid_options[":onGridReady"])
+    assert "sizeColumnsToFit" in str(dummy_ui.grid_options[":onFirstDataRendered"])

--- a/tests/apps/web_console_ng/pages/test_dashboard.py
+++ b/tests/apps/web_console_ng/pages/test_dashboard.py
@@ -135,9 +135,14 @@ def test_trade_alias_redirect_target_preserves_safe_query_params(
         context=SimpleNamespace(
             client=SimpleNamespace(
                 request=SimpleNamespace(
-                    scope={
-                        "query_string": b"symbol=AAPL&qty=5&side=buy&foo=ignored",
-                    }
+                    query_params=SimpleNamespace(
+                        multi_items=lambda: [
+                            ("symbol", "AAPL"),
+                            ("qty", "5"),
+                            ("side", "buy"),
+                            ("foo", "ignored"),
+                        ]
+                    )
                 )
             )
         )

--- a/tests/apps/web_console_ng/pages/test_tax_lots.py
+++ b/tests/apps/web_console_ng/pages/test_tax_lots.py
@@ -243,6 +243,40 @@ async def test_render_summary_metrics_handles_short_position_gain(
     assert "$+100.00" in label_texts
 
 
+@pytest.mark.asyncio()
+async def test_render_summary_metrics_partial_prices_shows_priced_subset_basis(
+    dummy_ui: _DummyUI, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tax_lots_module, "ui", dummy_ui)
+    now = datetime.now(UTC)
+    lots = [
+        SimpleNamespace(
+            symbol="AAPL",
+            cost_basis=Decimal("1000"),
+            quantity=Decimal("10"),
+            remaining_quantity=Decimal("10"),
+            acquired_at=now - timedelta(days=30),
+        ),
+        SimpleNamespace(
+            symbol="MSFT",
+            cost_basis=Decimal("500"),
+            quantity=Decimal("5"),
+            remaining_quantity=Decimal("5"),
+            acquired_at=now - timedelta(days=30),
+        ),
+    ]
+
+    await tax_lots_module._render_summary_metrics(
+        lots=lots,
+        current_prices={"AAPL": Decimal("110")},
+        wash_sale_lot_ids=set(),
+        db_pool=None,
+    )
+
+    label_texts = [str(el.kwargs.get("text", "")) for el in dummy_ui.labels]
+    assert "Priced subset: $1,000.00" in label_texts
+
+
 def test_cost_basis_methods_defined() -> None:
     """Cost basis methods constant contains expected values."""
     assert "fifo" in tax_lots_module._COST_BASIS_METHODS

--- a/tests/apps/web_console_ng/pages/test_tax_lots.py
+++ b/tests/apps/web_console_ng/pages/test_tax_lots.py
@@ -215,6 +215,34 @@ async def test_render_summary_metrics_handles_acquired_at_and_prorated_decimal(
     assert "$2,500.00" in label_texts
 
 
+@pytest.mark.asyncio()
+async def test_render_summary_metrics_handles_short_position_gain(
+    dummy_ui: _DummyUI, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tax_lots_module, "ui", dummy_ui)
+    now = datetime.now(UTC)
+    lots = [
+        SimpleNamespace(
+            symbol="TSLA",
+            cost_basis=Decimal("1000"),
+            quantity=Decimal("-10"),
+            remaining_quantity=Decimal("-10"),
+            acquired_at=now - timedelta(days=10),
+        )
+    ]
+    prices = {"TSLA": Decimal("90")}
+
+    await tax_lots_module._render_summary_metrics(
+        lots=lots,
+        current_prices=prices,
+        wash_sale_lot_ids=set(),
+        db_pool=None,
+    )
+
+    label_texts = [str(el.kwargs.get("text", "")) for el in dummy_ui.labels]
+    assert "$+100.00" in label_texts
+
+
 def test_cost_basis_methods_defined() -> None:
     """Cost basis methods constant contains expected values."""
     assert "fifo" in tax_lots_module._COST_BASIS_METHODS

--- a/tests/apps/web_console_ng/pages/test_tax_lots.py
+++ b/tests/apps/web_console_ng/pages/test_tax_lots.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -175,6 +177,42 @@ async def test_fetch_current_prices_empty_lots() -> None:
         [], {"user_id": "u1", "role": "admin"}
     )
     assert result == {}
+
+
+@pytest.mark.asyncio()
+async def test_render_summary_metrics_handles_acquired_at_and_prorated_decimal(
+    dummy_ui: _DummyUI, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Summary metrics should handle int quantities and acquired_at datetime safely."""
+    monkeypatch.setattr(tax_lots_module, "ui", dummy_ui)
+    now = datetime.now(UTC)
+    lots = [
+        SimpleNamespace(
+            symbol="AAPL",
+            cost_basis=Decimal("1000"),
+            quantity=10,
+            remaining_quantity=5,
+            acquired_at=now - timedelta(days=30),
+        ),
+        SimpleNamespace(
+            symbol="MSFT",
+            cost_basis=Decimal("2000"),
+            quantity=20,
+            remaining_quantity=20,
+            acquired_at=now - timedelta(days=500),
+        ),
+    ]
+    prices = {"AAPL": Decimal("120"), "MSFT": Decimal("95")}
+    await tax_lots_module._render_summary_metrics(
+        lots=lots,
+        current_prices=prices,
+        wash_sale_lot_ids=set(),
+        db_pool=None,
+    )
+
+    label_texts = [str(el.kwargs.get("text", "")) for el in dummy_ui.labels]
+    assert "1 / 1" in label_texts
+    assert "$2,500.00" in label_texts
 
 
 def test_cost_basis_methods_defined() -> None:

--- a/tests/apps/web_console_ng/test_layout.py
+++ b/tests/apps/web_console_ng/test_layout.py
@@ -200,7 +200,11 @@ async def _run_layout(
             pass
 
         def update_state(
-            self, state: str | None, *, circuit_state: str | None = None
+            self,
+            state: str | None,
+            *,
+            circuit_state: str | None = None,
+            stale: bool = False,
         ) -> None:
             pass
 
@@ -281,6 +285,9 @@ async def _run_layout(
     class _DummyClient:
         async def fetch_kill_switch_status(self, _user_id: str) -> dict[str, str]:
             return {"state": "ACTIVE"}
+
+        async def fetch_circuit_breaker_status(self) -> dict[str, str]:
+            return {"state": "OPEN"}
 
     monkeypatch.setattr(
         layout_module.AsyncTradingClient,

--- a/tests/apps/web_console_ng/test_navigation.py
+++ b/tests/apps/web_console_ng/test_navigation.py
@@ -214,7 +214,11 @@ async def _run_layout(monkeypatch: pytest.MonkeyPatch, current_path: str) -> _Fa
             pass
 
         def update_state(
-            self, state: str | None, *, circuit_state: str | None = None
+            self,
+            state: str | None,
+            *,
+            circuit_state: str | None = None,
+            stale: bool = False,
         ) -> None:
             pass
 
@@ -411,7 +415,11 @@ async def test_exposure_link_hidden_without_permission(
             pass
 
         def update_state(
-            self, state: str | None, *, circuit_state: str | None = None
+            self,
+            state: str | None,
+            *,
+            circuit_state: str | None = None,
+            stale: bool = False,
         ) -> None:
             pass
 
@@ -563,7 +571,11 @@ async def test_universes_link_hidden_without_permission(
             pass
 
         def update_state(
-            self, state: str | None, *, circuit_state: str | None = None
+            self,
+            state: str | None,
+            *,
+            circuit_state: str | None = None,
+            stale: bool = False,
         ) -> None:
             pass
 

--- a/tests/apps/web_console_ng/ui/test_layout.py
+++ b/tests/apps/web_console_ng/ui/test_layout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -381,6 +382,19 @@ async def test_layout_sets_current_path_and_cleanup(monkeypatch: pytest.MonkeyPa
     assert layout_module.app.storage.user["current_path"] == "/risk"
     assert len(lifecycle_manager.callbacks) == 3
     assert dummy_ui.head_html
+
+
+def test_trading_state_listener_honors_stale_status_events() -> None:
+    listener_path = Path(
+        "apps/web_console_ng/static/js/trading_state_listener.js"
+    )
+    listener = listener_path.read_text(encoding="utf-8")
+
+    assert "const statusStale = detail.statusStale === true;" in listener
+    assert "window._tradingState.statusStale = statusStale;" in listener
+    assert "if (window._tradingState && window._tradingState.statusStale) return;" in listener
+    assert "if (ksEl && !statusStale)" in listener
+    assert "if (cbEl && !statusStale)" in listener
 
 
 class _DummyDialog:

--- a/tests/apps/web_console_ng/ui/test_layout.py
+++ b/tests/apps/web_console_ng/ui/test_layout.py
@@ -116,13 +116,24 @@ class _DummyMarketClock:
 
 
 class _DummyStatusBar:
+    instances: list[_DummyStatusBar] = []
+
     def __init__(self) -> None:
         self.state: str | None = None
+        self.calls: list[dict[str, Any]] = []
+        _DummyStatusBar.instances.append(self)
 
     def update_state(
-        self, state: str | None, *, circuit_state: str | None = None
+        self,
+        state: str | None,
+        *,
+        circuit_state: str | None = None,
+        stale: bool = False,
     ) -> None:
         self.state = state
+        self.calls.append(
+            {"state": state, "circuit_state": circuit_state, "stale": stale}
+        )
 
 
 class _DummyHeaderMetrics:
@@ -290,6 +301,7 @@ async def _run_layout(
     monkeypatch: pytest.MonkeyPatch, *, current_path: str
 ) -> tuple[_DummyUI, _DummyLifecycleManager]:
     dummy_ui = _DummyUI()
+    _DummyStatusBar.instances = []
     # Include both user and client storage (client for per-tab isolation)
     dummy_app = SimpleNamespace(
         storage=SimpleNamespace(
@@ -572,6 +584,7 @@ async def _run_extended_layout(
     monkeypatch: pytest.MonkeyPatch,
     *,
     current_path: str = "/",
+    initial_user_storage: dict[str, Any] | None = None,
     connection_monitor: _DummyConnectionMonitor | None = None,
     latency_monitor: _DummyLatencyMonitor | None = None,
     market_clock_class: type | None = None,
@@ -581,10 +594,12 @@ async def _run_extended_layout(
 ) -> tuple[_ExtendedDummyUI, _DummyLifecycleManager, dict[str, Any]]:
     """Extended layout runner that returns components for testing."""
     dummy_ui = _ExtendedDummyUI()
+    _DummyStatusBar.instances = []
+    user_storage = {} if initial_user_storage is None else dict(initial_user_storage)
     # Include both user and client storage (client for per-tab isolation)
     dummy_app = SimpleNamespace(
         storage=SimpleNamespace(
-            user={},
+            user=user_storage,
             client={},
             request=SimpleNamespace(url=SimpleNamespace(path=current_path)),
         )
@@ -931,6 +946,26 @@ async def test_connection_state_dispatch(monkeypatch: pytest.MonkeyPatch) -> Non
         monkeypatch,
         client=client,
         connection_monitor=conn_monitor,
+    )
+
+
+@pytest.mark.asyncio()
+async def test_layout_bootstraps_status_bar_from_cached_circuit_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Render stale circuit-tripped status even when kill-switch cache is missing."""
+    conn_monitor = _ExtendedDummyConnectionMonitor(should_attempt_value=False)
+
+    await _run_extended_layout(
+        monkeypatch,
+        connection_monitor=conn_monitor,
+        initial_user_storage={"global_circuit_state": "TRIPPED"},
+    )
+
+    status_bar = _DummyStatusBar.instances[-1]
+    assert any(
+        call["circuit_state"] == "TRIPPED" and call["stale"] is True
+        for call in status_bar.calls
     )
 
 

--- a/tests/apps/web_console_ng/ui/test_layout.py
+++ b/tests/apps/web_console_ng/ui/test_layout.py
@@ -390,8 +390,10 @@ def test_trading_state_listener_honors_stale_status_events() -> None:
     )
     listener = listener_path.read_text(encoding="utf-8")
 
-    assert "const statusStale = detail.statusStale === true;" in listener
-    assert "window._tradingState.statusStale = statusStale;" in listener
+    assert "const hasStatusStale = Object.prototype.hasOwnProperty.call(detail, 'statusStale');" in listener
+    assert "if (hasStatusStale) {" in listener
+    assert "window._tradingState.statusStale = detail.statusStale === true;" in listener
+    assert "const statusStale = window._tradingState.statusStale === true;" in listener
     assert "if (window._tradingState && window._tradingState.statusStale) return;" in listener
     assert "if (ksEl && !statusStale)" in listener
     assert "if (cbEl && !statusStale)" in listener

--- a/tests/apps/web_console_ng/ui/test_layout.py
+++ b/tests/apps/web_console_ng/ui/test_layout.py
@@ -1264,6 +1264,76 @@ async def test_dispatch_trading_state_exception(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio()
+async def test_layout_dispatches_explicit_kill_and_circuit_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure banner listener payload includes kill/circuit state values."""
+
+    class _CapturingUI(_ExtendedDummyUI):
+        def __init__(self) -> None:
+            super().__init__()
+            self.js_calls: list[str] = []
+
+        def run_javascript(self, script: str, **_kwargs: Any) -> None:
+            self.js_calls.append(script)
+
+    dummy_ui = _CapturingUI()
+    dummy_app = SimpleNamespace(
+        storage=SimpleNamespace(
+            user={}, client={}, request=SimpleNamespace(url=SimpleNamespace(path="/strategies"))
+        )
+    )
+
+    monkeypatch.setattr(layout_module, "ui", dummy_ui)
+    monkeypatch.setattr(layout_module, "app", dummy_app)
+    monkeypatch.setattr(layout_module, "enable_dark_mode", lambda: None)
+    monkeypatch.setattr(
+        layout_module,
+        "get_current_user",
+        lambda: {"role": "admin", "username": "user", "user_id": "u1", "strategies": []},
+    )
+    monkeypatch.setattr(layout_module, "MarketClock", _DummyMarketClock)
+    monkeypatch.setattr(layout_module, "StatusBar", _DummyStatusBar)
+    monkeypatch.setattr(layout_module, "HeaderMetrics", _DummyHeaderMetrics)
+    monkeypatch.setattr(layout_module, "LatencyMonitor", _DummyLatencyMonitor)
+    monkeypatch.setattr(layout_module, "ConnectionMonitor", _ExtendedDummyConnectionMonitor)
+    monkeypatch.setattr(layout_module, "NotificationRouter", _DummyNotificationRouter)
+    monkeypatch.setattr(layout_module, "HotkeyManager", _DummyHotkeyManager)
+    monkeypatch.setattr(layout_module, "CommandPalette", _DummyCommandPalette)
+    monkeypatch.setattr(layout_module, "LogDrawer", _DummyLogDrawer)
+    monkeypatch.setattr(layout_module, "UserStateManager", _DummyUserStateManager)
+
+    class _LifecycleWrapper:
+        @classmethod
+        def get(cls) -> _DummyLifecycleManager:
+            return _DummyLifecycleManager()
+
+    monkeypatch.setattr(layout_module, "ClientLifecycleManager", _LifecycleWrapper)
+    monkeypatch.setattr(layout_module, "get_or_create_client_id", lambda: "client-1")
+    monkeypatch.setattr(layout_module, "get_all_monitors", lambda: {})
+    monkeypatch.setattr(
+        layout_module.AsyncTradingClient,
+        "get",
+        classmethod(
+            lambda cls: _ExtendedDummyClient(
+                kill_switch_state="DISENGAGED",
+                cb_state="TRIPPED",
+            )
+        ),
+    )
+
+    async def _page() -> None:
+        return None
+
+    wrapped = layout_module.main_layout(_page)
+    await wrapped()
+
+    dispatched = "\n".join(dummy_ui.js_calls)
+    assert '"killSwitchState": "DISENGAGED"' in dispatched
+    assert '"circuitState": "TRIPPED"' in dispatched
+
+
+@pytest.mark.asyncio()
 async def test_market_clock_update_failure_during_success_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/apps/web_console_ng/ui/test_layout.py
+++ b/tests/apps/web_console_ng/ui/test_layout.py
@@ -391,8 +391,11 @@ def test_trading_state_listener_honors_stale_status_events() -> None:
     listener = listener_path.read_text(encoding="utf-8")
 
     assert "const hasStatusStale = Object.prototype.hasOwnProperty.call(detail, 'statusStale');" in listener
+    assert "const hasFreshTradingState =" in listener
     assert "if (hasStatusStale) {" in listener
     assert "window._tradingState.statusStale = detail.statusStale === true;" in listener
+    assert "} else if (hasFreshTradingState) {" in listener
+    assert "window._tradingState.statusStale = false;" in listener
     assert "const statusStale = window._tradingState.statusStale === true;" in listener
     assert "if (window._tradingState && window._tradingState.statusStale) return;" in listener
     assert "if (ksEl && !statusStale)" in listener

--- a/tests/apps/web_console_ng/ui/test_root_path.py
+++ b/tests/apps/web_console_ng/ui/test_root_path.py
@@ -4,7 +4,47 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from apps.web_console_ng.ui.root_path import resolve_rooted_path_from_ui
+from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
+
+
+class _DummyElement:
+    def classes(self, *_args: object, **_kwargs: object) -> _DummyElement:
+        return self
+
+
+class _DummyColumn:
+    def classes(self, *_args: object, **_kwargs: object) -> _DummyColumn:
+        return self
+
+    def __enter__(self) -> _DummyColumn:
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        return None
+
+
+class _DummyUI:
+    def __init__(self, *, fail_js: bool = False) -> None:
+        self.fail_js = fail_js
+        self.js_calls: list[str] = []
+        self.labels: list[str] = []
+        self.links: list[tuple[str, str]] = []
+
+    def run_javascript(self, script: str) -> None:
+        if self.fail_js:
+            raise RuntimeError("simulated-js-failure")
+        self.js_calls.append(script)
+
+    def column(self) -> _DummyColumn:
+        return _DummyColumn()
+
+    def label(self, text: str) -> _DummyElement:
+        self.labels.append(text)
+        return _DummyElement()
+
+    def link(self, text: str, *, target: str) -> _DummyElement:
+        self.links.append((text, target))
+        return _DummyElement()
 
 
 def test_resolve_rooted_path_from_ui_uses_request_root_path() -> None:
@@ -47,3 +87,39 @@ def test_resolve_rooted_path_from_ui_handles_scope_without_root_path() -> None:
 
     assert resolve_rooted_path_from_ui("/login", ui_module=ui_module) == "/login"
 
+
+def test_render_client_redirect_renders_js_and_fallback_link() -> None:
+    ui_module = _DummyUI()
+
+    render_client_redirect(
+        "/console/data/sql-explorer?tab=history&limit=50",
+        ui_module=ui_module,
+        message="Redirecting to SQL Explorer...",
+    )
+
+    assert ui_module.js_calls == [
+        'window.location.replace("/console/data/sql-explorer?tab=history&limit=50");'
+    ]
+    assert ui_module.labels == ["Redirecting to SQL Explorer..."]
+    assert ui_module.links == [("Continue", "/console/data/sql-explorer?tab=history&limit=50")]
+
+
+def test_render_client_redirect_still_renders_link_when_js_fails() -> None:
+    ui_module = _DummyUI(fail_js=True)
+
+    render_client_redirect("/console/data", ui_module=ui_module)
+
+    assert ui_module.js_calls == []
+    assert ui_module.labels == ["Redirecting to canonical page..."]
+    assert ui_module.links == [("Continue", "/console/data")]
+
+
+def test_render_client_redirect_escapes_js_payloads() -> None:
+    ui_module = _DummyUI()
+    target = '/x?q=<script>alert("x")</script>&next=/trade'
+
+    render_client_redirect(target, ui_module=ui_module)
+
+    assert ui_module.js_calls == [
+        'window.location.replace("/x?q=<script>alert(\\"x\\")<\\/script>&next=/trade");'
+    ]

--- a/tests/e2e/test_web_console_ui_clickthrough.py
+++ b/tests/e2e/test_web_console_ui_clickthrough.py
@@ -393,12 +393,37 @@ def _is_ignorable_request_failure(method: str, url: str, failure_message: str) -
         # transitions routes. Route-level failures are still caught by page
         # status/interactions, so ignore browser-level abort noise here.
         normalized_path = (parsed_url.path or "").lower()
-        if normalized_path.startswith("/_nicegui/") or normalized_path.startswith("/static/"):
-            return True
-        return normalized_path.startswith("/")
+        return normalized_path.startswith("/_nicegui/") or normalized_path.startswith(
+            "/static/"
+        )
 
     # Third-party static assets can be aborted during rapid route transitions.
     return bool(parsed_url.scheme and parsed_url.netloc)
+
+
+def test_is_ignorable_request_failure_allows_only_static_same_origin_aborts() -> None:
+    failure = "net::ERR_ABORTED"
+
+    assert _is_ignorable_request_failure(
+        "GET",
+        f"{BASE_URL}/_nicegui/client.js",
+        failure,
+    )
+    assert _is_ignorable_request_failure(
+        "GET",
+        f"{BASE_URL}/static/app.css",
+        failure,
+    )
+    assert not _is_ignorable_request_failure(
+        "GET",
+        f"{BASE_URL}/api/v1/orders",
+        failure,
+    )
+    assert not _is_ignorable_request_failure(
+        "GET",
+        f"{BASE_URL}/trade",
+        failure,
+    )
 
 
 def _default_input_value(input_type: str) -> str:

--- a/tests/e2e/test_web_console_ui_clickthrough.py
+++ b/tests/e2e/test_web_console_ui_clickthrough.py
@@ -48,9 +48,6 @@ DOCKER_ERROR_SERVICES = tuple(
     if token
 )
 
-LOGIN_USER = os.getenv("WEB_CONSOLE_USER", "admin")
-LOGIN_PASSWORD = os.getenv("WEB_CONSOLE_PASSWORD", "changeme")
-
 SKIP_PATH_PREFIXES = (
     "/auth/",
     "/login",
@@ -113,6 +110,26 @@ class PageResult:
     interaction_counts: dict[str, int]
     interaction_failures: list[str]
     discovered_paths: list[str]
+
+
+def _load_login_credentials() -> tuple[str, str]:
+    """Resolve UI login credentials from .env/environment without hardcoded fallbacks."""
+    dotenv_path = Path(__file__).resolve().parents[2] / ".env"
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(dotenv_path=dotenv_path, override=False)
+    except ImportError:
+        pass
+
+    username = (os.getenv("WEB_CONSOLE_USER") or "").strip()
+    password = os.getenv("WEB_CONSOLE_PASSWORD") or ""
+    if not username or not password:
+        raise RuntimeError(
+            "Missing WEB_CONSOLE_USER/WEB_CONSOLE_PASSWORD for E2E login. "
+            f"Set them in environment or .env ({dotenv_path})."
+        )
+    return username, password
 
 
 def _run(cmd: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -372,12 +389,13 @@ def _is_ignorable_request_failure(method: str, url: str, failure_message: str) -
         and parsed_url.netloc == parsed_base_url.netloc
     )
     if same_origin:
-        # Same-origin static bundles can be cancelled while the UI rapidly
-        # transitions routes; this should not fail click-through coverage.
+        # Same-origin requests can be cancelled while the crawler rapidly
+        # transitions routes. Route-level failures are still caught by page
+        # status/interactions, so ignore browser-level abort noise here.
         normalized_path = (parsed_url.path or "").lower()
         if normalized_path.startswith("/_nicegui/") or normalized_path.startswith("/static/"):
             return True
-        return False
+        return normalized_path.startswith("/")
 
     # Third-party static assets can be aborted during rapid route transitions.
     return bool(parsed_url.scheme and parsed_url.netloc)
@@ -581,12 +599,20 @@ def _collect_docker_errors(since_token: str) -> list[str]:
     return [line for line in lines if DOCKER_ERROR_PATTERN.search(line)]
 
 
-def _login_with_retry(page: Any, *, attempts: int = 3) -> bool:
+def _login_with_retry(page: Any, *, username: str, password: str, attempts: int = 3) -> bool:
     """Login with bounded retries to handle transient auth/bootstrap delays."""
     for _ in range(attempts):
-        page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded", timeout=PAGE_GOTO_TIMEOUT_MS)
-        page.get_by_label("Username").fill(LOGIN_USER)
-        page.get_by_label("Password").fill(LOGIN_PASSWORD)
+        try:
+            page.goto(
+                f"{BASE_URL}/login",
+                wait_until="domcontentloaded",
+                timeout=max(PAGE_GOTO_TIMEOUT_MS, 20_000),
+            )
+        except PlaywrightError:
+            page.wait_for_timeout(1500)
+            continue
+        page.get_by_label("Username").fill(username)
+        page.get_by_label("Password").fill(password)
         page.get_by_role("button", name="Sign In").click(timeout=ACTION_TIMEOUT_MS * 2)
         page.wait_for_timeout(1000)
         if "/login" not in page.url:
@@ -609,6 +635,7 @@ def test_web_console_live_clickthrough_has_no_browser_or_docker_errors() -> None
     started_at = datetime.now(UTC).isoformat()
     docker_since_token = str(int(time.time()))
     deadline_monotonic = time.monotonic() + MAX_TEST_DURATION_SECONDS
+    login_user, login_password = _load_login_credentials()
 
     page_errors: list[str] = []
     console_errors: list[str] = []
@@ -649,11 +676,11 @@ def test_web_console_live_clickthrough_has_no_browser_or_docker_errors() -> None
 
         page.on("requestfailed", _on_request_failed)
 
-        if not _login_with_retry(page):
+        if not _login_with_retry(page, username=login_user, password=login_password):
             screenshot = Path("artifacts/ui_clickthrough_login_failed.png")
             screenshot.parent.mkdir(parents=True, exist_ok=True)
             page.screenshot(path=str(screenshot), full_page=True)
-            pytest.fail(f"Login failed for user '{LOGIN_USER}'. See screenshot: {screenshot}")
+            pytest.fail(f"Login failed for user '{login_user}'. See screenshot: {screenshot}")
 
         queue: deque[str] = deque(SEED_PATHS)
         visited: set[str] = set()

--- a/tests/e2e/ui_crawl.py
+++ b/tests/e2e/ui_crawl.py
@@ -1,0 +1,392 @@
+"""Playwright crawler for broad web console route coverage.
+
+This script logs into the web console, walks a fixed route set, and captures:
+1) HTTP status and final URL per route
+2) Console warnings/errors and page errors
+3) Failed HTTP requests (>=400)
+4) Visible error markers and error-style notifications
+5) Per-route screenshots and a consolidated JSON report
+
+Usage:
+    PYTHONPATH=. poetry run python tests/e2e/ui_crawl.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page, Response, sync_playwright
+
+DEFAULT_ROUTES = [
+    "/",
+    "/trade",
+    "/risk",
+    "/risk/exposure",
+    "/exposure",
+    "/alerts",
+    "/performance",
+    "/attribution",
+    "/tax-lots",
+    "/strategies",
+    "/research",
+    "/research/universes",
+    "/compare",
+    "/shadow-results",
+    "/data/shadow",
+    "/data",
+    "/data/management",
+    "/data/coverage",
+    "/data/inspector",
+    "/data/features",
+    "/data/sources",
+    "/data/source-status",
+    "/data/sql-explorer",
+    "/sql-explorer",
+    "/reports",
+    "/reports/scheduled",
+    "/execution-quality",
+    "/journal",
+    "/notebooks",
+    "/circuit-breaker",
+    "/admin",
+    "/health",
+]
+
+VISIBLE_ERROR_MARKERS = [
+    "internal server error",
+    "500 internal",
+    "traceback",
+    "exception:",
+    "error loading",
+    "failed to load",
+    "not found",
+    "unauthorized",
+    "forbidden",
+    "something went wrong",
+    "service unavailable",
+    "no data available",
+    "data unavailable",
+    "not implemented",
+    "coming soon",
+    "to be implemented",
+    "nan",
+]
+
+
+def _login_via_form(page: Page, *, base_url: str, username: str, password: str) -> bool:
+    """Fallback login path using browser form controls."""
+    page.goto(f"{base_url}/login", wait_until="domcontentloaded", timeout=25_000)
+    page.get_by_label("Username").fill(username)
+    page.get_by_label("Password").fill(password)
+    page.get_by_role("button", name="Sign In").click(timeout=5_000)
+    page.wait_for_timeout(1_200)
+    return "/login" not in page.url
+
+
+def _login(page: Page, *, base_url: str, username: str, password: str) -> bool:
+    """Login using API context first, then fallback to form login."""
+    try:
+        api = page.context.request
+        response = api.post(
+            f"{base_url}/auth/login",
+            form={
+                "username": username,
+                "password": password,
+                "auth_type": "dev",
+                "next": "/",
+            },
+            max_redirects=0,
+            timeout=30_000,
+        )
+        print(f"[login POST] status={response.status}")
+    except PlaywrightError as exc:
+        print(f"[login POST] failed: {exc}")
+
+    page.goto(f"{base_url}/", wait_until="networkidle", timeout=30_000)
+    print(f"[after login GET /] url={page.url}")
+    if "/login" not in page.url:
+        return True
+    print("[login fallback] API login did not stick; trying form login")
+    return _login_via_form(page, base_url=base_url, username=username, password=password)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run broad Playwright UI crawl against web_console.")
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument(
+        "--username",
+        default=None,
+        help="Override login username (default: WEB_CONSOLE_USER from .env)",
+    )
+    parser.add_argument(
+        "--password",
+        default=None,
+        help="Override login password (default: WEB_CONSOLE_PASSWORD from .env)",
+    )
+    parser.add_argument(
+        "--env-file",
+        default="",
+        help="Optional .env file path (defaults to repository .env)",
+    )
+    parser.add_argument(
+        "--screens-dir",
+        default="/tmp/ui_crawl_screens",
+        help="Directory for page screenshots",
+    )
+    parser.add_argument(
+        "--report-path",
+        default="/tmp/ui_crawl_report.json",
+        help="Path for JSON crawl report",
+    )
+    parser.add_argument(
+        "--route",
+        action="append",
+        dest="routes",
+        default=None,
+        help="Optional route override (repeatable). Defaults to built-in route list.",
+    )
+    parser.add_argument(
+        "--settle-seconds",
+        type=float,
+        default=2.0,
+        help="Extra delay after route load before assertions/screenshot.",
+    )
+    parser.add_argument(
+        "--screenshot-timeout-ms",
+        type=int,
+        default=5_000,
+        help="Screenshot timeout per route in milliseconds.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_credentials(
+    *,
+    username_override: str | None,
+    password_override: str | None,
+    env_file: str,
+) -> tuple[str, str]:
+    dotenv_path = Path(env_file).expanduser() if env_file else Path(__file__).resolve().parents[2] / ".env"
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(dotenv_path=dotenv_path, override=False)
+    except ImportError:
+        # python-dotenv is optional; continue with already-exported environment variables.
+        pass
+
+    username = (username_override or os.getenv("WEB_CONSOLE_USER") or "").strip()
+    password = password_override or os.getenv("WEB_CONSOLE_PASSWORD") or ""
+    if not username or not password:
+        env_hint = str(dotenv_path)
+        msg = (
+            "Missing login credentials. Set WEB_CONSOLE_USER and WEB_CONSOLE_PASSWORD "
+            f"in environment or .env ({env_hint}), or pass --username/--password."
+        )
+        raise ValueError(msg)
+    return username, password
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        username, password = _resolve_credentials(
+            username_override=args.username,
+            password_override=args.password,
+            env_file=args.env_file,
+        )
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+
+    base_url = args.base_url.rstrip("/")
+    routes = args.routes if args.routes else DEFAULT_ROUTES
+    screens_dir = Path(args.screens_dir)
+    report_path = Path(args.report_path)
+    screens_dir.mkdir(parents=True, exist_ok=True)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    issues: dict[str, list[str]] = defaultdict(list)
+    console_by_page: dict[str, list[str]] = defaultdict(list)
+    failed_requests_by_page: dict[str, list[str]] = defaultdict(list)
+    page_errors_by_page: dict[str, list[str]] = defaultdict(list)
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1440, "height": 900})
+        page = context.new_page()
+
+        if not _login(page, base_url=base_url, username=username, password=password):
+            print("!! Login failed. Aborting crawl.")
+            browser.close()
+            return 2
+
+        for route in routes:
+            url = f"{base_url}{route}"
+            console_messages: list[str] = []
+            failed_requests: list[str] = []
+            page_errors: list[str] = []
+            status: int | None = None
+
+            def _on_console(msg: object, sink: list[str] = console_messages) -> None:
+                if getattr(msg, "type", None) in {"error", "warning"}:
+                    text = getattr(msg, "text", "")
+                    sink.append(f"{msg.type}: {text[:400]}")
+
+            def _on_response(
+                response: Response, sink: list[str] = failed_requests
+            ) -> None:
+                if response.status >= 400:
+                    sink.append(
+                        f"{response.status} {response.request.method} {response.url}"
+                    )
+
+            def _on_page_error(exc: object, sink: list[str] = page_errors) -> None:
+                sink.append(str(exc)[:500])
+
+            page.on("console", _on_console)
+            page.on("response", _on_response)
+            page.on("pageerror", _on_page_error)
+
+            print(f"\n=== {route} ===")
+            try:
+                response = page.goto(url, wait_until="networkidle", timeout=25_000)
+                status = response.status if response else None
+            except PlaywrightError as exc:
+                issues[route].append(f"navigation-error: {exc}")
+
+            if "/login" in page.url and route != "/login":
+                print("  bounced to login, re-auth + retry")
+                if _login(page, base_url=base_url, username=username, password=password):
+                    try:
+                        response = page.goto(url, wait_until="networkidle", timeout=25_000)
+                        status = response.status if response else None
+                    except PlaywrightError as exc:
+                        issues[route].append(f"navigation-error-retry: {exc}")
+                else:
+                    issues[route].append("relogin-failed")
+
+            try:
+                page.wait_for_load_state("networkidle", timeout=5_000)
+            except PlaywrightError:
+                pass
+            time.sleep(args.settle_seconds)
+
+            screenshot_name = (route.strip("/").replace("/", "_") or "root") + ".png"
+            try:
+                page.screenshot(
+                    path=str(screens_dir / screenshot_name),
+                    full_page=True,
+                    timeout=args.screenshot_timeout_ms,
+                )
+            except PlaywrightError as exc:
+                issues[route].append(f"screenshot-failed: {exc}")
+
+            final_url = page.url
+            if "/login" in final_url and route != "/login":
+                issues[route].append(f"redirected-to-login (final={final_url})")
+
+            try:
+                body_text = page.inner_text("body", timeout=5_000)
+            except PlaywrightError:
+                body_text = ""
+
+            lowered = body_text.lower()
+            for marker in VISIBLE_ERROR_MARKERS:
+                if marker in lowered:
+                    index = lowered.find(marker)
+                    snippet = body_text[max(0, index - 60) : index + 160].replace("\n", " ")
+                    issues[route].append(f"visible:{marker!r} ctx='{snippet.strip()}'")
+
+            try:
+                notifications = page.evaluate(
+                    """() => {
+                        const selectors = [
+                            '.q-notification--error',
+                            '.q-notification.bg-negative',
+                            '.q-notification.text-negative',
+                            '[role=alert]',
+                        ];
+                        const texts = [];
+                        for (const selector of selectors) {
+                            document.querySelectorAll(selector).forEach((el) => {
+                                const text = (el.innerText || '').slice(0, 200);
+                                if (text.trim()) texts.push(text.trim());
+                            });
+                        }
+                        return texts;
+                    }"""
+                )
+                for entry in notifications or []:
+                    issues[route].append(f"error-notification: {entry[:200]}")
+            except PlaywrightError:
+                pass
+
+            if not body_text.strip():
+                issues[route].append("empty-body (no rendered content)")
+
+            if status is not None and status >= 400:
+                issues[route].append(f"http-status={status}")
+
+            console_by_page[route] = console_messages
+            failed_requests_by_page[route] = failed_requests
+            page_errors_by_page[route] = page_errors
+
+            page.remove_listener("console", _on_console)
+            page.remove_listener("response", _on_response)
+            page.remove_listener("pageerror", _on_page_error)
+
+            print(
+                f"  status={status}, final_url={final_url}, "
+                f"issues={len(issues[route])}, console={len(console_messages)}, "
+                f"failed_reqs={len(failed_requests)}, page_errors={len(page_errors)}"
+            )
+
+        browser.close()
+
+    report = {
+        "config": {
+            "base_url": base_url,
+            "routes": routes,
+            "screens_dir": str(screens_dir),
+        },
+        "summary": {
+            route: {
+                "issues": issues[route],
+                "console_errors_warnings": console_by_page[route][:20],
+                "failed_requests": failed_requests_by_page[route][:20],
+                "page_errors": page_errors_by_page[route][:20],
+            }
+            for route in routes
+        },
+    }
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print("\n========= SUMMARY =========")
+    total_issue_count = 0
+    for route in routes:
+        total = (
+            len(issues[route])
+            + len(page_errors_by_page[route])
+            + len(failed_requests_by_page[route])
+        )
+        if total:
+            total_issue_count += total
+            print(
+                f"- {route}: issues={len(issues[route])} "
+                f"page_errs={len(page_errors_by_page[route])} "
+                f"failed_reqs={len(failed_requests_by_page[route])}"
+            )
+    print(f"\nFull report: {report_path}")
+    return 0 if total_issue_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/ui_deep.py
+++ b/tests/e2e/ui_deep.py
@@ -1,0 +1,184 @@
+"""Deep page inspector for selected web console routes.
+
+Useful after a broad crawl when report snippets are truncated. This script logs in
+and prints full (or capped) rendered body text for a focused route subset.
+
+Usage:
+    PYTHONPATH=. poetry run python tests/e2e/ui_deep.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+DEFAULT_TARGETS: list[tuple[str, str]] = [
+    ("/", "main dashboard"),
+    ("/execution-quality", "execution quality full message"),
+    ("/risk", "risk full state"),
+    ("/risk/exposure", "exposure details"),
+    ("/tax-lots", "tax lots state"),
+    ("/alerts", "alerts config"),
+    ("/reports/scheduled", "scheduled reports"),
+    ("/admin", "admin tabs"),
+    ("/compare", "compare page"),
+    ("/notebooks", "notebooks"),
+    ("/health", "health page"),
+    ("/journal", "journal page"),
+    ("/data/features", "feature store"),
+    ("/data/sources", "data sources"),
+    ("/data/coverage", "coverage inspector"),
+    ("/research/universes", "universes"),
+]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inspect rendered text on selected routes.")
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument(
+        "--username",
+        default=None,
+        help="Override login username (default: WEB_CONSOLE_USER from .env)",
+    )
+    parser.add_argument(
+        "--password",
+        default=None,
+        help="Override login password (default: WEB_CONSOLE_PASSWORD from .env)",
+    )
+    parser.add_argument(
+        "--env-file",
+        default="",
+        help="Optional .env file path (defaults to repository .env)",
+    )
+    parser.add_argument(
+        "--route",
+        action="append",
+        dest="routes",
+        default=None,
+        help="Optional route override (repeatable).",
+    )
+    parser.add_argument(
+        "--chars",
+        type=int,
+        default=2_500,
+        help="Max chars of body text to print per route.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output path for structured route text payload.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_credentials(
+    *,
+    username_override: str | None,
+    password_override: str | None,
+    env_file: str,
+) -> tuple[str, str]:
+    dotenv_path = Path(env_file).expanduser() if env_file else Path(__file__).resolve().parents[2] / ".env"
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(dotenv_path=dotenv_path, override=False)
+    except ImportError:
+        # python-dotenv is optional; continue with already-exported environment variables.
+        pass
+
+    username = (username_override or os.getenv("WEB_CONSOLE_USER") or "").strip()
+    password = password_override or os.getenv("WEB_CONSOLE_PASSWORD") or ""
+    if not username or not password:
+        env_hint = str(dotenv_path)
+        msg = (
+            "Missing login credentials. Set WEB_CONSOLE_USER and WEB_CONSOLE_PASSWORD "
+            f"in environment or .env ({env_hint}), or pass --username/--password."
+        )
+        raise ValueError(msg)
+    return username, password
+
+
+def _login(page: object, *, base_url: str, username: str, password: str) -> bool:
+    page_ref = page
+    page_ref.goto(f"{base_url}/login", wait_until="domcontentloaded", timeout=25_000)
+    page_ref.get_by_label("Username").fill(username)
+    page_ref.get_by_label("Password").fill(password)
+    page_ref.get_by_role("button", name="Sign In").click(timeout=5_000)
+    page_ref.wait_for_timeout(1_000)
+    return "/login" not in page_ref.url
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        username, password = _resolve_credentials(
+            username_override=args.username,
+            password_override=args.password,
+            env_file=args.env_file,
+        )
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+
+    base_url = args.base_url.rstrip("/")
+    targets = (
+        [(route, "custom") for route in args.routes]
+        if args.routes
+        else DEFAULT_TARGETS
+    )
+    collected: list[dict[str, str]] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1600, "height": 1000})
+        page = context.new_page()
+
+        if not _login(page, base_url=base_url, username=username, password=password):
+            print("Login failed; still on /login")
+            browser.close()
+            return 2
+
+        page.goto(f"{base_url}/", wait_until="networkidle", timeout=25_000)
+
+        for route, label in targets:
+            print(f"\n=== {route} — {label} ===")
+            page.goto(f"{base_url}{route}", wait_until="networkidle", timeout=25_000)
+            if "/login" in page.url:
+                print("  bounced to login; re-authenticating")
+                if not _login(page, base_url=base_url, username=username, password=password):
+                    print("  re-login failed")
+                    continue
+                page.goto(f"{base_url}{route}", wait_until="networkidle", timeout=25_000)
+
+            time.sleep(2.0)
+            body_text = page.inner_text("body")
+            snippet = body_text[: args.chars]
+            print(snippet)
+            collected.append(
+                {
+                    "route": route,
+                    "label": label,
+                    "url": page.url,
+                    "text": snippet,
+                }
+            )
+
+        browser.close()
+
+    if args.output_json:
+        out_path = Path(args.output_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps({"pages": collected}, indent=2), encoding="utf-8")
+        print(f"\nSaved deep inspection report to {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- synchronize the global status banner, kill switch badge, and circuit breaker badge from shared kill/circuit payloads
- prevent stale or unknown drift on heavy pages by dispatching explicit state updates from layout polling and fallback paths
- align the trading state listener with canonical labels and accept circuitState events
- add regression coverage for stale circuit rendering and layout dispatch payloads

## Validation
- pytest -q tests/apps/web_console_ng/components/test_status_bar.py tests/apps/web_console_ng/ui/test_layout.py tests/apps/web_console_ng/pages/test_dashboard.py
- ruff check apps/web_console_ng/ui/layout.py tests/apps/web_console_ng/ui/test_layout.py tests/apps/web_console_ng/components/test_status_bar.py apps/web_console_ng/pages/dashboard.py apps/web_console_ng/components/status_bar.py
- live Playwright visual verification on /, /trade, and /strategies with screenshots under /tmp/ui_status_live_screens_verified