### PR TITLE
[codex] Populate trade market data and chart controls

### DIFF
--- a/apps/market_data_service/routes/market_data.py
+++ b/apps/market_data_service/routes/market_data.py
@@ -11,7 +11,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from apps.market_data_service.api.dependencies import build_market_data_authenticator
 from apps.market_data_service.config import settings
-from apps.market_data_service.schemas import ADVResponse, BarPoint, BarsResponse
+from apps.market_data_service.schemas import (
+    ADVResponse,
+    BarPoint,
+    BarsResponse,
+    LatestQuoteResponse,
+)
 from libs.core.common.api_auth_dependency import APIAuthConfig, AuthContext, api_auth
 from libs.core.common.rate_limit_dependency import RateLimitConfig, rate_limit
 from libs.core.redis_client import RedisClient
@@ -275,3 +280,32 @@ async def get_historical_bars(
         timeframe=timeframe,
         bars=[BarPoint.model_validate(bar) for bar in bars],
     )
+
+
+@router.get("/api/v1/market-data/{symbol}/latest-quote", response_model=LatestQuoteResponse)
+async def get_latest_quote(
+    symbol: str,
+    _auth: AuthContext = Depends(market_data_auth),
+    _rl: int = Depends(market_data_rl),
+) -> LatestQuoteResponse:
+    """Get latest best bid/ask quote for a symbol."""
+    normalized_symbol = symbol.upper()
+    provider = _get_provider()
+    try:
+        quote = await provider.get_latest_quote(normalized_symbol)
+    except MarketDataError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Latest quote unavailable: {exc}",
+        ) from exc
+
+    if quote is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "symbol_not_found",
+                "detail": f"Latest quote data not available for {normalized_symbol}",
+            },
+        )
+
+    return LatestQuoteResponse.model_validate(quote)

--- a/apps/market_data_service/schemas.py
+++ b/apps/market_data_service/schemas.py
@@ -38,3 +38,14 @@ class BarsResponse(BaseModel):
     symbol: str = Field(..., description="Stock symbol")
     timeframe: str = Field(..., description="Requested timeframe")
     bars: list[BarPoint] = Field(..., description="Historical bars in ascending time order")
+
+
+class LatestQuoteResponse(BaseModel):
+    """Latest top-of-book quote response payload."""
+
+    symbol: str = Field(..., description="Stock symbol")
+    bid_price: float | None = Field(default=None, description="Best bid price")
+    ask_price: float | None = Field(default=None, description="Best ask price")
+    bid_size: int | None = Field(default=None, description="Best bid size")
+    ask_size: int | None = Field(default=None, description="Best ask size")
+    timestamp: datetime | None = Field(default=None, description="Quote timestamp (UTC)")

--- a/apps/market_data_service/schemas.py
+++ b/apps/market_data_service/schemas.py
@@ -5,6 +5,7 @@ Defines request/response models used by HTTP API routes.
 """
 
 from datetime import date, datetime
+from decimal import Decimal
 
 from pydantic import BaseModel, Field
 
@@ -44,8 +45,8 @@ class LatestQuoteResponse(BaseModel):
     """Latest top-of-book quote response payload."""
 
     symbol: str = Field(..., description="Stock symbol")
-    bid_price: float | None = Field(default=None, description="Best bid price")
-    ask_price: float | None = Field(default=None, description="Best ask price")
+    bid_price: Decimal | None = Field(default=None, description="Best bid price")
+    ask_price: Decimal | None = Field(default=None, description="Best ask price")
     bid_size: int | None = Field(default=None, description="Best bid size")
     ask_size: int | None = Field(default=None, description="Best ask size")
     timestamp: datetime | None = Field(default=None, description="Quote timestamp (UTC)")

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -315,11 +315,23 @@ class MarketContextComponent:
             last_price=bar_snapshot.last_price if bar_snapshot is not None else None,
             prev_close=bar_snapshot.prev_close if bar_snapshot is not None else None,
             volume=bar_snapshot.volume if bar_snapshot is not None else None,
-            timestamp=(
-                (quote_snapshot.timestamp if quote_snapshot is not None else None)
-                or (bar_snapshot.timestamp if bar_snapshot is not None else None)
+            timestamp=MarketContextComponent._latest_timestamp(
+                quote_snapshot.timestamp if quote_snapshot is not None else None,
+                bar_snapshot.timestamp if bar_snapshot is not None else None,
             ),
         )
+
+    @staticmethod
+    def _latest_timestamp(*timestamps: datetime | None) -> datetime | None:
+        """Return the newest available timestamp after normalizing to UTC."""
+        normalized = [
+            timestamp
+            for timestamp in (
+                MarketContextComponent._ensure_utc_timestamp(value) for value in timestamps
+            )
+            if timestamp is not None
+        ]
+        return max(normalized) if normalized else None
 
     async def _fetch_latest_quote_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
         """Use latest real quote to seed bid/ask/spread before live ticks arrive."""
@@ -426,14 +438,13 @@ class MarketContextComponent:
             close, timestamp = self._parse_bar_price(intraday_bar, symbol)
             if close is None and daily_bar is not None:
                 close, timestamp = self._parse_bar_price(daily_bar, symbol)
-            volume_raw = daily_bar.get("volume") if daily_bar is not None else None
-            volume = int(volume_raw) if volume_raw is not None else None
         except (InvalidOperation, ValueError, TypeError) as exc:
             logger.debug(
                 "market_context_bar_parse_failed",
                 extra={"symbol": symbol, "error_type": type(exc).__name__},
             )
             return None
+        volume = self._parse_bar_volume(daily_bar, symbol)
 
         return MarketDataSnapshot(
             symbol=symbol,
@@ -488,6 +499,23 @@ class MarketContextComponent:
         return close, MarketContextComponent._ensure_utc_timestamp(
             parse_iso_timestamp(str(timestamp_raw))
         )
+
+    @staticmethod
+    def _parse_bar_volume(bar: dict[str, Any] | None, symbol: str) -> int | None:
+        """Parse daily volume without invalidating an otherwise useful price seed."""
+        if bar is None:
+            return None
+        volume_raw = bar.get("volume")
+        if volume_raw is None:
+            return None
+        try:
+            return int(volume_raw)
+        except (ValueError, TypeError) as exc:
+            logger.debug(
+                "market_context_bar_volume_parse_failed",
+                extra={"symbol": symbol, "error_type": type(exc).__name__},
+            )
+            return None
 
     # ================= Price Data Callbacks =================
 

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -230,8 +230,8 @@ class MarketContextComponent:
         quote_snapshot, bar_snapshot = await self._fetch_initial_snapshots(symbol)
         snapshot = self._merge_snapshots(symbol, quote_snapshot, bar_snapshot)
         if snapshot is not None and symbol == self._current_symbol:
-            if self._should_keep_existing_snapshot(symbol, snapshot):
-                self._data = self._merge_seed_into_existing(symbol, snapshot)
+            if self._data is not None and self._data.symbol == symbol:
+                self._data = self._merge_seed_with_existing(symbol, snapshot)
                 self._update_ui()
                 return
             self._data = snapshot
@@ -240,38 +240,40 @@ class MarketContextComponent:
 
         logger.debug(f"Waiting for price data for {symbol} via callback")
 
-    def _should_keep_existing_snapshot(self, symbol: str, candidate: MarketDataSnapshot) -> bool:
-        """Avoid overwriting a newer live tick with an older initial API seed."""
-        existing = self._data
-        if existing is None or existing.symbol != symbol:
-            return False
-        if existing.timestamp is not None and candidate.timestamp is None:
-            return True
-        if existing.timestamp is not None and candidate.timestamp is not None:
-            return existing.timestamp >= candidate.timestamp
-        return False
-
-    def _merge_seed_into_existing(
+    def _merge_seed_with_existing(
         self, symbol: str, candidate: MarketDataSnapshot
     ) -> MarketDataSnapshot:
-        """Fill seed-only gaps without replacing a fresher live snapshot."""
+        """Merge an API seed into an existing same-symbol live snapshot.
+
+        Seed fetches can complete after live ticks arrive. Prefer the fresher
+        source per field, but never let sparse seed payloads clear live values.
+        """
         existing = self._data
         if existing is None or existing.symbol != symbol:
             return candidate
 
-        def coalesce(existing_value: Any, candidate_value: Any) -> Any:
+        existing_ts = self._ensure_utc_timestamp(existing.timestamp)
+        candidate_ts = self._ensure_utc_timestamp(candidate.timestamp)
+        prefer_candidate = (
+            existing_ts is None
+            or (candidate_ts is not None and candidate_ts >= existing_ts)
+        )
+
+        def coalesce(candidate_value: Any, existing_value: Any) -> Any:
+            if prefer_candidate:
+                return candidate_value if candidate_value is not None else existing_value
             return existing_value if existing_value is not None else candidate_value
 
         return MarketDataSnapshot(
             symbol=symbol,
-            bid_price=coalesce(existing.bid_price, candidate.bid_price),
-            ask_price=coalesce(existing.ask_price, candidate.ask_price),
-            bid_size=coalesce(existing.bid_size, candidate.bid_size),
-            ask_size=coalesce(existing.ask_size, candidate.ask_size),
-            last_price=coalesce(existing.last_price, candidate.last_price),
-            prev_close=coalesce(existing.prev_close, candidate.prev_close),
-            volume=coalesce(existing.volume, candidate.volume),
-            timestamp=coalesce(existing.timestamp, candidate.timestamp),
+            bid_price=coalesce(candidate.bid_price, existing.bid_price),
+            ask_price=coalesce(candidate.ask_price, existing.ask_price),
+            bid_size=coalesce(candidate.bid_size, existing.bid_size),
+            ask_size=coalesce(candidate.ask_size, existing.ask_size),
+            last_price=coalesce(candidate.last_price, existing.last_price),
+            prev_close=coalesce(candidate.prev_close, existing.prev_close),
+            volume=coalesce(candidate.volume, existing.volume),
+            timestamp=self._latest_timestamp(existing_ts, candidate_ts),
         )
 
     async def _fetch_initial_snapshots(
@@ -360,9 +362,9 @@ class MarketContextComponent:
             ask_raw = self._mapping_value(response, "ask_price", "ask")
             bid = Decimal(str(bid_raw)) if bid_raw is not None else None
             ask = Decimal(str(ask_raw)) if ask_raw is not None else None
-            if bid is not None and (not bid.is_finite() or bid <= 0):
+            if bid is not None and (not bid.is_finite() or bid < 0):
                 bid = None
-            if ask is not None and (not ask.is_finite() or ask <= 0):
+            if ask is not None and (not ask.is_finite() or ask < 0):
                 ask = None
             if bid is None and ask is None:
                 return None
@@ -490,9 +492,9 @@ class MarketContextComponent:
         if close_raw is None or timestamp_raw is None:
             return None, None
         close = Decimal(str(close_raw))
-        if not close.is_finite() or close <= 0:
+        if not close.is_finite() or close < 0:
             logger.debug(
-                "market_context_bar_non_positive_close",
+                "market_context_bar_negative_close",
                 extra={"symbol": symbol},
             )
             return None, None

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -226,13 +226,139 @@ class MarketContextComponent:
         if self._disposed:
             return
 
-        snapshot = await self._fetch_latest_bar_snapshot(symbol)
+        quote_snapshot, bar_snapshot = await self._fetch_initial_snapshots(symbol)
+        snapshot = self._merge_snapshots(symbol, quote_snapshot, bar_snapshot)
         if snapshot is not None and symbol == self._current_symbol:
             self._data = snapshot
             self._update_ui()
             return
 
         logger.debug(f"Waiting for price data for {symbol} via callback")
+
+    async def _fetch_initial_snapshots(
+        self, symbol: str
+    ) -> tuple[MarketDataSnapshot | None, MarketDataSnapshot | None]:
+        """Fetch real top-of-book and OHLCV seeds without blocking on one source."""
+        import asyncio
+
+        quote_result, bar_result = await asyncio.gather(
+            self._fetch_latest_quote_snapshot(symbol),
+            self._fetch_latest_bar_snapshot(symbol),
+            return_exceptions=True,
+        )
+        quote_snapshot = quote_result if isinstance(quote_result, MarketDataSnapshot) else None
+        bar_snapshot = bar_result if isinstance(bar_result, MarketDataSnapshot) else None
+        return quote_snapshot, bar_snapshot
+
+    @staticmethod
+    def _merge_snapshots(
+        symbol: str,
+        quote_snapshot: MarketDataSnapshot | None,
+        bar_snapshot: MarketDataSnapshot | None,
+    ) -> MarketDataSnapshot | None:
+        """Merge quote and bar seeds into a single Level 1 display snapshot."""
+        if quote_snapshot is None and bar_snapshot is None:
+            return None
+        return MarketDataSnapshot(
+            symbol=symbol,
+            bid_price=quote_snapshot.bid_price if quote_snapshot is not None else None,
+            ask_price=quote_snapshot.ask_price if quote_snapshot is not None else None,
+            bid_size=quote_snapshot.bid_size if quote_snapshot is not None else None,
+            ask_size=quote_snapshot.ask_size if quote_snapshot is not None else None,
+            last_price=(
+                bar_snapshot.last_price
+                if bar_snapshot is not None
+                else quote_snapshot.last_price
+                if quote_snapshot is not None
+                else None
+            ),
+            prev_close=bar_snapshot.prev_close if bar_snapshot is not None else None,
+            volume=bar_snapshot.volume if bar_snapshot is not None else None,
+            timestamp=(
+                quote_snapshot.timestamp
+                if quote_snapshot is not None and quote_snapshot.timestamp is not None
+                else bar_snapshot.timestamp
+                if bar_snapshot is not None
+                else None
+            ),
+        )
+
+    async def _fetch_latest_quote_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
+        """Use latest real quote to seed bid/ask/spread before live ticks arrive."""
+        fetch_latest_quote = getattr(self._client, "fetch_latest_quote", None)
+        if fetch_latest_quote is None or not self._user_id:
+            return None
+
+        request_kwargs: dict[str, Any] = {"symbol": symbol}
+        authenticated_kwargs: dict[str, Any] = {
+            **request_kwargs,
+            "user_id": self._user_id,
+            "role": self._role,
+            "strategies": self._strategies,
+        }
+        supports_auth_kwargs = self._call_supports_auth_kwargs(fetch_latest_quote)
+
+        try:
+            response = await fetch_latest_quote(
+                **(authenticated_kwargs if supports_auth_kwargs else request_kwargs)
+            )
+        except TypeError:
+            try:
+                response = await fetch_latest_quote(
+                    **(request_kwargs if supports_auth_kwargs else authenticated_kwargs)
+                )
+            except Exception as exc:
+                logger.debug("Initial market context quote fetch failed for %s: %s", symbol, exc)
+                return None
+        except Exception as exc:
+            logger.debug("Initial market context quote fetch failed for %s: %s", symbol, exc)
+            return None
+
+        if not isinstance(response, dict):
+            return None
+
+        try:
+            bid_raw = response.get("bid_price") or response.get("bid")
+            ask_raw = response.get("ask_price") or response.get("ask")
+            bid = Decimal(str(bid_raw)) if bid_raw is not None else None
+            ask = Decimal(str(ask_raw)) if ask_raw is not None else None
+            if bid is not None and (not bid.is_finite() or bid <= 0):
+                bid = None
+            if ask is not None and (not ask.is_finite() or ask <= 0):
+                ask = None
+            if bid is None and ask is None:
+                return None
+            bid_size_raw = response.get("bid_size")
+            ask_size_raw = response.get("ask_size")
+            timestamp_raw = response.get("timestamp")
+            timestamp = parse_iso_timestamp(str(timestamp_raw)) if timestamp_raw else None
+        except (InvalidOperation, ValueError, TypeError):
+            return None
+
+        return MarketDataSnapshot(
+            symbol=symbol,
+            bid_price=bid,
+            ask_price=ask,
+            bid_size=int(bid_size_raw) if bid_size_raw is not None else None,
+            ask_size=int(ask_size_raw) if ask_size_raw is not None else None,
+            last_price=(bid + ask) / 2 if bid is not None and ask is not None else bid or ask,
+            timestamp=timestamp,
+        )
+
+    @staticmethod
+    def _call_supports_auth_kwargs(callable_obj: Any) -> bool:
+        """Detect whether a client method accepts web-console auth kwargs."""
+        try:
+            signature = inspect.signature(callable_obj)
+            parameters = signature.parameters
+            has_var_keyword = any(
+                param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
+            )
+            return has_var_keyword or all(
+                key in parameters for key in ("user_id", "role", "strategies")
+            )
+        except (TypeError, ValueError):
+            return True
 
     async def _fetch_latest_bar_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
         """Use recent OHLCV bars to seed last/volume before live quote ticks arrive."""
@@ -251,18 +377,7 @@ class MarketContextComponent:
             "role": self._role,
             "strategies": self._strategies,
         }
-        supports_auth_kwargs = True
-        try:
-            signature = inspect.signature(fetch_historical_bars)
-            parameters = signature.parameters
-            has_var_keyword = any(
-                param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
-            )
-            supports_auth_kwargs = has_var_keyword or all(
-                key in parameters for key in ("user_id", "role", "strategies")
-            )
-        except (TypeError, ValueError):
-            supports_auth_kwargs = True
+        supports_auth_kwargs = self._call_supports_auth_kwargs(fetch_historical_bars)
 
         try:
             response = await fetch_historical_bars(

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -8,6 +8,7 @@ Data Flow: Redis → RealtimeUpdater → OrderEntryContext → MarketContext.set
 
 from __future__ import annotations
 
+import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -89,6 +90,9 @@ class MarketContextComponent:
         on_price_updated: (
             Callable[[str, Decimal | None, datetime | None], Awaitable[None]] | None
         ) = None,
+        user_id: str | None = None,
+        role: str | None = None,
+        strategies: list[str] | None = None,
     ) -> None:
         """Initialize MarketContext.
 
@@ -98,6 +102,9 @@ class MarketContextComponent:
         """
         self._client = trading_client
         self._on_price_updated = on_price_updated
+        self._user_id = user_id
+        self._role = role
+        self._strategies = strategies or []
         self._current_symbol: str | None = None
         self._data: MarketDataSnapshot | None = None
         self._last_ui_update: float = 0
@@ -215,17 +222,91 @@ class MarketContextComponent:
         """Fetch initial market data from API.
 
         Called when symbol changes to populate UI before real-time updates arrive.
-
-        NOTE: Initial data fetch is optional - real-time updates via set_price_data()
-        will populate the data. This method is a placeholder for future API integration
-        when a quote endpoint is available.
         """
         if self._disposed:
             return
 
-        # Real-time updates will populate data via set_price_data() callback
-        # No direct API call needed - OrderEntryContext will provide initial data
+        snapshot = await self._fetch_latest_bar_snapshot(symbol)
+        if snapshot is not None and symbol == self._current_symbol:
+            self._data = snapshot
+            self._update_ui()
+            return
+
         logger.debug(f"Waiting for price data for {symbol} via callback")
+
+    async def _fetch_latest_bar_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
+        """Use recent OHLCV bars to seed last/volume before live quote ticks arrive."""
+        fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
+        if fetch_historical_bars is None or not self._user_id:
+            return None
+
+        request_kwargs: dict[str, Any] = {
+            "symbol": symbol,
+            "timeframe": "5Min",
+            "limit": 1,
+        }
+        authenticated_kwargs: dict[str, Any] = {
+            **request_kwargs,
+            "user_id": self._user_id,
+            "role": self._role,
+            "strategies": self._strategies,
+        }
+        supports_auth_kwargs = True
+        try:
+            signature = inspect.signature(fetch_historical_bars)
+            parameters = signature.parameters
+            has_var_keyword = any(
+                param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
+            )
+            supports_auth_kwargs = has_var_keyword or all(
+                key in parameters for key in ("user_id", "role", "strategies")
+            )
+        except (TypeError, ValueError):
+            supports_auth_kwargs = True
+
+        try:
+            response = await fetch_historical_bars(
+                **(authenticated_kwargs if supports_auth_kwargs else request_kwargs)
+            )
+        except TypeError:
+            try:
+                response = await fetch_historical_bars(
+                    **(request_kwargs if supports_auth_kwargs else authenticated_kwargs)
+                )
+            except Exception as exc:
+                logger.debug("Initial market context bar fetch failed for %s: %s", symbol, exc)
+                return None
+        except Exception as exc:
+            logger.debug("Initial market context bar fetch failed for %s: %s", symbol, exc)
+            return None
+
+        bars = response.get("bars") if isinstance(response, dict) else None
+        if not isinstance(bars, list) or not bars:
+            return None
+        latest = bars[-1]
+        if not isinstance(latest, dict):
+            return None
+
+        try:
+            close_raw = latest.get("close")
+            timestamp_raw = latest.get("timestamp")
+            if close_raw is None or timestamp_raw is None:
+                return None
+            close = Decimal(str(close_raw))
+            if not close.is_finite() or close <= 0:
+                return None
+            volume_raw = latest.get("volume")
+            volume = int(volume_raw) if volume_raw is not None else None
+            timestamp = parse_iso_timestamp(str(timestamp_raw))
+        except (InvalidOperation, ValueError, TypeError):
+            return None
+
+        return MarketDataSnapshot(
+            symbol=symbol,
+            last_price=close,
+            volume=volume,
+            timestamp=timestamp,
+        )
 
     # ================= Price Data Callbacks =================
 
@@ -301,16 +382,25 @@ class MarketContextComponent:
 
         # Build snapshot with safe parsing
         symbol = data.get("symbol") or self._current_symbol or ""
+        existing = self._data
+        bid_price = safe_decimal("bid") or safe_decimal("bid_price")
+        ask_price = safe_decimal("ask") or safe_decimal("ask_price")
+        bid_size = safe_int("bid_size")
+        ask_size = safe_int("ask_size")
+        last_price = safe_decimal("price") or safe_decimal("last_price")
+        prev_close = safe_decimal("prev_close")
+        parsed_volume = safe_int("volume")
+        timestamp = safe_timestamp("timestamp")
         self._data = MarketDataSnapshot(
             symbol=symbol,
-            bid_price=safe_decimal("bid") or safe_decimal("bid_price"),
-            ask_price=safe_decimal("ask") or safe_decimal("ask_price"),
-            bid_size=safe_int("bid_size"),
-            ask_size=safe_int("ask_size"),
-            last_price=safe_decimal("price") or safe_decimal("last_price"),
-            prev_close=safe_decimal("prev_close"),
-            volume=safe_int("volume"),
-            timestamp=safe_timestamp("timestamp"),
+            bid_price=bid_price if bid_price is not None else (existing.bid_price if existing else None),
+            ask_price=ask_price if ask_price is not None else (existing.ask_price if existing else None),
+            bid_size=bid_size if bid_size is not None else (existing.bid_size if existing else None),
+            ask_size=ask_size if ask_size is not None else (existing.ask_size if existing else None),
+            last_price=last_price if last_price is not None else (existing.last_price if existing else None),
+            prev_close=prev_close if prev_close is not None else (existing.prev_close if existing else None),
+            volume=parsed_volume if parsed_volume is not None else (existing.volume if existing else None),
+            timestamp=timestamp if timestamp is not None else (existing.timestamp if existing else None),
         )
 
     def _notify_price_updated(self) -> None:

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -230,11 +230,24 @@ class MarketContextComponent:
         quote_snapshot, bar_snapshot = await self._fetch_initial_snapshots(symbol)
         snapshot = self._merge_snapshots(symbol, quote_snapshot, bar_snapshot)
         if snapshot is not None and symbol == self._current_symbol:
+            if self._should_keep_existing_snapshot(symbol, snapshot):
+                return
             self._data = snapshot
             self._update_ui()
             return
 
         logger.debug(f"Waiting for price data for {symbol} via callback")
+
+    def _should_keep_existing_snapshot(self, symbol: str, candidate: MarketDataSnapshot) -> bool:
+        """Avoid overwriting a newer live tick with an older initial API seed."""
+        existing = self._data
+        if existing is None or existing.symbol != symbol:
+            return False
+        if existing.timestamp is not None and candidate.timestamp is None:
+            return True
+        if existing.timestamp is not None and candidate.timestamp is not None:
+            return existing.timestamp >= candidate.timestamp
+        return False
 
     async def _fetch_initial_snapshots(
         self, symbol: str
@@ -345,10 +358,29 @@ class MarketContextComponent:
 
     async def _fetch_latest_bar_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
         """Use bars to seed last traded price and daily volume before live ticks arrive."""
-        intraday_response, daily_response = await asyncio.gather(
+        intraday_result: Any
+        daily_result: Any
+        intraday_result, daily_result = await asyncio.gather(
             self._fetch_latest_bar_response(symbol, "5Min"),
             self._fetch_latest_bar_response(symbol, "1Day"),
+            return_exceptions=True,
         )
+        if isinstance(intraday_result, Exception):
+            logger.debug(
+                "market_context_intraday_bar_seed_failed",
+                extra={"symbol": symbol, "error_type": type(intraday_result).__name__},
+            )
+            intraday_response = None
+        else:
+            intraday_response = intraday_result
+        if isinstance(daily_result, Exception):
+            logger.debug(
+                "market_context_daily_bar_seed_failed",
+                extra={"symbol": symbol, "error_type": type(daily_result).__name__},
+            )
+            daily_response = None
+        else:
+            daily_response = daily_result
         intraday_bar = self._latest_bar_from_response(intraday_response)
         daily_bar = self._latest_bar_from_response(daily_response)
         if intraday_bar is None and daily_bar is None:
@@ -502,7 +534,10 @@ class MarketContextComponent:
         ask_price = first_decimal("ask", "ask_price")
         bid_size = safe_int("bid_size")
         ask_size = safe_int("ask_size")
-        last_price = first_decimal("price", "last_price")
+        has_quote_fields = any(
+            data.get(key) is not None for key in ("bid", "bid_price", "ask", "ask_price")
+        )
+        last_price = safe_decimal("last_price") if has_quote_fields else first_decimal("price", "last_price")
         prev_close = safe_decimal("prev_close")
         parsed_volume = safe_int("volume")
         timestamp = safe_timestamp("timestamp")

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -357,7 +357,9 @@ class MarketContextComponent:
             bid_size_raw = response.get("bid_size")
             ask_size_raw = response.get("ask_size")
             timestamp_raw = response.get("timestamp")
-            timestamp = parse_iso_timestamp(str(timestamp_raw)) if timestamp_raw else None
+            timestamp = self._ensure_utc_timestamp(
+                parse_iso_timestamp(str(timestamp_raw)) if timestamp_raw else None
+            )
         except (InvalidOperation, ValueError, TypeError) as exc:
             logger.debug(
                 "market_context_quote_parse_failed",
@@ -380,6 +382,15 @@ class MarketContextComponent:
         """Return primary mapping value, preserving valid falsy numeric values."""
         value = data.get(primary_key)
         return value if value is not None else data.get(fallback_key)
+
+    @staticmethod
+    def _ensure_utc_timestamp(timestamp: datetime | None) -> datetime | None:
+        """Normalize parsed market-data timestamps to UTC-aware datetimes."""
+        if timestamp is None:
+            return None
+        if timestamp.tzinfo is None:
+            return timestamp.replace(tzinfo=UTC)
+        return timestamp.astimezone(UTC)
 
     async def _fetch_latest_bar_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
         """Use bars to seed last traded price and daily volume before live ticks arrive."""
@@ -474,7 +485,9 @@ class MarketContextComponent:
                 extra={"symbol": symbol},
             )
             return None, None
-        return close, parse_iso_timestamp(str(timestamp_raw))
+        return close, MarketContextComponent._ensure_utc_timestamp(
+            parse_iso_timestamp(str(timestamp_raw))
+        )
 
     # ================= Price Data Callbacks =================
 
@@ -543,7 +556,7 @@ class MarketContextComponent:
             if raw is None:
                 return None
             try:
-                return parse_iso_timestamp(str(raw))
+                return self._ensure_utc_timestamp(parse_iso_timestamp(str(raw)))
             except (ValueError, TypeError):
                 logger.warning(f"MarketContext: Invalid {key}: {raw!r}")
                 return None

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -278,11 +278,8 @@ class MarketContextComponent:
             prev_close=bar_snapshot.prev_close if bar_snapshot is not None else None,
             volume=bar_snapshot.volume if bar_snapshot is not None else None,
             timestamp=(
-                quote_snapshot.timestamp
-                if quote_snapshot is not None and quote_snapshot.timestamp is not None
-                else bar_snapshot.timestamp
-                if bar_snapshot is not None
-                else None
+                (quote_snapshot.timestamp if quote_snapshot is not None else None)
+                or (bar_snapshot.timestamp if bar_snapshot is not None else None)
             ),
         )
 
@@ -359,6 +356,8 @@ class MarketContextComponent:
 
         try:
             close, timestamp = self._parse_bar_price(intraday_bar, symbol)
+            if close is None and daily_bar is not None:
+                close, timestamp = self._parse_bar_price(daily_bar, symbol)
             volume_raw = daily_bar.get("volume") if daily_bar is not None else None
             volume = int(volume_raw) if volume_raw is not None else None
         except (InvalidOperation, ValueError, TypeError) as exc:
@@ -508,48 +507,24 @@ class MarketContextComponent:
         parsed_volume = safe_int("volume")
         timestamp = safe_timestamp("timestamp")
         same_symbol_existing = existing if existing is not None and existing.symbol == symbol else None
+
+        def coalesce(new_value: Any, field_name: str) -> Any:
+            if new_value is not None:
+                return new_value
+            if same_symbol_existing is None:
+                return None
+            return getattr(same_symbol_existing, field_name, None)
+
         self._data = MarketDataSnapshot(
             symbol=symbol,
-            bid_price=(
-                bid_price
-                if bid_price is not None
-                else (same_symbol_existing.bid_price if same_symbol_existing else None)
-            ),
-            ask_price=(
-                ask_price
-                if ask_price is not None
-                else (same_symbol_existing.ask_price if same_symbol_existing else None)
-            ),
-            bid_size=(
-                bid_size
-                if bid_size is not None
-                else (same_symbol_existing.bid_size if same_symbol_existing else None)
-            ),
-            ask_size=(
-                ask_size
-                if ask_size is not None
-                else (same_symbol_existing.ask_size if same_symbol_existing else None)
-            ),
-            last_price=(
-                last_price
-                if last_price is not None
-                else (same_symbol_existing.last_price if same_symbol_existing else None)
-            ),
-            prev_close=(
-                prev_close
-                if prev_close is not None
-                else (same_symbol_existing.prev_close if same_symbol_existing else None)
-            ),
-            volume=(
-                parsed_volume
-                if parsed_volume is not None
-                else (same_symbol_existing.volume if same_symbol_existing else None)
-            ),
-            timestamp=(
-                timestamp
-                if timestamp is not None
-                else (same_symbol_existing.timestamp if same_symbol_existing else None)
-            ),
+            bid_price=coalesce(bid_price, "bid_price"),
+            ask_price=coalesce(ask_price, "ask_price"),
+            bid_size=coalesce(bid_size, "bid_size"),
+            ask_size=coalesce(ask_size, "ask_size"),
+            last_price=coalesce(last_price, "last_price"),
+            prev_close=coalesce(prev_close, "prev_close"),
+            volume=coalesce(parsed_volume, "volume"),
+            timestamp=coalesce(timestamp, "timestamp"),
         )
 
     def _notify_price_updated(self) -> None:

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -231,6 +231,8 @@ class MarketContextComponent:
         snapshot = self._merge_snapshots(symbol, quote_snapshot, bar_snapshot)
         if snapshot is not None and symbol == self._current_symbol:
             if self._should_keep_existing_snapshot(symbol, snapshot):
+                self._data = self._merge_seed_into_existing(symbol, snapshot)
+                self._update_ui()
                 return
             self._data = snapshot
             self._update_ui()
@@ -248,6 +250,29 @@ class MarketContextComponent:
         if existing.timestamp is not None and candidate.timestamp is not None:
             return existing.timestamp >= candidate.timestamp
         return False
+
+    def _merge_seed_into_existing(
+        self, symbol: str, candidate: MarketDataSnapshot
+    ) -> MarketDataSnapshot:
+        """Fill seed-only gaps without replacing a fresher live snapshot."""
+        existing = self._data
+        if existing is None or existing.symbol != symbol:
+            return candidate
+
+        def coalesce(existing_value: Any, candidate_value: Any) -> Any:
+            return existing_value if existing_value is not None else candidate_value
+
+        return MarketDataSnapshot(
+            symbol=symbol,
+            bid_price=coalesce(existing.bid_price, candidate.bid_price),
+            ask_price=coalesce(existing.ask_price, candidate.ask_price),
+            bid_size=coalesce(existing.bid_size, candidate.bid_size),
+            ask_size=coalesce(existing.ask_size, candidate.ask_size),
+            last_price=coalesce(existing.last_price, candidate.last_price),
+            prev_close=coalesce(existing.prev_close, candidate.prev_close),
+            volume=coalesce(existing.volume, candidate.volume),
+            timestamp=coalesce(existing.timestamp, candidate.timestamp),
+        )
 
     async def _fetch_initial_snapshots(
         self, symbol: str

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -274,13 +274,7 @@ class MarketContextComponent:
             ask_price=quote_snapshot.ask_price if quote_snapshot is not None else None,
             bid_size=quote_snapshot.bid_size if quote_snapshot is not None else None,
             ask_size=quote_snapshot.ask_size if quote_snapshot is not None else None,
-            last_price=(
-                bar_snapshot.last_price
-                if bar_snapshot is not None
-                else quote_snapshot.last_price
-                if quote_snapshot is not None
-                else None
-            ),
+            last_price=bar_snapshot.last_price if bar_snapshot is not None else None,
             prev_close=bar_snapshot.prev_close if bar_snapshot is not None else None,
             volume=bar_snapshot.volume if bar_snapshot is not None else None,
             timestamp=(
@@ -513,16 +507,49 @@ class MarketContextComponent:
         prev_close = safe_decimal("prev_close")
         parsed_volume = safe_int("volume")
         timestamp = safe_timestamp("timestamp")
+        same_symbol_existing = existing if existing is not None and existing.symbol == symbol else None
         self._data = MarketDataSnapshot(
             symbol=symbol,
-            bid_price=bid_price if bid_price is not None else (existing.bid_price if existing else None),
-            ask_price=ask_price if ask_price is not None else (existing.ask_price if existing else None),
-            bid_size=bid_size if bid_size is not None else (existing.bid_size if existing else None),
-            ask_size=ask_size if ask_size is not None else (existing.ask_size if existing else None),
-            last_price=last_price if last_price is not None else (existing.last_price if existing else None),
-            prev_close=prev_close if prev_close is not None else (existing.prev_close if existing else None),
-            volume=parsed_volume if parsed_volume is not None else (existing.volume if existing else None),
-            timestamp=timestamp if timestamp is not None else (existing.timestamp if existing else None),
+            bid_price=(
+                bid_price
+                if bid_price is not None
+                else (same_symbol_existing.bid_price if same_symbol_existing else None)
+            ),
+            ask_price=(
+                ask_price
+                if ask_price is not None
+                else (same_symbol_existing.ask_price if same_symbol_existing else None)
+            ),
+            bid_size=(
+                bid_size
+                if bid_size is not None
+                else (same_symbol_existing.bid_size if same_symbol_existing else None)
+            ),
+            ask_size=(
+                ask_size
+                if ask_size is not None
+                else (same_symbol_existing.ask_size if same_symbol_existing else None)
+            ),
+            last_price=(
+                last_price
+                if last_price is not None
+                else (same_symbol_existing.last_price if same_symbol_existing else None)
+            ),
+            prev_close=(
+                prev_close
+                if prev_close is not None
+                else (same_symbol_existing.prev_close if same_symbol_existing else None)
+            ),
+            volume=(
+                parsed_volume
+                if parsed_volume is not None
+                else (same_symbol_existing.volume if same_symbol_existing else None)
+            ),
+            timestamp=(
+                timestamp
+                if timestamp is not None
+                else (same_symbol_existing.timestamp if same_symbol_existing else None)
+            ),
         )
 
     def _notify_price_updated(self) -> None:

--- a/apps/web_console_ng/components/market_context.py
+++ b/apps/web_console_ng/components/market_context.py
@@ -8,7 +8,7 @@ Data Flow: Redis → RealtimeUpdater → OrderEntryContext → MarketContext.set
 
 from __future__ import annotations
 
-import inspect
+import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from nicegui import ui
 
+from apps.web_console_ng.components.market_data_calls import call_market_data_client
 from apps.web_console_ng.utils.time import parse_iso_timestamp
 
 if TYPE_CHECKING:
@@ -239,13 +240,21 @@ class MarketContextComponent:
         self, symbol: str
     ) -> tuple[MarketDataSnapshot | None, MarketDataSnapshot | None]:
         """Fetch real top-of-book and OHLCV seeds without blocking on one source."""
-        import asyncio
-
         quote_result, bar_result = await asyncio.gather(
             self._fetch_latest_quote_snapshot(symbol),
             self._fetch_latest_bar_snapshot(symbol),
             return_exceptions=True,
         )
+        if isinstance(quote_result, Exception):
+            logger.debug(
+                "market_context_quote_seed_failed",
+                extra={"symbol": symbol, "error_type": type(quote_result).__name__},
+            )
+        if isinstance(bar_result, Exception):
+            logger.debug(
+                "market_context_bar_seed_failed",
+                extra={"symbol": symbol, "error_type": type(bar_result).__name__},
+            )
         quote_snapshot = quote_result if isinstance(quote_result, MarketDataSnapshot) else None
         bar_snapshot = bar_result if isinstance(bar_result, MarketDataSnapshot) else None
         return quote_snapshot, bar_snapshot
@@ -289,37 +298,25 @@ class MarketContextComponent:
         if fetch_latest_quote is None or not self._user_id:
             return None
 
-        request_kwargs: dict[str, Any] = {"symbol": symbol}
-        authenticated_kwargs: dict[str, Any] = {
-            **request_kwargs,
-            "user_id": self._user_id,
-            "role": self._role,
-            "strategies": self._strategies,
-        }
-        supports_auth_kwargs = self._call_supports_auth_kwargs(fetch_latest_quote)
-
-        try:
-            response = await fetch_latest_quote(
-                **(authenticated_kwargs if supports_auth_kwargs else request_kwargs)
-            )
-        except TypeError:
-            try:
-                response = await fetch_latest_quote(
-                    **(request_kwargs if supports_auth_kwargs else authenticated_kwargs)
-                )
-            except Exception as exc:
-                logger.debug("Initial market context quote fetch failed for %s: %s", symbol, exc)
-                return None
-        except Exception as exc:
-            logger.debug("Initial market context quote fetch failed for %s: %s", symbol, exc)
+        response = await call_market_data_client(
+            fetch_latest_quote,
+            request_kwargs={"symbol": symbol},
+            user_id=self._user_id,
+            role=self._role,
+            strategies=self._strategies,
+            logger=logger,
+            operation="market_context_latest_quote",
+            symbol=symbol,
+        )
+        if response is None:
             return None
 
         if not isinstance(response, dict):
             return None
 
         try:
-            bid_raw = response.get("bid_price") or response.get("bid")
-            ask_raw = response.get("ask_price") or response.get("ask")
+            bid_raw = self._mapping_value(response, "bid_price", "bid")
+            ask_raw = self._mapping_value(response, "ask_price", "ask")
             bid = Decimal(str(bid_raw)) if bid_raw is not None else None
             ask = Decimal(str(ask_raw)) if ask_raw is not None else None
             if bid is not None and (not bid.is_finite() or bid <= 0):
@@ -332,7 +329,11 @@ class MarketContextComponent:
             ask_size_raw = response.get("ask_size")
             timestamp_raw = response.get("timestamp")
             timestamp = parse_iso_timestamp(str(timestamp_raw)) if timestamp_raw else None
-        except (InvalidOperation, ValueError, TypeError):
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            logger.debug(
+                "market_context_quote_parse_failed",
+                extra={"symbol": symbol, "error_type": type(exc).__name__},
+            )
             return None
 
         return MarketDataSnapshot(
@@ -341,79 +342,36 @@ class MarketContextComponent:
             ask_price=ask,
             bid_size=int(bid_size_raw) if bid_size_raw is not None else None,
             ask_size=int(ask_size_raw) if ask_size_raw is not None else None,
-            last_price=(bid + ask) / 2 if bid is not None and ask is not None else bid or ask,
+            last_price=None,
             timestamp=timestamp,
         )
 
     @staticmethod
-    def _call_supports_auth_kwargs(callable_obj: Any) -> bool:
-        """Detect whether a client method accepts web-console auth kwargs."""
-        try:
-            signature = inspect.signature(callable_obj)
-            parameters = signature.parameters
-            has_var_keyword = any(
-                param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
-            )
-            return has_var_keyword or all(
-                key in parameters for key in ("user_id", "role", "strategies")
-            )
-        except (TypeError, ValueError):
-            return True
+    def _mapping_value(data: dict[str, Any], primary_key: str, fallback_key: str) -> Any:
+        """Return primary mapping value, preserving valid falsy numeric values."""
+        value = data.get(primary_key)
+        return value if value is not None else data.get(fallback_key)
 
     async def _fetch_latest_bar_snapshot(self, symbol: str) -> MarketDataSnapshot | None:
-        """Use recent OHLCV bars to seed last/volume before live quote ticks arrive."""
-        fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
-        if fetch_historical_bars is None or not self._user_id:
-            return None
-
-        request_kwargs: dict[str, Any] = {
-            "symbol": symbol,
-            "timeframe": "5Min",
-            "limit": 1,
-        }
-        authenticated_kwargs: dict[str, Any] = {
-            **request_kwargs,
-            "user_id": self._user_id,
-            "role": self._role,
-            "strategies": self._strategies,
-        }
-        supports_auth_kwargs = self._call_supports_auth_kwargs(fetch_historical_bars)
-
-        try:
-            response = await fetch_historical_bars(
-                **(authenticated_kwargs if supports_auth_kwargs else request_kwargs)
-            )
-        except TypeError:
-            try:
-                response = await fetch_historical_bars(
-                    **(request_kwargs if supports_auth_kwargs else authenticated_kwargs)
-                )
-            except Exception as exc:
-                logger.debug("Initial market context bar fetch failed for %s: %s", symbol, exc)
-                return None
-        except Exception as exc:
-            logger.debug("Initial market context bar fetch failed for %s: %s", symbol, exc)
-            return None
-
-        bars = response.get("bars") if isinstance(response, dict) else None
-        if not isinstance(bars, list) or not bars:
-            return None
-        latest = bars[-1]
-        if not isinstance(latest, dict):
+        """Use bars to seed last traded price and daily volume before live ticks arrive."""
+        intraday_response, daily_response = await asyncio.gather(
+            self._fetch_latest_bar_response(symbol, "5Min"),
+            self._fetch_latest_bar_response(symbol, "1Day"),
+        )
+        intraday_bar = self._latest_bar_from_response(intraday_response)
+        daily_bar = self._latest_bar_from_response(daily_response)
+        if intraday_bar is None and daily_bar is None:
             return None
 
         try:
-            close_raw = latest.get("close")
-            timestamp_raw = latest.get("timestamp")
-            if close_raw is None or timestamp_raw is None:
-                return None
-            close = Decimal(str(close_raw))
-            if not close.is_finite() or close <= 0:
-                return None
-            volume_raw = latest.get("volume")
+            close, timestamp = self._parse_bar_price(intraday_bar, symbol)
+            volume_raw = daily_bar.get("volume") if daily_bar is not None else None
             volume = int(volume_raw) if volume_raw is not None else None
-            timestamp = parse_iso_timestamp(str(timestamp_raw))
-        except (InvalidOperation, ValueError, TypeError):
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            logger.debug(
+                "market_context_bar_parse_failed",
+                extra={"symbol": symbol, "error_type": type(exc).__name__},
+            )
             return None
 
         return MarketDataSnapshot(
@@ -422,6 +380,51 @@ class MarketContextComponent:
             volume=volume,
             timestamp=timestamp,
         )
+
+    async def _fetch_latest_bar_response(self, symbol: str, timeframe: str) -> dict[str, Any] | None:
+        """Fetch one latest bar for a timeframe using shared auth fallback."""
+        fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
+        if fetch_historical_bars is None or not self._user_id:
+            return None
+        response = await call_market_data_client(
+            fetch_historical_bars,
+            request_kwargs={"symbol": symbol, "timeframe": timeframe, "limit": 1},
+            user_id=self._user_id,
+            role=self._role,
+            strategies=self._strategies,
+            logger=logger,
+            operation="market_context_latest_bar",
+            symbol=symbol,
+            extra={"timeframe": timeframe},
+        )
+        return response if isinstance(response, dict) else None
+
+    @staticmethod
+    def _latest_bar_from_response(response: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Extract the latest bar dict from a web-console bars response."""
+        bars = response.get("bars") if isinstance(response, dict) else None
+        if not isinstance(bars, list) or not bars:
+            return None
+        latest = bars[-1]
+        return latest if isinstance(latest, dict) else None
+
+    @staticmethod
+    def _parse_bar_price(bar: dict[str, Any] | None, symbol: str) -> tuple[Decimal | None, datetime | None]:
+        """Parse last trade proxy from an intraday bar."""
+        if bar is None:
+            return None, None
+        close_raw = bar.get("close")
+        timestamp_raw = bar.get("timestamp")
+        if close_raw is None or timestamp_raw is None:
+            return None, None
+        close = Decimal(str(close_raw))
+        if not close.is_finite() or close <= 0:
+            logger.debug(
+                "market_context_bar_non_positive_close",
+                extra={"symbol": symbol},
+            )
+            return None, None
+        return close, parse_iso_timestamp(str(timestamp_raw))
 
     # ================= Price Data Callbacks =================
 
@@ -498,11 +501,15 @@ class MarketContextComponent:
         # Build snapshot with safe parsing
         symbol = data.get("symbol") or self._current_symbol or ""
         existing = self._data
-        bid_price = safe_decimal("bid") or safe_decimal("bid_price")
-        ask_price = safe_decimal("ask") or safe_decimal("ask_price")
+        def first_decimal(primary_key: str, fallback_key: str) -> Decimal | None:
+            value = safe_decimal(primary_key)
+            return value if value is not None else safe_decimal(fallback_key)
+
+        bid_price = first_decimal("bid", "bid_price")
+        ask_price = first_decimal("ask", "ask_price")
         bid_size = safe_int("bid_size")
         ask_size = safe_int("ask_size")
-        last_price = safe_decimal("price") or safe_decimal("last_price")
+        last_price = first_decimal("price", "last_price")
         prev_close = safe_decimal("prev_close")
         parsed_volume = safe_int("volume")
         timestamp = safe_timestamp("timestamp")

--- a/apps/web_console_ng/components/market_data_calls.py
+++ b/apps/web_console_ng/components/market_data_calls.py
@@ -92,16 +92,12 @@ async def call_market_data_client(
                 "market_data_client_call_failed",
                 extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
             )
-            if index == 0:
-                continue
             raise
         except Exception as exc:
             logger.debug(
                 "market_data_client_call_failed",
                 extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
             )
-            if index == 0:
-                continue
             raise
 
     return None

--- a/apps/web_console_ng/components/market_data_calls.py
+++ b/apps/web_console_ng/components/market_data_calls.py
@@ -68,7 +68,11 @@ async def call_market_data_client(
         (preferred_mode, "legacy" if preferred_mode == "auth" else "auth")
     )
 
-    context: dict[str, Any] = {"operation": operation, "symbol": symbol}
+    context: dict[str, Any] = {
+        "operation": operation,
+        "symbol": symbol,
+        "strategy_id": ",".join(str(strategy) for strategy in strategies) if strategies else None,
+    }
     if extra:
         context.update(extra)
 
@@ -88,12 +92,16 @@ async def call_market_data_client(
                 "market_data_client_call_failed",
                 extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
             )
-            return None
+            if index == 0:
+                continue
+            raise
         except Exception as exc:
             logger.debug(
                 "market_data_client_call_failed",
                 extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
             )
-            return None
+            if index == 0:
+                continue
+            raise
 
     return None

--- a/apps/web_console_ng/components/market_data_calls.py
+++ b/apps/web_console_ng/components/market_data_calls.py
@@ -1,0 +1,99 @@
+"""Helpers for web-console market-data client calls.
+
+The web console supports both current authenticated client signatures and older
+test/client stubs. This module centralizes signature probing so UI components do
+not pay a TypeError fallback cost on every refresh.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal, TypeAlias
+
+AuthMode: TypeAlias = Literal["auth", "legacy"]
+_SIGNATURE_MODE_CACHE: dict[tuple[int, str], AuthMode] = {}
+
+
+def _signature_cache_key(callable_obj: Any) -> tuple[int, str]:
+    """Build a stable cache key for functions and recreated bound method objects."""
+    bound_self = getattr(callable_obj, "__self__", None)
+    bound_func = getattr(callable_obj, "__func__", None)
+    if bound_self is not None and bound_func is not None:
+        return (id(bound_self), getattr(bound_func, "__qualname__", repr(bound_func)))
+    return (id(callable_obj), getattr(callable_obj, "__qualname__", repr(callable_obj)))
+
+
+def _supports_auth_kwargs(callable_obj: Any) -> bool:
+    """Detect whether a client method accepts web-console auth kwargs."""
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        # Builtins/decorated callables may not expose a reliable signature.
+        return True
+
+    parameters = signature.parameters
+    has_var_keyword = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+    return has_var_keyword or all(key in parameters for key in ("user_id", "role", "strategies"))
+
+
+async def call_market_data_client(
+    callable_obj: Callable[..., Awaitable[Any]],
+    *,
+    request_kwargs: dict[str, Any],
+    user_id: str,
+    role: str | None,
+    strategies: list[str],
+    logger: logging.Logger,
+    operation: str,
+    symbol: str,
+    extra: dict[str, Any] | None = None,
+) -> Any | None:
+    """Call a market-data client method with cached auth/legacy signature fallback."""
+    auth_kwargs: dict[str, Any] = {
+        **request_kwargs,
+        "user_id": user_id,
+        "role": role,
+        "strategies": strategies,
+    }
+    cache_key = _signature_cache_key(callable_obj)
+    preferred_mode = _SIGNATURE_MODE_CACHE.get(cache_key)
+    if preferred_mode is None:
+        preferred_mode = "auth" if _supports_auth_kwargs(callable_obj) else "legacy"
+
+    attempt_modes: tuple[AuthMode, AuthMode] = (
+        (preferred_mode, "legacy" if preferred_mode == "auth" else "auth")
+    )
+
+    context: dict[str, Any] = {"operation": operation, "symbol": symbol}
+    if extra:
+        context.update(extra)
+
+    for index, mode in enumerate(attempt_modes):
+        try:
+            response = await callable_obj(**(auth_kwargs if mode == "auth" else request_kwargs))
+            _SIGNATURE_MODE_CACHE[cache_key] = mode
+            return response
+        except TypeError as exc:
+            if index == 0:
+                logger.debug(
+                    "market_data_client_signature_fallback",
+                    extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
+                )
+                continue
+            logger.debug(
+                "market_data_client_call_failed",
+                extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
+            )
+            return None
+        except Exception as exc:
+            logger.debug(
+                "market_data_client_call_failed",
+                extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
+            )
+            return None
+
+    return None

--- a/apps/web_console_ng/components/market_data_calls.py
+++ b/apps/web_console_ng/components/market_data_calls.py
@@ -7,6 +7,7 @@ not pay a TypeError fallback cost on every refresh.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
@@ -92,6 +93,8 @@ async def call_market_data_client(
                 "market_data_client_call_failed",
                 extra={**context, "attempt_mode": mode, "error_type": type(exc).__name__},
             )
+            raise
+        except asyncio.CancelledError:
             raise
         except Exception as exc:
             logger.debug(

--- a/apps/web_console_ng/components/order_entry_context.py
+++ b/apps/web_console_ng/components/order_entry_context.py
@@ -382,6 +382,9 @@ class OrderEntryContext:
         # This avoids redundant double-dispatch of price updates.
         self._market_context = MarketContextComponent(
             trading_client=self._client,
+            user_id=self._user_id,
+            role=self._role,
+            strategies=self._strategies,
         )
         return self._market_context.create()
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -420,14 +420,7 @@ class PriceChartComponent:
         candles = await self._fetch_candle_data(symbol, timeframe=requested_timeframe)
 
         # RACE CHECK: Ensure symbol hasn't changed during candle fetch
-        if (
-            symbol != self._current_symbol
-            or requested_timeframe != self._selected_timeframe
-            or (
-                reload_generation is not None
-                and reload_generation != self._timeframe_reload_generation
-            )
-        ):
+        if self._is_request_stale(symbol, requested_timeframe, reload_generation):
             return  # Stale - symbol changed during fetch
 
         self._candles = candles
@@ -442,14 +435,7 @@ class PriceChartComponent:
         markers = await self._fetch_execution_markers(symbol)
 
         # RACE CHECK: Ensure symbol hasn't changed during marker fetch
-        if (
-            symbol != self._current_symbol
-            or requested_timeframe != self._selected_timeframe
-            or (
-                reload_generation is not None
-                and reload_generation != self._timeframe_reload_generation
-            )
-        ):
+        if self._is_request_stale(symbol, requested_timeframe, reload_generation):
             return  # Stale - symbol changed during fetch
 
         self._markers = markers
@@ -459,6 +445,22 @@ class PriceChartComponent:
 
         # NOTE: No direct Redis subscription here!
         # Real-time updates come via set_price_data() callback from OrderEntryContext
+
+    def _is_request_stale(
+        self,
+        symbol: str,
+        requested_timeframe: str,
+        reload_generation: int | None,
+    ) -> bool:
+        """Return whether an async chart reload no longer matches current UI state."""
+        return (
+            symbol != self._current_symbol
+            or requested_timeframe != self._selected_timeframe
+            or (
+                reload_generation is not None
+                and reload_generation != self._timeframe_reload_generation
+            )
+        )
 
     # ================= Price Data Callbacks =================
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -97,12 +97,14 @@ class PriceChartComponent:
     CANDLE_INTERVAL_SECONDS = _parse_interval_seconds(CANDLE_INTERVAL)
     MAX_CHART_CANDLES = 500
     CHART_TRIM_HIGH_WATER_MARK = 600
-    HISTORICAL_TIMEFRAME_FALLBACKS: tuple[tuple[str, int], ...] = (
-        ("5Min", 240),
-        ("15Min", 240),
-        ("1Hour", 200),
-        ("1Day", 120),
-    )
+    TIMEFRAME_OPTIONS: dict[str, tuple[str, int, str]] = {
+        "1Min": ("1m", 390, "1-minute bars"),
+        "5Min": ("5m", 240, "5-minute bars"),
+        "15Min": ("15m", 240, "15-minute bars"),
+        "1Hour": ("1h", 200, "1-hour bars"),
+        "1Day": ("1d", 120, "Daily bars"),
+    }
+    DEFAULT_HISTORICAL_TIMEFRAME = "5Min"
     HISTORICAL_TIMEFRAME_SECONDS: dict[str, int] = {
         "1min": 60,
         "5min": 300,
@@ -153,6 +155,10 @@ class PriceChartComponent:
         self._no_data_overlay_visible: bool = False
         self._stale_overlay_visible: bool = False
         self._fallback_overlay_visible: bool = False
+        self._selected_timeframe: str = self.DEFAULT_HISTORICAL_TIMEFRAME
+        self._title_label: ui.label | None = None
+        self._subtitle_label: ui.label | None = None
+        self._timeframe_buttons: dict[str, Any] = {}
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -199,7 +205,7 @@ class PriceChartComponent:
         # Start realtime staleness monitor (tracked via timer_tracker)
         self._start_realtime_staleness_monitor(timer_tracker)
 
-    def create(self, width: int = 600, height: int = 300, *, fill_parent: bool = False) -> ui.html:
+    def create(self, width: int = 600, height: int = 300, *, fill_parent: bool = False) -> Any:
         """Create the chart container.
 
         NOTE: Does NOT start timers. Timer for chart initialization is started
@@ -216,12 +222,79 @@ class PriceChartComponent:
         self._fill_parent = fill_parent
         height_style = "100%" if fill_parent else f"{height}px"
 
-        # Container div
-        container = ui.html(
-            f'<div id="{self._container_id}" ' f'style="width:100%;height:{height_style};"></div>'
-        )
+        with ui.element("div").classes(
+            "workspace-v2-chart-shell w-full h-full"
+        ) as shell:
+            with ui.row().classes("workspace-v2-chart-header w-full items-center justify-between"):
+                with ui.column().classes("gap-0"):
+                    self._title_label = ui.label(self._chart_title_text()).classes(
+                        "workspace-v2-chart-title"
+                    )
+                    self._subtitle_label = ui.label(self._chart_subtitle_text()).classes(
+                        "workspace-v2-kv workspace-v2-data-mono"
+                    )
+                with ui.row().classes("workspace-v2-chart-timeframe-toggle"):
+                    for timeframe, option in self.TIMEFRAME_OPTIONS.items():
+                        label = option[0]
+                        button = ui.button(
+                            label,
+                            on_click=lambda tf=timeframe: self._schedule_timeframe_change(tf),
+                        ).props("flat dense unelevated")
+                        self._timeframe_buttons[timeframe] = button
+                    self._update_timeframe_button_state()
 
-        return container
+            ui.html(
+                f'<div id="{self._container_id}" '
+                f'class="workspace-v2-chart-container" '
+                f'style="width:100%;height:{height_style};"></div>'
+            ).classes("workspace-v2-chart-canvas")
+
+        return shell
+
+    def _chart_title_text(self) -> str:
+        symbol = self._current_symbol or "No symbol selected"
+        return f"{symbol} Price Chart"
+
+    def _chart_subtitle_text(self) -> str:
+        _, _, description = self.TIMEFRAME_OPTIONS[self._selected_timeframe]
+        return f"Alpaca · {description}"
+
+    def _update_header_labels(self) -> None:
+        if self._title_label is not None:
+            self._title_label.text = self._chart_title_text()
+        if self._subtitle_label is not None:
+            self._subtitle_label.text = self._chart_subtitle_text()
+        self._update_timeframe_button_state()
+
+    def _update_timeframe_button_state(self) -> None:
+        for timeframe, button in self._timeframe_buttons.items():
+            if timeframe == self._selected_timeframe:
+                button.classes(
+                    "workspace-v2-chart-timeframe-button workspace-v2-chart-timeframe-button-active",
+                    remove="workspace-v2-chart-timeframe-button-inactive",
+                )
+            else:
+                button.classes(
+                    "workspace-v2-chart-timeframe-button workspace-v2-chart-timeframe-button-inactive",
+                    remove="workspace-v2-chart-timeframe-button-active",
+                )
+
+    def _schedule_timeframe_change(self, timeframe: str) -> None:
+        """Schedule timeframe changes from NiceGUI's synchronous event callback."""
+        if timeframe not in self.TIMEFRAME_OPTIONS or timeframe == self._selected_timeframe:
+            return
+        self._selected_timeframe = timeframe
+        self._update_header_labels()
+        if self._disposed or not self._current_symbol:
+            return
+        task = asyncio.create_task(self._reload_selected_symbol())
+        self._pending_update_tasks.add(task)
+        task.add_done_callback(lambda t: self._pending_update_tasks.discard(t))
+
+    async def _reload_selected_symbol(self) -> None:
+        symbol = self._current_symbol
+        if symbol:
+            await self.on_symbol_changed(symbol)
 
     async def _run_javascript(
         self,
@@ -303,7 +376,11 @@ class PriceChartComponent:
         before updating state/UI to prevent stale fetches from overwriting newer data.
         """
         self._current_symbol = symbol
-        self._live_bucket_interval_seconds = self.CANDLE_INTERVAL_SECONDS
+        self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
+            self._selected_timeframe.strip().lower(),
+            self.CANDLE_INTERVAL_SECONDS,
+        )
+        self._update_header_labels()
 
         # CRITICAL: Reset realtime update timestamp for staleness tracking
         # Without this, staleness badge would show wrong age for new symbol
@@ -699,7 +776,10 @@ class PriceChartComponent:
         """Fetch historical candle data for the selected symbol."""
         if self._disposed:
             return []
-        self._live_bucket_interval_seconds = self.CANDLE_INTERVAL_SECONDS
+        self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
+            self._selected_timeframe.strip().lower(),
+            self.CANDLE_INTERVAL_SECONDS,
+        )
 
         fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
         if fetch_historical_bars is None:
@@ -723,58 +803,54 @@ class PriceChartComponent:
             # Builtins/decorated callables may not expose a reliable signature.
             supports_auth_kwargs = True
 
-        for timeframe, limit in self.HISTORICAL_TIMEFRAME_FALLBACKS:
-            request_kwargs: dict[str, Any] = {
-                "symbol": symbol,
-                "timeframe": timeframe,
-                "limit": limit,
-            }
-            authenticated_request_kwargs: dict[str, Any] = {
-                **request_kwargs,
-                "user_id": self._user_id,
-                "role": self._role,
-                "strategies": self._strategies,
-            }
+        timeframe = self._selected_timeframe
+        _, limit, _ = self.TIMEFRAME_OPTIONS[timeframe]
+        request_kwargs: dict[str, Any] = {
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "limit": limit,
+        }
+        authenticated_request_kwargs: dict[str, Any] = {
+            **request_kwargs,
+            "user_id": self._user_id,
+            "role": self._role,
+            "strategies": self._strategies,
+        }
 
+        try:
+            primary_kwargs = authenticated_request_kwargs if supports_auth_kwargs else request_kwargs
+            response = await fetch_historical_bars(**primary_kwargs)
+        except TypeError:
+            # Signature introspection may be wrong for decorated/wrapped callables.
+            fallback_kwargs = request_kwargs if supports_auth_kwargs else authenticated_request_kwargs
             try:
-                primary_kwargs = (
-                    authenticated_request_kwargs if supports_auth_kwargs else request_kwargs
-                )
-                response = await fetch_historical_bars(**primary_kwargs)
-            except TypeError:
-                # Signature introspection may be wrong for decorated/wrapped callables.
-                fallback_kwargs = (
-                    request_kwargs if supports_auth_kwargs else authenticated_request_kwargs
-                )
-                try:
-                    response = await fetch_historical_bars(**fallback_kwargs)
-                    supports_auth_kwargs = not supports_auth_kwargs
-                except Exception as fallback_exc:
-                    logger.debug(
-                        "Historical bars fetch failed for %s (%s): %s",
-                        symbol,
-                        timeframe,
-                        fallback_exc,
-                    )
-                    continue
-            except Exception as exc:
+                response = await fetch_historical_bars(**fallback_kwargs)
+            except Exception as fallback_exc:
                 logger.debug(
                     "Historical bars fetch failed for %s (%s): %s",
                     symbol,
                     timeframe,
-                    exc,
+                    fallback_exc,
                 )
-                continue
+                return []
+        except Exception as exc:
+            logger.debug(
+                "Historical bars fetch failed for %s (%s): %s",
+                symbol,
+                timeframe,
+                exc,
+            )
+            return []
 
-            candles = self._parse_historical_bars(response.get("bars", []))
-            if candles:
-                self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-                    timeframe.strip().lower(),
-                    self.CANDLE_INTERVAL_SECONDS,
-                )
-                return candles
+        candles = self._parse_historical_bars(response.get("bars", []))
+        if candles:
+            self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
+                timeframe.strip().lower(),
+                self.CANDLE_INTERVAL_SECONDS,
+            )
+            return candles
 
-        logger.debug("Historical bars unavailable for %s across fallback timeframes", symbol)
+        logger.debug("Historical bars unavailable for %s (%s)", symbol, timeframe)
         return []
 
     async def _fetch_execution_markers(self, symbol: str) -> list[ExecutionMarker]:

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -847,17 +847,30 @@ class PriceChartComponent:
             "timeframe": selected_timeframe,
             "limit": limit,
         }
-        response = await call_market_data_client(
-            fetch_historical_bars,
-            request_kwargs=request_kwargs,
-            user_id=self._user_id,
-            role=self._role,
-            strategies=self._strategies,
-            logger=logger,
-            operation="price_chart_historical_bars",
-            symbol=symbol,
-            extra={"timeframe": selected_timeframe, "limit": limit},
-        )
+        try:
+            response = await call_market_data_client(
+                fetch_historical_bars,
+                request_kwargs=request_kwargs,
+                user_id=self._user_id,
+                role=self._role,
+                strategies=self._strategies,
+                logger=logger,
+                operation="price_chart_historical_bars",
+                symbol=symbol,
+                extra={"timeframe": selected_timeframe, "limit": limit},
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug(
+                "historical_bars_fetch_failed",
+                extra={
+                    "symbol": symbol,
+                    "timeframe": selected_timeframe,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return []
         if not isinstance(response, dict):
             return []
 

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -9,7 +9,6 @@ Data Flow: Redis → RealtimeUpdater → OrderEntryContext → PriceChart.set_pr
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import logging
 import math
@@ -19,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from nicegui import ui
 
+from apps.web_console_ng.components.market_data_calls import call_market_data_client
 from apps.web_console_ng.ui.lightweight_charts import (
     CHART_INIT_JS,
     LIGHTWEIGHT_CHARTS_CDN,
@@ -130,7 +130,7 @@ class PriceChartComponent:
         self._client = trading_client
         self._user_id = user_id
         self._role = role
-        self._strategies = strategies
+        self._strategies = strategies or []
         self._current_symbol: str | None = None
         self._chart_id: str = f"chart_{id(self)}"
         self._container_id: str = f"container_{id(self)}"
@@ -783,25 +783,11 @@ class PriceChartComponent:
 
         fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
         if fetch_historical_bars is None:
-            logger.debug(f"Historical bars client API unavailable for {symbol}")
+            logger.debug("historical_bars_client_api_unavailable", extra={"symbol": symbol})
             return []
         if not self._user_id:
-            logger.debug("Historical bars fetch skipped: user_id unavailable")
+            logger.debug("historical_bars_fetch_skipped", extra={"symbol": symbol, "reason": "missing_user"})
             return []
-
-        supports_auth_kwargs = True
-        try:
-            signature = inspect.signature(fetch_historical_bars)
-            parameters = signature.parameters
-            has_var_keyword = any(
-                param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
-            )
-            supports_auth_kwargs = has_var_keyword or all(
-                key in parameters for key in ("user_id", "role", "strategies")
-            )
-        except (TypeError, ValueError):
-            # Builtins/decorated callables may not expose a reliable signature.
-            supports_auth_kwargs = True
 
         timeframe = self._selected_timeframe
         _, limit, _ = self.TIMEFRAME_OPTIONS[timeframe]
@@ -810,36 +796,18 @@ class PriceChartComponent:
             "timeframe": timeframe,
             "limit": limit,
         }
-        authenticated_request_kwargs: dict[str, Any] = {
-            **request_kwargs,
-            "user_id": self._user_id,
-            "role": self._role,
-            "strategies": self._strategies,
-        }
-
-        try:
-            primary_kwargs = authenticated_request_kwargs if supports_auth_kwargs else request_kwargs
-            response = await fetch_historical_bars(**primary_kwargs)
-        except TypeError:
-            # Signature introspection may be wrong for decorated/wrapped callables.
-            fallback_kwargs = request_kwargs if supports_auth_kwargs else authenticated_request_kwargs
-            try:
-                response = await fetch_historical_bars(**fallback_kwargs)
-            except Exception as fallback_exc:
-                logger.debug(
-                    "Historical bars fetch failed for %s (%s): %s",
-                    symbol,
-                    timeframe,
-                    fallback_exc,
-                )
-                return []
-        except Exception as exc:
-            logger.debug(
-                "Historical bars fetch failed for %s (%s): %s",
-                symbol,
-                timeframe,
-                exc,
-            )
+        response = await call_market_data_client(
+            fetch_historical_bars,
+            request_kwargs=request_kwargs,
+            user_id=self._user_id,
+            role=self._role,
+            strategies=self._strategies,
+            logger=logger,
+            operation="price_chart_historical_bars",
+            symbol=symbol,
+            extra={"timeframe": timeframe, "limit": limit},
+        )
+        if not isinstance(response, dict):
             return []
 
         candles = self._parse_historical_bars(response.get("bars", []))
@@ -850,7 +818,10 @@ class PriceChartComponent:
             )
             return candles
 
-        logger.debug("Historical bars unavailable for %s (%s)", symbol, timeframe)
+        logger.debug(
+            "historical_bars_unavailable",
+            extra={"symbol": symbol, "timeframe": timeframe},
+        )
         return []
 
     async def _fetch_execution_markers(self, symbol: str) -> list[ExecutionMarker]:

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -394,10 +394,6 @@ class PriceChartComponent:
         """
         self._current_symbol = symbol
         requested_timeframe = expected_timeframe or self._selected_timeframe
-        self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-            requested_timeframe.strip().lower(),
-            self.CANDLE_INTERVAL_SECONDS,
-        )
         self._update_header_labels()
 
         # CRITICAL: Reset realtime update timestamp for staleness tracking
@@ -417,17 +413,33 @@ class PriceChartComponent:
             logger.warning(f"Failed to ensure chart initialized: {exc}")
 
         # Fetch historical data
-        candles = await self._fetch_candle_data(symbol, timeframe=requested_timeframe)
+        candles = await self._fetch_candle_data(
+            symbol,
+            timeframe=requested_timeframe,
+            apply_interval=False,
+        )
 
         # RACE CHECK: Ensure symbol hasn't changed during candle fetch
         if self._is_request_stale(symbol, requested_timeframe, reload_generation):
             return  # Stale - symbol changed during fetch
 
-        self._candles = candles
-        if candles:
+        live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
+            requested_timeframe.strip().lower(),
+            self.CANDLE_INTERVAL_SECONDS,
+        )
+        async with self._get_price_update_lock():
+            if self._is_request_stale(symbol, requested_timeframe, reload_generation):
+                return
+            self._live_bucket_interval_seconds = live_bucket_interval_seconds
+            self._candles = candles
+        has_candles = bool(candles)
+        if has_candles:
             await self._hide_no_data_overlay()
         else:
-            self._markers = []
+            async with self._get_price_update_lock():
+                if self._is_request_stale(symbol, requested_timeframe, reload_generation):
+                    return
+                self._markers = []
             await self._clear_chart_series()
             await self._show_no_data_overlay(symbol)
 
@@ -438,7 +450,10 @@ class PriceChartComponent:
         if self._is_request_stale(symbol, requested_timeframe, reload_generation):
             return  # Stale - symbol changed during fetch
 
-        self._markers = markers
+        async with self._get_price_update_lock():
+            if self._is_request_stale(symbol, requested_timeframe, reload_generation):
+                return
+            self._markers = markers
 
         # Update chart (only if symbol still current)
         await self._update_chart_data()
@@ -811,14 +826,11 @@ class PriceChartComponent:
         symbol: str,
         *,
         timeframe: str | None = None,
+        apply_interval: bool = True,
     ) -> list[CandleData]:
         """Fetch historical candle data for the selected symbol."""
         if self._disposed:
             return []
-        self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-            (timeframe or self._selected_timeframe).strip().lower(),
-            self.CANDLE_INTERVAL_SECONDS,
-        )
 
         fetch_historical_bars = getattr(self._client, "fetch_historical_bars", None)
         if fetch_historical_bars is None:
@@ -851,10 +863,11 @@ class PriceChartComponent:
 
         candles = self._parse_historical_bars(response.get("bars", []))
         if candles:
-            self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-                selected_timeframe.strip().lower(),
-                self.CANDLE_INTERVAL_SECONDS,
-            )
+            if apply_interval:
+                self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
+                    selected_timeframe.strip().lower(),
+                    self.CANDLE_INTERVAL_SECONDS,
+                )
             return candles
 
         logger.debug(

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -864,10 +864,12 @@ class PriceChartComponent:
         candles = self._parse_historical_bars(response.get("bars", []))
         if candles:
             if apply_interval:
-                self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
+                live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
                     selected_timeframe.strip().lower(),
                     self.CANDLE_INTERVAL_SECONDS,
                 )
+                async with self._get_price_update_lock():
+                    self._live_bucket_interval_seconds = live_bucket_interval_seconds
             return candles
 
         logger.debug(

--- a/apps/web_console_ng/components/price_chart.py
+++ b/apps/web_console_ng/components/price_chart.py
@@ -159,6 +159,8 @@ class PriceChartComponent:
         self._title_label: ui.label | None = None
         self._subtitle_label: ui.label | None = None
         self._timeframe_buttons: dict[str, Any] = {}
+        self._timeframe_reload_generation: int = 0
+        self._timeframe_reload_task: asyncio.Task[None] | None = None
         try:
             # Bind to originating NiceGUI client so JS calls from background tasks
             # execute in the correct browser context.
@@ -287,14 +289,23 @@ class PriceChartComponent:
         self._update_header_labels()
         if self._disposed or not self._current_symbol:
             return
-        task = asyncio.create_task(self._reload_selected_symbol())
+        self._timeframe_reload_generation += 1
+        generation = self._timeframe_reload_generation
+        if self._timeframe_reload_task is not None and not self._timeframe_reload_task.done():
+            self._timeframe_reload_task.cancel()
+        task = asyncio.create_task(self._reload_selected_symbol(timeframe, generation))
+        self._timeframe_reload_task = task
         self._pending_update_tasks.add(task)
         task.add_done_callback(lambda t: self._pending_update_tasks.discard(t))
 
-    async def _reload_selected_symbol(self) -> None:
+    async def _reload_selected_symbol(self, timeframe: str, generation: int) -> None:
         symbol = self._current_symbol
         if symbol:
-            await self.on_symbol_changed(symbol)
+            await self.on_symbol_changed(
+                symbol,
+                expected_timeframe=timeframe,
+                reload_generation=generation,
+            )
 
     async def _run_javascript(
         self,
@@ -361,7 +372,13 @@ class PriceChartComponent:
 
     # ================= Symbol Management =================
 
-    async def on_symbol_changed(self, symbol: str | None) -> None:
+    async def on_symbol_changed(
+        self,
+        symbol: str | None,
+        *,
+        expected_timeframe: str | None = None,
+        reload_generation: int | None = None,
+    ) -> None:
         """Called by OrderEntryContext when selected symbol changes.
 
         NOTE: PriceChart does NOT subscribe to Redis directly.
@@ -376,8 +393,9 @@ class PriceChartComponent:
         before updating state/UI to prevent stale fetches from overwriting newer data.
         """
         self._current_symbol = symbol
+        requested_timeframe = expected_timeframe or self._selected_timeframe
         self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-            self._selected_timeframe.strip().lower(),
+            requested_timeframe.strip().lower(),
             self.CANDLE_INTERVAL_SECONDS,
         )
         self._update_header_labels()
@@ -399,10 +417,17 @@ class PriceChartComponent:
             logger.warning(f"Failed to ensure chart initialized: {exc}")
 
         # Fetch historical data
-        candles = await self._fetch_candle_data(symbol)
+        candles = await self._fetch_candle_data(symbol, timeframe=requested_timeframe)
 
         # RACE CHECK: Ensure symbol hasn't changed during candle fetch
-        if symbol != self._current_symbol:
+        if (
+            symbol != self._current_symbol
+            or requested_timeframe != self._selected_timeframe
+            or (
+                reload_generation is not None
+                and reload_generation != self._timeframe_reload_generation
+            )
+        ):
             return  # Stale - symbol changed during fetch
 
         self._candles = candles
@@ -417,7 +442,14 @@ class PriceChartComponent:
         markers = await self._fetch_execution_markers(symbol)
 
         # RACE CHECK: Ensure symbol hasn't changed during marker fetch
-        if symbol != self._current_symbol:
+        if (
+            symbol != self._current_symbol
+            or requested_timeframe != self._selected_timeframe
+            or (
+                reload_generation is not None
+                and reload_generation != self._timeframe_reload_generation
+            )
+        ):
             return  # Stale - symbol changed during fetch
 
         self._markers = markers
@@ -772,12 +804,17 @@ class PriceChartComponent:
             parsed = parsed[-self.MAX_CHART_CANDLES :]
         return parsed
 
-    async def _fetch_candle_data(self, symbol: str) -> list[CandleData]:
+    async def _fetch_candle_data(
+        self,
+        symbol: str,
+        *,
+        timeframe: str | None = None,
+    ) -> list[CandleData]:
         """Fetch historical candle data for the selected symbol."""
         if self._disposed:
             return []
         self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-            self._selected_timeframe.strip().lower(),
+            (timeframe or self._selected_timeframe).strip().lower(),
             self.CANDLE_INTERVAL_SECONDS,
         )
 
@@ -789,11 +826,11 @@ class PriceChartComponent:
             logger.debug("historical_bars_fetch_skipped", extra={"symbol": symbol, "reason": "missing_user"})
             return []
 
-        timeframe = self._selected_timeframe
-        _, limit, _ = self.TIMEFRAME_OPTIONS[timeframe]
+        selected_timeframe = timeframe or self._selected_timeframe
+        _, limit, _ = self.TIMEFRAME_OPTIONS[selected_timeframe]
         request_kwargs: dict[str, Any] = {
             "symbol": symbol,
-            "timeframe": timeframe,
+            "timeframe": selected_timeframe,
             "limit": limit,
         }
         response = await call_market_data_client(
@@ -805,7 +842,7 @@ class PriceChartComponent:
             logger=logger,
             operation="price_chart_historical_bars",
             symbol=symbol,
-            extra={"timeframe": timeframe, "limit": limit},
+            extra={"timeframe": selected_timeframe, "limit": limit},
         )
         if not isinstance(response, dict):
             return []
@@ -813,14 +850,14 @@ class PriceChartComponent:
         candles = self._parse_historical_bars(response.get("bars", []))
         if candles:
             self._live_bucket_interval_seconds = self.HISTORICAL_TIMEFRAME_SECONDS.get(
-                timeframe.strip().lower(),
+                selected_timeframe.strip().lower(),
                 self.CANDLE_INTERVAL_SECONDS,
             )
             return candles
 
         logger.debug(
             "historical_bars_unavailable",
-            extra={"symbol": symbol, "timeframe": timeframe},
+            extra={"symbol": symbol, "timeframe": selected_timeframe},
         )
         return []
 
@@ -1370,6 +1407,7 @@ class PriceChartComponent:
                 except asyncio.CancelledError:
                     pass
         self._pending_update_tasks.clear()
+        self._timeframe_reload_task = None
         self._price_update_task = None
         self._pending_price_update = None
 

--- a/apps/web_console_ng/core/client.py
+++ b/apps/web_console_ng/core/client.py
@@ -499,6 +499,30 @@ class AsyncTradingClient:
         resp.raise_for_status()
         return self._json_dict(resp)
 
+    @with_retry(max_attempts=3, backoff_base=1.0, method="GET")
+    async def fetch_latest_quote(
+        self,
+        symbol: str,
+        user_id: str,
+        role: str | None = None,
+        strategies: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Fetch latest top-of-book quote for a symbol from market-data-service."""
+        safe_symbol = url_quote(symbol.upper(), safe="")
+        path = f"/api/v1/market-data/{safe_symbol}/latest-quote"
+        headers = self._get_market_data_auth_headers(
+            method="GET",
+            path=path,
+            query="",
+            body=None,
+            user_id=user_id,
+            role=role,
+            strategies=strategies,
+        )
+        resp = await self._market_client.get(path, headers=headers)
+        resp.raise_for_status()
+        return self._json_dict(resp)
+
     @with_retry(max_attempts=3, backoff_base=1.0, method="POST")
     async def subscribe_market_data_symbols(
         self,

--- a/apps/web_console_ng/core/level2_websocket.py
+++ b/apps/web_console_ng/core/level2_websocket.py
@@ -72,7 +72,15 @@ class Level2WebSocketService:
         # Explicit mock mode
         if os.getenv("ALPACA_L2_USE_MOCK", "").lower() in {"1", "true", "yes"}:
             return True, "Mock mode (synthetic data)"
-        enabled = os.getenv("ALPACA_L2_ENABLED", "false").lower() in {"1", "true", "yes"}
+        enabled_raw = os.getenv("ALPACA_L2_ENABLED")
+        if enabled_raw is None and os.getenv("WEB_CONSOLE_NG_DEBUG", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            return True, "Mock mode (local dev synthetic data)"
+        enabled = str(enabled_raw or "").lower() in {"1", "true", "yes"}
         if not enabled:
             return False, "Level 2 data not enabled"
         api_key = os.getenv("ALPACA_PRO_API_KEY", "").strip()

--- a/apps/web_console_ng/core/level2_websocket.py
+++ b/apps/web_console_ng/core/level2_websocket.py
@@ -26,8 +26,9 @@ def l2_channel(user_id: str, symbol: str) -> str:
 class Level2WebSocketService:
     """Manage Alpaca Level 2 WebSocket with Redis fanout.
 
-    NOTE: In environments without Alpaca credentials, the service runs in mock
-    mode and publishes synthetic orderbook snapshots.
+    NOTE: Mock depth is only enabled by explicit opt-in via ALPACA_L2_USE_MOCK.
+    Normal local development must not show synthetic order book data as if it
+    were live market data.
     """
 
     _instance: Level2WebSocketService | None = None
@@ -66,20 +67,13 @@ class Level2WebSocketService:
         """Return entitlement status for L2 data.
 
         Returns (entitled: bool, message: str).
-        When mock mode is active (explicit or fallback), message indicates this
-        to prevent misleading traders about data source.
+        When mock mode is active, message indicates this to prevent misleading
+        traders about data source.
         """
         # Explicit mock mode
         if os.getenv("ALPACA_L2_USE_MOCK", "").lower() in {"1", "true", "yes"}:
             return True, "Mock mode (synthetic data)"
         enabled_raw = os.getenv("ALPACA_L2_ENABLED")
-        if enabled_raw is None and os.getenv("WEB_CONSOLE_NG_DEBUG", "").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }:
-            return True, "Mock mode (local dev synthetic data)"
         enabled = str(enabled_raw or "").lower() in {"1", "true", "yes"}
         if not enabled:
             return False, "Level 2 data not enabled"
@@ -87,15 +81,12 @@ class Level2WebSocketService:
         api_secret = os.getenv("ALPACA_PRO_API_SECRET", "").strip()
         if not api_key or not api_secret:
             return False, "Alpaca Pro credentials missing"
-        # Real connection not yet implemented - fall back to mock with clear warning
-        # TODO: Remove this when real Alpaca WebSocket is implemented
-        return True, "Mock mode (real connection not implemented)"
+        return False, "Real Level 2 provider not implemented"
 
     def _should_use_mock(self) -> bool:
         if os.getenv("ALPACA_L2_USE_MOCK", "").lower() in {"1", "true", "yes"}:
             return True
-        entitled, _ = self.entitlement_status()
-        return not entitled
+        return False
 
     async def subscribe(self, user_id: str, symbol: str) -> bool:
         symbol = symbol.upper()
@@ -260,18 +251,14 @@ class Level2WebSocketService:
                 await self.publish_update(symbol, payload)
 
     async def _connection_loop(self) -> None:
-        """Placeholder for real Alpaca connection - falls back to mock mode.
+        """Placeholder for real Alpaca L2 connection.
 
-        The real Alpaca WebSocket implementation will be added in a future PR.
-        For now, log a warning and fall back to mock mode to avoid crash loops.
+        Real L2 depth is intentionally not simulated here. Until a real provider
+        is implemented, subscription remains disabled unless explicit mock mode
+        is enabled for tests or demos.
         """
-        logger.warning(
-            "level2_real_connection_not_implemented",
-            extra={"action": "falling_back_to_mock_mode"},
-        )
-        # Fall back to mock mode instead of crash-looping
-        self._mock_mode = True
-        await self._mock_loop()
+        logger.warning("level2_real_connection_not_implemented")
+        self._running = False
 
     def _generate_mock_snapshot(self, symbol: str, now: float) -> dict[str, Any]:
         base = self._mock_prices.get(symbol)

--- a/apps/web_console_ng/static/css/custom.css
+++ b/apps/web_console_ng/static/css/custom.css
@@ -558,14 +558,14 @@
     padding: 2px 8px;
 }
 
-.workspace-v2-chart-timeframe-button-active {
-    background: rgba(14, 165, 233, 0.22) !important;
-    color: #e0f2fe !important;
+.workspace-v2-chart-timeframe-toggle .workspace-v2-chart-timeframe-button-active {
+    background: rgba(14, 165, 233, 0.22);
+    color: #e0f2fe;
 }
 
-.workspace-v2-chart-timeframe-button-inactive {
-    background: transparent !important;
-    color: var(--workspace-text-muted) !important;
+.workspace-v2-chart-timeframe-toggle .workspace-v2-chart-timeframe-button-inactive {
+    background: transparent;
+    color: var(--workspace-text-muted);
 }
 
 .workspace-v2-microstructure {

--- a/apps/web_console_ng/static/css/custom.css
+++ b/apps/web_console_ng/static/css/custom.css
@@ -508,6 +508,66 @@
     overflow: hidden;
 }
 
+.workspace-v2-chart-shell {
+    background: rgba(15, 23, 42, 0.72);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.workspace-v2-chart-header {
+    border-bottom: 1px solid rgba(51, 65, 85, 0.72);
+    flex: 0 0 auto;
+    gap: 8px;
+    min-height: 42px;
+    padding: 6px 8px;
+}
+
+.workspace-v2-chart-title {
+    color: var(--workspace-text);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.workspace-v2-chart-canvas {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.workspace-v2-chart-container {
+    min-height: 0;
+}
+
+.workspace-v2-chart-timeframe-toggle {
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid rgba(51, 65, 85, 0.82);
+    border-radius: 999px;
+    flex: 0 0 auto;
+    gap: 2px;
+    padding: 2px;
+}
+
+.workspace-v2-chart-timeframe-button {
+    border-radius: 999px;
+    color: var(--workspace-text-muted);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.66rem;
+    min-height: 24px;
+    padding: 2px 8px;
+}
+
+.workspace-v2-chart-timeframe-button-active {
+    background: rgba(14, 165, 233, 0.22) !important;
+    color: #e0f2fe !important;
+}
+
+.workspace-v2-chart-timeframe-button-inactive {
+    background: transparent !important;
+    color: var(--workspace-text-muted) !important;
+}
+
 .workspace-v2-microstructure {
     display: grid;
     flex: 1 1 auto;

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -258,15 +258,15 @@ class MarketDataProvider:
             )
             raise MarketDataError(str(exc)) from exc
 
-        quote = quotes.get(symbol) if isinstance(quotes, dict) else None
+        quote = self._extract_latest_quote(quotes, symbol)
         if quote is None:
             return None
 
-        bid_raw = getattr(quote, "bid_price", None) or getattr(quote, "bp", None)
-        ask_raw = getattr(quote, "ask_price", None) or getattr(quote, "ap", None)
-        bid_size_raw = getattr(quote, "bid_size", None) or getattr(quote, "bs", None)
-        ask_size_raw = getattr(quote, "ask_size", None) or getattr(quote, "as", None)
-        ts_raw = getattr(quote, "timestamp", None) or getattr(quote, "t", None)
+        bid_raw = self._quote_field(quote, "bid_price", "bp")
+        ask_raw = self._quote_field(quote, "ask_price", "ap")
+        bid_size_raw = self._quote_field(quote, "bid_size", "bs")
+        ask_size_raw = self._quote_field(quote, "ask_size", "as")
+        ts_raw = self._quote_field(quote, "timestamp", "t")
         timestamp = self._normalize_bar_timestamp(ts_raw)
 
         try:
@@ -288,6 +288,25 @@ class MarketDataProvider:
             "ask_size": ask_size,
             "timestamp": timestamp.isoformat() if timestamp is not None else None,
         }
+
+    @staticmethod
+    def _extract_latest_quote(quotes: Any, symbol: str) -> Any | None:
+        """Extract a symbol quote from Alpaca SDK or test-double response shapes."""
+        data = getattr(quotes, "data", None)
+        if isinstance(data, dict):
+            return data.get(symbol)
+        if isinstance(quotes, dict):
+            return quotes.get(symbol)
+        return None
+
+    @staticmethod
+    def _quote_field(quote: Any, primary_name: str, fallback_name: str) -> Any:
+        """Read a quote field from dict/object response shapes without treating 0 as missing."""
+        if isinstance(quote, dict):
+            value = quote.get(primary_name)
+            return value if value is not None else quote.get(fallback_name)
+        value = getattr(quote, primary_name, None)
+        return value if value is not None else getattr(quote, fallback_name, None)
 
     def _get_adv_sync(self, symbol: str) -> ADVData | None:
         symbol = symbol.upper().strip()

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import math
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 try:
@@ -270,11 +271,11 @@ class MarketDataProvider:
         timestamp = self._normalize_bar_timestamp(ts_raw)
 
         try:
-            bid = float(bid_raw) if bid_raw is not None else None
-            ask = float(ask_raw) if ask_raw is not None else None
+            bid = Decimal(str(bid_raw)) if bid_raw is not None else None
+            ask = Decimal(str(ask_raw)) if ask_raw is not None else None
             bid_size = int(bid_size_raw) if bid_size_raw is not None else None
             ask_size = int(ask_size_raw) if ask_size_raw is not None else None
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, InvalidOperation):
             return None
 
         if bid is None and ask is None:

--- a/libs/data/market_data/provider.py
+++ b/libs/data/market_data/provider.py
@@ -10,7 +10,7 @@ from typing import Any
 
 try:
     from alpaca.data.historical import StockHistoricalDataClient
-    from alpaca.data.requests import StockBarsRequest
+    from alpaca.data.requests import StockBarsRequest, StockLatestQuoteRequest
     from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 
     ALPACA_AVAILABLE = True
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover - optional dependency
     ALPACA_AVAILABLE = False
     StockHistoricalDataClient = None  # type: ignore[assignment,misc]
     StockBarsRequest = None  # type: ignore[assignment,misc]
+    StockLatestQuoteRequest = None  # type: ignore[assignment,misc]
     TimeFrame = None  # type: ignore[assignment,misc]
     TimeFrameUnit = None  # type: ignore[assignment,misc]
 
@@ -54,6 +55,10 @@ class MarketDataProvider:
             timeframe,
             limit,
         )
+
+    async def get_latest_quote(self, symbol: str) -> dict[str, Any] | None:
+        """Get latest top-of-book quote for a symbol."""
+        return await asyncio.to_thread(self._get_latest_quote_sync, symbol)
 
     def _resolve_timeframe(self, timeframe: str) -> Any:
         """Resolve supported timeframe strings to Alpaca TimeFrame."""
@@ -234,6 +239,55 @@ class MarketDataProvider:
 
         normalized.sort(key=self._normalized_bar_sort_key)
         return normalized
+
+    def _get_latest_quote_sync(self, symbol: str) -> dict[str, Any] | None:
+        symbol = symbol.upper().strip()
+        if not symbol:
+            return None
+
+        try:
+            request_kwargs: dict[str, Any] = {"symbol_or_symbols": symbol}
+            if self._data_feed:
+                request_kwargs["feed"] = self._data_feed
+            request = StockLatestQuoteRequest(**request_kwargs)
+            quotes = self._client.get_stock_latest_quote(request)
+        except Exception as exc:  # pragma: no cover - provider errors
+            logger.warning(
+                "latest_quote_provider_error",
+                extra={"symbol": symbol, "error": type(exc).__name__},
+            )
+            raise MarketDataError(str(exc)) from exc
+
+        quote = quotes.get(symbol) if isinstance(quotes, dict) else None
+        if quote is None:
+            return None
+
+        bid_raw = getattr(quote, "bid_price", None) or getattr(quote, "bp", None)
+        ask_raw = getattr(quote, "ask_price", None) or getattr(quote, "ap", None)
+        bid_size_raw = getattr(quote, "bid_size", None) or getattr(quote, "bs", None)
+        ask_size_raw = getattr(quote, "ask_size", None) or getattr(quote, "as", None)
+        ts_raw = getattr(quote, "timestamp", None) or getattr(quote, "t", None)
+        timestamp = self._normalize_bar_timestamp(ts_raw)
+
+        try:
+            bid = float(bid_raw) if bid_raw is not None else None
+            ask = float(ask_raw) if ask_raw is not None else None
+            bid_size = int(bid_size_raw) if bid_size_raw is not None else None
+            ask_size = int(ask_size_raw) if ask_size_raw is not None else None
+        except (TypeError, ValueError):
+            return None
+
+        if bid is None and ask is None:
+            return None
+
+        return {
+            "symbol": symbol,
+            "bid_price": bid,
+            "ask_price": ask,
+            "bid_size": bid_size,
+            "ask_size": ask_size,
+            "timestamp": timestamp.isoformat() if timestamp is not None else None,
+        }
 
     def _get_adv_sync(self, symbol: str) -> ADVData | None:
         symbol = symbol.upper().strip()

--- a/libs/data/market_data/types.py
+++ b/libs/data/market_data/types.py
@@ -113,6 +113,17 @@ class PriceUpdateEvent(BaseModel):
     symbol: str = Field(..., description="Stock symbol")
     price: Decimal = Field(..., description="Mid price", ge=0)
     timestamp: str = Field(..., description="ISO format timestamp")
+    bid: Decimal | None = Field(default=None, description="Best bid price")
+    ask: Decimal | None = Field(default=None, description="Best ask price")
+    bid_price: Decimal | None = Field(default=None, description="Best bid price alias")
+    ask_price: Decimal | None = Field(default=None, description="Best ask price alias")
+    bid_size: int | None = Field(default=None, description="Best bid size in shares")
+    ask_size: int | None = Field(default=None, description="Best ask size in shares")
+    exchange: str | None = Field(default=None, description="Quote exchange code")
+    volume: int | None = Field(
+        default=None,
+        description="Latest traded volume when available from the data source",
+    )
 
     @classmethod
     def from_quote(cls, quote: QuoteData) -> PriceUpdateEvent:
@@ -121,6 +132,13 @@ class PriceUpdateEvent(BaseModel):
             symbol=quote.symbol,
             price=quote.mid_price,
             timestamp=quote.timestamp.isoformat(),
+            bid=quote.bid_price,
+            ask=quote.ask_price,
+            bid_price=quote.bid_price,
+            ask_price=quote.ask_price,
+            bid_size=quote.bid_size,
+            ask_size=quote.ask_size,
+            exchange=quote.exchange,
         )
 
 

--- a/tests/apps/market_data_service/test_adv_endpoint.py
+++ b/tests/apps/market_data_service/test_adv_endpoint.py
@@ -45,9 +45,10 @@ class DummyCache:
 
 
 class DummyProvider:
-    def __init__(self, adv_data=None, bars_data=None, error=None):
+    def __init__(self, adv_data=None, bars_data=None, quote_data=None, error=None):
         self._adv_data = adv_data
         self._bars_data = bars_data or []
+        self._quote_data = quote_data
         self._error = error
 
     async def get_adv(self, symbol: str):
@@ -61,6 +62,11 @@ class DummyProvider:
         if self._error:
             raise self._error
         return list(self._bars_data)
+
+    async def get_latest_quote(self, symbol: str):
+        if self._error:
+            raise self._error
+        return self._quote_data
 
 
 def test_adv_returns_404_for_unknown_symbol(test_client, monkeypatch):
@@ -183,6 +189,43 @@ def test_bars_returns_historical_payload(test_client, monkeypatch):
         "2026-04-20T13:30:00Z",
         "2026-04-20T13:30:00+00:00",
     }
+
+
+def test_latest_quote_returns_top_of_book_payload(test_client, monkeypatch):
+    from apps.market_data_service.routes import market_data
+
+    monkeypatch.setattr(
+        market_data,
+        "_get_provider",
+        lambda: DummyProvider(
+            quote_data={
+                "symbol": "AAPL",
+                "bid_price": 180.1,
+                "ask_price": 180.2,
+                "bid_size": 100,
+                "ask_size": 200,
+                "timestamp": "2026-04-20T13:30:01+00:00",
+            }
+        ),
+    )
+
+    response = test_client.get("/api/v1/market-data/aapl/latest-quote")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["symbol"] == "AAPL"
+    assert body["bid_price"] == 180.1
+    assert body["ask_price"] == 180.2
+    assert body["bid_size"] == 100
+    assert body["ask_size"] == 200
+
+
+def test_latest_quote_returns_404_when_quote_missing(test_client, monkeypatch):
+    from apps.market_data_service.routes import market_data
+
+    monkeypatch.setattr(market_data, "_get_provider", lambda: DummyProvider(quote_data=None))
+
+    response = test_client.get("/api/v1/market-data/AAPL/latest-quote")
+    assert response.status_code == 404
 
 
 def test_bars_returns_400_for_invalid_limit(test_client):

--- a/tests/apps/market_data_service/test_adv_endpoint.py
+++ b/tests/apps/market_data_service/test_adv_endpoint.py
@@ -4,6 +4,7 @@ Tests for ADV endpoint in Market Data Service.
 
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
@@ -200,8 +201,8 @@ def test_latest_quote_returns_top_of_book_payload(test_client, monkeypatch):
         lambda: DummyProvider(
             quote_data={
                 "symbol": "AAPL",
-                "bid_price": 180.1,
-                "ask_price": 180.2,
+                "bid_price": Decimal("180.1"),
+                "ask_price": Decimal("180.2"),
                 "bid_size": 100,
                 "ask_size": 200,
                 "timestamp": "2026-04-20T13:30:01+00:00",
@@ -213,8 +214,8 @@ def test_latest_quote_returns_top_of_book_payload(test_client, monkeypatch):
     assert response.status_code == 200
     body = response.json()
     assert body["symbol"] == "AAPL"
-    assert body["bid_price"] == 180.1
-    assert body["ask_price"] == 180.2
+    assert body["bid_price"] == "180.1"
+    assert body["ask_price"] == "180.2"
     assert body["bid_size"] == 100
     assert body["ask_size"] == 200
 

--- a/tests/apps/market_data_service/test_alpaca_stream.py
+++ b/tests/apps/market_data_service/test_alpaca_stream.py
@@ -7,6 +7,7 @@ Integration tests with real Alpaca API are separate.
 
 import asyncio
 from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -140,6 +141,11 @@ class TestAlpacaMarketDataStream:
         from libs.data.market_data.types import PriceUpdateEvent
 
         assert isinstance(pub_call_args[0][1], PriceUpdateEvent)
+        event = pub_call_args[0][1]
+        assert event.bid == Decimal("150.00")
+        assert event.ask == Decimal("150.10")
+        assert event.bid_size == 100
+        assert event.ask_size == 200
 
     @pytest.mark.asyncio()
     async def test_handle_quote_with_invalid_data(self, stream, mock_redis, mock_publisher):

--- a/tests/apps/market_data_service/test_types.py
+++ b/tests/apps/market_data_service/test_types.py
@@ -185,6 +185,13 @@ class TestPriceUpdateEvent:
         assert event.symbol == "AAPL"
         assert event.price == Decimal("150.05")  # Mid price
         assert event.timestamp == timestamp.isoformat()
+        assert event.bid == Decimal("150.00")
+        assert event.ask == Decimal("150.10")
+        assert event.bid_price == Decimal("150.00")
+        assert event.ask_price == Decimal("150.10")
+        assert event.bid_size == 100
+        assert event.ask_size == 200
+        assert event.exchange == "NASDAQ"
 
     def test_event_serialization(self):
         """Test event JSON serialization."""
@@ -198,3 +205,5 @@ class TestPriceUpdateEvent:
         assert event_dict["event_type"] == "price.updated"
         assert event_dict["symbol"] == "AAPL"
         assert event_dict["price"] == Decimal("150.05")
+        assert event_dict["bid"] is None
+        assert event_dict["ask"] is None

--- a/tests/apps/web_console_ng/core/test_level2_websocket.py
+++ b/tests/apps/web_console_ng/core/test_level2_websocket.py
@@ -96,6 +96,13 @@ def test_entitlement_status_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Mock mode" in reason
 
     monkeypatch.delenv("ALPACA_L2_USE_MOCK", raising=False)
+    monkeypatch.delenv("ALPACA_L2_ENABLED", raising=False)
+    monkeypatch.setenv("WEB_CONSOLE_NG_DEBUG", "true")
+    entitled, reason = Level2WebSocketService.entitlement_status()
+    assert entitled is True
+    assert "local dev synthetic data" in reason
+
+    monkeypatch.setenv("WEB_CONSOLE_NG_DEBUG", "false")
     monkeypatch.setenv("ALPACA_L2_ENABLED", "false")
     entitled, reason = Level2WebSocketService.entitlement_status()
     assert entitled is False

--- a/tests/apps/web_console_ng/core/test_level2_websocket.py
+++ b/tests/apps/web_console_ng/core/test_level2_websocket.py
@@ -99,8 +99,8 @@ def test_entitlement_status_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ALPACA_L2_ENABLED", raising=False)
     monkeypatch.setenv("WEB_CONSOLE_NG_DEBUG", "true")
     entitled, reason = Level2WebSocketService.entitlement_status()
-    assert entitled is True
-    assert "local dev synthetic data" in reason
+    assert entitled is False
+    assert "not enabled" in reason
 
     monkeypatch.setenv("WEB_CONSOLE_NG_DEBUG", "false")
     monkeypatch.setenv("ALPACA_L2_ENABLED", "false")
@@ -114,6 +114,12 @@ def test_entitlement_status_env(monkeypatch: pytest.MonkeyPatch) -> None:
     entitled, reason = Level2WebSocketService.entitlement_status()
     assert entitled is False
     assert "credentials missing" in reason
+
+    monkeypatch.setenv("ALPACA_PRO_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_PRO_API_SECRET", "secret")
+    entitled, reason = Level2WebSocketService.entitlement_status()
+    assert entitled is False
+    assert "not implemented" in reason
 
 
 @pytest.mark.asyncio()
@@ -129,13 +135,19 @@ async def test_stop_if_idle_cancels_task() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_connection_loop_falls_back_to_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_connection_loop_does_not_fall_back_to_mock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service = Level2WebSocketService(max_symbols=1, mock_mode=False)
     mock_loop = AsyncMock()
     monkeypatch.setattr(service, "_mock_loop", mock_loop)
+    service._running = True
+
     await service._connection_loop()
-    assert service._mock_mode is True
-    mock_loop.assert_awaited_once()
+
+    assert service._running is False
+    assert service._mock_mode is False
+    mock_loop.assert_not_awaited()
 
 
 def test_generate_mock_snapshot_shape() -> None:

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -395,10 +395,20 @@ class TestMarketContextSymbolChange:
         assert component._current_symbol == "AAPL"
 
     @pytest.mark.asyncio()
-    async def test_symbol_change_seeds_last_and_volume_from_recent_bar(self) -> None:
-        """Recent bars populate last/volume while live bid/ask quote ticks warm up."""
+    async def test_symbol_change_seeds_l1_quote_and_recent_bar(self) -> None:
+        """Real quote and bars seed bid/ask/spread plus last/volume."""
         timestamp = datetime.now(UTC)
         client = MagicMock()
+        client.fetch_latest_quote = AsyncMock(
+            return_value={
+                "symbol": "AAPL",
+                "bid_price": 101.2,
+                "ask_price": 101.3,
+                "bid_size": 10,
+                "ask_size": 20,
+                "timestamp": timestamp.isoformat(),
+            }
+        )
         client.fetch_historical_bars = AsyncMock(
             return_value={
                 "bars": [
@@ -424,8 +434,18 @@ class TestMarketContextSymbolChange:
 
         assert component._data is not None
         assert component._data.symbol == "AAPL"
+        assert component._data.bid_price == Decimal("101.2")
+        assert component._data.ask_price == Decimal("101.3")
+        assert component._data.bid_size == 10
+        assert component._data.ask_size == 20
         assert component._data.last_price == Decimal("101.25")
         assert component._data.volume == 123456
+        client.fetch_latest_quote.assert_awaited_once_with(
+            symbol="AAPL",
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+        )
         client.fetch_historical_bars.assert_awaited_once_with(
             symbol="AAPL",
             timeframe="5Min",

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -253,6 +253,29 @@ class TestMarketContextPriceData:
         # UI update timestamp was NOT changed (UI was skipped)
         assert component._last_ui_update == initial_update_time
 
+    def test_set_price_data_preserves_seeded_volume(
+        self, component: MarketContextComponent
+    ) -> None:
+        """Quote-only live ticks preserve the most recent bar volume."""
+        component._current_symbol = "AAPL"
+        component._data = MarketDataSnapshot(
+            symbol="AAPL",
+            last_price=Decimal("100.00"),
+            volume=123456,
+        )
+
+        component.set_price_data(
+            {
+                "symbol": "AAPL",
+                "bid": "100.00",
+                "ask": "100.10",
+                "price": "100.05",
+            }
+        )
+
+        assert component._data is not None
+        assert component._data.volume == 123456
+
 
 class TestMarketContextStaleness:
     """Tests for staleness checks."""
@@ -370,6 +393,47 @@ class TestMarketContextSymbolChange:
         await component.on_symbol_changed("AAPL")
 
         assert component._current_symbol == "AAPL"
+
+    @pytest.mark.asyncio()
+    async def test_symbol_change_seeds_last_and_volume_from_recent_bar(self) -> None:
+        """Recent bars populate last/volume while live bid/ask quote ticks warm up."""
+        timestamp = datetime.now(UTC)
+        client = MagicMock()
+        client.fetch_historical_bars = AsyncMock(
+            return_value={
+                "bars": [
+                    {
+                        "timestamp": timestamp.isoformat(),
+                        "open": 100.0,
+                        "high": 102.0,
+                        "low": 99.0,
+                        "close": 101.25,
+                        "volume": 123456,
+                    }
+                ]
+            }
+        )
+        component = MarketContextComponent(
+            trading_client=client,
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+        )
+
+        await component.on_symbol_changed("AAPL")
+
+        assert component._data is not None
+        assert component._data.symbol == "AAPL"
+        assert component._data.last_price == Decimal("101.25")
+        assert component._data.volume == 123456
+        client.fetch_historical_bars.assert_awaited_once_with(
+            symbol="AAPL",
+            timeframe="5Min",
+            limit=1,
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+        )
 
 
 class TestMarketContextDispose:

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -156,7 +156,7 @@ class TestMarketContextPriceData:
                 "symbol": "AAPL",
                 "bid": "100.00",
                 "ask": "100.10",
-                "price": "100.05",
+                "last_price": "100.05",
                 "bid_size": 100,
                 "ask_size": 200,
             }
@@ -298,6 +298,32 @@ class TestMarketContextPriceData:
 
         assert component._data is not None
         assert component._data.volume == 123456
+        assert component._data.last_price == Decimal("100.00")
+
+    def test_quote_payload_mid_price_does_not_overwrite_last_trade(
+        self, component: MarketContextComponent
+    ) -> None:
+        """Quote mid-price payloads must not overwrite Last trade display."""
+        component._current_symbol = "AAPL"
+        component._data = MarketDataSnapshot(
+            symbol="AAPL",
+            last_price=Decimal("100.00"),
+            volume=123456,
+        )
+
+        component.set_price_data(
+            {
+                "symbol": "AAPL",
+                "bid": "100.00",
+                "ask": "100.10",
+                "price": "100.05",
+            }
+        )
+
+        assert component._data is not None
+        assert component._data.last_price == Decimal("100.00")
+        assert component._data.bid_price == Decimal("100.00")
+        assert component._data.ask_price == Decimal("100.10")
 
 
 class TestMarketContextStaleness:
@@ -550,6 +576,42 @@ class TestMarketContextSymbolChange:
         assert snapshot.last_price == Decimal("101.25")
         assert snapshot.volume == 987654
         assert snapshot.timestamp == timestamp
+
+    @pytest.mark.asyncio()
+    async def test_initial_seed_does_not_overwrite_newer_live_tick(self) -> None:
+        """Older API seed snapshots must not replace fresher live callback data."""
+        old_timestamp = datetime.now(UTC) - timedelta(minutes=1)
+        new_timestamp = datetime.now(UTC)
+        client = MagicMock()
+        component = MarketContextComponent(trading_client=client, user_id="user-1")
+        component._current_symbol = "AAPL"
+        component._data = MarketDataSnapshot(
+            symbol="AAPL",
+            last_price=Decimal("102.00"),
+            timestamp=new_timestamp,
+        )
+
+        with (
+            patch.object(
+                component,
+                "_fetch_initial_snapshots",
+                return_value=(
+                    None,
+                    MarketDataSnapshot(
+                        symbol="AAPL",
+                        last_price=Decimal("101.00"),
+                        timestamp=old_timestamp,
+                    ),
+                ),
+            ),
+            patch.object(component, "_update_ui") as mock_update_ui,
+        ):
+            await component._fetch_initial_data("AAPL")
+
+        assert component._data is not None
+        assert component._data.last_price == Decimal("102.00")
+        assert component._data.timestamp == new_timestamp
+        mock_update_ui.assert_not_called()
 
 
 class TestMarketContextDispose:

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -632,6 +632,38 @@ class TestMarketContextSymbolChange:
         assert snapshot.volume is None
         assert snapshot.timestamp == timestamp
 
+    @pytest.mark.asyncio()
+    async def test_quote_seed_allows_zero_prices(self) -> None:
+        """Zero quote prices are valid display data and should not be hidden."""
+        client = MagicMock()
+        client.fetch_latest_quote = AsyncMock(
+            return_value={
+                "symbol": "AAPL",
+                "bid_price": "0",
+                "ask_price": "0",
+                "bid_size": 10,
+                "ask_size": 20,
+                "timestamp": "2026-04-20T15:00:00Z",
+            }
+        )
+        component = MarketContextComponent(trading_client=client, user_id="user-1")
+
+        snapshot = await component._fetch_latest_quote_snapshot("AAPL")
+
+        assert snapshot is not None
+        assert snapshot.bid_price == Decimal("0")
+        assert snapshot.ask_price == Decimal("0")
+
+    def test_bar_parse_allows_zero_close(self) -> None:
+        """Zero close values are retained instead of being treated as missing."""
+        close, timestamp = MarketContextComponent._parse_bar_price(
+            {"close": "0", "timestamp": "2026-04-20T15:00:00Z"},
+            "AAPL",
+        )
+
+        assert close == Decimal("0")
+        assert timestamp == datetime(2026, 4, 20, 15, 0, tzinfo=UTC)
+
     def test_merge_snapshots_uses_freshest_timestamp(self) -> None:
         """Merged seed freshness should reflect the newest quote or bar timestamp."""
         old_timestamp = datetime(2026, 4, 20, 15, 0, tzinfo=UTC)
@@ -716,6 +748,49 @@ class TestMarketContextSymbolChange:
         assert component._data is not None
         assert component._data.bid_price == Decimal("102.00")
         assert component._data.last_price == Decimal("101.00")
+        assert component._data.volume == 123456
+        assert component._data.timestamp == new_timestamp
+        mock_update_ui.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_sparse_newer_seed_preserves_existing_live_fields(self) -> None:
+        """A newer quote-only seed must not clear live last/volume fields."""
+        old_timestamp = datetime.now(UTC) - timedelta(seconds=10)
+        new_timestamp = datetime.now(UTC)
+        client = MagicMock()
+        component = MarketContextComponent(trading_client=client, user_id="user-1")
+        component._current_symbol = "AAPL"
+        component._data = MarketDataSnapshot(
+            symbol="AAPL",
+            bid_price=Decimal("101.00"),
+            ask_price=Decimal("101.10"),
+            last_price=Decimal("101.05"),
+            volume=123456,
+            timestamp=old_timestamp,
+        )
+
+        with (
+            patch.object(
+                component,
+                "_fetch_initial_snapshots",
+                return_value=(
+                    MarketDataSnapshot(
+                        symbol="AAPL",
+                        bid_price=Decimal("102.00"),
+                        ask_price=Decimal("102.10"),
+                        timestamp=new_timestamp,
+                    ),
+                    None,
+                ),
+            ),
+            patch.object(component, "_update_ui") as mock_update_ui,
+        ):
+            await component._fetch_initial_data("AAPL")
+
+        assert component._data is not None
+        assert component._data.bid_price == Decimal("102.00")
+        assert component._data.ask_price == Decimal("102.10")
+        assert component._data.last_price == Decimal("101.05")
         assert component._data.volume == 123456
         assert component._data.timestamp == new_timestamp
         mock_update_ui.assert_called_once()

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -506,6 +506,51 @@ class TestMarketContextSymbolChange:
             any_order=True,
         )
 
+    @pytest.mark.asyncio()
+    async def test_bar_seed_uses_daily_close_when_intraday_missing(self) -> None:
+        """Daily bar close should seed Last when intraday bars are unavailable."""
+        timestamp = datetime.now(UTC)
+        client = MagicMock()
+
+        async def fetch_historical_bars(
+            *,
+            symbol: str,
+            timeframe: str,
+            limit: int,
+            user_id: str,
+            role: str,
+            strategies: list[str],
+        ) -> dict[str, list[dict[str, object]]]:
+            if timeframe == "5Min":
+                return {"bars": []}
+            return {
+                "bars": [
+                    {
+                        "timestamp": timestamp.isoformat(),
+                        "open": 100.0,
+                        "high": 102.0,
+                        "low": 99.0,
+                        "close": 101.25,
+                        "volume": 987654,
+                    }
+                ]
+            }
+
+        client.fetch_historical_bars = AsyncMock(side_effect=fetch_historical_bars)
+        component = MarketContextComponent(
+            trading_client=client,
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+        )
+
+        snapshot = await component._fetch_latest_bar_snapshot("AAPL")
+
+        assert snapshot is not None
+        assert snapshot.last_price == Decimal("101.25")
+        assert snapshot.volume == 987654
+        assert snapshot.timestamp == timestamp
+
 
 class TestMarketContextDispose:
     """Tests for dispose/cleanup."""

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -578,8 +578,8 @@ class TestMarketContextSymbolChange:
         assert snapshot.timestamp == timestamp
 
     @pytest.mark.asyncio()
-    async def test_initial_seed_does_not_overwrite_newer_live_tick(self) -> None:
-        """Older API seed snapshots must not replace fresher live callback data."""
+    async def test_initial_seed_merges_without_overwriting_newer_live_tick(self) -> None:
+        """Older API seed fills gaps without replacing fresher live callback fields."""
         old_timestamp = datetime.now(UTC) - timedelta(minutes=1)
         new_timestamp = datetime.now(UTC)
         client = MagicMock()
@@ -587,7 +587,7 @@ class TestMarketContextSymbolChange:
         component._current_symbol = "AAPL"
         component._data = MarketDataSnapshot(
             symbol="AAPL",
-            last_price=Decimal("102.00"),
+            bid_price=Decimal("102.00"),
             timestamp=new_timestamp,
         )
 
@@ -599,7 +599,9 @@ class TestMarketContextSymbolChange:
                     None,
                     MarketDataSnapshot(
                         symbol="AAPL",
+                        bid_price=Decimal("101.00"),
                         last_price=Decimal("101.00"),
+                        volume=123456,
                         timestamp=old_timestamp,
                     ),
                 ),
@@ -609,9 +611,11 @@ class TestMarketContextSymbolChange:
             await component._fetch_initial_data("AAPL")
 
         assert component._data is not None
-        assert component._data.last_price == Decimal("102.00")
+        assert component._data.bid_price == Decimal("102.00")
+        assert component._data.last_price == Decimal("101.00")
+        assert component._data.volume == 123456
         assert component._data.timestamp == new_timestamp
-        mock_update_ui.assert_not_called()
+        mock_update_ui.assert_called_once()
 
 
 class TestMarketContextDispose:

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -230,6 +230,29 @@ class TestMarketContextPriceData:
         assert component._data is not None
         assert component._data.bid_price is None
 
+    def test_set_price_data_does_not_reuse_previous_symbol_fields(
+        self, component: MarketContextComponent
+    ) -> None:
+        """Partial ticks must not carry stale fields across symbols."""
+        component._current_symbol = "AAPL"
+        component._data = MarketDataSnapshot(
+            symbol="MSFT",
+            bid_price=Decimal("300.00"),
+            ask_price=Decimal("300.10"),
+            last_price=Decimal("300.05"),
+            volume=100,
+        )
+        component._last_ui_update = 0
+
+        component.set_price_data({"symbol": "AAPL", "bid": "101.00"})
+
+        assert component._data is not None
+        assert component._data.symbol == "AAPL"
+        assert component._data.bid_price == Decimal("101.00")
+        assert component._data.ask_price is None
+        assert component._data.last_price is None
+        assert component._data.volume is None
+
     def test_set_price_data_throttled(self, component: MarketContextComponent) -> None:
         """UI updates are throttled but data is always updated."""
         import time

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -409,8 +409,22 @@ class TestMarketContextSymbolChange:
                 "timestamp": timestamp.isoformat(),
             }
         )
-        client.fetch_historical_bars = AsyncMock(
-            return_value={
+        async def fetch_historical_bars(
+            *,
+            symbol: str,
+            timeframe: str,
+            limit: int,
+            user_id: str,
+            role: str,
+            strategies: list[str],
+        ) -> dict[str, list[dict[str, object]]]:
+            assert symbol == "AAPL"
+            assert limit == 1
+            assert user_id == "user-1"
+            assert role == "admin"
+            assert strategies == ["alpha"]
+            volume = 987654 if timeframe == "1Day" else 123456
+            return {
                 "bars": [
                     {
                         "timestamp": timestamp.isoformat(),
@@ -418,11 +432,12 @@ class TestMarketContextSymbolChange:
                         "high": 102.0,
                         "low": 99.0,
                         "close": 101.25,
-                        "volume": 123456,
+                        "volume": volume,
                     }
                 ]
             }
-        )
+
+        client.fetch_historical_bars = AsyncMock(side_effect=fetch_historical_bars)
         component = MarketContextComponent(
             trading_client=client,
             user_id="user-1",
@@ -439,20 +454,33 @@ class TestMarketContextSymbolChange:
         assert component._data.bid_size == 10
         assert component._data.ask_size == 20
         assert component._data.last_price == Decimal("101.25")
-        assert component._data.volume == 123456
+        assert component._data.volume == 987654
         client.fetch_latest_quote.assert_awaited_once_with(
             symbol="AAPL",
             user_id="user-1",
             role="admin",
             strategies=["alpha"],
         )
-        client.fetch_historical_bars.assert_awaited_once_with(
-            symbol="AAPL",
-            timeframe="5Min",
-            limit=1,
-            user_id="user-1",
-            role="admin",
-            strategies=["alpha"],
+        client.fetch_historical_bars.assert_has_awaits(
+            [
+                call(
+                    symbol="AAPL",
+                    timeframe="5Min",
+                    limit=1,
+                    user_id="user-1",
+                    role="admin",
+                    strategies=["alpha"],
+                ),
+                call(
+                    symbol="AAPL",
+                    timeframe="1Day",
+                    limit=1,
+                    user_id="user-1",
+                    role="admin",
+                    strategies=["alpha"],
+                ),
+            ],
+            any_order=True,
         )
 
 

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -578,6 +578,80 @@ class TestMarketContextSymbolChange:
         assert snapshot.timestamp == timestamp
 
     @pytest.mark.asyncio()
+    async def test_bar_seed_keeps_last_price_when_daily_volume_missing(self) -> None:
+        """Missing daily volume must not discard a valid last-price seed."""
+        timestamp = datetime.now(UTC)
+        client = MagicMock()
+
+        async def fetch_historical_bars(
+            *,
+            symbol: str,
+            timeframe: str,
+            limit: int,
+            user_id: str,
+            role: str,
+            strategies: list[str],
+        ) -> dict[str, list[dict[str, object]]]:
+            if timeframe == "1Day":
+                return {
+                    "bars": [
+                        {
+                            "timestamp": timestamp.isoformat(),
+                            "open": 100.0,
+                            "high": 102.0,
+                            "low": 99.0,
+                            "close": 101.25,
+                        }
+                    ]
+                }
+            return {
+                "bars": [
+                    {
+                        "timestamp": timestamp.isoformat(),
+                        "open": 100.0,
+                        "high": 102.0,
+                        "low": 99.0,
+                        "close": 101.25,
+                        "volume": 123456,
+                    }
+                ]
+            }
+
+        client.fetch_historical_bars = AsyncMock(side_effect=fetch_historical_bars)
+        component = MarketContextComponent(
+            trading_client=client,
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+        )
+
+        snapshot = await component._fetch_latest_bar_snapshot("AAPL")
+
+        assert snapshot is not None
+        assert snapshot.last_price == Decimal("101.25")
+        assert snapshot.volume is None
+        assert snapshot.timestamp == timestamp
+
+    def test_merge_snapshots_uses_freshest_timestamp(self) -> None:
+        """Merged seed freshness should reflect the newest quote or bar timestamp."""
+        old_timestamp = datetime(2026, 4, 20, 15, 0, tzinfo=UTC)
+        new_timestamp = datetime(2026, 4, 20, 15, 5, tzinfo=UTC)
+
+        snapshot = MarketContextComponent._merge_snapshots(
+            "AAPL",
+            MarketDataSnapshot(symbol="AAPL", bid_price=Decimal("101.00"), timestamp=old_timestamp),
+            MarketDataSnapshot(
+                symbol="AAPL",
+                last_price=Decimal("101.25"),
+                volume=123456,
+                timestamp=new_timestamp,
+            ),
+        )
+
+        assert snapshot is not None
+        assert snapshot.timestamp == new_timestamp
+
+    @pytest.mark.asyncio()
     async def test_quote_seed_normalizes_naive_timestamp_to_utc(self) -> None:
         """Naive quote timestamps should not break aware staleness calculations."""
         client = MagicMock()

--- a/tests/apps/web_console_ng/test_market_context.py
+++ b/tests/apps/web_console_ng/test_market_context.py
@@ -578,6 +578,35 @@ class TestMarketContextSymbolChange:
         assert snapshot.timestamp == timestamp
 
     @pytest.mark.asyncio()
+    async def test_quote_seed_normalizes_naive_timestamp_to_utc(self) -> None:
+        """Naive quote timestamps should not break aware staleness calculations."""
+        client = MagicMock()
+        client.fetch_latest_quote = AsyncMock(
+            return_value={
+                "symbol": "AAPL",
+                "bid_price": 101.2,
+                "ask_price": 101.3,
+                "timestamp": "2026-04-20T15:00:00",
+            }
+        )
+        component = MarketContextComponent(trading_client=client, user_id="user-1")
+
+        snapshot = await component._fetch_latest_quote_snapshot("AAPL")
+
+        assert snapshot is not None
+        assert snapshot.timestamp == datetime(2026, 4, 20, 15, 0, tzinfo=UTC)
+
+    def test_bar_parse_normalizes_naive_timestamp_to_utc(self) -> None:
+        """Naive bar timestamps should be normalized before staleness math."""
+        close, timestamp = MarketContextComponent._parse_bar_price(
+            {"close": "101.25", "timestamp": "2026-04-20T15:00:00"},
+            "AAPL",
+        )
+
+        assert close == Decimal("101.25")
+        assert timestamp == datetime(2026, 4, 20, 15, 0, tzinfo=UTC)
+
+    @pytest.mark.asyncio()
     async def test_initial_seed_merges_without_overwriting_newer_live_tick(self) -> None:
         """Older API seed fills gaps without replacing fresher live callback fields."""
         old_timestamp = datetime.now(UTC) - timedelta(minutes=1)

--- a/tests/apps/web_console_ng/test_market_data_calls.py
+++ b/tests/apps/web_console_ng/test_market_data_calls.py
@@ -11,8 +11,8 @@ from apps.web_console_ng.components.market_data_calls import call_market_data_cl
 
 
 @pytest.mark.asyncio()
-async def test_call_market_data_client_logs_strategy_context() -> None:
-    """Signature fallback logs include strategy_id context for traceability."""
+async def test_call_market_data_client_retries_type_error_with_legacy_signature() -> None:
+    """TypeError signature fallback retries legacy mode and logs strategy_id context."""
 
     async def client_call(**kwargs: object) -> dict[str, str]:
         if "user_id" in kwargs:
@@ -66,8 +66,8 @@ async def test_call_market_data_client_reraises_final_type_error() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_call_market_data_client_fallback_survives_first_unexpected_error() -> None:
-    """First-attempt client failures should not bypass the fallback signature mode."""
+async def test_call_market_data_client_reraises_first_unexpected_error() -> None:
+    """Non-signature client failures should not be retried as legacy calls."""
 
     async def client_call(**kwargs: object) -> dict[str, str]:
         if "user_id" in kwargs:
@@ -76,18 +76,18 @@ async def test_call_market_data_client_fallback_survives_first_unexpected_error(
 
     logger = MagicMock(spec=logging.Logger)
 
-    response = await call_market_data_client(
-        client_call,
-        request_kwargs={"symbol": "AAPL"},
-        user_id="user-1",
-        role="admin",
-        strategies=["alpha"],
-        logger=logger,
-        operation="test_operation",
-        symbol="AAPL",
-    )
+    with pytest.raises(RuntimeError, match="auth wrapper unavailable"):
+        await call_market_data_client(
+            client_call,
+            request_kwargs={"symbol": "AAPL"},
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+            logger=logger,
+            operation="test_operation",
+            symbol="AAPL",
+        )
 
-    assert response == {"symbol": "AAPL"}
     logger.debug.assert_called_once()
     _, kwargs = logger.debug.call_args
     assert kwargs["extra"]["strategy_id"] == "alpha"

--- a/tests/apps/web_console_ng/test_market_data_calls.py
+++ b/tests/apps/web_console_ng/test_market_data_calls.py
@@ -1,0 +1,94 @@
+"""Tests for shared web-console market data call helpers."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from apps.web_console_ng.components.market_data_calls import call_market_data_client
+
+
+@pytest.mark.asyncio()
+async def test_call_market_data_client_logs_strategy_context() -> None:
+    """Signature fallback logs include strategy_id context for traceability."""
+
+    async def client_call(**kwargs: object) -> dict[str, str]:
+        if "user_id" in kwargs:
+            raise TypeError("legacy client")
+        return {"symbol": str(kwargs["symbol"])}
+
+    logger = MagicMock(spec=logging.Logger)
+
+    response = await call_market_data_client(
+        client_call,
+        request_kwargs={"symbol": "AAPL"},
+        user_id="user-1",
+        role="admin",
+        strategies=["alpha", "beta"],
+        logger=logger,
+        operation="test_operation",
+        symbol="AAPL",
+    )
+
+    assert response == {"symbol": "AAPL"}
+    logger.debug.assert_called_once()
+    _, kwargs = logger.debug.call_args
+    assert kwargs["extra"]["strategy_id"] == "alpha,beta"
+
+
+@pytest.mark.asyncio()
+async def test_call_market_data_client_reraises_final_type_error() -> None:
+    """A final TypeError is logged and re-raised instead of being masked as no data."""
+
+    async def client_call(**kwargs: object) -> None:
+        raise TypeError("internal client failure")
+
+    logger = MagicMock(spec=logging.Logger)
+
+    with pytest.raises(TypeError, match="internal client failure"):
+        await call_market_data_client(
+            client_call,
+            request_kwargs={"symbol": "AAPL"},
+            user_id="user-1",
+            role="admin",
+            strategies=["alpha"],
+            logger=logger,
+            operation="test_operation",
+            symbol="AAPL",
+        )
+
+    assert logger.debug.call_count == 2
+    _, kwargs = logger.debug.call_args
+    assert kwargs["extra"]["strategy_id"] == "alpha"
+    assert kwargs["extra"]["attempt_mode"] == "legacy"
+
+
+@pytest.mark.asyncio()
+async def test_call_market_data_client_fallback_survives_first_unexpected_error() -> None:
+    """First-attempt client failures should not bypass the fallback signature mode."""
+
+    async def client_call(**kwargs: object) -> dict[str, str]:
+        if "user_id" in kwargs:
+            raise RuntimeError("auth wrapper unavailable")
+        return {"symbol": str(kwargs["symbol"])}
+
+    logger = MagicMock(spec=logging.Logger)
+
+    response = await call_market_data_client(
+        client_call,
+        request_kwargs={"symbol": "AAPL"},
+        user_id="user-1",
+        role="admin",
+        strategies=["alpha"],
+        logger=logger,
+        operation="test_operation",
+        symbol="AAPL",
+    )
+
+    assert response == {"symbol": "AAPL"}
+    logger.debug.assert_called_once()
+    _, kwargs = logger.debug.call_args
+    assert kwargs["extra"]["strategy_id"] == "alpha"
+    assert kwargs["extra"]["attempt_mode"] == "auth"

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -649,6 +649,7 @@ class TestPriceChartSymbolChange:
     ) -> None:
         """Older timeframe reloads must not overwrite the currently selected interval."""
         component._selected_timeframe = "1Day"
+        component._live_bucket_interval_seconds = 86400
         candles = [CandleData(time=1, open=100, high=100, low=100, close=100, volume=1)]
         with (
             patch.object(component, "_ensure_chart_initialized", new_callable=AsyncMock),
@@ -660,6 +661,7 @@ class TestPriceChartSymbolChange:
             await component.on_symbol_changed("AAPL", expected_timeframe="5Min")
 
         assert component._candles == []
+        assert component._live_bucket_interval_seconds == 86400
         mock_hide.assert_not_called()
         mock_update.assert_not_called()
 

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -644,6 +644,26 @@ class TestPriceChartSymbolChange:
         mock_show.assert_not_called()
 
     @pytest.mark.asyncio()
+    async def test_stale_timeframe_reload_does_not_update_chart(
+        self, component: PriceChartComponent
+    ) -> None:
+        """Older timeframe reloads must not overwrite the currently selected interval."""
+        component._selected_timeframe = "1Day"
+        candles = [CandleData(time=1, open=100, high=100, low=100, close=100, volume=1)]
+        with (
+            patch.object(component, "_ensure_chart_initialized", new_callable=AsyncMock),
+            patch.object(component, "_fetch_candle_data", return_value=candles),
+            patch.object(component, "_fetch_execution_markers", return_value=[]),
+            patch.object(component, "_update_chart_data", new_callable=AsyncMock) as mock_update,
+            patch.object(component, "_hide_no_data_overlay", new_callable=AsyncMock) as mock_hide,
+        ):
+            await component.on_symbol_changed("AAPL", expected_timeframe="5Min")
+
+        assert component._candles == []
+        mock_hide.assert_not_called()
+        mock_update.assert_not_called()
+
+    @pytest.mark.asyncio()
     async def test_symbol_change_to_none_clears_symbol_changed_at(
         self, component: PriceChartComponent
     ) -> None:

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -744,32 +744,26 @@ class TestPriceChartHistoricalBars:
         assert candles == []
         assert component._client.calls == [  # type: ignore[attr-defined]
             ("MSFT", "5Min", 240),
-            ("MSFT", "15Min", 240),
-            ("MSFT", "1Hour", 200),
-            ("MSFT", "1Day", 120),
         ]
-        assert component._live_bucket_interval_seconds == component.CANDLE_INTERVAL_SECONDS
+        assert component._live_bucket_interval_seconds == 300
 
     @pytest.mark.asyncio()
-    async def test_fetch_candle_data_tracks_fallback_interval_for_live_bucketing(self) -> None:
-        """Fallback historical interval should drive subsequent realtime bucket sizing."""
+    async def test_fetch_candle_data_uses_selected_timeframe_for_live_bucketing(self) -> None:
+        """Selected chart interval should drive historical request and realtime buckets."""
         client = MagicMock()
         client.fetch_historical_bars = AsyncMock(
-            side_effect=[
-                {"bars": []},  # 5Min unavailable
-                {
-                    "bars": [
-                        {
-                            "timestamp": "2026-04-20T13:30:00Z",
-                            "open": 180.1,
-                            "high": 181.0,
-                            "low": 179.9,
-                            "close": 180.6,
-                            "volume": 1200,
-                        },
-                    ]
-                },
-            ]
+            return_value={
+                "bars": [
+                    {
+                        "timestamp": "2026-04-20T13:30:00Z",
+                        "open": 180.1,
+                        "high": 181.0,
+                        "low": 179.9,
+                        "close": 180.6,
+                        "volume": 1200,
+                    },
+                ]
+            }
         )
         component = PriceChartComponent(
             trading_client=client,
@@ -777,12 +771,28 @@ class TestPriceChartHistoricalBars:
             role="trader",
             strategies=["alpha"],
         )
+        component._selected_timeframe = "1Min"
 
         candles = await component._fetch_candle_data("AAPL")
 
         assert len(candles) == 1
-        assert component._live_bucket_interval_seconds == 900
-        assert client.fetch_historical_bars.await_count == 2
+        assert component._live_bucket_interval_seconds == 60
+        client.fetch_historical_bars.assert_awaited_once_with(
+            symbol="AAPL",
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+            timeframe="1Min",
+            limit=390,
+        )
+
+    def test_chart_header_text_includes_symbol_and_timeframe(self) -> None:
+        component = PriceChartComponent(trading_client=MagicMock())
+        component._current_symbol = "SPY"
+        component._selected_timeframe = "15Min"
+
+        assert component._chart_title_text() == "SPY Price Chart"
+        assert component._chart_subtitle_text() == "Alpaca · 15-minute bars"
 
 
 class TestPriceChartExecutionMarkers:

--- a/tests/apps/web_console_ng/test_price_chart.py
+++ b/tests/apps/web_console_ng/test_price_chart.py
@@ -770,6 +770,23 @@ class TestPriceChartHistoricalBars:
         assert component._live_bucket_interval_seconds == 300
 
     @pytest.mark.asyncio()
+    async def test_fetch_candle_data_degrades_on_market_data_failure(self) -> None:
+        """Historical API failures should render no-data instead of aborting symbol loads."""
+        client = MagicMock()
+        client.fetch_historical_bars = AsyncMock(side_effect=RuntimeError("market data down"))
+        component = PriceChartComponent(
+            trading_client=client,
+            user_id="user-1",
+            role="trader",
+            strategies=["alpha"],
+        )
+
+        candles = await component._fetch_candle_data("AAPL")
+
+        assert candles == []
+        client.fetch_historical_bars.assert_awaited_once()
+
+    @pytest.mark.asyncio()
     async def test_fetch_candle_data_uses_selected_timeframe_for_live_bucketing(self) -> None:
         """Selected chart interval should drive historical request and realtime buckets."""
         client = MagicMock()

--- a/tests/libs/data/market_data/test_alpaca_stream.py
+++ b/tests/libs/data/market_data/test_alpaca_stream.py
@@ -358,6 +358,10 @@ class TestQuoteHandling:
         assert isinstance(event, PriceUpdateEvent)
         assert event.symbol == "AAPL"
         assert event.price == Decimal("100.05")
+        assert event.bid == Decimal("100.00")
+        assert event.ask == Decimal("100.10")
+        assert event.bid_size == 10
+        assert event.ask_size == 12
 
     @pytest.mark.asyncio()
     async def test_handle_quote_alpaca_object_success(

--- a/tests/libs/data/market_data/test_provider.py
+++ b/tests/libs/data/market_data/test_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -119,8 +120,8 @@ def test_get_latest_quote_sync_normalizes_top_of_book(
     assert captured_kwargs["feed"] == "iex"
     assert quote == {
         "symbol": "AAPL",
-        "bid_price": 180.1,
-        "ask_price": 180.2,
+        "bid_price": Decimal("180.1"),
+        "ask_price": Decimal("180.2"),
         "bid_size": 100,
         "ask_size": 200,
         "timestamp": "2026-04-20T15:00:00+00:00",
@@ -160,8 +161,8 @@ def test_get_latest_quote_sync_reads_alpaca_response_data(
 
     assert quote == {
         "symbol": "AAPL",
-        "bid_price": 0.0,
-        "ask_price": 180.2,
+        "bid_price": Decimal("0.0"),
+        "ask_price": Decimal("180.2"),
         "bid_size": 0,
         "ask_size": 200,
         "timestamp": "2026-04-20T15:00:00+00:00",
@@ -199,8 +200,8 @@ def test_get_latest_quote_sync_reads_dict_quote_fields(
 
     assert quote == {
         "symbol": "AAPL",
-        "bid_price": 179.9,
-        "ask_price": 180.0,
+        "bid_price": Decimal("179.9"),
+        "ask_price": Decimal("180.0"),
         "bid_size": 10,
         "ask_size": 20,
         "timestamp": "2026-04-20T15:00:00+00:00",

--- a/tests/libs/data/market_data/test_provider.py
+++ b/tests/libs/data/market_data/test_provider.py
@@ -83,6 +83,50 @@ def test_get_bars_sync_requests_latest_window_with_desc_sort(monkeypatch: pytest
     assert bars[0]["timestamp"] == "2026-04-20T15:00:00+00:00"
 
 
+def test_get_latest_quote_sync_normalizes_top_of_book(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MarketDataProvider.__new__(MarketDataProvider)
+    provider._data_feed = "iex"
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_latest_quote_request(**kwargs: object) -> dict[str, object]:
+        captured_kwargs.update(kwargs)
+        return kwargs
+
+    class FakeClient:
+        def get_stock_latest_quote(self, request: object) -> dict[str, SimpleNamespace]:
+            return {
+                "AAPL": SimpleNamespace(
+                    bp=180.1,
+                    ap=180.2,
+                    bs=100,
+                    **{"as": 200},
+                    timestamp="2026-04-20T15:00:00+00:00",
+                )
+            }
+
+    provider._client = FakeClient()
+    monkeypatch.setattr(
+        "libs.data.market_data.provider.StockLatestQuoteRequest",
+        fake_latest_quote_request,
+    )
+
+    quote = provider._get_latest_quote_sync("aapl")
+
+    assert captured_kwargs["symbol_or_symbols"] == "AAPL"
+    assert captured_kwargs["feed"] == "iex"
+    assert quote == {
+        "symbol": "AAPL",
+        "bid_price": 180.1,
+        "ask_price": 180.2,
+        "bid_size": 100,
+        "ask_size": 200,
+        "timestamp": "2026-04-20T15:00:00+00:00",
+    }
+
+
 def test_get_bars_sync_sorts_results_chronologically(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = MarketDataProvider.__new__(MarketDataProvider)
     provider._data_feed = None

--- a/tests/libs/data/market_data/test_provider.py
+++ b/tests/libs/data/market_data/test_provider.py
@@ -127,6 +127,86 @@ def test_get_latest_quote_sync_normalizes_top_of_book(
     }
 
 
+def test_get_latest_quote_sync_reads_alpaca_response_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MarketDataProvider.__new__(MarketDataProvider)
+    provider._data_feed = None
+
+    def fake_latest_quote_request(**kwargs: object) -> dict[str, object]:
+        return kwargs
+
+    class FakeClient:
+        def get_stock_latest_quote(self, request: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                data={
+                    "AAPL": SimpleNamespace(
+                        bid_price=0.0,
+                        ask_price=180.2,
+                        bid_size=0,
+                        ask_size=200,
+                        timestamp="2026-04-20T15:00:00+00:00",
+                    )
+                }
+            )
+
+    provider._client = FakeClient()
+    monkeypatch.setattr(
+        "libs.data.market_data.provider.StockLatestQuoteRequest",
+        fake_latest_quote_request,
+    )
+
+    quote = provider._get_latest_quote_sync("AAPL")
+
+    assert quote == {
+        "symbol": "AAPL",
+        "bid_price": 0.0,
+        "ask_price": 180.2,
+        "bid_size": 0,
+        "ask_size": 200,
+        "timestamp": "2026-04-20T15:00:00+00:00",
+    }
+
+
+def test_get_latest_quote_sync_reads_dict_quote_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = MarketDataProvider.__new__(MarketDataProvider)
+    provider._data_feed = None
+
+    def fake_latest_quote_request(**kwargs: object) -> dict[str, object]:
+        return kwargs
+
+    class FakeClient:
+        def get_stock_latest_quote(self, request: object) -> dict[str, dict[str, object]]:
+            return {
+                "AAPL": {
+                    "bid_price": 179.9,
+                    "ask_price": 180.0,
+                    "bid_size": 10,
+                    "ask_size": 20,
+                    "timestamp": "2026-04-20T15:00:00+00:00",
+                }
+            }
+
+    provider._client = FakeClient()
+    monkeypatch.setattr(
+        "libs.data.market_data.provider.StockLatestQuoteRequest",
+        fake_latest_quote_request,
+    )
+
+    quote = provider._get_latest_quote_sync("AAPL")
+
+    assert quote == {
+        "symbol": "AAPL",
+        "bid_price": 179.9,
+        "ask_price": 180.0,
+        "bid_size": 10,
+        "ask_size": 20,
+        "timestamp": "2026-04-20T15:00:00+00:00",
+    }
+
+
 def test_get_bars_sync_sorts_results_chronologically(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = MarketDataProvider.__new__(MarketDataProvider)
     provider._data_feed = None

--- a/tests/libs/data/market_data/test_types.py
+++ b/tests/libs/data/market_data/test_types.py
@@ -76,3 +76,10 @@ def test_price_update_event_from_quote(quote: QuoteData) -> None:
     assert event.symbol == quote.symbol
     assert event.price == quote.mid_price
     assert event.timestamp == quote.timestamp.isoformat()
+    assert event.bid == quote.bid_price
+    assert event.ask == quote.ask_price
+    assert event.bid_price == quote.bid_price
+    assert event.ask_price == quote.ask_price
+    assert event.bid_size == quote.bid_size
+    assert event.ask_size == quote.ask_size
+    assert event.exchange == quote.exchange


### PR DESCRIPTION
## Summary

- Enrich trade page Level 1 market data so BID, ASK, spread, last, and volume populate from real Alpaca quote/bar data.
- Add a market-data-service latest-quote endpoint backed by Alpaca `StockLatestQuoteRequest`.
- Disable implicit synthetic L2/order-book data; mock depth now requires explicit `ALPACA_L2_USE_MOCK=true`.
- Add a trade chart header showing the selected symbol and selectable bar units: `1m`, `5m`, `15m`, `1h`, `1d`.

## Root Cause

The trade UI consumed quote pub/sub payloads that previously carried only `symbol`, `price`, and `timestamp`, so the Level 1 quote card did not receive bid/ask sizes or spread fields. Volume also needed a bar seed because quote ticks do not carry cumulative volume. The L2 panel was later made non-empty by a local dev synthetic fallback, but that was misleading without explicit mock opt-in.

## Validation

- `ruff check` on touched Python files.
- `mypy --strict` on touched web-console and market-data modules.
- Focused pytest suites for market data events, Alpaca stream conversion, market context, L2 entitlement, provider/latest quote, and price chart controls.
- Live local browser verification on `http://localhost:8080/` confirmed no implicit mock L2 label and real Level 1 BID/ASK/SPREAD/LAST/VOLUME render after service restart.
- Gemini and Claude reviewed the changes and approved.