### PR TITLE
[codex] Add manifest-backed data page foundation

### DIFF
--- a/apps/web_console_ng/components/data_context_ribbon.py
+++ b/apps/web_console_ng/components/data_context_ribbon.py
@@ -1,0 +1,75 @@
+"""Context ribbon for data manifest transparency."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_management_common import format_datetime
+from apps.web_console_ng.components.data_operations_grid import build_manifest_grid_rows
+from libs.web_console_services.data_manifest_service import AlpacaSipManifestSummaryDTO
+
+
+def build_manifest_context_metrics(
+    summary: AlpacaSipManifestSummaryDTO,
+) -> list[dict[str, Any]]:
+    """Build compact context metrics for the manifest transparency ribbon."""
+    healthy = sum(
+        1
+        for manifest in summary.manifests
+        if manifest.validation_status == "passed"
+    )
+    failed = sum(
+        1
+        for manifest in summary.manifests
+        if manifest.validation_status != "passed"
+    )
+    issue_count = len(summary.warnings) + failed
+    rows = build_manifest_grid_rows(summary)
+    blocked_for_backtest = sum(
+        1 for row in rows if str(row["readiness"]).startswith("blocked:")
+    )
+    latest_sync = summary.latest_sync
+    oldest_sync = min(
+        (manifest.sync_timestamp for manifest in summary.manifests),
+        default=None,
+    )
+    return [
+        {"label": "Healthy", "value": healthy, "tone": "positive"},
+        {"label": "Missing", "value": len(summary.missing_datasets), "tone": "negative"},
+        {
+            "label": "Untrusted",
+            "value": len(summary.missing_datasets) + failed,
+            "tone": "warning",
+        },
+        {"label": "Backtest Blocked", "value": blocked_for_backtest, "tone": "warning"},
+        {"label": "Issues", "value": issue_count, "tone": "negative" if issue_count else "positive"},
+        {"label": "Rows", "value": f"{summary.row_count:,}", "tone": "neutral"},
+        {"label": "Latest Manifest", "value": format_datetime(latest_sync), "tone": "neutral"},
+        {"label": "Oldest Manifest", "value": format_datetime(oldest_sync), "tone": "neutral"},
+    ]
+
+
+def render_manifest_context_ribbon(summary: AlpacaSipManifestSummaryDTO) -> None:
+    """Render top-level manifest state metrics."""
+    metrics = build_manifest_context_metrics(summary)
+    with ui.row().classes("w-full gap-2 flex-wrap"):
+        for metric in metrics:
+            tone_class = _tone_class(str(metric["tone"]))
+            with ui.card().classes(f"px-3 py-2 min-w-[108px] border {tone_class}"):
+                ui.label(str(metric["label"])).classes("text-xs text-gray-500")
+                ui.label(str(metric["value"])).classes("text-base font-bold")
+
+
+def _tone_class(tone: str) -> str:
+    if tone == "positive":
+        return "border-green-300"
+    if tone == "negative":
+        return "border-red-300"
+    if tone == "warning":
+        return "border-amber-300"
+    return "border-gray-200"
+
+
+__all__ = ["build_manifest_context_metrics", "render_manifest_context_ribbon"]

--- a/apps/web_console_ng/components/data_context_ribbon.py
+++ b/apps/web_console_ng/components/data_context_ribbon.py
@@ -8,8 +8,10 @@ from nicegui import ui
 
 from apps.web_console_ng.components.data_management_common import format_datetime
 from libs.web_console_services.data_manifest_service import (
-    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_MANIFEST_DATASETS,
     AlpacaSipManifestSummaryDTO,
+    ManifestSummaryDTO,
 )
 
 
@@ -20,12 +22,7 @@ def build_manifest_context_metrics(
     healthy = sum(1 for manifest in summary.manifests if manifest.validation_status == "passed")
     failed = sum(1 for manifest in summary.manifests if manifest.validation_status != "passed")
     issue_count = len(summary.warnings) + failed
-    corp_actions_ok = any(
-        manifest.dataset == ALPACA_SIP_CORP_ACTIONS_DATASET
-        and manifest.validation_status == "passed"
-        for manifest in summary.manifests
-    )
-    blocked_for_backtest = 2 - (1 if corp_actions_ok else 0)
+    blocked_for_backtest = _count_backtest_blocked_rows(summary)
     latest_sync = summary.latest_sync
     oldest_sync = min(
         (manifest.sync_timestamp for manifest in summary.manifests),
@@ -69,6 +66,25 @@ def _tone_class(tone: str) -> str:
         "warning": "border-amber-300",
     }
     return tone_map.get(tone, "border-gray-200")
+
+
+def _count_backtest_blocked_rows(summary: AlpacaSipManifestSummaryDTO) -> int:
+    manifests_by_dataset = {manifest.dataset: manifest for manifest in summary.manifests}
+    return sum(
+        int(_dataset_blocks_backtest(dataset, manifests_by_dataset.get(dataset)))
+        for dataset in ALPACA_SIP_MANIFEST_DATASETS
+    )
+
+
+def _dataset_blocks_backtest(
+    dataset: str,
+    manifest: ManifestSummaryDTO | None,
+) -> bool:
+    if manifest is None or manifest.validation_status != "passed":
+        return True
+    if dataset == ALPACA_SIP_DAILY_DATASET:
+        return manifest.read_time_adjustment_mode != "available"
+    return False
 
 
 __all__ = ["build_manifest_context_metrics", "render_manifest_context_ribbon"]

--- a/apps/web_console_ng/components/data_context_ribbon.py
+++ b/apps/web_console_ng/components/data_context_ribbon.py
@@ -7,29 +7,25 @@ from typing import Any
 from nicegui import ui
 
 from apps.web_console_ng.components.data_management_common import format_datetime
-from apps.web_console_ng.components.data_operations_grid import build_manifest_grid_rows
-from libs.web_console_services.data_manifest_service import AlpacaSipManifestSummaryDTO
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    AlpacaSipManifestSummaryDTO,
+)
 
 
 def build_manifest_context_metrics(
     summary: AlpacaSipManifestSummaryDTO,
 ) -> list[dict[str, Any]]:
     """Build compact context metrics for the manifest transparency ribbon."""
-    healthy = sum(
-        1
-        for manifest in summary.manifests
-        if manifest.validation_status == "passed"
-    )
-    failed = sum(
-        1
-        for manifest in summary.manifests
-        if manifest.validation_status != "passed"
-    )
+    healthy = sum(1 for manifest in summary.manifests if manifest.validation_status == "passed")
+    failed = sum(1 for manifest in summary.manifests if manifest.validation_status != "passed")
     issue_count = len(summary.warnings) + failed
-    rows = build_manifest_grid_rows(summary)
-    blocked_for_backtest = sum(
-        1 for row in rows if str(row["readiness"]).startswith("blocked:")
+    corp_actions_ok = any(
+        manifest.dataset == ALPACA_SIP_CORP_ACTIONS_DATASET
+        and manifest.validation_status == "passed"
+        for manifest in summary.manifests
     )
+    blocked_for_backtest = 2 - (1 if corp_actions_ok else 0)
     latest_sync = summary.latest_sync
     oldest_sync = min(
         (manifest.sync_timestamp for manifest in summary.manifests),
@@ -44,7 +40,11 @@ def build_manifest_context_metrics(
             "tone": "warning",
         },
         {"label": "Backtest Blocked", "value": blocked_for_backtest, "tone": "warning"},
-        {"label": "Issues", "value": issue_count, "tone": "negative" if issue_count else "positive"},
+        {
+            "label": "Issues",
+            "value": issue_count,
+            "tone": "negative" if issue_count else "positive",
+        },
         {"label": "Rows", "value": f"{summary.row_count:,}", "tone": "neutral"},
         {"label": "Latest Manifest", "value": format_datetime(latest_sync), "tone": "neutral"},
         {"label": "Oldest Manifest", "value": format_datetime(oldest_sync), "tone": "neutral"},
@@ -63,13 +63,12 @@ def render_manifest_context_ribbon(summary: AlpacaSipManifestSummaryDTO) -> None
 
 
 def _tone_class(tone: str) -> str:
-    if tone == "positive":
-        return "border-green-300"
-    if tone == "negative":
-        return "border-red-300"
-    if tone == "warning":
-        return "border-amber-300"
-    return "border-gray-200"
+    tone_map = {
+        "positive": "border-green-300",
+        "negative": "border-red-300",
+        "warning": "border-amber-300",
+    }
+    return tone_map.get(tone, "border-gray-200")
 
 
 __all__ = ["build_manifest_context_metrics", "render_manifest_context_ribbon"]

--- a/apps/web_console_ng/components/data_detail_drawer.py
+++ b/apps/web_console_ng/components/data_detail_drawer.py
@@ -15,6 +15,16 @@ from libs.web_console_services.data_manifest_service import (
     ManifestSummaryDTO,
 )
 
+_CANONICAL_STORAGE_MODES = {
+    ALPACA_SIP_DAILY_DATASET: "raw",
+    ALPACA_SIP_CORP_ACTIONS_DATASET: "not price bars",
+}
+
+_READ_TIME_ADJUSTMENT_MODES = {
+    ALPACA_SIP_DAILY_DATASET: "unavailable",
+    ALPACA_SIP_CORP_ACTIONS_DATASET: "not applicable",
+}
+
 
 def build_manifest_detail_fields(
     summary: AlpacaSipManifestSummaryDTO,
@@ -123,19 +133,11 @@ def _present_detail_fields(
 
 
 def _canonical_storage_mode(dataset: str) -> str:
-    if dataset == ALPACA_SIP_DAILY_DATASET:
-        return "raw"
-    if dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
-        return "not price bars"
-    return "-"
+    return _CANONICAL_STORAGE_MODES.get(dataset, "-")
 
 
 def _read_time_adjustment_mode(dataset: str) -> str:
-    if dataset == ALPACA_SIP_DAILY_DATASET:
-        return "unavailable"
-    if dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
-        return "not applicable"
-    return "-"
+    return _READ_TIME_ADJUSTMENT_MODES.get(dataset, "-")
 
 
 def _value(value: Any) -> str:

--- a/apps/web_console_ng/components/data_detail_drawer.py
+++ b/apps/web_console_ng/components/data_detail_drawer.py
@@ -1,0 +1,162 @@
+"""Selected-row manifest detail surface for the data page."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_management_common import format_datetime
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    AlpacaSipManifestSummaryDTO,
+    ManifestSummaryDTO,
+)
+
+
+def build_manifest_detail_fields(
+    summary: AlpacaSipManifestSummaryDTO,
+    dataset: str,
+) -> list[dict[str, str]]:
+    """Build compact detail fields for a selected manifest row."""
+    manifest = next(
+        (item for item in summary.manifests if item.dataset == dataset),
+        None,
+    )
+    if manifest is None:
+        return _missing_detail_fields(summary, dataset)
+    return _present_detail_fields(summary, manifest)
+
+
+def render_manifest_detail_drawer(
+    summary: AlpacaSipManifestSummaryDTO,
+    dataset: str,
+) -> None:
+    """Render detail fields for a selected dataset."""
+    fields = build_manifest_detail_fields(summary, dataset)
+    columns = [
+        {"name": "field", "label": "Field", "field": "field"},
+        {"name": "value", "label": "Value", "field": "value"},
+    ]
+    ui.table(columns=columns, rows=fields).classes("w-full")
+
+
+def _missing_detail_fields(
+    summary: AlpacaSipManifestSummaryDTO,
+    dataset: str,
+) -> list[dict[str, str]]:
+    blockers = ["alpaca_sip_untrusted_without_manifest"]
+    if dataset == ALPACA_SIP_DAILY_DATASET:
+        blockers.append("raw_sip_returns_unavailable")
+    return [
+        {"field": "Dataset", "value": dataset},
+        {"field": "Local state", "value": "missing"},
+        {"field": "Manifest status", "value": "missing"},
+        {"field": "Trusted manifest-backed", "value": "false"},
+        {"field": "Readiness", "value": "blocked"},
+        {"field": "Reason codes", "value": ", ".join(blockers)},
+        {"field": "Manifest provenance", "value": "unavailable"},
+        {"field": "Provider signature", "value": "unavailable"},
+        {"field": "Canonical storage mode", "value": _canonical_storage_mode(dataset)},
+        {"field": "Read-time adjustment mode", "value": _read_time_adjustment_mode(dataset)},
+        {"field": "Group status", "value": summary.sync_validation_status},
+    ]
+
+
+def _present_detail_fields(
+    summary: AlpacaSipManifestSummaryDTO,
+    manifest: ManifestSummaryDTO,
+) -> list[dict[str, str]]:
+    signature = manifest.provider_signature.model_dump(exclude_none=True)
+    warnings = [
+        warning
+        for warning in summary.warnings
+        if not warning.startswith("alpaca_sip_missing_manifest:")
+    ]
+    validation_ok = manifest.validation_status == "passed"
+    readiness = _readiness_for_present_manifest(manifest, warnings)
+    fields = [
+        {"field": "Dataset", "value": manifest.dataset},
+        {"field": "Local state", "value": "present"},
+        {"field": "Manifest status", "value": manifest.validation_status},
+        {"field": "Trusted manifest-backed", "value": str(validation_ok).lower()},
+        {"field": "Readiness", "value": readiness},
+        {"field": "Manifest ID", "value": _value(manifest.manifest_id)},
+        {"field": "Manifest reference", "value": manifest.manifest_reference},
+        {"field": "Manifest checksum", "value": manifest.manifest_checksum},
+        {"field": "Manifest version", "value": str(manifest.manifest_version)},
+        {"field": "Schema version", "value": manifest.schema_version},
+        {"field": "Row count", "value": f"{manifest.row_count:,}"},
+        {"field": "File count", "value": str(manifest.file_count)},
+        {"field": "Date range", "value": f"{manifest.start_date} to {manifest.end_date}"},
+        {"field": "Last sync", "value": format_datetime(manifest.sync_timestamp)},
+        {"field": "Sync started", "value": format_datetime(manifest.sync_started_at)},
+        {"field": "Sync finished", "value": format_datetime(manifest.sync_finished_at)},
+        {"field": "Provider ID", "value": _value(manifest.provider_id)},
+        {"field": "Provider version", "value": _value(manifest.provider_version)},
+        {"field": "Source feed", "value": _value(manifest.source_feed)},
+        {"field": "Adjustment mode", "value": _value(manifest.adjustment_mode)},
+        {"field": "Canonical storage mode", "value": _canonical_storage_mode(manifest.dataset)},
+        {
+            "field": "Read-time adjustment mode",
+            "value": _read_time_adjustment_mode(manifest.dataset),
+        },
+        {"field": "Symbol set hash", "value": _value(manifest.symbol_set_hash)},
+        {"field": "Query/params hash", "value": _value(manifest.query_params_hash)},
+        {"field": "Warnings", "value": ", ".join(warnings) if warnings else "-"},
+        {
+            "field": "Provider signature",
+            "value": json.dumps(signature, default=str, sort_keys=True),
+        },
+    ]
+    if manifest.dataset == ALPACA_SIP_DAILY_DATASET:
+        fields.extend(
+            [
+                {"field": "adj_close", "value": "not available"},
+                {"field": "ret", "value": "not available"},
+                {"field": "Backtest readiness", "value": readiness},
+            ]
+        )
+    return fields
+
+
+def _canonical_storage_mode(dataset: str) -> str:
+    if dataset == ALPACA_SIP_DAILY_DATASET:
+        return "raw"
+    if dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
+        return "not price bars"
+    return "-"
+
+
+def _read_time_adjustment_mode(dataset: str) -> str:
+    if dataset == ALPACA_SIP_DAILY_DATASET:
+        return "unavailable"
+    if dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
+        return "not applicable"
+    return "-"
+
+
+def _value(value: Any) -> str:
+    return "-" if value is None else str(value)
+
+
+def _readiness_for_present_manifest(
+    manifest: ManifestSummaryDTO,
+    warnings: list[str],
+) -> str:
+    is_daily = manifest.dataset == ALPACA_SIP_DAILY_DATASET
+    if manifest.validation_status != "passed":
+        readiness = "blocked: untrusted_manifest_validation_failed"
+        if is_daily:
+            readiness = f"{readiness}; raw_sip_returns_unavailable"
+        return readiness
+    if is_daily:
+        return "blocked: raw_sip_returns_unavailable"
+    if warnings:
+        return "warn: companion manifest issue"
+    return "corporate actions only"
+
+
+__all__ = ["build_manifest_detail_fields", "render_manifest_detail_drawer"]

--- a/apps/web_console_ng/components/data_management_common.py
+++ b/apps/web_console_ng/components/data_management_common.py
@@ -1,0 +1,32 @@
+"""Shared helpers for data-management UI components."""
+
+from __future__ import annotations
+
+from typing import Any
+
+TREND_DATASETS: tuple[str, ...] = (
+    "crsp",
+    "compustat",
+    "taq",
+    "fama_french",
+    "alpaca_sip",
+)
+
+
+def format_datetime(dt: Any) -> str:
+    """Format a datetime for display, handling None and non-datetime values."""
+    if dt is not None and hasattr(dt, "isoformat"):
+        return str(dt.isoformat())
+    return "-"
+
+
+def get_user_id_safe(user: Any) -> str | None:
+    """Extract user_id from user dict or object safely."""
+    if isinstance(user, dict):
+        val = user.get("id")
+        return str(val) if val is not None else None
+    val = getattr(user, "id", None)
+    return str(val) if val is not None else None
+
+
+__all__ = ["TREND_DATASETS", "format_datetime", "get_user_id_safe"]

--- a/apps/web_console_ng/components/data_manifest_panel.py
+++ b/apps/web_console_ng/components/data_manifest_panel.py
@@ -1,0 +1,87 @@
+"""Manifest transparency panel for the data-management page."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_context_ribbon import (
+    render_manifest_context_ribbon,
+)
+from apps.web_console_ng.components.data_detail_drawer import (
+    render_manifest_detail_drawer,
+)
+from apps.web_console_ng.components.data_operations_grid import (
+    build_manifest_grid_rows,
+    render_manifest_operations_grid,
+)
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_DAILY_DATASET,
+    AlpacaSipManifestSummaryDTO,
+)
+
+
+def render_manifest_transparency_panel(
+    summary: AlpacaSipManifestSummaryDTO,
+) -> None:
+    """Render Phase 1 manifest transparency UI for Alpaca SIP."""
+    rows = build_manifest_grid_rows(summary)
+    selected_dataset = _default_selected_dataset(rows)
+
+    with ui.column().classes("w-full p-4 mb-4 border border-gray-200 rounded"):
+        with ui.row().classes("w-full items-center justify-between gap-4"):
+            ui.label("Manifest Transparency").classes("text-lg font-bold")
+            ui.label(_group_status_text(summary)).classes("text-sm text-gray-600")
+
+        render_manifest_context_ribbon(summary)
+
+        if summary.warnings:
+            with ui.row().classes("w-full gap-2 mt-3 flex-wrap"):
+                for warning in summary.warnings:
+                    ui.label(warning).classes(
+                        "text-xs bg-amber-100 text-amber-800 px-2 py-1 rounded"
+                    )
+
+        with ui.row().classes("w-full gap-4 mt-4 items-start flex-wrap"):
+            with ui.column().classes("flex-[2_1_760px] min-w-0 overflow-x-auto"):
+                render_manifest_operations_grid(rows)
+            with ui.column().classes("flex-[1_1_360px] min-w-[280px]"):
+                ui.label("Selected Manifest").classes("font-bold mb-2")
+                dataset_select = ui.select(
+                    label="Dataset",
+                    options=[row["dataset"] for row in rows],
+                    value=selected_dataset,
+                ).classes("w-full mb-2")
+                detail_container = ui.column().classes("w-full")
+
+                def render_details(dataset: str | None) -> None:
+                    detail_container.clear()
+                    with detail_container:
+                        render_manifest_detail_drawer(
+                            summary,
+                            str(dataset or selected_dataset),
+                        )
+
+                dataset_select.on_value_change(lambda event: render_details(event.value))
+                render_details(selected_dataset)
+
+
+def _default_selected_dataset(rows: list[dict[str, Any]]) -> str:
+    for row in rows:
+        if row["dataset"] == ALPACA_SIP_DAILY_DATASET:
+            return str(row["dataset"])
+    return str(rows[0]["dataset"]) if rows else ALPACA_SIP_DAILY_DATASET
+
+
+def _group_status_text(summary: AlpacaSipManifestSummaryDTO) -> str:
+    if not summary.has_any_manifest:
+        return "Alpaca SIP manifests missing"
+    if summary.missing_datasets:
+        return f"Missing companion: {', '.join(summary.missing_datasets)}"
+    if summary.source_status == "ok":
+        return "Alpaca SIP manifests present"
+    return summary.source_error_message or summary.sync_validation_status
+
+
+__all__ = ["render_manifest_transparency_panel"]

--- a/apps/web_console_ng/components/data_operations_grid.py
+++ b/apps/web_console_ng/components/data_operations_grid.py
@@ -1,0 +1,156 @@
+"""Dense manifest-backed operations grid for the data page."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_management_common import format_datetime
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_MANIFEST_DATASETS,
+    AlpacaSipManifestSummaryDTO,
+    ManifestSummaryDTO,
+)
+
+
+def build_manifest_grid_rows(
+    summary: AlpacaSipManifestSummaryDTO,
+) -> list[dict[str, Any]]:
+    """Build one dense operations-grid row per expected Alpaca SIP manifest."""
+    by_dataset = {manifest.dataset: manifest for manifest in summary.manifests}
+    return [
+        _row_from_manifest_or_missing(dataset, by_dataset.get(dataset), summary)
+        for dataset in ALPACA_SIP_MANIFEST_DATASETS
+    ]
+
+
+def render_manifest_operations_grid(rows: list[dict[str, Any]]) -> None:
+    """Render the manifest operations grid."""
+    columns: list[dict[str, Any]] = [
+        {"name": "dataset", "label": "Dataset", "field": "dataset", "sortable": True},
+        {"name": "raw_state", "label": "Raw", "field": "raw_state"},
+        {"name": "local_state", "label": "Local", "field": "local_state", "sortable": True},
+        {
+            "name": "manifest_status",
+            "label": "Manifest",
+            "field": "manifest_status",
+            "sortable": True,
+        },
+        {"name": "last_sync", "label": "Last Sync", "field": "last_sync", "sortable": True},
+        {"name": "readiness", "label": "Readiness", "field": "readiness"},
+        {"name": "issues", "label": "Issues", "field": "issues", "sortable": True},
+        {"name": "row_count", "label": "Rows", "field": "row_count", "sortable": True},
+        {"name": "date_range", "label": "Date Range", "field": "date_range"},
+        {"name": "provider", "label": "Provider", "field": "provider"},
+        {"name": "schema_version", "label": "Schema", "field": "schema_version"},
+        {
+            "name": "adjustment_state",
+            "label": "Adjustment",
+            "field": "adjustment_state",
+        },
+    ]
+    ui.table(columns=columns, rows=rows, row_key="dataset").classes("w-full")
+
+
+def _row_from_manifest_or_missing(
+    dataset: str,
+    manifest: ManifestSummaryDTO | None,
+    summary: AlpacaSipManifestSummaryDTO,
+) -> dict[str, Any]:
+    warnings = _warnings_for_dataset(dataset, summary)
+    is_daily = dataset == ALPACA_SIP_DAILY_DATASET
+    raw_state = "Raw OHLC" if is_daily else "-"
+    adjustment_state = (
+        "adj_close: not available; ret: not available"
+        if is_daily
+        else "not price bars"
+    )
+    if manifest is None:
+        readiness = "blocked: alpaca_sip_untrusted_without_manifest"
+        if is_daily:
+            readiness = f"{readiness}; raw_sip_returns_unavailable"
+        return {
+            "dataset": dataset,
+            "family": "alpaca_sip",
+            "raw_state": raw_state,
+            "local_state": "missing",
+            "manifest_status": "missing",
+            "last_sync": "-",
+            "readiness": readiness,
+            "issues": max(1, len(warnings)),
+            "issue_codes": warnings,
+            "row_count": 0,
+            "date_range": "-",
+            "provider": "alpaca_sip",
+            "schema_version": "-",
+            "manifest_id": None,
+            "manifest_reference": None,
+            "manifest_checksum": None,
+            "adjustment_state": adjustment_state,
+            "canonical_storage_mode": "raw" if is_daily else None,
+            "read_time_adjustment_mode": "unavailable" if is_daily else None,
+            "trusted_manifest_backed": False,
+        }
+
+    validation_ok = manifest.validation_status == "passed"
+    issue_codes = list(warnings)
+    if not validation_ok:
+        issue_codes.append(f"manifest_validation_{manifest.validation_status}")
+
+    if not validation_ok:
+        readiness = "blocked: untrusted_manifest_validation_failed"
+        if is_daily:
+            readiness = f"{readiness}; raw_sip_returns_unavailable"
+    elif is_daily:
+        readiness = "blocked: raw_sip_returns_unavailable"
+    elif warnings:
+        readiness = "warn: companion manifest issue"
+    else:
+        readiness = "corporate actions only"
+
+    return {
+        "dataset": dataset,
+        "family": "alpaca_sip",
+        "raw_state": raw_state,
+        "local_state": "present",
+        "manifest_status": manifest.validation_status,
+        "last_sync": format_datetime(manifest.sync_timestamp),
+        "readiness": readiness,
+        "issues": len(issue_codes),
+        "issue_codes": sorted(set(issue_codes)),
+        "row_count": manifest.row_count,
+        "date_range": f"{manifest.start_date.isoformat()} to {manifest.end_date.isoformat()}",
+        "provider": manifest.provider_id or "alpaca_sip",
+        "schema_version": manifest.schema_version,
+        "manifest_id": manifest.manifest_id,
+        "manifest_reference": manifest.manifest_reference,
+        "manifest_checksum": manifest.manifest_checksum,
+        "adjustment_state": adjustment_state,
+        "canonical_storage_mode": manifest.canonical_storage_mode,
+        "read_time_adjustment_mode": manifest.read_time_adjustment_mode,
+        "trusted_manifest_backed": validation_ok,
+    }
+
+
+def _warnings_for_dataset(
+    dataset: str,
+    summary: AlpacaSipManifestSummaryDTO,
+) -> list[str]:
+    warnings: list[str] = []
+    for warning in summary.warnings:
+        if warning == f"alpaca_sip_missing_manifest:{dataset}":
+            warnings.append("alpaca_sip_untrusted_without_manifest")
+        elif (
+            not warning.startswith("alpaca_sip_missing_manifest:")
+            and dataset in {ALPACA_SIP_DAILY_DATASET, ALPACA_SIP_CORP_ACTIONS_DATASET}
+        ):
+            warnings.append(warning)
+    if dataset == ALPACA_SIP_DAILY_DATASET:
+        warnings.append("raw_sip_returns_unavailable")
+    return sorted(set(warnings))
+
+
+__all__ = ["build_manifest_grid_rows", "render_manifest_operations_grid"]

--- a/apps/web_console_ng/components/data_operations_grid.py
+++ b/apps/web_console_ng/components/data_operations_grid.py
@@ -64,9 +64,7 @@ def _row_from_manifest_or_missing(
     is_daily = dataset == ALPACA_SIP_DAILY_DATASET
     raw_state = "Raw OHLC" if is_daily else "-"
     adjustment_state = (
-        "adj_close: not available; ret: not available"
-        if is_daily
-        else "not price bars"
+        "adj_close: not available; ret: not available" if is_daily else "not price bars"
     )
     if manifest is None:
         readiness = "blocked: alpaca_sip_untrusted_without_manifest"
@@ -80,7 +78,7 @@ def _row_from_manifest_or_missing(
             "manifest_status": "missing",
             "last_sync": "-",
             "readiness": readiness,
-            "issues": max(1, len(warnings)),
+            "issues": len(warnings),
             "issue_codes": warnings,
             "row_count": 0,
             "date_range": "-",
@@ -143,10 +141,10 @@ def _warnings_for_dataset(
     for warning in summary.warnings:
         if warning == f"alpaca_sip_missing_manifest:{dataset}":
             warnings.append("alpaca_sip_untrusted_without_manifest")
-        elif (
-            not warning.startswith("alpaca_sip_missing_manifest:")
-            and dataset in {ALPACA_SIP_DAILY_DATASET, ALPACA_SIP_CORP_ACTIONS_DATASET}
-        ):
+        elif not warning.startswith("alpaca_sip_missing_manifest:") and dataset in {
+            ALPACA_SIP_DAILY_DATASET,
+            ALPACA_SIP_CORP_ACTIONS_DATASET,
+        }:
             warnings.append(warning)
     if dataset == ALPACA_SIP_DAILY_DATASET:
         warnings.append("raw_sip_returns_unavailable")

--- a/apps/web_console_ng/components/data_sync_section.py
+++ b/apps/web_console_ng/components/data_sync_section.py
@@ -29,6 +29,10 @@ def _resolve_dependencies(
     return ui if ui_module is None else ui_module, logger if logger_obj is None else logger_obj
 
 
+def _normalize_sync_reason(value: Any) -> str:
+    return str(value or "").strip()
+
+
 async def render_data_sync_section(
     user: dict[str, Any],
     sync_service: DataSyncService,
@@ -142,16 +146,15 @@ async def render_sync_status(
 
             async def trigger_sync() -> None:
                 dataset_val = dataset_input.value
+                reason_value = _normalize_sync_reason(reason_input.value)
                 if not dataset_val:
                     ui_ctx.notify("Please select a dataset", type="warning")
                     return
-                if not reason_input.value:
+                if not reason_value:
                     ui_ctx.notify("Please provide a reason for audit logging", type="warning")
                     return
                 try:
-                    job = await sync_service.trigger_sync(
-                        user, str(dataset_val), str(reason_input.value)
-                    )
+                    job = await sync_service.trigger_sync(user, str(dataset_val), reason_value)
                     ui_ctx.notify(f"Sync job {job.id} queued for {job.dataset}", type="positive")
                     reason_input.value = ""
                 except SyncRateLimitExceeded:

--- a/apps/web_console_ng/components/data_sync_section.py
+++ b/apps/web_console_ng/components/data_sync_section.py
@@ -22,42 +22,60 @@ from libs.web_console_services.schemas.data_management import SyncScheduleUpdate
 logger = logging.getLogger(__name__)
 
 
-def bind_page_globals(ui_module: Any, logger_obj: logging.Logger) -> None:
-    """Bind page-level globals for legacy tests that patch page.ui/logger."""
-    global logger, ui
-    ui = ui_module
-    logger = logger_obj
+def _resolve_dependencies(
+    ui_module: Any | None,
+    logger_obj: logging.Logger | None,
+) -> tuple[Any, logging.Logger]:
+    return ui if ui_module is None else ui_module, logger if logger_obj is None else logger_obj
 
 
 async def render_data_sync_section(
     user: dict[str, Any],
     sync_service: DataSyncService,
+    *,
+    ui_module: Any | None = None,
+    logger_obj: logging.Logger | None = None,
 ) -> ui.column | None:
     """Render Data Sync dashboard section. Returns the status container for refresh."""
-    ui.label("Data Sync Dashboard").classes("text-xl font-bold mb-2")
+    ui_ctx, logger_ctx = _resolve_dependencies(ui_module, logger_obj)
+    ui_ctx.label("Data Sync Dashboard").classes("text-xl font-bold mb-2")
 
     has_view = has_permission(user, Permission.VIEW_DATA_SYNC)
     has_trigger = has_permission(user, Permission.TRIGGER_DATA_SYNC)
     has_manage = has_permission(user, Permission.MANAGE_SYNC_SCHEDULE)
 
-    with ui.tabs().classes("w-full") as sync_tabs:
-        tab_status = ui.tab("Sync Status")
-        tab_logs = ui.tab("Sync Logs")
-        tab_schedule = ui.tab("Schedule Config")
+    with ui_ctx.tabs().classes("w-full") as sync_tabs:
+        tab_status = ui_ctx.tab("Sync Status")
+        tab_logs = ui_ctx.tab("Sync Logs")
+        tab_schedule = ui_ctx.tab("Schedule Config")
 
     sync_status_container: ui.column | None = None
 
-    with ui.tab_panels(sync_tabs, value=tab_status).classes("w-full"):
-        with ui.tab_panel(tab_status):
+    with ui_ctx.tab_panels(sync_tabs, value=tab_status).classes("w-full"):
+        with ui_ctx.tab_panel(tab_status):
             sync_status_container = await render_sync_status(
-                user, sync_service, has_view, has_trigger
+                user,
+                sync_service,
+                has_view,
+                has_trigger,
+                ui_module=ui_ctx,
+                logger_obj=logger_ctx,
             )
 
-        with ui.tab_panel(tab_logs):
-            await render_sync_logs(user, sync_service, has_view)
+        with ui_ctx.tab_panel(tab_logs):
+            await render_sync_logs(
+                user, sync_service, has_view, ui_module=ui_ctx, logger_obj=logger_ctx
+            )
 
-        with ui.tab_panel(tab_schedule):
-            await render_sync_schedule(user, sync_service, has_view, has_manage)
+        with ui_ctx.tab_panel(tab_schedule):
+            await render_sync_schedule(
+                user,
+                sync_service,
+                has_view,
+                has_manage,
+                ui_module=ui_ctx,
+                logger_obj=logger_ctx,
+            )
 
     return sync_status_container
 
@@ -67,23 +85,27 @@ async def render_sync_status(
     sync_service: DataSyncService,
     has_view: bool,
     has_trigger: bool,
+    *,
+    ui_module: Any | None = None,
+    logger_obj: logging.Logger | None = None,
 ) -> ui.column | None:
     """Render sync status table and manual trigger. Returns container for refresh."""
+    ui_ctx, logger_ctx = _resolve_dependencies(ui_module, logger_obj)
     status_container: ui.column | None = None
     dataset_names: list[str] = []
 
     if has_view:
-        ui.label("Dataset Sync Status").classes("font-bold mb-2")
-        status_container = ui.column().classes("w-full")
+        ui_ctx.label("Dataset Sync Status").classes("font-bold mb-2")
+        status_container = ui_ctx.column().classes("w-full")
         try:
             statuses = await sync_service.get_sync_status(user)
             dataset_names = [s.dataset for s in statuses]
             with status_container:
-                build_sync_status_table(statuses)
+                build_sync_status_table(statuses, ui_module=ui_ctx)
         except PermissionError as e:
-            ui.notify(str(e), type="negative")
+            ui_ctx.notify(str(e), type="negative")
         except Exception:
-            logger.exception(
+            logger_ctx.exception(
                 "service_call_failed",
                 extra={
                     "method": "get_sync_status",
@@ -91,31 +113,29 @@ async def render_sync_status(
                     "user_id": get_user_id_safe(user),
                 },
             )
-            ui.notify("Service temporarily unavailable", type="warning")
+            ui_ctx.notify("Service temporarily unavailable", type="warning")
     else:
-        ui.label("Sync status requires data-sync view permission").classes(
-            "text-gray-500"
-        )
+        ui_ctx.label("Sync status requires data-sync view permission").classes("text-gray-500")
 
     if has_trigger:
-        ui.separator().classes("my-4")
-        ui.label("Manual Sync").classes("font-bold mb-2")
+        ui_ctx.separator().classes("my-4")
+        ui_ctx.label("Manual Sync").classes("font-bold mb-2")
 
-        with ui.row().classes("gap-4 items-end"):
+        with ui_ctx.row().classes("gap-4 items-end"):
             dataset_input: Any
             if dataset_names:
-                dataset_input = ui.select(
+                dataset_input = ui_ctx.select(
                     label="Dataset",
                     options=dataset_names,
                     value=dataset_names[0],
                 ).classes("w-48")
             else:
-                dataset_input = ui.input(
+                dataset_input = ui_ctx.input(
                     label="Dataset Name",
                     placeholder="Enter dataset name",
                 ).classes("w-48")
 
-            reason_input = ui.input(
+            reason_input = ui_ctx.input(
                 label="Reason",
                 placeholder="Why run this sync now?",
             ).classes("w-64")
@@ -123,27 +143,23 @@ async def render_sync_status(
             async def trigger_sync() -> None:
                 dataset_val = dataset_input.value
                 if not dataset_val:
-                    ui.notify("Please select a dataset", type="warning")
+                    ui_ctx.notify("Please select a dataset", type="warning")
                     return
                 if not reason_input.value:
-                    ui.notify(
-                        "Please provide a reason for audit logging", type="warning"
-                    )
+                    ui_ctx.notify("Please provide a reason for audit logging", type="warning")
                     return
                 try:
                     job = await sync_service.trigger_sync(
                         user, str(dataset_val), str(reason_input.value)
                     )
-                    ui.notify(
-                        f"Sync job {job.id} queued for {job.dataset}", type="positive"
-                    )
+                    ui_ctx.notify(f"Sync job {job.id} queued for {job.dataset}", type="positive")
                     reason_input.value = ""
                 except SyncRateLimitExceeded:
-                    ui.notify("Rate limit: 1 sync per minute", type="warning")
+                    ui_ctx.notify("Rate limit: 1 sync per minute", type="warning")
                 except PermissionError as e:
-                    ui.notify(str(e), type="negative")
+                    ui_ctx.notify(str(e), type="negative")
                 except Exception:
-                    logger.exception(
+                    logger_ctx.exception(
                         "service_call_failed",
                         extra={
                             "method": "trigger_sync",
@@ -152,15 +168,20 @@ async def render_sync_status(
                             "user_id": get_user_id_safe(user),
                         },
                     )
-                    ui.notify("Service temporarily unavailable", type="warning")
+                    ui_ctx.notify("Service temporarily unavailable", type="warning")
 
-            ui.button("Trigger Sync", on_click=trigger_sync, color="primary")
+            ui_ctx.button("Trigger Sync", on_click=trigger_sync, color="primary")
 
     return status_container
 
 
-def build_sync_status_table(statuses: list[Any]) -> None:
+def build_sync_status_table(
+    statuses: list[Any],
+    *,
+    ui_module: Any | None = None,
+) -> None:
     """Build the sync status table from SyncStatusDTO list."""
+    ui_ctx, _ = _resolve_dependencies(ui_module, None)
     columns: list[dict[str, Any]] = [
         {"name": "dataset", "label": "Dataset", "field": "dataset", "sortable": True},
         {
@@ -185,34 +206,38 @@ def build_sync_status_table(statuses: list[Any]) -> None:
         }
         for s in statuses
     ]
-    ui.table(columns=columns, rows=rows).classes("w-full")
+    ui_ctx.table(columns=columns, rows=rows).classes("w-full")
 
 
 async def render_sync_logs(
     user: dict[str, Any],
     sync_service: DataSyncService,
     has_view: bool,
+    *,
+    ui_module: Any | None = None,
+    logger_obj: logging.Logger | None = None,
 ) -> None:
     """Render sync logs viewer with filters."""
+    ui_ctx, logger_ctx = _resolve_dependencies(ui_module, logger_obj)
     if not has_view:
-        ui.label("Sync logs require data-sync view permission").classes("text-gray-500")
+        ui_ctx.label("Sync logs require data-sync view permission").classes("text-gray-500")
         return
 
-    ui.label("Recent Sync Logs").classes("font-bold mb-2")
+    ui_ctx.label("Recent Sync Logs").classes("font-bold mb-2")
 
-    with ui.row().classes("gap-4 mb-4"):
-        dataset_filter = ui.select(
+    with ui_ctx.row().classes("gap-4 mb-4"):
+        dataset_filter = ui_ctx.select(
             label="Dataset",
             options=["all", *TREND_DATASETS],
             value="all",
         ).classes("w-40")
-        level_filter = ui.select(
+        level_filter = ui_ctx.select(
             label="Level",
             options=["all", "info", "warn", "error"],
             value="all",
         ).classes("w-32")
 
-    log_container = ui.column().classes("w-full")
+    log_container = ui_ctx.column().classes("w-full")
 
     async def load_logs() -> None:
         ds = None if dataset_filter.value == "all" else str(dataset_filter.value)
@@ -221,11 +246,11 @@ async def render_sync_logs(
             logs = await sync_service.get_sync_logs(user, dataset=ds, level=lvl)
             log_container.clear()
             with log_container:
-                build_sync_logs_table(logs)
+                build_sync_logs_table(logs, ui_module=ui_ctx)
         except PermissionError as e:
-            ui.notify(str(e), type="negative")
+            ui_ctx.notify(str(e), type="negative")
         except Exception:
-            logger.exception(
+            logger_ctx.exception(
                 "service_call_failed",
                 extra={
                     "method": "get_sync_logs",
@@ -233,7 +258,7 @@ async def render_sync_logs(
                     "user_id": get_user_id_safe(user),
                 },
             )
-            ui.notify("Service temporarily unavailable", type="warning")
+            ui_ctx.notify("Service temporarily unavailable", type="warning")
 
     dataset_filter.on_value_change(lambda _: load_logs())
     level_filter.on_value_change(lambda _: load_logs())
@@ -241,8 +266,13 @@ async def render_sync_logs(
     await load_logs()
 
 
-def build_sync_logs_table(logs: list[Any]) -> None:
+def build_sync_logs_table(
+    logs: list[Any],
+    *,
+    ui_module: Any | None = None,
+) -> None:
     """Build sync logs table from SyncLogEntry list."""
+    ui_ctx, _ = _resolve_dependencies(ui_module, None)
     columns: list[dict[str, Any]] = [
         {
             "name": "created_at",
@@ -263,7 +293,7 @@ def build_sync_logs_table(logs: list[Any]) -> None:
         }
         for log in logs
     ]
-    ui.table(columns=columns, rows=rows).classes("w-full")
+    ui_ctx.table(columns=columns, rows=rows).classes("w-full")
 
 
 async def render_sync_schedule(
@@ -271,23 +301,25 @@ async def render_sync_schedule(
     sync_service: DataSyncService,
     has_view: bool,
     has_manage: bool,
+    *,
+    ui_module: Any | None = None,
+    logger_obj: logging.Logger | None = None,
 ) -> None:
     """Render sync schedule configuration with optional inline editing."""
-    ui.label("Sync Schedule").classes("font-bold mb-2")
+    ui_ctx, logger_ctx = _resolve_dependencies(ui_module, logger_obj)
+    ui_ctx.label("Sync Schedule").classes("font-bold mb-2")
 
     if not has_view:
-        ui.label("Schedule viewing requires data-sync view permission").classes(
-            "text-gray-500"
-        )
+        ui_ctx.label("Schedule viewing requires data-sync view permission").classes("text-gray-500")
         return
 
     try:
         schedules = await sync_service.get_sync_schedule(user)
     except PermissionError as e:
-        ui.notify(str(e), type="negative")
+        ui_ctx.notify(str(e), type="negative")
         return
     except Exception:
-        logger.exception(
+        logger_ctx.exception(
             "service_call_failed",
             extra={
                 "method": "get_sync_schedule",
@@ -295,39 +327,39 @@ async def render_sync_schedule(
                 "user_id": get_user_id_safe(user),
             },
         )
-        ui.notify("Service temporarily unavailable", type="warning")
+        ui_ctx.notify("Service temporarily unavailable", type="warning")
         return
 
     if not has_manage:
-        ui.label("Schedule editing requires MANAGE_SYNC_SCHEDULE permission").classes(
+        ui_ctx.label("Schedule editing requires MANAGE_SYNC_SCHEDULE permission").classes(
             "text-gray-500 mb-2"
         )
 
     for sched in schedules:
-        with ui.card().classes("w-full p-4 mb-2"):
-            with ui.row().classes("items-center gap-4"):
-                ui.label(sched.dataset).classes("font-bold w-32")
-                ui.label(f"Cron: {sched.cron_expression}").classes("text-gray-600")
+        with ui_ctx.card().classes("w-full p-4 mb-2"):
+            with ui_ctx.row().classes("items-center gap-4"):
+                ui_ctx.label(sched.dataset).classes("font-bold w-32")
+                ui_ctx.label(f"Cron: {sched.cron_expression}").classes("text-gray-600")
                 status_label = "Enabled" if sched.enabled else "Disabled"
                 status_color = "text-green-600" if sched.enabled else "text-red-600"
-                ui.label(status_label).classes(status_color)
+                ui_ctx.label(status_label).classes(status_color)
 
                 if sched.last_scheduled_run:
-                    ui.label(
-                        f"Last: {format_datetime(sched.last_scheduled_run)}"
-                    ).classes("text-sm text-gray-500")
+                    ui_ctx.label(f"Last: {format_datetime(sched.last_scheduled_run)}").classes(
+                        "text-sm text-gray-500"
+                    )
                 if sched.next_scheduled_run:
-                    ui.label(
-                        f"Next: {format_datetime(sched.next_scheduled_run)}"
-                    ).classes("text-sm text-gray-500")
+                    ui_ctx.label(f"Next: {format_datetime(sched.next_scheduled_run)}").classes(
+                        "text-sm text-gray-500"
+                    )
 
             if has_manage:
-                with ui.row().classes("items-center gap-4 mt-2"):
-                    cron_input = ui.input(
+                with ui_ctx.row().classes("items-center gap-4 mt-2"):
+                    cron_input = ui_ctx.input(
                         label="Cron Expression",
                         value=sched.cron_expression,
                     ).classes("w-48")
-                    enabled_switch = ui.switch(
+                    enabled_switch = ui_ctx.switch(
                         "Enabled",
                         value=sched.enabled,
                     )
@@ -344,17 +376,15 @@ async def render_sync_schedule(
                                 cron_expression=str(cron_el.value),
                                 enabled=bool(enabled_el.value),
                             )
-                            result = await sync_service.update_sync_schedule(
-                                user, ds, update
-                            )
-                            ui.notify(
+                            result = await sync_service.update_sync_schedule(user, ds, update)
+                            ui_ctx.notify(
                                 f"Schedule updated for {result.dataset}",
                                 type="positive",
                             )
                         except PermissionError as e:
-                            ui.notify(str(e), type="negative")
+                            ui_ctx.notify(str(e), type="negative")
                         except Exception:
-                            logger.exception(
+                            logger_ctx.exception(
                                 "service_call_failed",
                                 extra={
                                     "method": "update_sync_schedule",
@@ -363,15 +393,12 @@ async def render_sync_schedule(
                                     "user_id": get_user_id_safe(user),
                                 },
                             )
-                            ui.notify(
-                                "Service temporarily unavailable", type="warning"
-                            )
+                            ui_ctx.notify("Service temporarily unavailable", type="warning")
 
-                    ui.button("Save", on_click=save_schedule).props("flat dense")
+                    ui_ctx.button("Save", on_click=save_schedule).props("flat dense")
 
 
 __all__ = [
-    "bind_page_globals",
     "build_sync_logs_table",
     "build_sync_status_table",
     "render_data_sync_section",

--- a/apps/web_console_ng/components/data_sync_section.py
+++ b/apps/web_console_ng/components/data_sync_section.py
@@ -1,0 +1,381 @@
+"""Data Sync section for the data-management page."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_management_common import (
+    TREND_DATASETS,
+    format_datetime,
+    get_user_id_safe,
+)
+from libs.platform.web_console_auth.permissions import Permission, has_permission
+from libs.web_console_services.data_sync_service import DataSyncService
+from libs.web_console_services.data_sync_service import (
+    RateLimitExceeded as SyncRateLimitExceeded,
+)
+from libs.web_console_services.schemas.data_management import SyncScheduleUpdateDTO
+
+logger = logging.getLogger(__name__)
+
+
+def bind_page_globals(ui_module: Any, logger_obj: logging.Logger) -> None:
+    """Bind page-level globals for legacy tests that patch page.ui/logger."""
+    global logger, ui
+    ui = ui_module
+    logger = logger_obj
+
+
+async def render_data_sync_section(
+    user: dict[str, Any],
+    sync_service: DataSyncService,
+) -> ui.column | None:
+    """Render Data Sync dashboard section. Returns the status container for refresh."""
+    ui.label("Data Sync Dashboard").classes("text-xl font-bold mb-2")
+
+    has_view = has_permission(user, Permission.VIEW_DATA_SYNC)
+    has_trigger = has_permission(user, Permission.TRIGGER_DATA_SYNC)
+    has_manage = has_permission(user, Permission.MANAGE_SYNC_SCHEDULE)
+
+    with ui.tabs().classes("w-full") as sync_tabs:
+        tab_status = ui.tab("Sync Status")
+        tab_logs = ui.tab("Sync Logs")
+        tab_schedule = ui.tab("Schedule Config")
+
+    sync_status_container: ui.column | None = None
+
+    with ui.tab_panels(sync_tabs, value=tab_status).classes("w-full"):
+        with ui.tab_panel(tab_status):
+            sync_status_container = await render_sync_status(
+                user, sync_service, has_view, has_trigger
+            )
+
+        with ui.tab_panel(tab_logs):
+            await render_sync_logs(user, sync_service, has_view)
+
+        with ui.tab_panel(tab_schedule):
+            await render_sync_schedule(user, sync_service, has_view, has_manage)
+
+    return sync_status_container
+
+
+async def render_sync_status(
+    user: dict[str, Any],
+    sync_service: DataSyncService,
+    has_view: bool,
+    has_trigger: bool,
+) -> ui.column | None:
+    """Render sync status table and manual trigger. Returns container for refresh."""
+    status_container: ui.column | None = None
+    dataset_names: list[str] = []
+
+    if has_view:
+        ui.label("Dataset Sync Status").classes("font-bold mb-2")
+        status_container = ui.column().classes("w-full")
+        try:
+            statuses = await sync_service.get_sync_status(user)
+            dataset_names = [s.dataset for s in statuses]
+            with status_container:
+                build_sync_status_table(statuses)
+        except PermissionError as e:
+            ui.notify(str(e), type="negative")
+        except Exception:
+            logger.exception(
+                "service_call_failed",
+                extra={
+                    "method": "get_sync_status",
+                    "service": "DataSyncService",
+                    "user_id": get_user_id_safe(user),
+                },
+            )
+            ui.notify("Service temporarily unavailable", type="warning")
+    else:
+        ui.label("Sync status requires data-sync view permission").classes(
+            "text-gray-500"
+        )
+
+    if has_trigger:
+        ui.separator().classes("my-4")
+        ui.label("Manual Sync").classes("font-bold mb-2")
+
+        with ui.row().classes("gap-4 items-end"):
+            dataset_input: Any
+            if dataset_names:
+                dataset_input = ui.select(
+                    label="Dataset",
+                    options=dataset_names,
+                    value=dataset_names[0],
+                ).classes("w-48")
+            else:
+                dataset_input = ui.input(
+                    label="Dataset Name",
+                    placeholder="Enter dataset name",
+                ).classes("w-48")
+
+            reason_input = ui.input(
+                label="Reason",
+                placeholder="Why run this sync now?",
+            ).classes("w-64")
+
+            async def trigger_sync() -> None:
+                dataset_val = dataset_input.value
+                if not dataset_val:
+                    ui.notify("Please select a dataset", type="warning")
+                    return
+                if not reason_input.value:
+                    ui.notify(
+                        "Please provide a reason for audit logging", type="warning"
+                    )
+                    return
+                try:
+                    job = await sync_service.trigger_sync(
+                        user, str(dataset_val), str(reason_input.value)
+                    )
+                    ui.notify(
+                        f"Sync job {job.id} queued for {job.dataset}", type="positive"
+                    )
+                    reason_input.value = ""
+                except SyncRateLimitExceeded:
+                    ui.notify("Rate limit: 1 sync per minute", type="warning")
+                except PermissionError as e:
+                    ui.notify(str(e), type="negative")
+                except Exception:
+                    logger.exception(
+                        "service_call_failed",
+                        extra={
+                            "method": "trigger_sync",
+                            "service": "DataSyncService",
+                            "dataset": str(dataset_val),
+                            "user_id": get_user_id_safe(user),
+                        },
+                    )
+                    ui.notify("Service temporarily unavailable", type="warning")
+
+            ui.button("Trigger Sync", on_click=trigger_sync, color="primary")
+
+    return status_container
+
+
+def build_sync_status_table(statuses: list[Any]) -> None:
+    """Build the sync status table from SyncStatusDTO list."""
+    columns: list[dict[str, Any]] = [
+        {"name": "dataset", "label": "Dataset", "field": "dataset", "sortable": True},
+        {
+            "name": "last_sync",
+            "label": "Last Sync",
+            "field": "last_sync",
+            "sortable": True,
+        },
+        {"name": "row_count", "label": "Row Count", "field": "row_count", "sortable": True},
+        {
+            "name": "validation_status",
+            "label": "Validation",
+            "field": "validation_status",
+        },
+    ]
+    rows: list[dict[str, Any]] = [
+        {
+            "dataset": s.dataset,
+            "last_sync": format_datetime(s.last_sync),
+            "row_count": s.row_count or 0,
+            "validation_status": s.validation_status or "-",
+        }
+        for s in statuses
+    ]
+    ui.table(columns=columns, rows=rows).classes("w-full")
+
+
+async def render_sync_logs(
+    user: dict[str, Any],
+    sync_service: DataSyncService,
+    has_view: bool,
+) -> None:
+    """Render sync logs viewer with filters."""
+    if not has_view:
+        ui.label("Sync logs require data-sync view permission").classes("text-gray-500")
+        return
+
+    ui.label("Recent Sync Logs").classes("font-bold mb-2")
+
+    with ui.row().classes("gap-4 mb-4"):
+        dataset_filter = ui.select(
+            label="Dataset",
+            options=["all", *TREND_DATASETS],
+            value="all",
+        ).classes("w-40")
+        level_filter = ui.select(
+            label="Level",
+            options=["all", "info", "warn", "error"],
+            value="all",
+        ).classes("w-32")
+
+    log_container = ui.column().classes("w-full")
+
+    async def load_logs() -> None:
+        ds = None if dataset_filter.value == "all" else str(dataset_filter.value)
+        lvl = None if level_filter.value == "all" else str(level_filter.value)
+        try:
+            logs = await sync_service.get_sync_logs(user, dataset=ds, level=lvl)
+            log_container.clear()
+            with log_container:
+                build_sync_logs_table(logs)
+        except PermissionError as e:
+            ui.notify(str(e), type="negative")
+        except Exception:
+            logger.exception(
+                "service_call_failed",
+                extra={
+                    "method": "get_sync_logs",
+                    "service": "DataSyncService",
+                    "user_id": get_user_id_safe(user),
+                },
+            )
+            ui.notify("Service temporarily unavailable", type="warning")
+
+    dataset_filter.on_value_change(lambda _: load_logs())
+    level_filter.on_value_change(lambda _: load_logs())
+
+    await load_logs()
+
+
+def build_sync_logs_table(logs: list[Any]) -> None:
+    """Build sync logs table from SyncLogEntry list."""
+    columns: list[dict[str, Any]] = [
+        {
+            "name": "created_at",
+            "label": "Timestamp",
+            "field": "created_at",
+            "sortable": True,
+        },
+        {"name": "dataset", "label": "Dataset", "field": "dataset"},
+        {"name": "level", "label": "Level", "field": "level"},
+        {"name": "message", "label": "Message", "field": "message"},
+    ]
+    rows: list[dict[str, Any]] = [
+        {
+            "created_at": format_datetime(log.created_at),
+            "dataset": log.dataset,
+            "level": log.level,
+            "message": log.message,
+        }
+        for log in logs
+    ]
+    ui.table(columns=columns, rows=rows).classes("w-full")
+
+
+async def render_sync_schedule(
+    user: dict[str, Any],
+    sync_service: DataSyncService,
+    has_view: bool,
+    has_manage: bool,
+) -> None:
+    """Render sync schedule configuration with optional inline editing."""
+    ui.label("Sync Schedule").classes("font-bold mb-2")
+
+    if not has_view:
+        ui.label("Schedule viewing requires data-sync view permission").classes(
+            "text-gray-500"
+        )
+        return
+
+    try:
+        schedules = await sync_service.get_sync_schedule(user)
+    except PermissionError as e:
+        ui.notify(str(e), type="negative")
+        return
+    except Exception:
+        logger.exception(
+            "service_call_failed",
+            extra={
+                "method": "get_sync_schedule",
+                "service": "DataSyncService",
+                "user_id": get_user_id_safe(user),
+            },
+        )
+        ui.notify("Service temporarily unavailable", type="warning")
+        return
+
+    if not has_manage:
+        ui.label("Schedule editing requires MANAGE_SYNC_SCHEDULE permission").classes(
+            "text-gray-500 mb-2"
+        )
+
+    for sched in schedules:
+        with ui.card().classes("w-full p-4 mb-2"):
+            with ui.row().classes("items-center gap-4"):
+                ui.label(sched.dataset).classes("font-bold w-32")
+                ui.label(f"Cron: {sched.cron_expression}").classes("text-gray-600")
+                status_label = "Enabled" if sched.enabled else "Disabled"
+                status_color = "text-green-600" if sched.enabled else "text-red-600"
+                ui.label(status_label).classes(status_color)
+
+                if sched.last_scheduled_run:
+                    ui.label(
+                        f"Last: {format_datetime(sched.last_scheduled_run)}"
+                    ).classes("text-sm text-gray-500")
+                if sched.next_scheduled_run:
+                    ui.label(
+                        f"Next: {format_datetime(sched.next_scheduled_run)}"
+                    ).classes("text-sm text-gray-500")
+
+            if has_manage:
+                with ui.row().classes("items-center gap-4 mt-2"):
+                    cron_input = ui.input(
+                        label="Cron Expression",
+                        value=sched.cron_expression,
+                    ).classes("w-48")
+                    enabled_switch = ui.switch(
+                        "Enabled",
+                        value=sched.enabled,
+                    )
+
+                    _ds = sched.dataset
+
+                    async def save_schedule(
+                        ds: str = _ds,
+                        cron_el: ui.input = cron_input,
+                        enabled_el: ui.switch = enabled_switch,
+                    ) -> None:
+                        try:
+                            update = SyncScheduleUpdateDTO(
+                                cron_expression=str(cron_el.value),
+                                enabled=bool(enabled_el.value),
+                            )
+                            result = await sync_service.update_sync_schedule(
+                                user, ds, update
+                            )
+                            ui.notify(
+                                f"Schedule updated for {result.dataset}",
+                                type="positive",
+                            )
+                        except PermissionError as e:
+                            ui.notify(str(e), type="negative")
+                        except Exception:
+                            logger.exception(
+                                "service_call_failed",
+                                extra={
+                                    "method": "update_sync_schedule",
+                                    "service": "DataSyncService",
+                                    "dataset": ds,
+                                    "user_id": get_user_id_safe(user),
+                                },
+                            )
+                            ui.notify(
+                                "Service temporarily unavailable", type="warning"
+                            )
+
+                    ui.button("Save", on_click=save_schedule).props("flat dense")
+
+
+__all__ = [
+    "bind_page_globals",
+    "build_sync_logs_table",
+    "build_sync_status_table",
+    "render_data_sync_section",
+    "render_sync_logs",
+    "render_sync_schedule",
+    "render_sync_status",
+]

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -13,8 +13,8 @@ Services:
     - DataExplorerService: Dataset browsing, SQL queries, export
     - DataQualityService: Validation, anomaly alerts, trends, quarantine
 
-TODO: This module has grown large. Refactor Sync, Explorer, and Quality tabs
-into independent component modules under apps/web_console_ng/components/.
+TODO: Continue extracting Explorer and Quality tabs into independent component
+modules under apps/web_console_ng/components/.
 """
 
 from __future__ import annotations
@@ -30,6 +30,17 @@ import plotly.graph_objects as go
 from nicegui import ui
 
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
+from apps.web_console_ng.components import data_manifest_panel as _data_manifest_panel
+from apps.web_console_ng.components import data_sync_section as _data_sync_section
+from apps.web_console_ng.components.data_management_common import (
+    TREND_DATASETS as _TREND_DATASETS,
+)
+from apps.web_console_ng.components.data_management_common import (
+    format_datetime as _format_datetime,
+)
+from apps.web_console_ng.components.data_management_common import (
+    get_user_id_safe as _get_user_id_safe,
+)
 from apps.web_console_ng.core.client_lifecycle import ClientLifecycleManager
 from apps.web_console_ng.ui.layout import main_layout
 from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
@@ -50,12 +61,9 @@ from libs.web_console_services.data_explorer_service import DataExplorerService
 from libs.web_console_services.data_explorer_service import (
     RateLimitExceeded as ExplorerRateLimitExceeded,
 )
+from libs.web_console_services.data_manifest_service import DataManifestService
 from libs.web_console_services.data_quality_service import DataQualityService
 from libs.web_console_services.data_sync_service import DataSyncService
-from libs.web_console_services.data_sync_service import (
-    RateLimitExceeded as SyncRateLimitExceeded,
-)
-from libs.web_console_services.schemas.data_management import SyncScheduleUpdateDTO
 
 logger = logging.getLogger(__name__)
 
@@ -90,31 +98,12 @@ _SEVERITY_COLORS: dict[str, str] = {
 # Acknowledged filter mapping: UI label -> service parameter
 _ACK_MAP: dict[str, bool | None] = {"all": None, "unacked": False, "acked": True}
 
-# Datasets available for quality trends (mirrors service-side _SUPPORTED_DATASETS)
-_TREND_DATASETS: tuple[str, ...] = ("crsp", "compustat", "taq", "fama_french", "alpaca_sip")
-
 # Quality trend chart threshold lines
 GOOD_QUALITY_THRESHOLD = 90.0
 CRITICAL_QUALITY_THRESHOLD = 70.0
 
 # Timer cleanup owner key (page-scoped, replaces only this page's callback)
 _CLEANUP_OWNER_KEY = "data_management_timers"
-
-
-def _format_datetime(dt: Any) -> str:
-    """Format a datetime for display, handling None and non-datetime values."""
-    if dt is not None and hasattr(dt, "isoformat"):
-        return str(dt.isoformat())
-    return "-"
-
-
-def _get_user_id_safe(user: Any) -> str | None:
-    """Extract user_id from user dict or object safely."""
-    if isinstance(user, dict):
-        val = user.get("id")
-        return str(val) if val is not None else None
-    val = getattr(user, "id", None)
-    return str(val) if val is not None else None
 
 
 @ui.page("/data")
@@ -128,6 +117,7 @@ async def data_management_page() -> None:
     sync_service = DataSyncService()
     explorer_service = DataExplorerService()
     quality_service = DataQualityService()
+    manifest_service = DataManifestService()
 
     # Page title
     ui.label("Data Management").classes("text-2xl font-bold mb-4")
@@ -167,6 +157,8 @@ async def data_management_page() -> None:
             "text-gray-500"
         )
         return
+
+    await _render_manifest_transparency(user, manifest_service)
 
     # Overlap guard flags (per-client scope — each page load creates a new function scope)
     _sync_refreshing = False
@@ -284,42 +276,49 @@ async def data_management_page() -> None:
         )
 
 
+async def _render_manifest_transparency(
+    user: dict[str, Any],
+    manifest_service: DataManifestService,
+) -> None:
+    """Render Phase 1 manifest transparency for authorized Alpaca SIP users."""
+    if not has_permission(user, Permission.VIEW_DATA_SYNC):
+        return
+    if not has_dataset_permission(user, "alpaca_sip"):
+        return
+
+    try:
+        summary = await asyncio.to_thread(manifest_service.get_alpaca_sip_summary)
+    except Exception:
+        logger.exception(
+            "service_call_failed",
+            extra={
+                "method": "get_alpaca_sip_summary",
+                "service": "DataManifestService",
+                "user_id": _get_user_id_safe(user),
+            },
+        )
+        ui.notify("Manifest status temporarily unavailable", type="warning")
+        return
+
+    _data_manifest_panel.render_manifest_transparency_panel(summary)
+
+
 # =============================================================================
 # Data Sync Section
 # =============================================================================
+
+
+def _bind_data_sync_component() -> None:
+    """Bind patchable page globals into the extracted Data Sync component."""
+    _data_sync_section.bind_page_globals(ui_module=ui, logger_obj=logger)
 
 
 async def _render_data_sync_section(
     user: dict[str, Any],
     sync_service: DataSyncService,
 ) -> ui.column | None:
-    """Render Data Sync dashboard section. Returns the status container for refresh."""
-    ui.label("Data Sync Dashboard").classes("text-xl font-bold mb-2")
-
-    has_view = has_permission(user, Permission.VIEW_DATA_SYNC)
-    has_trigger = has_permission(user, Permission.TRIGGER_DATA_SYNC)
-    has_manage = has_permission(user, Permission.MANAGE_SYNC_SCHEDULE)
-
-    with ui.tabs().classes("w-full") as sync_tabs:
-        tab_status = ui.tab("Sync Status")
-        tab_logs = ui.tab("Sync Logs")
-        tab_schedule = ui.tab("Schedule Config")
-
-    sync_status_container: ui.column | None = None
-
-    with ui.tab_panels(sync_tabs, value=tab_status).classes("w-full"):
-        with ui.tab_panel(tab_status):
-            sync_status_container = await _render_sync_status(
-                user, sync_service, has_view, has_trigger
-            )
-
-        with ui.tab_panel(tab_logs):
-            await _render_sync_logs(user, sync_service, has_view)
-
-        with ui.tab_panel(tab_schedule):
-            await _render_sync_schedule(user, sync_service, has_view, has_manage)
-
-    return sync_status_container
+    _bind_data_sync_component()
+    return await _data_sync_section.render_data_sync_section(user, sync_service)
 
 
 async def _render_sync_status(
@@ -328,127 +327,15 @@ async def _render_sync_status(
     has_view: bool,
     has_trigger: bool,
 ) -> ui.column | None:
-    """Render sync status table and manual trigger. Returns container for refresh."""
-    # Status table (requires VIEW_DATA_SYNC)
-    status_container: ui.column | None = None
-    dataset_names: list[str] = []
-
-    if has_view:
-        ui.label("Dataset Sync Status").classes("font-bold mb-2")
-        status_container = ui.column().classes("w-full")
-        try:
-            statuses = await sync_service.get_sync_status(user)
-            dataset_names = [s.dataset for s in statuses]
-            with status_container:
-                _build_sync_status_table(statuses)
-        except PermissionError as e:
-            ui.notify(str(e), type="negative")
-        except Exception:
-            logger.exception(
-                "service_call_failed",
-                extra={
-                    "method": "get_sync_status",
-                    "service": "DataSyncService",
-                    "user_id": _get_user_id_safe(user),
-                },
-            )
-            ui.notify("Service temporarily unavailable", type="warning")
-    else:
-        ui.label("Sync status requires data-sync view permission").classes(
-            "text-gray-500"
-        )
-
-    # Manual sync section (requires TRIGGER_DATA_SYNC)
-    if has_trigger:
-        ui.separator().classes("my-4")
-        ui.label("Manual Sync").classes("font-bold mb-2")
-
-        with ui.row().classes("gap-4 items-end"):
-            dataset_input: Any  # ui.select or ui.input depending on permissions
-            if dataset_names:
-                dataset_input = ui.select(
-                    label="Dataset",
-                    options=dataset_names,
-                    value=dataset_names[0],
-                ).classes("w-48")
-            else:
-                # Fallback: text input when user lacks VIEW_DATA_SYNC
-                dataset_input = ui.input(
-                    label="Dataset Name",
-                    placeholder="Enter dataset name",
-                ).classes("w-48")
-
-            reason_input = ui.input(
-                label="Reason",
-                placeholder="Why run this sync now?",
-            ).classes("w-64")
-
-            async def trigger_sync() -> None:
-                dataset_val = dataset_input.value
-                if not dataset_val:
-                    ui.notify("Please select a dataset", type="warning")
-                    return
-                if not reason_input.value:
-                    ui.notify(
-                        "Please provide a reason for audit logging", type="warning"
-                    )
-                    return
-                try:
-                    job = await sync_service.trigger_sync(
-                        user, str(dataset_val), str(reason_input.value)
-                    )
-                    ui.notify(
-                        f"Sync job {job.id} queued for {job.dataset}", type="positive"
-                    )
-                    reason_input.value = ""
-                except SyncRateLimitExceeded:
-                    ui.notify("Rate limit: 1 sync per minute", type="warning")
-                except PermissionError as e:
-                    ui.notify(str(e), type="negative")
-                except Exception:
-                    logger.exception(
-                        "service_call_failed",
-                        extra={
-                            "method": "trigger_sync",
-                            "service": "DataSyncService",
-                            "dataset": str(dataset_val),
-                            "user_id": _get_user_id_safe(user),
-                        },
-                    )
-                    ui.notify("Service temporarily unavailable", type="warning")
-
-            ui.button("Trigger Sync", on_click=trigger_sync, color="primary")
-
-    return status_container
+    _bind_data_sync_component()
+    return await _data_sync_section.render_sync_status(
+        user, sync_service, has_view, has_trigger
+    )
 
 
 def _build_sync_status_table(statuses: list[Any]) -> None:
-    """Build the sync status table from SyncStatusDTO list."""
-    columns: list[dict[str, Any]] = [
-        {"name": "dataset", "label": "Dataset", "field": "dataset", "sortable": True},
-        {
-            "name": "last_sync",
-            "label": "Last Sync",
-            "field": "last_sync",
-            "sortable": True,
-        },
-        {"name": "row_count", "label": "Row Count", "field": "row_count", "sortable": True},
-        {
-            "name": "validation_status",
-            "label": "Validation",
-            "field": "validation_status",
-        },
-    ]
-    rows: list[dict[str, Any]] = [
-        {
-            "dataset": s.dataset,
-            "last_sync": _format_datetime(s.last_sync),
-            "row_count": s.row_count or 0,
-            "validation_status": s.validation_status or "-",
-        }
-        for s in statuses
-    ]
-    ui.table(columns=columns, rows=rows).classes("w-full")
+    _bind_data_sync_component()
+    _data_sync_section.build_sync_status_table(statuses)
 
 
 async def _render_sync_logs(
@@ -456,79 +343,13 @@ async def _render_sync_logs(
     sync_service: DataSyncService,
     has_view: bool,
 ) -> None:
-    """Render sync logs viewer with filters."""
-    if not has_view:
-        ui.label("Sync logs require data-sync view permission").classes("text-gray-500")
-        return
-
-    ui.label("Recent Sync Logs").classes("font-bold mb-2")
-
-    # Filter controls
-    with ui.row().classes("gap-4 mb-4"):
-        dataset_filter = ui.select(
-            label="Dataset",
-            options=["all", *_TREND_DATASETS],
-            value="all",
-        ).classes("w-40")
-        level_filter = ui.select(
-            label="Level",
-            options=["all", "info", "warn", "error"],
-            value="all",
-        ).classes("w-32")
-
-    log_container = ui.column().classes("w-full")
-
-    async def load_logs() -> None:
-        ds = None if dataset_filter.value == "all" else str(dataset_filter.value)
-        lvl = None if level_filter.value == "all" else str(level_filter.value)
-        try:
-            logs = await sync_service.get_sync_logs(user, dataset=ds, level=lvl)
-            log_container.clear()
-            with log_container:
-                _build_sync_logs_table(logs)
-        except PermissionError as e:
-            ui.notify(str(e), type="negative")
-        except Exception:
-            logger.exception(
-                "service_call_failed",
-                extra={
-                    "method": "get_sync_logs",
-                    "service": "DataSyncService",
-                    "user_id": _get_user_id_safe(user),
-                },
-            )
-            ui.notify("Service temporarily unavailable", type="warning")
-
-    dataset_filter.on_value_change(lambda _: load_logs())
-    level_filter.on_value_change(lambda _: load_logs())
-
-    # Initial load
-    await load_logs()
+    _bind_data_sync_component()
+    await _data_sync_section.render_sync_logs(user, sync_service, has_view)
 
 
 def _build_sync_logs_table(logs: list[Any]) -> None:
-    """Build sync logs table from SyncLogEntry list."""
-    columns: list[dict[str, Any]] = [
-        {
-            "name": "created_at",
-            "label": "Timestamp",
-            "field": "created_at",
-            "sortable": True,
-        },
-        {"name": "dataset", "label": "Dataset", "field": "dataset"},
-        {"name": "level", "label": "Level", "field": "level"},
-        {"name": "message", "label": "Message", "field": "message"},
-    ]
-    rows: list[dict[str, Any]] = [
-        {
-            "created_at": _format_datetime(log.created_at),
-            "dataset": log.dataset,
-            "level": log.level,
-            "message": log.message,
-        }
-        for log in logs
-    ]
-    ui.table(columns=columns, rows=rows).classes("w-full")
+    _bind_data_sync_component()
+    _data_sync_section.build_sync_logs_table(logs)
 
 
 async def _render_sync_schedule(
@@ -537,103 +358,8 @@ async def _render_sync_schedule(
     has_view: bool,
     has_manage: bool,
 ) -> None:
-    """Render sync schedule configuration with optional inline editing."""
-    ui.label("Sync Schedule").classes("font-bold mb-2")
-
-    if not has_view:
-        ui.label("Schedule viewing requires data-sync view permission").classes(
-            "text-gray-500"
-        )
-        return
-
-    try:
-        schedules = await sync_service.get_sync_schedule(user)
-    except PermissionError as e:
-        ui.notify(str(e), type="negative")
-        return
-    except Exception:
-        logger.exception(
-            "service_call_failed",
-            extra={
-                "method": "get_sync_schedule",
-                "service": "DataSyncService",
-                "user_id": _get_user_id_safe(user),
-            },
-        )
-        ui.notify("Service temporarily unavailable", type="warning")
-        return
-
-    if not has_manage:
-        ui.label("Schedule editing requires MANAGE_SYNC_SCHEDULE permission").classes(
-            "text-gray-500 mb-2"
-        )
-
-    for sched in schedules:
-        with ui.card().classes("w-full p-4 mb-2"):
-            with ui.row().classes("items-center gap-4"):
-                ui.label(sched.dataset).classes("font-bold w-32")
-                ui.label(f"Cron: {sched.cron_expression}").classes("text-gray-600")
-                status_label = "Enabled" if sched.enabled else "Disabled"
-                status_color = "text-green-600" if sched.enabled else "text-red-600"
-                ui.label(status_label).classes(status_color)
-
-                if sched.last_scheduled_run:
-                    ui.label(
-                        f"Last: {_format_datetime(sched.last_scheduled_run)}"
-                    ).classes("text-sm text-gray-500")
-                if sched.next_scheduled_run:
-                    ui.label(
-                        f"Next: {_format_datetime(sched.next_scheduled_run)}"
-                    ).classes("text-sm text-gray-500")
-
-            # Inline edit (requires MANAGE_SYNC_SCHEDULE)
-            if has_manage:
-                with ui.row().classes("items-center gap-4 mt-2"):
-                    cron_input = ui.input(
-                        label="Cron Expression",
-                        value=sched.cron_expression,
-                    ).classes("w-48")
-                    enabled_switch = ui.switch(
-                        "Enabled",
-                        value=sched.enabled,
-                    )
-
-                    _ds = sched.dataset
-
-                    async def save_schedule(
-                        ds: str = _ds,
-                        cron_el: ui.input = cron_input,
-                        enabled_el: ui.switch = enabled_switch,
-                    ) -> None:
-                        try:
-                            update = SyncScheduleUpdateDTO(
-                                cron_expression=str(cron_el.value),
-                                enabled=bool(enabled_el.value),
-                            )
-                            result = await sync_service.update_sync_schedule(
-                                user, ds, update
-                            )
-                            ui.notify(
-                                f"Schedule updated for {result.dataset}",
-                                type="positive",
-                            )
-                        except PermissionError as e:
-                            ui.notify(str(e), type="negative")
-                        except Exception:
-                            logger.exception(
-                                "service_call_failed",
-                                extra={
-                                    "method": "update_sync_schedule",
-                                    "service": "DataSyncService",
-                                    "dataset": ds,
-                                    "user_id": _get_user_id_safe(user),
-                                },
-                            )
-                            ui.notify(
-                                "Service temporarily unavailable", type="warning"
-                            )
-
-                    ui.button("Save", on_click=save_schedule).props("flat dense")
+    _bind_data_sync_component()
+    await _data_sync_section.render_sync_schedule(user, sync_service, has_view, has_manage)
 
 
 # =============================================================================

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -173,9 +173,7 @@ async def data_management_page() -> None:
     with ui.tab_panels(tabs, value=default_tab).classes("w-full"):
         if show_sync_tab:
             with ui.tab_panel(tab_sync):
-                sync_status_container = await _render_data_sync_section(
-                    user, sync_service
-                )
+                sync_status_container = await _render_data_sync_section(user, sync_service)
 
         if show_explorer_tab:
             with ui.tab_panel(tab_explorer):
@@ -183,9 +181,11 @@ async def data_management_page() -> None:
 
         if has_quality:
             with ui.tab_panel(tab_quality):
-                alerts_container, scores_container, _load_alerts_fn = (
-                    await _render_data_quality_section(user, quality_service)
-                )
+                (
+                    alerts_container,
+                    scores_container,
+                    _load_alerts_fn,
+                ) = await _render_data_quality_section(user, quality_service)
 
     # === Auto-refresh Timers ===
     async def refresh_sync_status() -> None:
@@ -308,17 +308,13 @@ async def _render_manifest_transparency(
 # =============================================================================
 
 
-def _bind_data_sync_component() -> None:
-    """Bind patchable page globals into the extracted Data Sync component."""
-    _data_sync_section.bind_page_globals(ui_module=ui, logger_obj=logger)
-
-
 async def _render_data_sync_section(
     user: dict[str, Any],
     sync_service: DataSyncService,
 ) -> ui.column | None:
-    _bind_data_sync_component()
-    return await _data_sync_section.render_data_sync_section(user, sync_service)
+    return await _data_sync_section.render_data_sync_section(
+        user, sync_service, ui_module=ui, logger_obj=logger
+    )
 
 
 async def _render_sync_status(
@@ -327,15 +323,18 @@ async def _render_sync_status(
     has_view: bool,
     has_trigger: bool,
 ) -> ui.column | None:
-    _bind_data_sync_component()
     return await _data_sync_section.render_sync_status(
-        user, sync_service, has_view, has_trigger
+        user,
+        sync_service,
+        has_view,
+        has_trigger,
+        ui_module=ui,
+        logger_obj=logger,
     )
 
 
 def _build_sync_status_table(statuses: list[Any]) -> None:
-    _bind_data_sync_component()
-    _data_sync_section.build_sync_status_table(statuses)
+    _data_sync_section.build_sync_status_table(statuses, ui_module=ui)
 
 
 async def _render_sync_logs(
@@ -343,13 +342,13 @@ async def _render_sync_logs(
     sync_service: DataSyncService,
     has_view: bool,
 ) -> None:
-    _bind_data_sync_component()
-    await _data_sync_section.render_sync_logs(user, sync_service, has_view)
+    await _data_sync_section.render_sync_logs(
+        user, sync_service, has_view, ui_module=ui, logger_obj=logger
+    )
 
 
 def _build_sync_logs_table(logs: list[Any]) -> None:
-    _bind_data_sync_component()
-    _data_sync_section.build_sync_logs_table(logs)
+    _data_sync_section.build_sync_logs_table(logs, ui_module=ui)
 
 
 async def _render_sync_schedule(
@@ -358,8 +357,14 @@ async def _render_sync_schedule(
     has_view: bool,
     has_manage: bool,
 ) -> None:
-    _bind_data_sync_component()
-    await _data_sync_section.render_sync_schedule(user, sync_service, has_view, has_manage)
+    await _data_sync_section.render_sync_schedule(
+        user,
+        sync_service,
+        has_view,
+        has_manage,
+        ui_module=ui,
+        logger_obj=logger,
+    )
 
 
 # =============================================================================
@@ -431,13 +436,9 @@ async def _render_data_explorer_section(
                     with metadata_container:
                         ui.label("Dataset Info").classes("font-bold mb-1")
                         if info.description:
-                            ui.label(info.description).classes(
-                                "text-sm text-gray-600"
-                            )
+                            ui.label(info.description).classes("text-sm text-gray-600")
                         if info.row_count is not None:
-                            ui.label(f"Rows: {info.row_count:,}").classes(
-                                "text-sm text-gray-600"
-                            )
+                            ui.label(f"Rows: {info.row_count:,}").classes("text-sm text-gray-600")
                         if info.symbol_count is not None:
                             ui.label(f"Symbols: {info.symbol_count:,}").classes(
                                 "text-sm text-gray-600"
@@ -445,9 +446,7 @@ async def _render_data_explorer_section(
                         if info.date_range:
                             start = info.date_range.get("start", "?")
                             end = info.date_range.get("end", "?")
-                            ui.label(f"Range: {start} to {end}").classes(
-                                "text-sm text-gray-600"
-                            )
+                            ui.label(f"Range: {start} to {end}").classes("text-sm text-gray-600")
 
                 async def _load_schema(ds_name: str | None) -> None:
                     """Load schema preview for dataset (requires QUERY_DATA)."""
@@ -460,15 +459,11 @@ async def _render_data_explorer_section(
                                 )
                         return
                     try:
-                        preview = await explorer_service.get_dataset_preview(
-                            user, ds_name, limit=5
-                        )
+                        preview = await explorer_service.get_dataset_preview(user, ds_name, limit=5)
                         with schema_container:
                             ui.label("Schema Preview").classes("font-bold mb-1")
                             for col in preview.columns:
-                                ui.label(f"  {col}").classes(
-                                    "text-sm text-gray-600 font-mono"
-                                )
+                                ui.label(f"  {col}").classes("text-sm text-gray-600 font-mono")
                     except PermissionError:
                         with schema_container:
                             ui.label("Schema requires query permission").classes(
@@ -528,9 +523,7 @@ async def _render_data_explorer_section(
                                 ui.notify("Please enter a query", type="warning")
                                 return
                             try:
-                                result = await explorer_service.execute_query(
-                                    user, ds, query_val
-                                )
+                                result = await explorer_service.execute_query(user, ds, query_val)
                                 results_container.clear()
                                 with results_container:
                                     _build_query_results(result)
@@ -553,30 +546,22 @@ async def _render_data_explorer_section(
                                         "user_id": _get_user_id_safe(user),
                                     },
                                 )
-                                ui.notify(
-                                    "Service temporarily unavailable", type="warning"
-                                )
+                                ui.notify("Service temporarily unavailable", type="warning")
 
-                        ui.button(
-                            "Run Query", on_click=run_query, color="primary"
-                        )
+                        ui.button("Run Query", on_click=run_query, color="primary")
 
                         if has_export:
                             export_format: dict[str, str] = {"value": "csv"}
                             ui.radio(
                                 ["csv", "parquet"],
                                 value="csv",
-                                on_change=lambda e: export_format.update(
-                                    {"value": str(e.value)}
-                                ),
+                                on_change=lambda e: export_format.update({"value": str(e.value)}),
                             ).props("inline")
 
                             async def export_data() -> None:
                                 ds = selected_dataset["value"]
                                 if not ds:
-                                    ui.notify(
-                                        "Please select a dataset", type="warning"
-                                    )
+                                    ui.notify("Please select a dataset", type="warning")
                                     return
                                 query_val = str(query_textarea.value).strip()
                                 if not query_val:
@@ -619,9 +604,7 @@ async def _render_data_explorer_section(
                                         type="warning",
                                     )
 
-                            ui.button(
-                                "Export Results", on_click=export_data
-                            ).props("flat")
+                            ui.button("Export Results", on_click=export_data).props("flat")
                 else:
                     ui.label("Query execution requires QUERY_DATA permission").classes(
                         "text-gray-400"
@@ -635,17 +618,14 @@ def _build_query_results(result: Any) -> None:
         return
 
     columns: list[dict[str, Any]] = [
-        {"name": col, "label": col, "field": col, "sortable": True}
-        for col in result.columns
+        {"name": col, "label": col, "field": col, "sortable": True} for col in result.columns
     ]
     ui.table(columns=columns, rows=result.rows).classes("w-full")
 
     with ui.row().classes("gap-4 mt-2"):
         ui.label(f"Total: {result.total_count} rows").classes("text-sm text-gray-600")
         if result.has_more:
-            ui.label("(more results available)").classes(
-                "text-sm text-amber-600"
-            )
+            ui.label("(more results available)").classes("text-sm text-amber-600")
 
 
 # =============================================================================
@@ -684,9 +664,7 @@ async def _render_data_quality_section(
             await _render_validation_results(user, quality_service)
 
         with ui.tab_panel(tab_anomalies):
-            alerts_container, load_alerts_fn = await _render_anomaly_alerts(
-                user, quality_service
-            )
+            alerts_container, load_alerts_fn = await _render_anomaly_alerts(user, quality_service)
 
         with ui.tab_panel(tab_trends):
             await _render_quality_trends(user, quality_service)
@@ -703,12 +681,8 @@ async def _build_quality_score_cards(
 ) -> None:
     """Build quality score cards per dataset using compute_quality_scores()."""
     try:
-        validations = await quality_service.get_validation_results(
-            user, dataset=None
-        )
-        alerts = await quality_service.get_anomaly_alerts(
-            user, severity=None, acknowledged=None
-        )
+        validations = await quality_service.get_validation_results(user, dataset=None)
+        alerts = await quality_service.get_anomaly_alerts(user, severity=None, acknowledged=None)
         quarantine = await quality_service.get_quarantine_status(user)
     except PermissionError as exc:
         ui.notify(str(exc), type="negative")
@@ -756,12 +730,8 @@ async def _build_quality_score_cards(
                         if score.validation_pass_rate is not None
                         else "N/A"
                     )
-                    ui.label(f"Pass Rate: {rate_text}").classes(
-                        "text-sm text-gray-600"
-                    )
-                    ui.label(f"Anomalies: {score.anomaly_count}").classes(
-                        "text-sm text-gray-600"
-                    )
+                    ui.label(f"Pass Rate: {rate_text}").classes("text-sm text-gray-600")
+                    ui.label(f"Anomalies: {score.anomaly_count}").classes("text-sm text-gray-600")
                     ui.label(f"Quarantine: {score.quarantine_count}").classes(
                         "text-sm text-gray-600"
                     )
@@ -919,9 +889,7 @@ def _normalize_and_filter_alerts(
     result: list[Any] = []
     severity_lookup: dict[str, str] = {}
     for alert in raw_alerts:
-        normalized = _SEVERITY_MAP.get(
-            alert.severity.lower(), alert.severity.lower()
-        )
+        normalized = _SEVERITY_MAP.get(alert.severity.lower(), alert.severity.lower())
         severity_lookup[alert.id] = normalized
         if severity_filter == "all" or normalized == severity_filter:
             result.append(alert)
@@ -943,20 +911,14 @@ def _build_anomaly_alert_cards(
 
     for alert in alerts:
         sev = severity_lookup.get(alert.id, alert.severity)
-        color_class = _SEVERITY_COLORS.get(
-            sev, "bg-gray-100 border-gray-300 text-gray-700"
-        )
+        color_class = _SEVERITY_COLORS.get(sev, "bg-gray-100 border-gray-300 text-gray-700")
         with ui.card().classes(f"w-full p-4 mb-2 border-l-4 {color_class}"):
             with ui.row().classes("items-center gap-2"):
                 ui.label(sev.upper()).classes("font-bold")
                 ui.label(alert.metric).classes("text-sm")
-                ui.label(_format_datetime(alert.created_at)).classes(
-                    "text-sm text-gray-500"
-                )
+                ui.label(_format_datetime(alert.created_at)).classes("text-sm text-gray-500")
                 if alert.acknowledged:
-                    ui.label("ACK").classes(
-                        "text-xs bg-green-200 px-2 py-0.5 rounded"
-                    )
+                    ui.label("ACK").classes("text-xs bg-green-200 px-2 py-0.5 rounded")
             ui.label(alert.message).classes("mt-1")
 
             if alert.deviation_pct is not None:
@@ -989,13 +951,9 @@ def _build_anomaly_alert_cards(
                                 "user_id": _get_user_id_safe(user),
                             },
                         )
-                        ui.notify(
-                            "Service temporarily unavailable", type="warning"
-                        )
+                        ui.notify("Service temporarily unavailable", type="warning")
 
-                ui.button(
-                    "Acknowledge", on_click=ack_alert
-                ).props("flat dense").classes("mt-1")
+                ui.button("Acknowledge", on_click=ack_alert).props("flat dense").classes("mt-1")
 
 
 async def _render_quality_trends(
@@ -1007,9 +965,7 @@ async def _render_quality_trends(
 
     accessible = [ds for ds in _TREND_DATASETS if has_dataset_permission(user, ds)]
     if not accessible:
-        ui.label("No accessible datasets for trend analysis.").classes(
-            "text-gray-500"
-        )
+        ui.label("No accessible datasets for trend analysis.").classes("text-gray-500")
         return
 
     dataset_select = ui.select(
@@ -1049,9 +1005,9 @@ def _build_quality_trend_chart(trend: Any) -> None:
     """Build Plotly trend chart with threshold lines and trend summary cards."""
     if not trend.data_points:
         with ui.card().classes("w-full p-4"):
-            ui.label(
-                f"Quality Trends - {trend.dataset} ({trend.period_days}d)"
-            ).classes("text-lg mb-4")
+            ui.label(f"Quality Trends - {trend.dataset} ({trend.period_days}d)").classes(
+                "text-lg mb-4"
+            )
             ui.label("No trend data available yet").classes("text-gray-500")
         return
 
@@ -1071,12 +1027,16 @@ def _build_quality_trend_chart(trend: Any) -> None:
         )
 
     fig.add_hline(
-        y=GOOD_QUALITY_THRESHOLD, line_dash="dash", line_color="green",
+        y=GOOD_QUALITY_THRESHOLD,
+        line_dash="dash",
+        line_color="green",
         annotation_text=f"Good ({GOOD_QUALITY_THRESHOLD:.0f})",
         annotation_position="top right",
     )
     fig.add_hline(
-        y=CRITICAL_QUALITY_THRESHOLD, line_dash="dash", line_color="red",
+        y=CRITICAL_QUALITY_THRESHOLD,
+        line_dash="dash",
+        line_color="red",
         annotation_text=f"Critical ({CRITICAL_QUALITY_THRESHOLD:.0f})",
         annotation_position="bottom right",
     )
@@ -1109,28 +1069,18 @@ def _build_quality_trend_chart(trend: Any) -> None:
             with ui.card().classes("flex-1 p-4 text-center"):
                 ui.label("Current Score").classes("text-sm text-gray-500")
                 current_text = (
-                    f"{summary.current_score:.1f}%"
-                    if summary.current_score is not None
-                    else "N/A"
+                    f"{summary.current_score:.1f}%" if summary.current_score is not None else "N/A"
                 )
                 ui.label(current_text).classes("text-3xl font-bold text-green-600")
 
             with ui.card().classes("flex-1 p-4 text-center"):
                 ui.label("7-Day Average").classes("text-sm text-gray-500")
-                avg7_text = (
-                    f"{summary.avg_7d:.1f}%"
-                    if summary.avg_7d is not None
-                    else "N/A"
-                )
+                avg7_text = f"{summary.avg_7d:.1f}%" if summary.avg_7d is not None else "N/A"
                 ui.label(avg7_text).classes("text-3xl font-bold text-green-600")
 
             with ui.card().classes("flex-1 p-4 text-center"):
                 ui.label("30-Day Average").classes("text-sm text-gray-500")
-                avg30_text = (
-                    f"{summary.avg_30d:.1f}%"
-                    if summary.avg_30d is not None
-                    else "N/A"
-                )
+                avg30_text = f"{summary.avg_30d:.1f}%" if summary.avg_30d is not None else "N/A"
                 ui.label(avg30_text).classes("text-3xl font-bold text-green-600")
 
             with ui.card().classes("flex-1 p-4 text-center"):
@@ -1141,9 +1091,7 @@ def _build_quality_trend_chart(trend: Any) -> None:
 
         # Degradation alert
         if summary.degradation_alert:
-            with ui.card().classes(
-                "w-full p-4 mt-2 bg-amber-100 border-l-4 border-amber-500"
-            ):
+            with ui.card().classes("w-full p-4 mt-2 bg-amber-100 border-l-4 border-amber-500"):
                 ui.label(
                     f"Quality degradation detected: 7-day average is significantly "
                     f"below 30-day average for {trend.dataset}"
@@ -1187,16 +1135,12 @@ async def _render_quarantine_inspector(
 
     for ds_name in sorted(by_dataset):
         ds_entries = by_dataset[ds_name]
-        with ui.expansion(f"{ds_name} ({len(ds_entries)} entries)").classes(
-            "w-full mb-2"
-        ):
+        with ui.expansion(f"{ds_name} ({len(ds_entries)} entries)").classes("w-full mb-2"):
             for entry in ds_entries:
                 with ui.card().classes("w-full p-3 mb-2 border-l-4 border-amber-400"):
                     with ui.row().classes("items-center gap-4"):
                         ui.label(entry.reason).classes("font-bold")
-                        ui.label(entry.quarantine_path).classes(
-                            "text-sm text-gray-500 font-mono"
-                        )
+                        ui.label(entry.quarantine_path).classes("text-sm text-gray-500 font-mono")
                         ui.label(_format_datetime(entry.created_at)).classes(
                             "text-sm text-gray-400"
                         )
@@ -1211,9 +1155,7 @@ async def _render_quarantine_inspector(
                         with preview_container:
                             await _load_quarantine_preview(qe)
 
-                    ui.button(
-                        "Inspect", on_click=inspect_entry
-                    ).props("flat dense").classes("mt-1")
+                    ui.button("Inspect", on_click=inspect_entry).props("flat dense").classes("mt-1")
 
 
 async def _load_quarantine_preview(entry: Any) -> None:
@@ -1264,9 +1206,7 @@ async def _load_quarantine_preview(entry: Any) -> None:
         status, result = await asyncio.to_thread(_validate_and_query)
 
         if status == "path_escape":
-            ui.label("Path validation failed at access time").classes(
-                "text-red-600"
-            )
+            ui.label("Path validation failed at access time").classes("text-red-600")
             return
         if status == "no_dir":
             ui.label(
@@ -1288,12 +1228,11 @@ async def _load_quarantine_preview(entry: Any) -> None:
             ui.label("No matching data for this entry").classes("text-gray-500")
             return
 
-        ui.label(
-            f"Quarantine Preview: {entry.dataset} — {len(result)} rows"
-        ).classes("font-bold mb-2")
+        ui.label(f"Quarantine Preview: {entry.dataset} — {len(result)} rows").classes(
+            "font-bold mb-2"
+        )
         columns: list[dict[str, Any]] = [
-            {"name": col, "label": col, "field": col, "sortable": True}
-            for col in result.columns
+            {"name": col, "label": col, "field": col, "sortable": True} for col in result.columns
         ]
         rows = result.to_dicts()
         ui.table(columns=columns, rows=rows).classes("w-full")
@@ -1306,9 +1245,7 @@ async def _load_quarantine_preview(entry: Any) -> None:
                 "quarantine_path": entry.quarantine_path,
             },
         )
-        ui.label(
-            "Preview unavailable — error loading quarantine data."
-        ).classes("text-red-600")
+        ui.label("Preview unavailable — error loading quarantine data.").classes("text-red-600")
 
 
 __all__ = ["data_management_page"]

--- a/docs/TASKS/2026-05-03-data-page-service-boundary-plan.md
+++ b/docs/TASKS/2026-05-03-data-page-service-boundary-plan.md
@@ -1,0 +1,578 @@
+# Data Page Service Boundary And Implementation Plan
+
+Date: 2026-05-03
+Companion: `docs/TASKS/2026-05-03-data-page-ui-optimization-plan.md`
+Status: Planning
+
+## Purpose
+
+This document turns the Data Page UI optimization direction into implementation-sized service and UI slices. It is intentionally conservative: first make existing local data state visible and consistent, then add acquisition controls, then replace mock explorer and quality paths.
+
+## Design Rules
+
+1. Manifest-backed local parquet is the source of truth for local data availability.
+2. Alpaca SIP canonical storage is raw. UI code must not imply adjusted storage.
+3. Data Explorer and SQL Explorer must not implement separate path resolution rules.
+4. RBAC and dataset-level authorization stay in services, not page code.
+5. Heavy filesystem/DuckDB operations stay off the NiceGUI event loop.
+6. Architecture changes that introduce shared provider/catalog services should get an ADR before implementation if the scope expands beyond UI/service read models.
+7. Queryable local parquet and trusted manifest-backed availability are distinct states. SQL Explorer may expose tightly bounded fallback reads for local inspection, but readiness and provenance views must require manifests.
+8. Alpaca SIP canonical datasets (`alpaca_sip_daily`, `alpaca_sip_corp_actions`) require manifests for `/data` preview, `/data` SQL handoff, readiness, and backtest handoff. Fallback parquet discovery is untrusted local inspection only and must not expose readiness or provenance claims.
+9. Canonical storage mode and read-time adjustment mode are distinct fields. For Alpaca SIP after PR #218, canonical storage is `raw` and read-time adjustment is unavailable until a dedicated layer exists.
+
+## Proposed Service Boundaries
+
+Any `provider_signature` returned to UI/API consumers is a sanitized replay bundle. It must follow one shared allowlist contract across manifest summaries, acquisition jobs, dataset summaries, previews, and handoff payloads. Credentials, tokens, auth headers, raw URLs with secrets, and unbounded raw request payloads are never exposed.
+
+### Provider Signature Contract
+
+Candidate shared serializer:
+
+- `libs/web_console_services/provider_signature.py`
+
+Allowed keys:
+
+- `provider_id`
+- `provider_version`
+- `source_feed`
+- `adjustment_mode`
+- `canonical_storage_mode`
+- `read_time_adjustment_mode`
+- `symbol_set_hash`
+- `query_params_hash`
+- `manifest_id`
+- `manifest_reference`
+- `manifest_checksum`
+- `manifest_version`
+- `schema_version`
+- `sync_started_at`
+- `sync_finished_at`
+- `data_roles`
+- `dataset_keys`
+
+DTO shape:
+
+```python
+class ProviderSignatureDTO(BaseModel):
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    adjustment_mode: str | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+    symbol_set_hash: str | None = None
+    query_params_hash: str | None = None
+    manifest_id: str | None = None
+    manifest_reference: str | None = None
+    manifest_checksum: str | None = None
+    manifest_version: str | None = None
+    schema_version: str | None = None
+    sync_started_at: AwareDatetime | None = None
+    sync_finished_at: AwareDatetime | None = None
+    data_roles: dict[str, str] | None = None
+    dataset_keys: list[str] | None = None
+```
+
+Rules:
+
+- All UI/API-facing provider signatures must be produced by the shared serializer.
+- Source manifests may store fields individually, but services must derive the same sanitized signature shape before returning them to the UI.
+- The serializer must reject or drop credentials, tokens, auth headers, signed URLs, raw request URLs containing secrets, and oversized raw request bodies.
+
+### 1. Manifest Summary Read Model
+
+Candidate module:
+
+- `libs/web_console_services/data_manifest_service.py`
+
+Responsibilities:
+
+- Load `SyncManifest` records for one dataset or a dataset group.
+- Normalize manifest fields for UI display.
+- Resolve file count, row count, checksum, schema version, validation status, sync timestamp, age, and missing companions.
+- Return reversible provenance fields: `manifest_id`, manifest path/reference, manifest checksum, `provider_id`, `provider_version`, `source_feed`, `adjustment_mode`, `symbol_set_hash`, `sync_started_at`, `sync_finished_at`, `wrds_query_hash` or equivalent params hash, and sanitized `provider_signature` produced by the shared allowlist serializer.
+- Define `provider_signature` as the canonical replay bundle for UI/API consumers. If a source manifest stores individual fields instead of a nested signature, the service must derive the signature from those fields and document the exact field list.
+- For Alpaca SIP, return a grouped status for:
+  - `alpaca_sip_daily`
+  - `alpaca_sip_corp_actions`
+- For Alpaca SIP, compute paired-manifest cohesion warnings for missing companions, materially different date coverage, and mismatched symbol-set hashes.
+- Today, with hash-only symbol sets, symbol-set hash mismatch is a warning by default and end-date drift greater than one business day is `alpaca_sip_companion_manifest_stale`.
+- Future manifests that expose full symbol sets can add a Jaccard overlap check; overlap below 0.99 is stale.
+- Never execute DuckDB queries.
+- Never mutate manifests.
+
+Primary consumers:
+
+- `DataSyncService`
+- `DataSourceStatusService`
+- `DataExplorerService`
+- `/data` operations grid and detail drawer
+- `/data/source-status`
+
+Notes:
+
+- The existing manifest logic in `DataSyncService` and `DataSourceStatusService` can move here first.
+- SQL Explorer path safety is stricter than summary display. Share primitives carefully; do not weaken SQL Explorer validation.
+
+### 2. Dataset Catalog Read Model
+
+Candidate module:
+
+- `libs/web_console_services/data_catalog_service.py`
+
+Responsibilities:
+
+- List authorized datasets.
+- Combine dataset/table metadata with local availability from the manifest summary and SQL table availability.
+- Link to static `ProviderSpec` metadata only where a dataset has a historical provider identity. Do not assume `ProviderSpec` covers Compustat, TAQ, Fama-French, or every future table family.
+- Replace repeated `_SUPPORTED_DATASETS` tuples in sync/explorer/quality services.
+- Return display metadata:
+  - dataset key
+  - provider ID
+  - provider display name
+  - tables
+  - capabilities
+  - production allowed
+  - canonical storage mode
+  - read-time adjustment mode
+  - local availability
+  - last sync
+
+Primary consumers:
+
+- `DataSyncService`
+- `DataExplorerService`
+- `DataQualityService`
+- `/data` top context strip
+- `/data/sql-explorer` dataset selector, eventually
+
+### 3. Acquisition Job Interface
+
+Candidate modules:
+
+- `libs/web_console_services/data_sync_service.py`
+- `libs/web_console_services/schemas/data_management.py`
+- future worker adapter if sync execution moves out of process
+
+New DTOs to consider:
+
+```python
+class DataAcquisitionPreflightRequestDTO(BaseModel):
+    dataset: str
+    provider_id: str | None = None
+    source_feed: str | None = None
+    adjustment: Literal["raw"] | None = None
+    mode: Literal["incremental", "targeted_backfill", "full_backfill"]
+    start_date: date | None = None
+    end_date: date | None = None
+    symbols: list[str] | None = None
+    universe_id: str | None = None
+    reason: str
+
+
+class DataAcquisitionPreflightDTO(BaseModel):
+    dataset: str
+    provider_id: str | None = None
+    source_feed: str | None = None
+    adjustment: Literal["raw"] | None = None
+    idempotency_key: str
+    submit_token: str
+    submit_token_expires_at: AwareDatetime
+    normalized_scope: dict[str, Any]
+    estimated_api_calls: int | None = None
+    estimated_rows: int | None = None
+    estimated_bytes: int | None = None
+    required_manifests: list[str]
+    output_paths: list[str]
+    warnings: list[str]
+    blocked_reason: str | None = None
+
+
+class DataAcquisitionSubmitRequestDTO(BaseModel):
+    dataset: str
+    idempotency_key: str
+    submit_token: str
+    normalized_scope: dict[str, Any]
+    reason: str
+
+
+class DataAcquisitionJobDTO(BaseModel):
+    id: str
+    dataset: str
+    provider_id: str | None = None
+    source_feed: str | None = None
+    adjustment: Literal["raw"] | None = None
+    idempotency_key: str
+    preflight_status: Literal["consumed", "expired"] | None = None
+    status: Literal["queued", "running", "succeeded", "failed", "cancelled"]
+    produced_manifest_ids: list[str]
+    produced_manifest_references: list[str]
+    provider_signature: ProviderSignatureDTO | None = None
+    row_count: int | None = None
+    started_at: AwareDatetime | None = None
+    completed_at: AwareDatetime | None = None
+    error: str | None = None
+```
+
+Rules:
+
+- Trigger requires `TRIGGER_DATA_SYNC`.
+- User must have dataset access.
+- Reason is required for audit logging.
+- Alpaca SIP canonical daily sync must display and enforce `adjustment=raw`.
+- Alpaca SIP preflight must reject requests that omit `adjustment` or set anything other than `"raw"` for canonical raw-only datasets; the server must not silently coerce missing adjustment values.
+- `adjustment=None` is permitted only for non-adjustment datasets such as corporate actions. The `Literal["raw"]` type should widen only when a real adjusted-mode contract exists.
+- Corporate-actions sync carries provider/source provenance but does not require an `adjustment` field because it does not store adjusted price bars.
+- Alpaca SIP daily sync currently supports symbol lists and year-partitioned `start_year`/`end_year` behavior. Arbitrary partial-date targeted backfills require either preflight normalization to year scope or a new sync-manager capability.
+- The server calculates the idempotency key from normalized dataset, provider, source feed, adjustment, mode, symbol scope, and date/year scope.
+- Submission must include the preflight idempotency key and submit token through `DataAcquisitionSubmitRequestDTO`; the server must verify they still match the current request parameters.
+- Submit tokens are single-use and expire after five minutes. Expired, reused, or mismatched tokens return a stable `preflight_required` error so the UI can prompt a fresh preflight rather than silently re-preflighting.
+- `submit_token` is a cryptographically random opaque value bound server-side to the idempotency key and requesting principal. It is never derivable from request inputs.
+- Job DTOs, logs, and UI job state must never return the submit-token value after submission. They may expose token status or expiry only.
+- Duplicate in-flight jobs for the same dataset/scope should return existing job state or fail clearly.
+- Placeholder or queued adapters must enforce the same raw adjustment check, submit-token verification, and duplicate rejection as the eventual background worker path.
+
+### 4. Explorer Preview Interface
+
+Candidate modules:
+
+- `libs/web_console_services/data_explorer_service.py`
+- required public resolver/query-preview API extracted from `libs/web_console_services/sql_explorer_service.py` or placed in a dedicated shared module
+
+Responsibilities:
+
+- Provide safe preview, schema, and summaries for one authorized dataset/table.
+- Use the same available-table validation, path validation, DuckDB memory/thread limits, blocked-function policy, and dataset authorization model as SQL Explorer.
+- Use bounded limits for previews.
+- Return manifest/provenance metadata alongside rows.
+- Provide SQL Explorer handoff payloads rather than executing arbitrary cross-dataset SQL in the selected-row preview strip.
+
+New DTOs to consider:
+
+```python
+class DatasetTableSummaryDTO(BaseModel):
+    dataset: str
+    table: str
+    available: bool
+    trusted_manifest_backed: bool
+    manifest_id: str | None = None
+    manifest_reference: str | None = None
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    provider_signature: ProviderSignatureDTO | None = None
+    row_count: int | None = None
+    min_date: str | None = None
+    max_date: str | None = None
+    symbol_count: int | None = None
+    columns: list[str]
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+
+
+class DatasetPreviewRequestDTO(BaseModel):
+    dataset: str
+    table: str
+    limit: int = 100
+    symbol: str | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+
+
+class DatasetPreviewDTO(BaseModel):
+    columns: list[str]
+    rows: list[dict[str, Any]]
+    total_count: int | None
+    has_more: bool
+    manifest_id: str | None = None
+    manifest_reference: str | None = None
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    provider_signature: ProviderSignatureDTO | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+    null_column_reasons: dict[str, str]
+    warnings: list[str]
+
+
+class SqlExplorerHandoffDTO(BaseModel):
+    dataset: str
+    table: str
+    query: str
+    trusted_manifest_backed: bool
+    manifest_id: str | None = None
+    manifest_reference: str | None = None
+    manifest_checksum: str | None = None
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    adjustment_mode: str | None = None
+    provider_signature: ProviderSignatureDTO | None = None
+    warnings: list[str]
+
+
+class BacktestHandoffPayloadDTO(BaseModel):
+    workflow: str
+    dataset_keys: list[str]
+    data_roles: dict[str, str]
+    manifest_ids: dict[str, str | None]
+    manifest_references: dict[str, str | None]
+    manifest_checksums: dict[str, str | None]
+    provider_ids: dict[str, str | None]
+    provider_versions: dict[str, str | None]
+    source_feeds: dict[str, str | None]
+    canonical_storage_modes: dict[str, str | None]
+    read_time_adjustment_modes: dict[str, str | None]
+    provider_signatures: dict[str, ProviderSignatureDTO]
+    null_column_reasons: dict[str, str]
+    blockers: list[str]
+```
+
+Rules:
+
+- Default preview for `alpaca_sip_daily` must state that OHLC is raw and `adj_close`/`ret` are unavailable because canonical storage is raw.
+- Preview must not derive returns from raw close.
+- Exact row counts, min/max dates, and symbol counts must be manifest-derived, cached, or bounded by explicit timeout and memory limits. They may be null when an exact scan would be too expensive.
+- `/data` preview and generated SQL handoff for Alpaca SIP canonical datasets require `trusted_manifest_backed=True`. Fallback parquet without manifests may be visible as untrusted local inspection state but must not expose `/data` preview/readiness/backtest actions.
+- For advanced queries, hand off to SQL Explorer with a generated safe query and `SqlExplorerHandoffDTO`.
+- SQL Explorer must verify the manifest reference/checksum in the handoff still matches current path resolution before treating the query as trusted. If it does not match, SQL Explorer must refuse the trusted handoff or downgrade it to explicit untrusted local inspection.
+- Backtest handoff uses `BacktestHandoffPayloadDTO` so hybrid and adjustment-aware workflows carry per-role provenance for `universe`, `prices`, and `corp_actions`.
+- `BacktestHandoffPayloadDTO` role-keyed maps use canonical role keys `universe`, `prices`, and `corp_actions`. `data_roles` maps each role to the selected dataset/provider source, while `dataset_keys` lists every referenced dataset key. The manifest/provider/feed/storage/adjustment maps and `provider_signatures` are keyed by the same role keys so UI, `/backtest`, and tests do not mix role keys with dataset keys or collapse hybrid replay provenance into one provider.
+
+### 5. Readiness Checks
+
+Candidate module:
+
+- `libs/web_console_services/data_readiness_service.py`
+
+Responsibilities:
+
+- Answer whether a dataset/provider is usable for a workflow.
+- Workflows:
+  - data preview
+  - simple backtest
+  - hybrid research backtest
+  - quality analysis
+  - SQL exploration
+- Return blockers and warnings with links/actions.
+- Use stable reason codes so `/data`, `/backtest`, and tests can assert the same fail-closed states.
+
+Example checks:
+
+- Alpaca SIP daily manifest exists.
+- Alpaca SIP corporate-actions manifest exists when adjustment-aware workflow is requested.
+- Requested date range is within provider history.
+- Provider is production allowed or the environment is explicitly non-production.
+- CRSP universe availability exists for hybrid workflow.
+- Selected adjustment mode is supported.
+- `raw_sip_returns_unavailable`: block any workflow that would require `ret`, `adj_close`, or derived returns from raw Alpaca SIP OHLC while read-time adjustment is unavailable.
+- `alpaca_sip_untrusted_without_manifest`: block trusted/readiness workflows when only fallback parquet files exist without manifests.
+- `alpaca_sip_companion_manifest_stale`: warn or block when daily bars and corporate actions are materially out of date relative to each other for an adjustment-aware workflow.
+- `alpaca_sip_companion_symbol_set_mismatch`: warn when paired daily bars and corporate actions have different symbol-set hashes under the current hash-only manifest format.
+- `crsp_universe_unavailable`: block hybrid workflows when the CRSP universe role is required but unavailable.
+
+## UI Component Split
+
+Target files:
+
+- `apps/web_console_ng/pages/data_management.py`
+- new `apps/web_console_ng/components/data_operations_grid.py`
+- new `apps/web_console_ng/components/data_context_ribbon.py`
+- new `apps/web_console_ng/components/data_detail_drawer.py`
+- new `apps/web_console_ng/components/data_acquisition_section.py`
+- new `apps/web_console_ng/components/data_preview_strip.py`
+- new `apps/web_console_ng/components/data_quality_section.py`
+- new `apps/web_console_ng/components/data_readiness_section.py`
+
+Initial split should preserve behavior before changing service contracts. This lowers risk because `data_management.py` is already large and timer-heavy. The final composition should be grid-first: context ribbon, dense operations grid, selected-row detail drawer, and compact preview/query strip.
+
+## Implementation Slices
+
+### Slice 1: Component Split Only
+
+Files:
+
+- `apps/web_console_ng/pages/data_management.py`
+- new component files under `apps/web_console_ng/components/`
+- existing tests for `/data`
+
+Work:
+
+- Move sync, explorer, and quality render helpers into components.
+- Introduce the grid/detail-drawer scaffolding without changing service outputs.
+- Keep existing service calls unchanged.
+- Keep timers and cleanup ownership behavior intact.
+
+Acceptance:
+
+- Existing tests pass without service behavior changes.
+- Page still renders for each permission combination.
+- The page has a single primary dataset/table grid placeholder rather than independent top-level Sync, Explorer, and Quality surfaces.
+
+### Slice 2: Manifest Summary Service
+
+Files:
+
+- `libs/web_console_services/data_manifest_service.py`
+- `libs/web_console_services/data_sync_service.py`
+- `libs/web_console_services/data_source_status_service.py`
+- service tests
+
+Work:
+
+- Extract Alpaca SIP manifest loading and grouped status.
+- Add tests for no manifests, one manifest missing, both present/passed, present/failed.
+- Add tests for provenance fields and paired-manifest date/symbol cohesion warnings.
+- Replace duplicated private helpers.
+
+Acceptance:
+
+- `/data` sync status and `/data/source-status` report the same Alpaca SIP status.
+- File counts, row counts, and validation statuses are deterministic in tests.
+- Provenance fields required by PR #218 are visible in the returned read model.
+
+### Slice 3: Dense Operations Grid UI
+
+Files:
+
+- `apps/web_console_ng/components/data_context_ribbon.py`
+- `apps/web_console_ng/components/data_operations_grid.py`
+- `apps/web_console_ng/components/data_detail_drawer.py`
+- `apps/web_console_ng/pages/data_management.py`
+- page/component tests
+
+Work:
+
+- Add top context ribbon, dense dataset/table grid, and selected-row details drawer.
+- Display provider capabilities and manifest details in grid columns and drawer sections.
+- Add raw-data badge for Alpaca SIP.
+- Display issue-count jump links that filter the operations grid.
+- Move acquisition, quality, readiness, and preview affordances into selected-row drawer sections.
+
+Acceptance:
+
+- Users can see manifest IDs and missing companion manifests without opening SQL Explorer.
+- UI never labels Alpaca SIP canonical data as adjusted.
+- The primary page can be scanned from one grid without switching feature tabs.
+
+### Slice 4: Acquisition Preflight
+
+Files:
+
+- `libs/web_console_services/schemas/data_management.py`
+- `libs/web_console_services/data_sync_service.py`
+- `apps/web_console_ng/components/data_acquisition_section.py`
+- tests for permissions, validation, idempotency, and UI state
+
+Work:
+
+- Add preflight request/result DTOs.
+- Add preflight endpoint/service method for Alpaca SIP daily and corporate actions.
+- Add submit flow gated by preflight and reason.
+- Keep execution as a queued/placeholder adapter if full background job integration is not ready, but the placeholder path must enforce raw adjustment, submit-token verification, and duplicate rejection.
+- Resolve Open Question 1 before starting this slice; the chosen placeholder/script-backed/worker path must still meet the same safety rules.
+
+Acceptance:
+
+- No direct sync submission without a preflight result.
+- UI shows `adjustment=raw` for canonical Alpaca SIP daily sync.
+- Alpaca SIP preflight rejects missing or non-raw adjustment values for canonical raw-only datasets.
+- Corporate-actions preflight does not require adjustment metadata.
+- Preflight returns an idempotency key derived from normalized sync scope, plus a cryptographically random opaque submit token bound server-side to that idempotency key, normalized scope, and requesting principal.
+- Submit request consumes the preflight token, and job responses/logs never expose the consumed token value.
+- Alpaca SIP daily preflight documents current year-partitioned sync behavior or blocks unsupported targeted-date sync.
+- Duplicate dataset/scope submissions are guarded.
+
+### Slice 5: Explorer Backend Replacement
+
+Files:
+
+- `libs/web_console_services/data_explorer_service.py`
+- extracted SQL/path helper module, if needed
+- `apps/web_console_ng/components/data_preview_strip.py`
+- tests for path safety, permission filtering, previews, and handoff
+
+Work:
+
+- Replace placeholder metadata with catalog/manifest/table availability.
+- Add a local availability classifier that combines manifest summary state with SQL Explorer path resolution so the UI can distinguish trusted manifest-backed availability from `queryable fallback only`.
+- Add bounded DuckDB preview using validated table paths.
+- Add query templates.
+- Add "Open in SQL Explorer" handoff route/query state with `SqlExplorerHandoffDTO`.
+- Add SQL Explorer ingestion of `SqlExplorerHandoffDTO`, current-manifest re-resolution, checksum comparison, and trusted-to-untrusted downgrade/refusal behavior.
+
+Acceptance:
+
+- `alpaca_sip_daily` trusted previews read manifest-pinned parquet paths.
+- Explorer availability matches SQL Explorer availability.
+- Explorer distinguishes queryable fallback parquet from trusted manifest-backed data.
+- Alpaca SIP fallback parquet without manifests is not previewable or eligible for generated `/data` SQL handoff.
+- SQL Explorer handoff refuses or downgrades trusted state when manifest reference/checksum no longer matches.
+- Unauthorized datasets are hidden or rejected server-side.
+
+### Slice 6: Quality And Readiness
+
+Files:
+
+- `libs/web_console_services/data_quality_service.py`
+- `libs/web_console_services/data_readiness_service.py`
+- `apps/web_console_ng/components/data_quality_section.py`
+- `apps/web_console_ng/components/data_readiness_section.py`
+- tests
+
+Work:
+
+- Wire manifest/integrity/feed-delta result summaries.
+- Add readiness checks for backtest workflows.
+- Link blockers to acquisition or quality actions.
+- Define concrete quality inputs before implementation: manifest validation status, `alpaca_sip_integrity` reports, `alpaca_feed_delta` reports, staleness rules, and persisted alert acknowledgments.
+
+Acceptance:
+
+- Missing Alpaca SIP manifests are readiness blockers.
+- Raw-return fail-closed behavior is visible before backtest submission.
+- Quality cards are not mock-only for Alpaca SIP.
+- Quality cards identify their data source and timestamp, or render as unavailable rather than mock-derived.
+- Alert acknowledgments persist server-side with actor, time, source, and issue scope before they affect operational state. If persistence is unavailable, acknowledgment controls render unavailable.
+
+## Test Strategy
+
+Service tests:
+
+- Manifest summary for missing/partial/passed/failed manifests.
+- Dataset catalog permission filtering.
+- Preflight validation and idempotency keys.
+- Submit-token lifecycle: cryptographically random opaque tokens bound to idempotency key and requesting principal, single use, five-minute expiry, stable `preflight_required` for expired/reused/mismatched/forged tokens, and no token values in job DTOs/logs.
+- Provider signature allowlist serialization, including negative tests for credentials, auth headers, tokens, signed URLs, and oversized raw request bodies across manifest summaries, acquisition jobs, previews, SQL handoff, and backtest handoff.
+- Preview path safety and row limits.
+- SQL Explorer handoff provenance and manifest revalidation.
+- Backtest handoff per-role manifest/provider/feed/storage/adjustment metadata, provider signatures, provider versions, and canonical map key convention.
+- Readiness checks for Alpaca SIP and hybrid provider, including explicit assertions for `raw_sip_returns_unavailable`, `alpaca_sip_untrusted_without_manifest`, `alpaca_sip_companion_manifest_stale`, `alpaca_sip_companion_symbol_set_mismatch`, and `crsp_universe_unavailable`.
+- Persisted quality acknowledgment behavior, including actor/time/source/scope metadata and unavailable UI state when persistence is unavailable.
+
+Page/component tests:
+
+- Permission-specific grid row, drawer section, and action visibility.
+- Raw-data badges.
+- Missing manifest warnings.
+- Preflight-required submit behavior.
+- SQL Explorer handoff URL/query payload and provenance payload.
+
+Regression tests:
+
+- Existing SQL Explorer safety tests remain authoritative for query execution.
+- Existing source-status tests should be updated to use the shared manifest service.
+- Backtest UI tests should assert per-role provider/provenance handoff once readiness links are added.
+
+## Open Questions
+
+1. Which execution mechanism should Slice 4 use first: in-process placeholder, script/sync-manager shellout, or a new background worker? Decision required before Slice 4; all options must enforce the same safety rules above.
+2. Should `/data/source-status` remain a full page, or become an alias/deep link into `/data` once the hub has source-health parity?
+3. Where should shared SQL table/path resolution live so SQL Explorer remains hardened while Data Explorer can reuse it?
+4. Does the adjustment layer require a new ADR before any adjusted preview prototype? This plan assumes yes.
+5. What is the first target operator workflow: Alpaca SIP daily backfill, corporate-actions backfill, or dataset readiness for backtests?
+
+## Immediate Next Step
+
+Start with Slice 1 and Slice 2. That creates a safer structure and removes duplicated Alpaca SIP manifest logic without changing sync execution or adding adjustment behavior.

--- a/docs/TASKS/2026-05-03-data-page-ui-optimization-plan.md
+++ b/docs/TASKS/2026-05-03-data-page-ui-optimization-plan.md
@@ -1,0 +1,360 @@
+# Data Page UI Optimization Plan (Gemini-Informed)
+
+Date: 2026-05-03
+Branch: `feature/data-page-ui-optimization-plan`
+Base: latest `master` at PR #218 merge commit `c7fb3526`
+Scope: `apps/web_console_ng/pages/data_management.py`, related `/data/*` pages, and `libs/web_console_services/*data*`
+
+## Inputs Used
+
+- Latest `master` after merged PR #218, "[codex] Harden Alpaca SIP raw semantics".
+- GitHub PR #218 metadata and merge summary.
+- Direct Gemini CLI discussion (`gemini -p`) focused on data acquisition, data utilization, and UI optimization.
+- Local inspection of:
+  - `apps/web_console_ng/pages/data_management.py`
+  - `apps/web_console_ng/pages/data_source_status.py`
+  - `apps/web_console_ng/pages/data_coverage.py`
+  - `apps/web_console_ng/pages/data_inspector.py`
+  - `apps/web_console_ng/pages/sql_explorer.py`
+  - `libs/web_console_services/data_sync_service.py`
+  - `libs/web_console_services/data_explorer_service.py`
+  - `libs/web_console_services/data_quality_service.py`
+  - `libs/web_console_services/data_source_status_service.py`
+  - `libs/web_console_services/sql_explorer_service.py`
+  - `libs/data/data_providers/registry.py`
+  - `docs/ADRs/ADR-0041-alpaca-sip-historical-provider.md`
+  - `docs/ADRs/ADR-0042-hybrid-crsp-sip-research-provider.md`
+  - `docs/TASKS/2026-04-28-alpaca-sip-data-source-plan.md`
+
+## PR #218 Constraints To Preserve
+
+PR #218 changed the data surface in ways the UI must make obvious:
+
+1. Alpaca SIP canonical sync stores raw daily OHLC.
+2. `adj_close` and `ret` remain null until an explicit read-time adjustment layer exists.
+3. Raw SIP-priced simple backtests fail closed instead of deriving split-unsafe returns from raw close.
+4. Provider provenance/signature metadata is stricter and must remain reversible.
+5. Alpaca SIP daily bars and corporate actions are local parquet datasets with manifests.
+6. SQL Explorer already uses manifest-pinned Alpaca SIP paths; the rest of the data UI should not drift from that source of truth.
+7. Alpaca SIP canonical datasets require manifests for `/data` previews, readiness, SQL handoff, and backtest handoff. Fallback parquet discovery without manifests is untrusted local inspection only and must not carry readiness or provenance claims.
+
+## Current Backend Reality
+
+The current data UI is useful but fragmented:
+
+1. `/data` is a large tabbed page with Data Sync, Data Explorer, and Data Quality sections. The module already has a TODO to split sections into components.
+2. `DataSyncService` is still mostly placeholder data, but it now reads Alpaca SIP manifests for `alpaca_sip` status.
+3. `DataExplorerService` still returns placeholder dataset metadata and empty query/preview results.
+4. `DataQualityService` still uses mock/in-memory results and acknowledgments.
+5. `/data/source-status` uses `DataSourceStatusService`; Alpaca SIP status is manifest-backed.
+6. `/data/sql-explorer` is the most production-like data UI today. It safely creates DuckDB views over authorized local parquet tables and already maps `alpaca_sip_daily` and `alpaca_sip_corp_actions` through manifest-aware path resolution.
+7. `/data/coverage` and `/data/inspector` are useful but disconnected from manifest/provenance state and the newer provider registry.
+8. Provider metadata is centralized in `libs/data/data_providers/registry.py`, including production readiness, history start, feed parity, survivorship safety, corporate-action support, and default adjustment mode.
+9. `ProviderSpec` is not a complete dataset catalog. It covers historical provider identities such as CRSP, yfinance, Alpaca SIP, hybrid, and auto, but not every UI dataset/table family such as Compustat, TAQ, or Fama-French.
+
+## Product Direction
+
+Make `/data` the operator and researcher entry point for the complete local-data lifecycle:
+
+1. See what data exists and whether it is trustworthy.
+2. Acquire or refresh data with preflight checks.
+3. Inspect exactly which manifest, files, provider, feed, and adjustment mode are being used.
+4. Explore data through safe previews and SQL handoff.
+5. Understand whether a dataset is ready for backtests or model research.
+
+This is not a visual redesign for its own sake. The page needs to reduce bad research decisions caused by raw/adjusted confusion, stale manifests, missing corporate actions, or mock UI confidence.
+
+## Information Architecture
+
+Replace the current "three tabs plus separate pages" feel with a dense Dataset Operations Grid. The primary unit of the page is a dataset/table row, not a feature tab.
+
+The old mental model is:
+
+- Data Sync
+- Data Explorer
+- Data Quality
+- Source Status
+- Coverage
+- SQL Explorer
+
+The target mental model is:
+
+- All authorized datasets/tables in one dense operational grid.
+- Fast filters for `Needs Attention`, `Backtest Ready`, `Alpaca SIP`, `Missing Manifest`, `Untrusted`, `Quality Issues`, and `Queryable`.
+- A right-side details drawer for the selected row.
+- A compact bottom preview/query strip when the selected row is queryable.
+- Deep links to `/data/source-status`, `/data/coverage`, `/data/inspector`, and `/data/sql-explorer` remain available, but the main `/data` page is the entry point and summary surface.
+
+### Top Context Ribbon
+
+Show global data state across all authorized datasets:
+
+- Provider readiness: `ok`, `stale`, `error`, `missing`, `unknown`.
+- Counts for healthy, stale, missing, untrusted, blocked-for-backtest, and quality-issue rows.
+- Oldest/latest manifest age.
+- Total local rows.
+- Permission-scoped hidden dataset count.
+- Issue count with jump links that filter the main grid.
+
+For Alpaca SIP, always show a raw-data badge until an adjustment layer exists:
+
+- `Raw OHLC`
+- `canonical_storage_mode: raw`
+- `read_time_adjustment_mode: unavailable`
+- `adj_close: not available`
+- `ret: not available`
+- `corp actions: present/missing`
+
+### Main Dataset Operations Grid
+
+Render one row per authorized dataset/table or table group. This grid replaces low-information cards and most top-level tabs.
+
+Column tiers:
+
+- Always visible and pinned: dataset/table name, raw-data pill when canonical storage is raw, local state, manifest status, last sync age, backtest readiness, issue count, and quick actions.
+- Visible on wide layouts or when the user enables columns: provider or dataset family, row count, approximate size, date range, symbol count, quality state, canonical storage mode, and read-time adjustment mode.
+- Drawer-only by default: manifest path/reference, checksum, schema version, validation details, full provenance fields, detailed quality output, companion-manifest cohesion details, and acquisition job logs.
+
+Grid behavior:
+
+- Keep rows dense and sortable/filterable.
+- Pin dataset/table and status columns.
+- Use compact badges instead of large cards.
+- Keep fixed row height by default. Long values truncate with tooltip disclosure, and full values live in the details drawer.
+- Let the top ribbon filters apply directly to grid rows.
+- Do not show large prose instructions in the UI; use tooltips and details drawer fields.
+
+### Selected Row Details Drawer
+
+Selecting a grid row opens a right-side drawer with compact sections. The drawer replaces separate low-density status, explorer, quality, readiness, and sync panels.
+
+Sections:
+
+- Summary: provider/dataset family, state, row count, date range, symbol count, readiness.
+- Manifest and provenance: manifest version, manifest path/reference, checksum, row count, schema version, validation status, `manifest_id`, `provider_id`, `provider_version`, `source_feed`, `adjustment_mode`, `symbol_set_hash`, sync start/finish times, query/params hash, and sanitized `provider_signature` from the shared allowlist serializer sufficient to reconstruct provenance without relying on a hash alone.
+- Alpaca SIP pairing: daily/corporate-actions companion status, date coverage, symbol-set hash, and cohesion warnings.
+- Acquisition: preflight controls, estimated calls/bytes, output paths, idempotency key, submit-token expiry/status, and job state. Token values appear only in the immediate preflight response used by submit, not in job state or logs.
+- Quality: latest validation, integrity, feed-delta, staleness, and alert state.
+- Readiness: workflow-specific blockers and warnings, including stable reason codes.
+- Query: safe preview, query templates, and SQL Explorer handoff.
+
+Keep `/data/source-status` as a deep link or redirect while the main `/data` grid becomes the primary path.
+
+### Acquisition Drawer Section
+
+Turn "Manual Sync" from a dataset/reason form into a guarded selected-row acquisition workflow:
+
+- Dataset/provider selection comes from the selected grid row.
+- Mode: preflight, incremental sync, targeted backfill, full backfill.
+- Inputs by dataset:
+  - Alpaca SIP daily: symbols/universe, start date, end date, feed, adjustment policy locked to raw for canonical sync.
+  - Alpaca SIP corporate actions: symbols/universe, start date, end date.
+  - CRSP/Compustat/TAQ/Fama-French: future adapters as they become available.
+- Current Alpaca SIP daily sync capabilities are year-partition oriented. The UI preflight must either round date ranges to supported `start_year`/`end_year` semantics or require a separate targeted-date implementation before exposing arbitrary partial-date sync.
+- Preflight output:
+  - estimated API calls or file scans
+  - disk space estimate
+  - expected output paths
+  - server-calculated idempotency key, submit token, and token expiry
+  - provider/feed/adjustment provenance
+  - required credentials or unavailable reason
+- Job status with logs, manifest produced, row count, validation result, and consumed/expired preflight status. Job state never shows the submit-token value.
+
+Do not let the UI suggest adjusted SIP bars are being stored. Canonical Alpaca SIP acquisition remains raw.
+
+### Preview And SQL Strip
+
+Replace the mock `DataExplorerService` behavior with a DuckDB-backed, manifest-pinned explorer path:
+
+- Dataset metadata comes from a shared catalog, not duplicated `_SUPPORTED_DATASETS` tuples.
+- Preview is scoped to the selected grid row and uses the same table/path resolution as SQL Explorer.
+- Alpaca SIP canonical previews and `/data` SQL handoffs require manifest-pinned paths. If only fallback parquet files are discovered, the grid may show `queryable fallback only`, but `/data` disables preview, readiness, and backtest handoff and points users to standalone SQL Explorer local inspection with an explicit untrusted warning.
+- Schema view includes physical table, manifest ID, storage path, and provider.
+- Preview results include provider/feed/provenance metadata and explicit null-column reason codes for `adj_close` and `ret`.
+- Add "Open in SQL Explorer" action that pre-populates a safe query for the selected dataset/table and carries a provenance-bearing handoff payload.
+- Provide curated query templates for common questions:
+  - latest rows by symbol
+  - date coverage by symbol
+  - row count by partition year
+  - Alpaca SIP corporate actions near a date range
+  - daily bars with missing `adj_close`/`ret`
+
+### Quality Drawer Section
+
+Shift Data Quality from mock score cards toward manifest and check outputs:
+
+- Alpaca SIP integrity check results.
+- Alpaca feed delta check results.
+- Manifest completeness and schema checks.
+- Corporate-actions pairing checks.
+- Manifest/date/symbol cohesion checks between paired Alpaca SIP datasets.
+- Coverage gaps from the same local table mappings used by Explorer.
+- Alert acknowledgments persisted server-side before treating them as operational state.
+
+### Readiness Drawer Section
+
+Add a focused "Can I use this data?" view:
+
+- Backtest readiness for each provider.
+- Missing conditions that would cause fail-closed behavior.
+- History start and requested date compatibility.
+- Survivorship safety and PIT support.
+- Required manifests for the selected workflow.
+- Stable blocker/warning reason codes, including `raw_sip_returns_unavailable`, `alpaca_sip_untrusted_without_manifest`, `alpaca_sip_companion_manifest_stale`, `alpaca_sip_companion_symbol_set_mismatch`, and `crsp_universe_unavailable`.
+
+For Alpaca SIP:
+
+- `alpaca_sip` simple price-only research is allowed only when the workflow does not require `ret`, `adj_close`, or derived returns.
+- `alpaca_sip` and `hybrid_crsp_universe_sip_prices` simple backtests are blocked when they would compute returns from raw SIP close. They remain blocked until a read-time adjustment layer exists or trusted adjusted returns are available.
+- `hybrid_crsp_universe_sip_prices` requires CRSP universe data plus SIP price data and remains research-only.
+- Any UI handoff to backtest must carry role-keyed provider IDs/versions/signatures, manifest IDs/references/checksums, canonical storage modes, read-time adjustment modes, and data role provenance.
+
+## Gemini Notes Incorporated
+
+Gemini highlighted three useful corrections:
+
+1. Treat manifest visibility as the center of the UI, not a side detail.
+2. Make raw-versus-adjusted state explicit before adding an adjustment toggle.
+3. Avoid a second explorer backend; use or share the SQL Explorer path that already enforces manifest-pinned reads.
+
+The plan follows those points but keeps adjustment as a later phase because PR #218 intentionally leaves `adj_close` and `ret` null until a real read-time layer exists.
+
+## Phased Plan
+
+### Phase 1: Manifest Transparency
+
+Goal: users can tell exactly what local data exists.
+
+Work:
+
+- Add shared manifest summary read model.
+- Surface manifest version, checksum, row count, validation status, schema version, age, and file count.
+- Surface provider/feed/provenance fields required for replay: `manifest_id`, manifest path/reference, manifest checksum, `provider_id`, `provider_version`, `source_feed`, `adjustment_mode`, `symbol_set_hash`, sync start/finish times, query/params hash, and sanitized `provider_signature` from the shared allowlist serializer.
+- Add Alpaca SIP paired-manifest status for daily bars and corporate actions.
+- Add Alpaca SIP raw-data badges and null-column reason text in the first operations-grid slice, not only in the later adjustment-design phase.
+- Add source detail drawer to `/data`.
+- Keep manual refresh guarded by existing RBAC and Redis lock semantics.
+
+Acceptance:
+
+- Alpaca SIP with no manifests shows a clear missing state.
+- Alpaca SIP with only one of the two manifests shows which companion dataset is missing.
+- Alpaca SIP warns when paired daily/corporate-action manifests exceed the configured cohesion thresholds from the service plan.
+- Alpaca SIP always shows raw canonical storage and unavailable read-time adjustment state.
+- Alpaca SIP provenance views expose enough sanitized provider/manifest metadata to reconstruct data provenance without relying on hash fields alone.
+- Alpaca SIP without manifests does not make readiness or provenance claims. Queryable fallback labeling lands with the real explorer backend in Phase 3.
+- Status shown in `/data` and `/data/source-status` matches.
+
+### Phase 2: Acquisition Workflow
+
+Goal: users can safely grab data from the UI without guessing what scripts do.
+
+Work:
+
+- Replace one-field manual sync with a preflight-first form.
+- Add structured acquisition DTOs for dataset, date range, symbol source, mode, reason, and dry-run/preflight.
+- Route Alpaca SIP requests to the existing sync managers or script-backed job adapter, with supported year-based daily sync semantics documented in the preflight result.
+- Show job state, logs, produced manifest IDs, and validation output.
+- Enforce single in-flight sync per dataset/scope using a server-calculated idempotency key and submit token.
+
+Acceptance:
+
+- Triggering Alpaca SIP daily or corporate-actions sync requires a reason and a preflight.
+- The UI displays raw canonical storage policy before job submission.
+- Alpaca SIP daily-bar submissions carry `provider_id`, `source_feed`, `adjustment=raw`, and the preflight idempotency key. Corporate-actions submissions carry provider/source provenance and do not require meaningless adjustment metadata.
+- Submit tokens are consumed only by the immediate submit request. Job state and UI logs show token expiry/status but never display the token value.
+- Duplicate submissions reuse or reject by idempotency key rather than creating duplicate jobs.
+
+### Phase 3: Real Explorer Backend
+
+Goal: users can utilize local data through safe previews and SQL handoff.
+
+Work:
+
+- Replace `DataExplorerService` mocks with a catalog plus DuckDB-backed preview path.
+- Reuse a public SQL Explorer table validation and manifest-aware path resolution API. Do not call private SQL Explorer internals from Data Explorer.
+- Add schema, row count, min/max date, symbols count, and partition summary when they are manifest-derived, cached, or bounded by timeout and memory limits.
+- Add query templates and "Open in SQL Explorer" handoff.
+- Keep exports on the hardened SQL Explorer/export path.
+
+Acceptance:
+
+- Preview rows for `alpaca_sip_daily` come from manifest-pinned parquet.
+- Preview rows for `alpaca_sip_corp_actions` come from the paired manifest.
+- Dataset availability distinguishes queryable local parquet from trusted manifest-backed availability. Alpaca SIP readiness remains missing/untrusted without manifests even if SQL Explorer can find fallback snapshot files.
+- Alpaca SIP fallback parquet without manifests is labeled `queryable fallback only`/untrusted in the grid and drawer.
+- Alpaca SIP canonical tables without manifests do not expose `/data` preview, readiness, SQL handoff, or backtest handoff actions; standalone SQL Explorer inspection, if available, is explicitly untrusted and never promoted to readiness.
+
+### Phase 4: Raw/Adjusted UX And Read-Time Adjustment Design
+
+Goal: design future adjusted previews after the raw state is already visible in Phase 1.
+
+Work:
+
+- Keep raw-data warning and adjustment-mode display in all data views.
+- Keep adjusted preview controls disabled until an accepted ADR or task defines the read-time adjustment layer.
+- Draft the adjustment service contract:
+  - raw input remains immutable
+  - corporate actions are read-only adjustment inputs
+  - adjusted output is preview/result metadata, not stored canonical OHLC
+  - return derivation is never from raw close
+- Add backtest handoff metadata for role-keyed canonical storage and read-time adjustment modes.
+
+Acceptance:
+
+- The UI never labels raw SIP close as adjusted.
+- Users can see why `adj_close` and `ret` are null.
+- Backtest-handoff payloads include per-role/per-dataset provenance: `manifest_ids`, manifest references/checksums, provider IDs/versions/signatures, source feeds, canonical storage modes, read-time adjustment modes, and data roles for `universe`, `prices`, and `corp_actions` when an adjusted mode is selected or explicitly unavailable.
+- Any future adjusted preview path is explicitly marked as derived.
+
+### Phase 5: Quality And Backtest Readiness
+
+Goal: users know whether data can be trusted for the intended workflow.
+
+Work:
+
+- Wire quality cards to real validation, integrity, feed-delta, and manifest outputs.
+- Add readiness checks for provider/date/workflow, including raw-return dependency checks.
+- Add links from failed readiness conditions to the selected-row acquisition or quality drawer sections.
+- Add backtest preflight integration for provider, date range, manifests, and adjustment mode.
+
+Acceptance:
+
+- Alpaca SIP readiness blocks or warns on missing corporate-actions manifest where the workflow needs adjustments.
+- Alpaca SIP readiness blocks simple backtests that require `ret`/`adj_close` while only raw OHLC is available.
+- Alpaca SIP and hybrid readiness expose all stable reason codes used by the service contract: `raw_sip_returns_unavailable`, `alpaca_sip_untrusted_without_manifest`, `alpaca_sip_companion_manifest_stale`, `alpaca_sip_companion_symbol_set_mismatch`, and `crsp_universe_unavailable`.
+- Hybrid readiness requires both CRSP universe availability and SIP price availability.
+- Quality acknowledgments are persisted server-side with actor, time, source, and issue scope before they affect operational state; if persistence is unavailable, acknowledgment controls render unavailable.
+- Fail-closed conditions are visible before the user submits a backtest job.
+
+## Non-Goals
+
+- No UI editing of local parquet data.
+- No silent data correction from the console.
+- No live Alpaca API calls during previews or backtests; live calls belong to explicit sync/acquisition jobs.
+- No production-grade PIT hybrid design in this UI plan.
+- No cross-dataset arbitrary join surface in the simplified Data Explorer; advanced SQL remains in SQL Explorer.
+- No derivation of returns from raw SIP close.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Users confuse raw and adjusted prices | Always show canonical storage mode, read-time adjustment mode, and raw badges for Alpaca SIP. |
+| Data UI drifts from SQL Explorer paths | Extract a public shared resolver/query-preview boundary with SQL Explorer safety tests as the authority. |
+| Mock services create false confidence | Replace mocks in Explorer/Quality before expanding UI affordances. |
+| Read-time adjustment becomes expensive | Limit preview rows and require a separate design before broad use. |
+| Concurrent sync jobs duplicate work | Use dataset/scope idempotency keys and existing lock patterns. |
+| Licensing/RBAC regressions | Keep service-level permission and dataset filtering as enforcement boundaries. |
+| Large DuckDB previews block NiceGUI | Offload to worker threads and enforce row/time/memory limits. |
+| Provider registry is mistaken for dataset catalog | Add a separate dataset/table catalog and only link to `ProviderSpec` where a dataset has a provider identity. |
+
+## Suggested PR Order
+
+1. Component split for `data_management.py` without behavior changes.
+2. Manifest summary read model and `/data` operations grid with raw/provenance display.
+3. Dataset/table catalog and public shared table/path resolver.
+4. Data acquisition preflight DTOs and Alpaca SIP sync job UI.
+5. Data Explorer service replacement using the shared resolver/query-preview boundary.
+6. Quality/readiness wiring and backtest handoff metadata.
+7. Adjustment-layer ADR and prototype only after raw/adjusted UI is explicit.

--- a/libs/web_console_services/__init__.py
+++ b/libs/web_console_services/__init__.py
@@ -25,6 +25,7 @@ from libs.web_console_services.config import (
     EXECUTION_GATEWAY_URL,
 )
 from libs.web_console_services.data_explorer_service import DataExplorerService
+from libs.web_console_services.data_manifest_service import DataManifestService
 from libs.web_console_services.data_quality_service import DataQualityService
 from libs.web_console_services.data_sync_service import DataSyncService
 from libs.web_console_services.exposure_service import ExposureService
@@ -42,6 +43,7 @@ __all__ = [
     "CircuitBreakerService",
     "ComparisonService",
     "DataExplorerService",
+    "DataManifestService",
     "DataQualityService",
     "ExposureService",
     "DataSyncService",

--- a/libs/web_console_services/data_manifest_service.py
+++ b/libs/web_console_services/data_manifest_service.py
@@ -1,0 +1,323 @@
+"""Manifest summary read model for data-management UI services."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import AwareDatetime, BaseModel
+
+from libs.data.data_quality.manifest import ManifestManager, SyncManifest
+from libs.web_console_services.provider_signature import (
+    ProviderSignatureDTO,
+    sanitize_provider_signature,
+)
+from libs.web_console_services.schemas.data_management import SyncStatusDTO
+
+ALPACA_SIP_DATASET_KEY = "alpaca_sip"
+ALPACA_SIP_DAILY_DATASET = "alpaca_sip_daily"
+ALPACA_SIP_CORP_ACTIONS_DATASET = "alpaca_sip_corp_actions"
+ALPACA_SIP_MANIFEST_DATASETS: tuple[str, ...] = (
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+)
+
+_ALPACA_SIP_COMPANION_MAX_END_DATE_DRIFT_DAYS = 1
+
+
+class ManifestSummaryDTO(BaseModel):
+    """UI-facing summary of one sync manifest."""
+
+    dataset: str
+    manifest_reference: str
+    manifest_id: str | None = None
+    manifest_checksum: str
+    manifest_version: int
+    schema_version: str
+    validation_status: str
+    sync_timestamp: AwareDatetime
+    sync_started_at: AwareDatetime | None = None
+    sync_finished_at: AwareDatetime | None = None
+    start_date: date
+    end_date: date
+    row_count: int
+    file_count: int
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    adjustment_mode: str | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+    symbol_set_hash: str | None = None
+    query_params_hash: str | None = None
+    provider_signature: ProviderSignatureDTO
+
+
+class AlpacaSipManifestSummaryDTO(BaseModel):
+    """Grouped Alpaca SIP manifest state for summary surfaces."""
+
+    dataset: str = ALPACA_SIP_DATASET_KEY
+    manifests: list[ManifestSummaryDTO]
+    present_datasets: list[str]
+    missing_datasets: list[str]
+    latest_sync: AwareDatetime | None = None
+    row_count: int
+    schema_versions: list[str]
+    validation_statuses: list[str]
+    sync_validation_status: str
+    source_status: str
+    source_error_message: str | None = None
+    source_error_rate_pct: float
+    warnings: list[str]
+
+    @property
+    def has_any_manifest(self) -> bool:
+        """Whether at least one expected Alpaca SIP manifest exists."""
+        return bool(self.manifests)
+
+    def to_sync_status(self) -> SyncStatusDTO:
+        """Convert the group summary to the legacy sync-status DTO."""
+        return SyncStatusDTO(
+            dataset=self.dataset,
+            last_sync=self.latest_sync,
+            row_count=self.row_count,
+            validation_status=self.sync_validation_status,
+            schema_version=",".join(self.schema_versions) or None,
+        )
+
+    def apply_to_source_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Return a source-status spec updated from manifest state."""
+        if not self.has_any_manifest:
+            return spec
+
+        now = datetime.now(UTC)
+        latest_sync = self.latest_sync
+        age_seconds = (
+            max(0.0, (now - latest_sync).total_seconds())
+            if latest_sync is not None
+            else 0.0
+        )
+
+        updated = dict(spec)
+        updated["status"] = self.source_status
+        updated["minutes_ago"] = max(0, int(age_seconds // 60))
+        updated["row_count"] = self.row_count
+        updated["error_rate_pct"] = self.source_error_rate_pct
+        updated["error_message"] = self.source_error_message
+        return updated
+
+
+class DataManifestService:
+    """Read-only manifest summary service.
+
+    The default constructor resolves ``DATA_ROOT`` at call time so tests and
+    operators can change the environment before each request.
+    """
+
+    def __init__(
+        self,
+        *,
+        data_root: Path | None = None,
+        manifest_manager: ManifestManager | None = None,
+    ) -> None:
+        self._data_root = data_root
+        self._manifest_manager = manifest_manager
+
+    def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
+        """Return grouped status for Alpaca SIP daily and corporate-actions manifests."""
+        summaries = [
+            summary
+            for dataset in ALPACA_SIP_MANIFEST_DATASETS
+            if (summary := self.get_manifest_summary(dataset)) is not None
+        ]
+        present = sorted(summary.dataset for summary in summaries)
+        missing = sorted(set(ALPACA_SIP_MANIFEST_DATASETS) - set(present))
+        validation_statuses = sorted({summary.validation_status for summary in summaries})
+        schema_versions = sorted({summary.schema_version for summary in summaries})
+        latest_sync = max((summary.sync_timestamp for summary in summaries), default=None)
+
+        sync_validation_status = self._build_sync_validation_status(
+            missing, validation_statuses
+        )
+        source_status, error_message = self._build_source_status(
+            missing, validation_statuses
+        )
+        warnings = self._build_alpaca_sip_warnings(summaries, missing)
+
+        return AlpacaSipManifestSummaryDTO(
+            manifests=summaries,
+            present_datasets=present,
+            missing_datasets=missing,
+            latest_sync=latest_sync,
+            row_count=sum(summary.row_count for summary in summaries),
+            schema_versions=schema_versions,
+            validation_statuses=validation_statuses,
+            sync_validation_status=sync_validation_status,
+            source_status=source_status,
+            source_error_message=error_message,
+            source_error_rate_pct=0.0 if source_status == "ok" else 100.0,
+            warnings=warnings,
+        )
+
+    def get_manifest_summary(self, dataset: str) -> ManifestSummaryDTO | None:
+        """Load and summarize one manifest, returning ``None`` when absent."""
+        manager = self._manager()
+        manifest = manager.load_manifest(dataset)
+        if manifest is None:
+            return None
+        manifest_reference = f"manifests://{dataset}.json"
+        return self._summarize_manifest(manifest, manifest_reference)
+
+    def _manager(self) -> ManifestManager:
+        if self._manifest_manager is not None:
+            return self._manifest_manager
+
+        data_root = (
+            self._data_root
+            if self._data_root is not None
+            else Path(os.getenv("DATA_ROOT", "data"))
+        ).resolve()
+        return ManifestManager(
+            storage_path=data_root / "manifests",
+            lock_dir=data_root / "locks",
+            data_root=data_root,
+        )
+
+    def _summarize_manifest(
+        self,
+        manifest: SyncManifest,
+        manifest_reference: str,
+    ) -> ManifestSummaryDTO:
+        canonical_storage_mode = None
+        read_time_adjustment_mode = None
+        if manifest.dataset == ALPACA_SIP_DAILY_DATASET:
+            canonical_storage_mode = "raw"
+            read_time_adjustment_mode = "unavailable"
+
+        provider_signature = sanitize_provider_signature(
+            {
+                "provider_id": manifest.provider_id,
+                "provider_version": manifest.provider_version,
+                "source_feed": manifest.source_feed,
+                "adjustment_mode": manifest.adjustment_mode,
+                "canonical_storage_mode": canonical_storage_mode,
+                "read_time_adjustment_mode": read_time_adjustment_mode,
+                "symbol_set_hash": manifest.symbol_set_hash,
+                "query_params_hash": manifest.wrds_query_hash,
+                "manifest_id": manifest.manifest_id,
+                "manifest_reference": manifest_reference,
+                "manifest_checksum": manifest.checksum,
+                "manifest_version": str(manifest.manifest_version),
+                "schema_version": manifest.schema_version,
+                "sync_started_at": manifest.sync_started_at,
+                "sync_finished_at": manifest.sync_finished_at,
+                "data_roles": _data_roles_for_dataset(manifest.dataset),
+                "dataset_keys": [manifest.dataset],
+            }
+        )
+
+        return ManifestSummaryDTO(
+            dataset=manifest.dataset,
+            manifest_reference=manifest_reference,
+            manifest_id=manifest.manifest_id,
+            manifest_checksum=manifest.checksum,
+            manifest_version=manifest.manifest_version,
+            schema_version=manifest.schema_version,
+            validation_status=manifest.validation_status,
+            sync_timestamp=manifest.sync_timestamp,
+            sync_started_at=manifest.sync_started_at,
+            sync_finished_at=manifest.sync_finished_at,
+            start_date=manifest.start_date,
+            end_date=manifest.end_date,
+            row_count=manifest.row_count,
+            file_count=len(manifest.file_paths),
+            provider_id=manifest.provider_id,
+            provider_version=manifest.provider_version,
+            source_feed=manifest.source_feed,
+            adjustment_mode=manifest.adjustment_mode,
+            canonical_storage_mode=canonical_storage_mode,
+            read_time_adjustment_mode=read_time_adjustment_mode,
+            symbol_set_hash=manifest.symbol_set_hash,
+            query_params_hash=manifest.wrds_query_hash,
+            provider_signature=provider_signature,
+        )
+
+    def _build_alpaca_sip_warnings(
+        self,
+        summaries: list[ManifestSummaryDTO],
+        missing: list[str],
+    ) -> list[str]:
+        warnings = [
+            f"alpaca_sip_missing_manifest:{dataset}"
+            for dataset in missing
+        ]
+        by_dataset = {summary.dataset: summary for summary in summaries}
+        daily = by_dataset.get(ALPACA_SIP_DAILY_DATASET)
+        corp_actions = by_dataset.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
+        if daily is None or corp_actions is None:
+            return warnings
+
+        if (
+            daily.symbol_set_hash
+            and corp_actions.symbol_set_hash
+            and daily.symbol_set_hash != corp_actions.symbol_set_hash
+        ):
+            warnings.append("alpaca_sip_companion_symbol_set_mismatch")
+
+        end_date_drift = abs((daily.end_date - corp_actions.end_date).days)
+        if end_date_drift > _ALPACA_SIP_COMPANION_MAX_END_DATE_DRIFT_DAYS:
+            warnings.append("alpaca_sip_companion_manifest_stale")
+
+        return warnings
+
+    @staticmethod
+    def _build_sync_validation_status(
+        missing: list[str],
+        validation_statuses: list[str],
+    ) -> str:
+        if not validation_statuses:
+            return "missing"
+        if missing:
+            return f"missing: {', '.join(missing)}"
+        if validation_statuses == ["passed"]:
+            return "ok"
+        return ",".join(validation_statuses)
+
+    @staticmethod
+    def _build_source_status(
+        missing: list[str],
+        validation_statuses: list[str],
+    ) -> tuple[str, str | None]:
+        if not validation_statuses:
+            return (
+                "unknown",
+                "Local SIP sync status unavailable until manifest-backed status lands",
+            )
+        if missing:
+            return "error", f"Missing SIP manifests: {', '.join(missing)}"
+        if validation_statuses == ["passed"]:
+            return "ok", None
+        return (
+            "error",
+            f"SIP manifest validation statuses: {', '.join(validation_statuses)}",
+        )
+
+
+def _data_roles_for_dataset(dataset: str) -> dict[str, str] | None:
+    if dataset == ALPACA_SIP_DAILY_DATASET:
+        return {"prices": dataset}
+    if dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
+        return {"corp_actions": dataset}
+    return None
+
+
+__all__ = [
+    "ALPACA_SIP_CORP_ACTIONS_DATASET",
+    "ALPACA_SIP_DAILY_DATASET",
+    "ALPACA_SIP_MANIFEST_DATASETS",
+    "DataManifestService",
+    "ManifestSummaryDTO",
+    "AlpacaSipManifestSummaryDTO",
+]

--- a/libs/web_console_services/data_manifest_service.py
+++ b/libs/web_console_services/data_manifest_service.py
@@ -95,9 +95,7 @@ class AlpacaSipManifestSummaryDTO(BaseModel):
         now = datetime.now(UTC)
         latest_sync = self.latest_sync
         age_seconds = (
-            max(0.0, (now - latest_sync).total_seconds())
-            if latest_sync is not None
-            else 0.0
+            max(0.0, (now - latest_sync).total_seconds()) if latest_sync is not None else 0.0
         )
 
         updated = dict(spec)
@@ -138,12 +136,8 @@ class DataManifestService:
         schema_versions = sorted({summary.schema_version for summary in summaries})
         latest_sync = max((summary.sync_timestamp for summary in summaries), default=None)
 
-        sync_validation_status = self._build_sync_validation_status(
-            missing, validation_statuses
-        )
-        source_status, error_message = self._build_source_status(
-            missing, validation_statuses
-        )
+        sync_validation_status = self._build_sync_validation_status(missing, validation_statuses)
+        source_status, error_message = self._build_source_status(missing, validation_statuses)
         warnings = self._build_alpaca_sip_warnings(summaries, missing)
 
         return AlpacaSipManifestSummaryDTO(
@@ -175,9 +169,7 @@ class DataManifestService:
             return self._manifest_manager
 
         data_root = (
-            self._data_root
-            if self._data_root is not None
-            else Path(os.getenv("DATA_ROOT", "data"))
+            self._data_root if self._data_root is not None else Path(os.getenv("DATA_ROOT", "data"))
         ).resolve()
         return ManifestManager(
             storage_path=data_root / "manifests",
@@ -249,10 +241,7 @@ class DataManifestService:
         summaries: list[ManifestSummaryDTO],
         missing: list[str],
     ) -> list[str]:
-        warnings = [
-            f"alpaca_sip_missing_manifest:{dataset}"
-            for dataset in missing
-        ]
+        warnings = [f"alpaca_sip_missing_manifest:{dataset}" for dataset in missing]
         by_dataset = {summary.dataset: summary for summary in summaries}
         daily = by_dataset.get(ALPACA_SIP_DAILY_DATASET)
         corp_actions = by_dataset.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
@@ -306,11 +295,11 @@ class DataManifestService:
 
 
 def _data_roles_for_dataset(dataset: str) -> dict[str, str] | None:
-    if dataset == ALPACA_SIP_DAILY_DATASET:
-        return {"prices": dataset}
-    if dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
-        return {"corp_actions": dataset}
-    return None
+    role_map = {
+        ALPACA_SIP_DAILY_DATASET: {"prices": dataset},
+        ALPACA_SIP_CORP_ACTIONS_DATASET: {"corp_actions": dataset},
+    }
+    return role_map.get(dataset)
 
 
 __all__ = [

--- a/libs/web_console_services/data_manifest_service.py
+++ b/libs/web_console_services/data_manifest_service.py
@@ -25,6 +25,7 @@ ALPACA_SIP_MANIFEST_DATASETS: tuple[str, ...] = (
 )
 
 _ALPACA_SIP_COMPANION_MAX_END_DATE_DRIFT_DAYS = 1
+_DEFAULT_DATA_ROOT = Path(os.getenv("DATA_ROOT", "data")).resolve()
 
 
 class ManifestSummaryDTO(BaseModel):
@@ -110,8 +111,8 @@ class AlpacaSipManifestSummaryDTO(BaseModel):
 class DataManifestService:
     """Read-only manifest summary service.
 
-    The default constructor resolves ``DATA_ROOT`` at call time so tests and
-    operators can change the environment before each request.
+    The default constructor uses the process-level ``DATA_ROOT`` captured at
+    import time. Tests and alternate roots should pass ``data_root`` explicitly.
     """
 
     def __init__(
@@ -120,7 +121,7 @@ class DataManifestService:
         data_root: Path | None = None,
         manifest_manager: ManifestManager | None = None,
     ) -> None:
-        self._data_root = data_root
+        self._data_root = data_root.resolve() if data_root is not None else _DEFAULT_DATA_ROOT
         self._manifest_manager = manifest_manager
 
     def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
@@ -168,9 +169,7 @@ class DataManifestService:
         if self._manifest_manager is not None:
             return self._manifest_manager
 
-        data_root = (
-            self._data_root if self._data_root is not None else Path(os.getenv("DATA_ROOT", "data"))
-        ).resolve()
+        data_root = self._data_root
         return ManifestManager(
             storage_path=data_root / "manifests",
             lock_dir=data_root / "locks",

--- a/libs/web_console_services/data_source_status_service.py
+++ b/libs/web_console_services/data_source_status_service.py
@@ -8,22 +8,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
 
 import redis.asyncio as redis_asyncio
 import redis.exceptions
 
-from libs.data.data_quality.manifest import ManifestManager, SyncManifest
 from libs.platform.web_console_auth.permissions import (
     Permission,
     has_dataset_permission,
     has_permission,
 )
+from libs.web_console_services.data_manifest_service import DataManifestService
 
 from .schemas.data_management import DataSourceStatusDTO
 
@@ -33,7 +31,6 @@ _REFRESH_LOCK_TTL_SECONDS = 60
 _REFRESH_TIMEOUT_SECONDS = 45
 _REFRESH_LOCK_KEY_PREFIX = "data_source_status:refresh"
 _VALID_DATA_MODES: tuple[Literal["mock", "real"], ...] = ("mock", "real")
-_ALPACA_SIP_MANIFEST_DATASETS = ("alpaca_sip_daily", "alpaca_sip_corp_actions")
 
 _DATA_SOURCES: tuple[dict[str, Any], ...] = (
     {
@@ -130,11 +127,13 @@ class DataSourceStatusService:
         self,
         redis_client_factory: Callable[[], Awaitable[redis_asyncio.Redis]] | None = None,
         data_mode: Literal["mock", "real"] = "mock",
+        data_manifest_service: DataManifestService | None = None,
     ) -> None:
         if data_mode not in _VALID_DATA_MODES:
             raise ValueError(f"Invalid data_mode: {data_mode}")
         self._redis_client_factory = redis_client_factory
         self._data_mode: Literal["mock", "real"] = data_mode
+        self._data_manifest_service = data_manifest_service or DataManifestService()
         self._last_refresh_results: dict[str, DataSourceStatusDTO] = {}
 
     async def get_all_sources(self, user: Any) -> list[DataSourceStatusDTO]:
@@ -339,49 +338,8 @@ class DataSourceStatusService:
         return sources
 
     def _alpaca_sip_spec_from_manifests(self, spec: dict[str, Any]) -> dict[str, Any]:
-        manifests = self._load_alpaca_sip_manifests()
-        if not manifests:
-            return spec
-
-        present_datasets = {manifest.dataset for manifest in manifests}
-        missing_datasets = sorted(set(_ALPACA_SIP_MANIFEST_DATASETS) - present_datasets)
-        latest = max(manifest.sync_timestamp for manifest in manifests)
-        now = datetime.now(UTC)
-        age_seconds = max(0.0, (now - latest).total_seconds())
-        validation_statuses = {manifest.validation_status for manifest in manifests}
-        if missing_datasets:
-            status = "error"
-            error_message = f"Missing SIP manifests: {', '.join(missing_datasets)}"
-        elif validation_statuses == {"passed"}:
-            status = "ok"
-            error_message = None
-        else:
-            status = "error"
-            error_message = (
-                f"SIP manifest validation statuses: {', '.join(sorted(validation_statuses))}"
-            )
-
-        updated = dict(spec)
-        updated["status"] = status
-        updated["minutes_ago"] = max(0, int(age_seconds // 60))
-        updated["row_count"] = sum(manifest.row_count for manifest in manifests)
-        updated["error_rate_pct"] = 0.0 if status == "ok" else 100.0
-        updated["error_message"] = error_message
-        return updated
-
-    def _load_alpaca_sip_manifests(self) -> list[SyncManifest]:
-        data_root = Path(os.getenv("DATA_ROOT", "data")).resolve()
-        manager = ManifestManager(
-            storage_path=data_root / "manifests",
-            lock_dir=data_root / "locks",
-            data_root=data_root,
-        )
-        manifests: list[SyncManifest] = []
-        for dataset in _ALPACA_SIP_MANIFEST_DATASETS:
-            manifest = manager.load_manifest(dataset)
-            if manifest is not None:
-                manifests.append(manifest)
-        return manifests
+        summary = self._data_manifest_service.get_alpaca_sip_summary()
+        return summary.apply_to_source_spec(spec)
 
 
 def _validate_source_name(name: str) -> None:

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -5,13 +5,10 @@ Enforces RBAC, dataset-level access, and rate limiting at server-side.
 
 from __future__ import annotations
 
-import os
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from libs.data.data_quality.manifest import ManifestManager, SyncManifest
 from libs.platform.web_console_auth.helpers import get_user_id
 from libs.platform.web_console_auth.permissions import (
     Permission,
@@ -19,6 +16,7 @@ from libs.platform.web_console_auth.permissions import (
     has_permission,
 )
 from libs.platform.web_console_auth.rate_limiter import RateLimiter, get_rate_limiter
+from libs.web_console_services.data_manifest_service import DataManifestService
 
 from .schemas.data_management import (
     SyncJobDTO,
@@ -29,7 +27,6 @@ from .schemas.data_management import (
 )
 
 _SUPPORTED_DATASETS = ("crsp", "compustat", "taq", "fama_french", "alpaca_sip")
-_ALPACA_SIP_MANIFEST_DATASETS = ("alpaca_sip_daily", "alpaca_sip_corp_actions")
 
 
 class RateLimitExceeded(RuntimeError):
@@ -51,8 +48,13 @@ class DataSyncService:
     - Integration with actual data pipeline sync infrastructure
     """
 
-    def __init__(self, rate_limiter: RateLimiter | None = None) -> None:
+    def __init__(
+        self,
+        rate_limiter: RateLimiter | None = None,
+        data_manifest_service: DataManifestService | None = None,
+    ) -> None:
         self._rate_limiter = rate_limiter or get_rate_limiter()
+        self._data_manifest_service = data_manifest_service or DataManifestService()
 
     async def get_sync_status(self, user: Any) -> list[SyncStatusDTO]:
         """Get sync status for datasets user has access to.
@@ -226,48 +228,7 @@ class DataSyncService:
                 schema_version="v1",
             )
 
-        manifests = self._load_alpaca_sip_manifests()
-        if not manifests:
-            return SyncStatusDTO(
-                dataset=dataset,
-                last_sync=None,
-                row_count=0,
-                validation_status="missing",
-                schema_version=None,
-            )
-
-        latest = max(manifest.sync_timestamp for manifest in manifests)
-        statuses = {manifest.validation_status for manifest in manifests}
-        present_datasets = {manifest.dataset for manifest in manifests}
-        missing_datasets = sorted(set(_ALPACA_SIP_MANIFEST_DATASETS) - present_datasets)
-        if missing_datasets:
-            validation_status = f"missing: {', '.join(missing_datasets)}"
-        elif statuses == {"passed"}:
-            validation_status = "ok"
-        else:
-            validation_status = ",".join(sorted(statuses))
-        schema_versions = sorted({manifest.schema_version for manifest in manifests})
-        return SyncStatusDTO(
-            dataset=dataset,
-            last_sync=latest,
-            row_count=sum(manifest.row_count for manifest in manifests),
-            validation_status=validation_status,
-            schema_version=",".join(schema_versions),
-        )
-
-    def _load_alpaca_sip_manifests(self) -> list[SyncManifest]:
-        data_root = Path(os.getenv("DATA_ROOT", "data")).resolve()
-        manager = ManifestManager(
-            storage_path=data_root / "manifests",
-            lock_dir=data_root / "locks",
-            data_root=data_root,
-        )
-        manifests: list[SyncManifest] = []
-        for dataset in _ALPACA_SIP_MANIFEST_DATASETS:
-            manifest = manager.load_manifest(dataset)
-            if manifest is not None:
-                manifests.append(manifest)
-        return manifests
+        return self._data_manifest_service.get_alpaca_sip_summary().to_sync_status()
 
 
 __all__ = ["DataSyncService", "RateLimitExceeded"]

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -5,6 +5,7 @@ Enforces RBAC, dataset-level access, and rate limiting at server-side.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -66,10 +67,7 @@ class DataSyncService:
         self._require_permission(user, Permission.VIEW_DATA_SYNC)
 
         now = datetime.now(UTC)
-        mock = [
-            self._mock_or_manifest_status(name, now)
-            for name in _SUPPORTED_DATASETS
-        ]
+        mock = await asyncio.to_thread(self._build_sync_statuses, now)
         return [item for item in mock if has_dataset_permission(user, item.dataset)]
 
     async def get_sync_logs(
@@ -229,6 +227,9 @@ class DataSyncService:
             )
 
         return self._data_manifest_service.get_alpaca_sip_summary().to_sync_status()
+
+    def _build_sync_statuses(self, now: datetime) -> list[SyncStatusDTO]:
+        return [self._mock_or_manifest_status(name, now) for name in _SUPPORTED_DATASETS]
 
 
 __all__ = ["DataSyncService", "RateLimitExceeded"]

--- a/libs/web_console_services/provider_signature.py
+++ b/libs/web_console_services/provider_signature.py
@@ -1,0 +1,150 @@
+"""Sanitized provider provenance signatures for UI/API payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+from pydantic import AwareDatetime, BaseModel
+
+_MAX_SIGNATURE_VALUE_LENGTH = 2048
+_MAX_SIGNATURE_COLLECTION_ITEMS = 32
+_SENSITIVE_VALUE_MARKERS = (
+    "authorization=",
+    "api_key=",
+    "api_secret=",
+    "apikey=",
+    "apisecret=",
+    "bearer ",
+    "password=",
+    "pwd=",
+    "secret=",
+    "signature=",
+    "submit_token=",
+    "token=",
+    "x-amz-credential=",
+    "x-amz-signature=",
+)
+
+
+class ProviderSignatureDTO(BaseModel):
+    """Replay-safe provider signature fields exposed to UI consumers."""
+
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    adjustment_mode: str | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+    symbol_set_hash: str | None = None
+    query_params_hash: str | None = None
+    manifest_id: str | None = None
+    manifest_reference: str | None = None
+    manifest_checksum: str | None = None
+    manifest_version: str | None = None
+    schema_version: str | None = None
+    sync_started_at: AwareDatetime | None = None
+    sync_finished_at: AwareDatetime | None = None
+    data_roles: dict[str, str] | None = None
+    dataset_keys: list[str] | None = None
+
+
+_ALLOWED_SIGNATURE_KEYS = frozenset(ProviderSignatureDTO.model_fields)
+_STRING_FIELDS = {
+    "provider_id",
+    "provider_version",
+    "source_feed",
+    "adjustment_mode",
+    "canonical_storage_mode",
+    "read_time_adjustment_mode",
+    "symbol_set_hash",
+    "query_params_hash",
+    "manifest_id",
+    "manifest_reference",
+    "manifest_checksum",
+    "manifest_version",
+    "schema_version",
+}
+
+
+def sanitize_provider_signature(raw: Mapping[str, Any]) -> ProviderSignatureDTO:
+    """Return an allowlisted provider signature DTO.
+
+    Unknown keys are dropped, so credentials, auth headers, signed URLs, tokens,
+    and raw request payloads cannot leak through this helper.
+    """
+    sanitized: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key not in _ALLOWED_SIGNATURE_KEYS or value is None:
+            continue
+        if key in _STRING_FIELDS:
+            text = str(value)
+            if _is_safe_string_value(text):
+                sanitized[key] = text
+            continue
+        if key in {"sync_started_at", "sync_finished_at"}:
+            if isinstance(value, datetime):
+                sanitized[key] = value
+            continue
+        if key == "data_roles":
+            roles = _sanitize_string_mapping(value)
+            if roles:
+                sanitized[key] = roles
+            continue
+        if key == "dataset_keys":
+            dataset_keys = _sanitize_string_sequence(value)
+            if dataset_keys:
+                sanitized[key] = dataset_keys
+
+    return ProviderSignatureDTO.model_validate(sanitized)
+
+
+def _sanitize_string_mapping(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    result: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        if len(result) >= _MAX_SIGNATURE_COLLECTION_ITEMS:
+            break
+        key = str(raw_key)
+        mapped = str(raw_value)
+        if (
+            key
+            and mapped
+            and _is_safe_string_value(key)
+            and _is_safe_string_value(mapped)
+        ):
+            result[key] = mapped
+    return result
+
+
+def _sanitize_string_sequence(value: Any) -> list[str]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        return []
+    result: list[str] = []
+    for item in value:
+        if len(result) >= _MAX_SIGNATURE_COLLECTION_ITEMS:
+            break
+        text = str(item)
+        if text and _is_safe_string_value(text):
+            result.append(text)
+    return result
+
+
+def _is_safe_string_value(value: str) -> bool:
+    if len(value) > _MAX_SIGNATURE_VALUE_LENGTH:
+        return False
+    lowered = value.lower()
+    return not (
+        any(marker in lowered for marker in _SENSITIVE_VALUE_MARKERS)
+        or _looks_like_jwt(value)
+    )
+
+
+def _looks_like_jwt(value: str) -> bool:
+    parts = value.split(".")
+    return len(parts) == 3 and parts[0].startswith("eyJ")
+
+
+__all__ = ["ProviderSignatureDTO", "sanitize_provider_signature"]

--- a/libs/web_console_services/provider_signature.py
+++ b/libs/web_console_services/provider_signature.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlsplit
 
 from pydantic import AwareDatetime, BaseModel
 
@@ -109,12 +110,7 @@ def _sanitize_string_mapping(value: Any) -> dict[str, str]:
             break
         key = str(raw_key)
         mapped = str(raw_value)
-        if (
-            key
-            and mapped
-            and _is_safe_string_value(key)
-            and _is_safe_string_value(mapped)
-        ):
+        if key and mapped and _is_safe_string_value(key) and _is_safe_string_value(mapped):
             result[key] = mapped
     return result
 
@@ -138,8 +134,19 @@ def _is_safe_string_value(value: str) -> bool:
     lowered = value.lower()
     return not (
         any(marker in lowered for marker in _SENSITIVE_VALUE_MARKERS)
+        or _contains_uri_userinfo(value)
         or _looks_like_jwt(value)
     )
+
+
+def _contains_uri_userinfo(value: str) -> bool:
+    if "@" not in value:
+        return False
+    try:
+        parsed = urlsplit(value.strip())
+    except ValueError:
+        return "://" in value or value.startswith("//")
+    return bool(parsed.netloc and (parsed.username is not None or parsed.password is not None))
 
 
 def _looks_like_jwt(value: str) -> bool:

--- a/tests/apps/web_console_ng/components/test_data_manifest_components.py
+++ b/tests/apps/web_console_ng/components/test_data_manifest_components.py
@@ -29,15 +29,23 @@ def _manifest(
     validation_status: str = "passed",
     end: date = date(2026, 4, 30),
     symbol_hash: str | None = "symbols-v1",
+    read_time_adjustment_mode: str | None = None,
 ) -> ManifestSummaryDTO:
     is_daily = dataset == ALPACA_SIP_DAILY_DATASET
+    adjustment_read_mode = (
+        read_time_adjustment_mode
+        if read_time_adjustment_mode is not None
+        else "unavailable"
+        if is_daily
+        else None
+    )
     signature = ProviderSignatureDTO(
         provider_id="alpaca_sip",
         provider_version="2026.04",
         source_feed="sip",
         adjustment_mode="raw" if is_daily else None,
         canonical_storage_mode="raw" if is_daily else None,
-        read_time_adjustment_mode="unavailable" if is_daily else None,
+        read_time_adjustment_mode=adjustment_read_mode,
         symbol_set_hash=symbol_hash,
         query_params_hash=f"{dataset}-query",
         manifest_id=f"{dataset}@v1:checksum",
@@ -70,7 +78,7 @@ def _manifest(
         source_feed="sip",
         adjustment_mode="raw" if is_daily else None,
         canonical_storage_mode="raw" if is_daily else None,
-        read_time_adjustment_mode="unavailable" if is_daily else None,
+        read_time_adjustment_mode=adjustment_read_mode,
         symbol_set_hash=symbol_hash,
         query_params_hash=f"{dataset}-query",
         provider_signature=signature,
@@ -135,9 +143,7 @@ def test_grid_and_detail_expose_present_raw_manifest_provenance() -> None:
 
     rows = build_manifest_grid_rows(summary)
     daily = next(row for row in rows if row["dataset"] == ALPACA_SIP_DAILY_DATASET)
-    corp_actions = next(
-        row for row in rows if row["dataset"] == ALPACA_SIP_CORP_ACTIONS_DATASET
-    )
+    corp_actions = next(row for row in rows if row["dataset"] == ALPACA_SIP_CORP_ACTIONS_DATASET)
     detail = build_manifest_detail_fields(summary, ALPACA_SIP_DAILY_DATASET)
     detail_map = {item["field"]: item["value"] for item in detail}
 
@@ -168,8 +174,7 @@ def test_invalid_manifest_is_untrusted_and_blocked() -> None:
     detail = build_manifest_detail_fields(summary, ALPACA_SIP_DAILY_DATASET)
     detail_map = {item["field"]: item["value"] for item in detail}
     metrics = {
-        metric["label"]: metric["value"]
-        for metric in build_manifest_context_metrics(summary)
+        metric["label"]: metric["value"] for metric in build_manifest_context_metrics(summary)
     }
 
     assert daily["trusted_manifest_backed"] is False
@@ -203,8 +208,7 @@ def test_context_metrics_count_missing_and_pairing_warnings() -> None:
     )
 
     metrics = {
-        metric["label"]: metric["value"]
-        for metric in build_manifest_context_metrics(summary)
+        metric["label"]: metric["value"] for metric in build_manifest_context_metrics(summary)
     }
     rows = build_manifest_grid_rows(summary)
 
@@ -215,6 +219,21 @@ def test_context_metrics_count_missing_and_pairing_warnings() -> None:
     assert all(row["issues"] >= 1 for row in rows)
 
 
+def test_context_metrics_clear_backtest_blockers_when_inputs_ready() -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+
+    metrics = {
+        metric["label"]: metric["value"] for metric in build_manifest_context_metrics(summary)
+    }
+
+    assert metrics["Backtest Blocked"] == 0
+
+
 def test_missing_companion_warning_stays_on_missing_row() -> None:
     summary = _summary(
         [_manifest(ALPACA_SIP_DAILY_DATASET)],
@@ -223,10 +242,12 @@ def test_missing_companion_warning_stays_on_missing_row() -> None:
     )
 
     rows = build_manifest_grid_rows(summary)
+    metrics = {
+        metric["label"]: metric["value"] for metric in build_manifest_context_metrics(summary)
+    }
     daily = next(row for row in rows if row["dataset"] == ALPACA_SIP_DAILY_DATASET)
-    corp_actions = next(
-        row for row in rows if row["dataset"] == ALPACA_SIP_CORP_ACTIONS_DATASET
-    )
+    corp_actions = next(row for row in rows if row["dataset"] == ALPACA_SIP_CORP_ACTIONS_DATASET)
 
+    assert metrics["Backtest Blocked"] == 2
     assert "alpaca_sip_untrusted_without_manifest" not in daily["issue_codes"]
     assert "alpaca_sip_untrusted_without_manifest" in corp_actions["issue_codes"]

--- a/tests/apps/web_console_ng/components/test_data_manifest_components.py
+++ b/tests/apps/web_console_ng/components/test_data_manifest_components.py
@@ -1,0 +1,232 @@
+"""Tests for Phase 1 data manifest UI read models."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from apps.web_console_ng.components.data_context_ribbon import (
+    build_manifest_context_metrics,
+)
+from apps.web_console_ng.components.data_detail_drawer import (
+    build_manifest_detail_fields,
+)
+from apps.web_console_ng.components.data_operations_grid import build_manifest_grid_rows
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    AlpacaSipManifestSummaryDTO,
+    ManifestSummaryDTO,
+)
+from libs.web_console_services.provider_signature import ProviderSignatureDTO
+
+NOW = datetime(2026, 5, 1, 12, tzinfo=UTC)
+
+
+def _manifest(
+    dataset: str,
+    *,
+    row_count: int = 10,
+    validation_status: str = "passed",
+    end: date = date(2026, 4, 30),
+    symbol_hash: str | None = "symbols-v1",
+) -> ManifestSummaryDTO:
+    is_daily = dataset == ALPACA_SIP_DAILY_DATASET
+    signature = ProviderSignatureDTO(
+        provider_id="alpaca_sip",
+        provider_version="2026.04",
+        source_feed="sip",
+        adjustment_mode="raw" if is_daily else None,
+        canonical_storage_mode="raw" if is_daily else None,
+        read_time_adjustment_mode="unavailable" if is_daily else None,
+        symbol_set_hash=symbol_hash,
+        query_params_hash=f"{dataset}-query",
+        manifest_id=f"{dataset}@v1:checksum",
+        manifest_reference=f"manifests://{dataset}.json",
+        manifest_checksum=f"{dataset}-checksum",
+        manifest_version="1",
+        schema_version="v1.0.0",
+        sync_started_at=NOW,
+        sync_finished_at=NOW,
+        data_roles={("prices" if is_daily else "corp_actions"): dataset},
+        dataset_keys=[dataset],
+    )
+    return ManifestSummaryDTO(
+        dataset=dataset,
+        manifest_reference=f"manifests://{dataset}.json",
+        manifest_id=f"{dataset}@v1:checksum",
+        manifest_checksum=f"{dataset}-checksum",
+        manifest_version=1,
+        schema_version="v1.0.0",
+        validation_status=validation_status,
+        sync_timestamp=NOW,
+        sync_started_at=NOW,
+        sync_finished_at=NOW,
+        start_date=date(2026, 4, 1),
+        end_date=end,
+        row_count=row_count,
+        file_count=1,
+        provider_id="alpaca_sip",
+        provider_version="2026.04",
+        source_feed="sip",
+        adjustment_mode="raw" if is_daily else None,
+        canonical_storage_mode="raw" if is_daily else None,
+        read_time_adjustment_mode="unavailable" if is_daily else None,
+        symbol_set_hash=symbol_hash,
+        query_params_hash=f"{dataset}-query",
+        provider_signature=signature,
+    )
+
+
+def _summary(
+    manifests: list[ManifestSummaryDTO],
+    *,
+    missing: list[str] | None = None,
+    warnings: list[str] | None = None,
+) -> AlpacaSipManifestSummaryDTO:
+    missing_datasets = missing if missing is not None else []
+    statuses = sorted({manifest.validation_status for manifest in manifests})
+    return AlpacaSipManifestSummaryDTO(
+        manifests=manifests,
+        present_datasets=sorted(manifest.dataset for manifest in manifests),
+        missing_datasets=missing_datasets,
+        latest_sync=max((manifest.sync_timestamp for manifest in manifests), default=None),
+        row_count=sum(manifest.row_count for manifest in manifests),
+        schema_versions=sorted({manifest.schema_version for manifest in manifests}),
+        validation_statuses=statuses,
+        sync_validation_status=(
+            "missing" if not manifests else "ok" if statuses == ["passed"] else ",".join(statuses)
+        ),
+        source_status="unknown" if not manifests else "ok",
+        source_error_message=None,
+        source_error_rate_pct=0.0 if manifests else 100.0,
+        warnings=warnings or [],
+    )
+
+
+def test_grid_rows_make_missing_manifests_and_raw_sip_blockers_visible() -> None:
+    summary = _summary(
+        [],
+        missing=[ALPACA_SIP_DAILY_DATASET, ALPACA_SIP_CORP_ACTIONS_DATASET],
+        warnings=[
+            f"alpaca_sip_missing_manifest:{ALPACA_SIP_DAILY_DATASET}",
+            f"alpaca_sip_missing_manifest:{ALPACA_SIP_CORP_ACTIONS_DATASET}",
+        ],
+    )
+
+    rows = build_manifest_grid_rows(summary)
+    daily = next(row for row in rows if row["dataset"] == ALPACA_SIP_DAILY_DATASET)
+
+    assert daily["local_state"] == "missing"
+    assert daily["manifest_status"] == "missing"
+    assert daily["raw_state"] == "Raw OHLC"
+    assert daily["trusted_manifest_backed"] is False
+    assert "alpaca_sip_untrusted_without_manifest" in daily["readiness"]
+    assert "raw_sip_returns_unavailable" in daily["readiness"]
+    assert daily["adjustment_state"] == "adj_close: not available; ret: not available"
+
+
+def test_grid_and_detail_expose_present_raw_manifest_provenance() -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, row_count=42),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET, row_count=3),
+        ]
+    )
+
+    rows = build_manifest_grid_rows(summary)
+    daily = next(row for row in rows if row["dataset"] == ALPACA_SIP_DAILY_DATASET)
+    corp_actions = next(
+        row for row in rows if row["dataset"] == ALPACA_SIP_CORP_ACTIONS_DATASET
+    )
+    detail = build_manifest_detail_fields(summary, ALPACA_SIP_DAILY_DATASET)
+    detail_map = {item["field"]: item["value"] for item in detail}
+
+    assert daily["trusted_manifest_backed"] is True
+    assert daily["canonical_storage_mode"] == "raw"
+    assert daily["read_time_adjustment_mode"] == "unavailable"
+    assert daily["manifest_id"] == "alpaca_sip_daily@v1:checksum"
+    assert corp_actions["readiness"] == "corporate actions only"
+    assert detail_map["Manifest checksum"] == "alpaca_sip_daily-checksum"
+    assert detail_map["Canonical storage mode"] == "raw"
+    assert detail_map["Read-time adjustment mode"] == "unavailable"
+    assert detail_map["adj_close"] == "not available"
+    assert detail_map["ret"] == "not available"
+    assert "raw_sip_returns_unavailable" in detail_map["Backtest readiness"]
+    assert "provider_id" in detail_map["Provider signature"]
+
+
+def test_invalid_manifest_is_untrusted_and_blocked() -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, validation_status="failed"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+
+    rows = build_manifest_grid_rows(summary)
+    daily = next(row for row in rows if row["dataset"] == ALPACA_SIP_DAILY_DATASET)
+    detail = build_manifest_detail_fields(summary, ALPACA_SIP_DAILY_DATASET)
+    detail_map = {item["field"]: item["value"] for item in detail}
+    metrics = {
+        metric["label"]: metric["value"]
+        for metric in build_manifest_context_metrics(summary)
+    }
+
+    assert daily["trusted_manifest_backed"] is False
+    assert daily["issues"] >= 1
+    assert "untrusted_manifest_validation_failed" in daily["readiness"]
+    assert "manifest_validation_failed" in daily["issue_codes"]
+    assert detail_map["Trusted manifest-backed"] == "false"
+    assert "untrusted_manifest_validation_failed" in detail_map["Readiness"]
+    assert "untrusted_manifest_validation_failed" in detail_map["Backtest readiness"]
+    assert metrics["Untrusted"] == 1
+
+
+def test_context_metrics_count_missing_and_pairing_warnings() -> None:
+    summary = _summary(
+        [
+            _manifest(
+                ALPACA_SIP_DAILY_DATASET,
+                end=date(2026, 4, 30),
+                symbol_hash="daily-symbols",
+            ),
+            _manifest(
+                ALPACA_SIP_CORP_ACTIONS_DATASET,
+                end=date(2026, 4, 27),
+                symbol_hash="corp-symbols",
+            ),
+        ],
+        warnings=[
+            "alpaca_sip_companion_symbol_set_mismatch",
+            "alpaca_sip_companion_manifest_stale",
+        ],
+    )
+
+    metrics = {
+        metric["label"]: metric["value"]
+        for metric in build_manifest_context_metrics(summary)
+    }
+    rows = build_manifest_grid_rows(summary)
+
+    assert metrics["Healthy"] == 2
+    assert metrics["Missing"] == 0
+    assert metrics["Backtest Blocked"] == 1
+    assert metrics["Issues"] == 2
+    assert all(row["issues"] >= 1 for row in rows)
+
+
+def test_missing_companion_warning_stays_on_missing_row() -> None:
+    summary = _summary(
+        [_manifest(ALPACA_SIP_DAILY_DATASET)],
+        missing=[ALPACA_SIP_CORP_ACTIONS_DATASET],
+        warnings=[f"alpaca_sip_missing_manifest:{ALPACA_SIP_CORP_ACTIONS_DATASET}"],
+    )
+
+    rows = build_manifest_grid_rows(summary)
+    daily = next(row for row in rows if row["dataset"] == ALPACA_SIP_DAILY_DATASET)
+    corp_actions = next(
+        row for row in rows if row["dataset"] == ALPACA_SIP_CORP_ACTIONS_DATASET
+    )
+
+    assert "alpaca_sip_untrusted_without_manifest" not in daily["issue_codes"]
+    assert "alpaca_sip_untrusted_without_manifest" in corp_actions["issue_codes"]

--- a/tests/apps/web_console_ng/components/test_data_sync_section.py
+++ b/tests/apps/web_console_ng/components/test_data_sync_section.py
@@ -41,3 +41,8 @@ def test_build_sync_status_table_accepts_explicit_ui_module() -> None:
     data_sync_section.build_sync_status_table([status], ui_module=ui_module)
 
     ui_module.table.assert_called_once()
+
+
+def test_normalize_sync_reason_strips_whitespace() -> None:
+    assert data_sync_section._normalize_sync_reason("  backfill gap  ") == "backfill gap"
+    assert data_sync_section._normalize_sync_reason("   ") == ""

--- a/tests/apps/web_console_ng/components/test_data_sync_section.py
+++ b/tests/apps/web_console_ng/components/test_data_sync_section.py
@@ -1,0 +1,47 @@
+"""Tests for the extracted data sync NiceGUI component."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from apps.web_console_ng.components import data_sync_section
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.components.data_sync_section.ui")
+async def test_render_sync_status_without_view_permission_skips_service(
+    mock_ui: MagicMock,
+) -> None:
+    mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+    sync_service = MagicMock()
+    sync_service.get_sync_status = AsyncMock(return_value=[])
+
+    result = await data_sync_section.render_sync_status(
+        {"role": "viewer"},
+        sync_service,
+        has_view=False,
+        has_trigger=False,
+    )
+
+    assert result is None
+    sync_service.get_sync_status.assert_not_awaited()
+
+
+def test_bind_page_globals_updates_patchable_dependencies() -> None:
+    original_ui = data_sync_section.ui
+    original_logger = data_sync_section.logger
+    ui_module = MagicMock()
+    logger_obj = MagicMock()
+
+    try:
+        data_sync_section.bind_page_globals(ui_module=ui_module, logger_obj=logger_obj)
+
+        assert data_sync_section.ui is ui_module
+        assert data_sync_section.logger is logger_obj
+    finally:
+        data_sync_section.bind_page_globals(
+            ui_module=original_ui,
+            logger_obj=original_logger,
+        )

--- a/tests/apps/web_console_ng/components/test_data_sync_section.py
+++ b/tests/apps/web_console_ng/components/test_data_sync_section.py
@@ -29,19 +29,15 @@ async def test_render_sync_status_without_view_permission_skips_service(
     sync_service.get_sync_status.assert_not_awaited()
 
 
-def test_bind_page_globals_updates_patchable_dependencies() -> None:
-    original_ui = data_sync_section.ui
-    original_logger = data_sync_section.logger
+def test_build_sync_status_table_accepts_explicit_ui_module() -> None:
     ui_module = MagicMock()
-    logger_obj = MagicMock()
+    status = MagicMock(
+        dataset="alpaca_sip",
+        last_sync=None,
+        row_count=10,
+        validation_status="ok",
+    )
 
-    try:
-        data_sync_section.bind_page_globals(ui_module=ui_module, logger_obj=logger_obj)
+    data_sync_section.build_sync_status_table([status], ui_module=ui_module)
 
-        assert data_sync_section.ui is ui_module
-        assert data_sync_section.logger is logger_obj
-    finally:
-        data_sync_section.bind_page_globals(
-            ui_module=original_ui,
-            logger_obj=original_logger,
-        )
+    ui_module.table.assert_called_once()

--- a/tests/apps/web_console_ng/pages/test_data_management.py
+++ b/tests/apps/web_console_ng/pages/test_data_management.py
@@ -31,6 +31,83 @@ async def test_data_sync_no_view_shows_placeholder(
 
 
 @pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=False)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission")
+async def test_manifest_transparency_requires_sync_view_permission(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+) -> None:
+    manifest_service = MagicMock()
+
+    await dm_module._render_manifest_transparency({"role": "viewer"}, manifest_service)
+
+    manifest_service.get_alpaca_sip_summary.assert_not_called()
+    mock_dataset_permission.assert_not_called()
+    mock_permission.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=False)
+async def test_manifest_transparency_requires_alpaca_sip_dataset_permission(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+) -> None:
+    manifest_service = MagicMock()
+
+    await dm_module._render_manifest_transparency({"role": "viewer"}, manifest_service)
+
+    manifest_service.get_alpaca_sip_summary.assert_not_called()
+    mock_permission.assert_called_once()
+    mock_dataset_permission.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_manifest_panel")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_manifest_transparency_renders_authorized_summary(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_panel: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    summary = MagicMock()
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = summary
+
+    await dm_module._render_manifest_transparency({"role": "operator"}, manifest_service)
+
+    manifest_service.get_alpaca_sip_summary.assert_called_once_with()
+    mock_panel.render_manifest_transparency_panel.assert_called_once_with(summary)
+    mock_permission.assert_called_once()
+    mock_dataset_permission.assert_called_once()
+    mock_ui.notify.assert_not_called()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_manifest_transparency_warns_when_service_unavailable(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.side_effect = RuntimeError("boom")
+
+    await dm_module._render_manifest_transparency({"role": "operator"}, manifest_service)
+
+    mock_ui.notify.assert_called_once_with(
+        "Manifest status temporarily unavailable", type="warning"
+    )
+    mock_permission.assert_called_once()
+    mock_dataset_permission.assert_called_once()
+
+
+@pytest.mark.asyncio()
 @patch("apps.web_console_ng.pages.data_management.ui")
 async def test_data_quality_section_creates_tabs(
     mock_ui: MagicMock,

--- a/tests/libs/web_console_services/test_data_manifest_service.py
+++ b/tests/libs/web_console_services/test_data_manifest_service.py
@@ -1,0 +1,192 @@
+"""Tests for shared manifest summary service."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+from libs.data.data_quality.manifest import SyncManifest
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_DATASET_KEY,
+    AlpacaSipManifestSummaryDTO,
+    DataManifestService,
+)
+from libs.web_console_services.provider_signature import sanitize_provider_signature
+
+SYNC_TS = datetime(2026, 5, 1, 12, tzinfo=UTC)
+
+
+def _write_manifest(
+    data_root: Path,
+    *,
+    dataset: str,
+    row_count: int = 10,
+    validation_status: str = "passed",
+    end_date: date = date(2026, 4, 30),
+    symbol_set_hash: str | None = "symbols-v1",
+) -> None:
+    manifest_dir = data_root / "manifests"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest = SyncManifest(
+        dataset=dataset,
+        sync_timestamp=SYNC_TS,
+        start_date=date(2026, 4, 1),
+        end_date=end_date,
+        row_count=row_count,
+        checksum=f"{dataset}-checksum",
+        schema_version="v1.0.0",
+        wrds_query_hash=f"{dataset}-query-hash",
+        file_paths=[f"alpaca/sip/{dataset}.parquet"],
+        validation_status=validation_status,  # type: ignore[arg-type]
+        provider_id="alpaca_sip",
+        provider_version="2026.04",
+        source_feed="sip",
+        adjustment_mode="raw" if dataset == ALPACA_SIP_DAILY_DATASET else None,
+        manifest_id=f"{dataset}@v1:{dataset}-checksum",
+        symbol_set_hash=symbol_set_hash,
+        sync_started_at=SYNC_TS,
+        sync_finished_at=SYNC_TS,
+    )
+    (manifest_dir / f"{dataset}.json").write_text(manifest.model_dump_json())
+
+
+def test_alpaca_sip_summary_reports_missing_when_no_manifests(tmp_path: Path) -> None:
+    service = DataManifestService(data_root=tmp_path / "data")
+
+    summary = service.get_alpaca_sip_summary()
+
+    assert summary.present_datasets == []
+    assert summary.missing_datasets == [
+        ALPACA_SIP_CORP_ACTIONS_DATASET,
+        ALPACA_SIP_DAILY_DATASET,
+    ]
+    assert summary.to_sync_status().validation_status == "missing"
+    assert summary.apply_to_source_spec({"status": "unknown"}) == {"status": "unknown"}
+
+
+def test_alpaca_sip_summary_marks_partial_companion_missing(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    _write_manifest(data_root, dataset=ALPACA_SIP_DAILY_DATASET, row_count=42)
+    service = DataManifestService(data_root=data_root)
+
+    summary = service.get_alpaca_sip_summary()
+
+    assert summary.row_count == 42
+    assert summary.to_sync_status().validation_status == (
+        f"missing: {ALPACA_SIP_CORP_ACTIONS_DATASET}"
+    )
+    updated = summary.apply_to_source_spec({"status": "unknown"})
+    assert updated["status"] == "error"
+    assert updated["row_count"] == 42
+    assert updated["error_message"] == (
+        f"Missing SIP manifests: {ALPACA_SIP_CORP_ACTIONS_DATASET}"
+    )
+
+
+def test_alpaca_sip_summary_exposes_raw_daily_provenance(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    _write_manifest(data_root, dataset=ALPACA_SIP_DAILY_DATASET, row_count=42)
+    _write_manifest(data_root, dataset=ALPACA_SIP_CORP_ACTIONS_DATASET, row_count=3)
+    service = DataManifestService(data_root=data_root)
+
+    summary = service.get_alpaca_sip_summary()
+    daily = next(item for item in summary.manifests if item.dataset == ALPACA_SIP_DAILY_DATASET)
+
+    assert summary.to_sync_status().validation_status == "ok"
+    assert summary.row_count == 45
+    assert daily.canonical_storage_mode == "raw"
+    assert daily.read_time_adjustment_mode == "unavailable"
+    assert daily.provider_signature.canonical_storage_mode == "raw"
+    assert daily.provider_signature.read_time_adjustment_mode == "unavailable"
+    assert daily.manifest_reference == "manifests://alpaca_sip_daily.json"
+    assert daily.provider_signature.manifest_reference == daily.manifest_reference
+    assert daily.provider_signature.manifest_checksum == daily.manifest_checksum
+    assert daily.provider_signature.query_params_hash == "alpaca_sip_daily-query-hash"
+    assert str(data_root) not in daily.manifest_reference
+
+
+def test_alpaca_sip_summary_adds_companion_warnings(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    _write_manifest(
+        data_root,
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        end_date=date(2026, 4, 30),
+        symbol_set_hash="daily-symbols",
+    )
+    _write_manifest(
+        data_root,
+        dataset=ALPACA_SIP_CORP_ACTIONS_DATASET,
+        end_date=date(2026, 4, 27),
+        symbol_set_hash="corp-symbols",
+    )
+    service = DataManifestService(data_root=data_root)
+
+    summary = service.get_alpaca_sip_summary()
+
+    assert "alpaca_sip_companion_symbol_set_mismatch" in summary.warnings
+    assert "alpaca_sip_companion_manifest_stale" in summary.warnings
+
+
+def test_provider_signature_sanitizer_drops_unknown_sensitive_fields() -> None:
+    signature = sanitize_provider_signature(
+        {
+            "provider_id": "alpaca_sip",
+            "manifest_checksum": "checksum",
+            "manifest_reference": "https://example.test/file?X-Amz-Signature=secret",
+            "provider_version": "Bearer abc.def.ghi",
+            "schema_version": "password=hunter2",
+            "auth_header": "Bearer secret",
+            "submit_token": "secret-token",
+            "raw_request_body": "x" * 4096,
+            "dataset_keys": [f"dataset_{idx}" for idx in range(40)],
+        }
+    )
+
+    dumped = signature.model_dump(exclude_none=True)
+    assert dumped == {
+        "provider_id": "alpaca_sip",
+        "manifest_checksum": "checksum",
+        "dataset_keys": [f"dataset_{idx}" for idx in range(32)],
+    }
+
+
+def test_apply_to_source_spec_handles_missing_latest_sync_defensively(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    _write_manifest(data_root, dataset=ALPACA_SIP_DAILY_DATASET)
+    manifest_summary = DataManifestService(data_root=data_root).get_manifest_summary(
+        ALPACA_SIP_DAILY_DATASET
+    )
+    assert manifest_summary is not None
+    summary = AlpacaSipManifestSummaryDTO(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        manifests=[manifest_summary],
+        present_datasets=[ALPACA_SIP_DAILY_DATASET],
+        missing_datasets=[],
+        latest_sync=None,
+        row_count=10,
+        schema_versions=["v1.0.0"],
+        validation_statuses=["passed"],
+        sync_validation_status="ok",
+        source_status="ok",
+        source_error_rate_pct=0.0,
+        warnings=[],
+    )
+
+    updated = summary.apply_to_source_spec({"status": "unknown"})
+
+    assert updated["status"] == "ok"
+    assert updated["minutes_ago"] == 0
+
+
+def test_unknown_manifest_dataset_has_no_data_roles(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    _write_manifest(data_root, dataset="custom_dataset")
+
+    summary = DataManifestService(data_root=data_root).get_manifest_summary("custom_dataset")
+
+    assert summary is not None
+    assert summary.provider_signature.data_roles is None

--- a/tests/libs/web_console_services/test_data_manifest_service.py
+++ b/tests/libs/web_console_services/test_data_manifest_service.py
@@ -80,9 +80,7 @@ def test_alpaca_sip_summary_marks_partial_companion_missing(tmp_path: Path) -> N
     updated = summary.apply_to_source_spec({"status": "unknown"})
     assert updated["status"] == "error"
     assert updated["row_count"] == 42
-    assert updated["error_message"] == (
-        f"Missing SIP manifests: {ALPACA_SIP_CORP_ACTIONS_DATASET}"
-    )
+    assert updated["error_message"] == (f"Missing SIP manifests: {ALPACA_SIP_CORP_ACTIONS_DATASET}")
 
 
 def test_alpaca_sip_summary_exposes_raw_daily_provenance(tmp_path: Path) -> None:
@@ -137,6 +135,7 @@ def test_provider_signature_sanitizer_drops_unknown_sensitive_fields() -> None:
             "manifest_reference": "https://example.test/file?X-Amz-Signature=secret",
             "provider_version": "Bearer abc.def.ghi",
             "schema_version": "password=hunter2",
+            "query_params_hash": "https://user:password@example.test/path",
             "auth_header": "Bearer secret",
             "submit_token": "secret-token",
             "raw_request_body": "x" * 4096,

--- a/tests/libs/web_console_services/test_data_source_status_service.py
+++ b/tests/libs/web_console_services/test_data_source_status_service.py
@@ -14,6 +14,7 @@ import redis.exceptions
 from libs.data.data_quality.manifest import SyncManifest
 from libs.platform.web_console_auth.permissions import Role
 from libs.web_console_services import data_source_status_service as module
+from libs.web_console_services.data_manifest_service import DataManifestService
 from libs.web_console_services.data_source_status_service import (
     _REFRESH_TIMEOUT_SECONDS,
     DataSourceStatusService,
@@ -159,7 +160,6 @@ async def test_refresh_alpaca_sip_source(operator_user: DummyUser) -> None:
 async def test_alpaca_sip_source_uses_manifest_status(
     admin_user: DummyUser,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_root = tmp_path / "data"
     manifest_dir = data_root / "manifests"
@@ -190,12 +190,11 @@ async def test_alpaca_sip_source_uses_manifest_status(
         validation_status="passed",
     )
     (manifest_dir / "alpaca_sip_daily.json").write_text(manifest.model_dump_json())
-    (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
-        corp_manifest.model_dump_json()
-    )
-    monkeypatch.setenv("DATA_ROOT", str(data_root))
+    (manifest_dir / "alpaca_sip_corp_actions.json").write_text(corp_manifest.model_dump_json())
 
-    service = DataSourceStatusService()
+    service = DataSourceStatusService(
+        data_manifest_service=DataManifestService(data_root=data_root)
+    )
     sources = await service.get_all_sources(admin_user)
 
     sip = next(source for source in sources if source.name == "alpaca_sip")
@@ -208,7 +207,6 @@ async def test_alpaca_sip_source_uses_manifest_status(
 async def test_alpaca_sip_source_requires_all_expected_manifests(
     admin_user: DummyUser,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_root = tmp_path / "data"
     manifest_dir = data_root / "manifests"
@@ -226,9 +224,10 @@ async def test_alpaca_sip_source_requires_all_expected_manifests(
         validation_status="passed",
     )
     (manifest_dir / "alpaca_sip_daily.json").write_text(manifest.model_dump_json())
-    monkeypatch.setenv("DATA_ROOT", str(data_root))
 
-    service = DataSourceStatusService()
+    service = DataSourceStatusService(
+        data_manifest_service=DataManifestService(data_root=data_root)
+    )
     sources = await service.get_all_sources(admin_user)
 
     sip = next(source for source in sources if source.name == "alpaca_sip")
@@ -241,13 +240,14 @@ async def test_alpaca_sip_source_requires_all_expected_manifests(
 async def test_refresh_alpaca_sip_rechecks_manifests_after_cached_unknown(
     operator_user: DummyUser,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_root = tmp_path / "data"
     manifest_dir = data_root / "manifests"
     manifest_dir.mkdir(parents=True)
-    monkeypatch.setenv("DATA_ROOT", str(data_root))
-    service = DataSourceStatusService(redis_client_factory=None)
+    service = DataSourceStatusService(
+        redis_client_factory=None,
+        data_manifest_service=DataManifestService(data_root=data_root),
+    )
 
     first_refresh = await service.refresh_source(operator_user, "alpaca_sip")
     assert first_refresh.status == "unknown"
@@ -277,9 +277,7 @@ async def test_refresh_alpaca_sip_rechecks_manifests_after_cached_unknown(
         validation_status="passed",
     )
     (manifest_dir / "alpaca_sip_daily.json").write_text(manifest.model_dump_json())
-    (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
-        corp_manifest.model_dump_json()
-    )
+    (manifest_dir / "alpaca_sip_corp_actions.json").write_text(corp_manifest.model_dump_json())
 
     listed = await service.get_all_sources(operator_user)
     listed_sip = next(source for source in listed if source.name == "alpaca_sip")

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -135,6 +135,23 @@ async def test_get_sync_status_marks_partial_alpaca_sip_manifests_missing(
     assert sip.last_sync == sync_timestamp
     assert sip.row_count == 10
     assert sip.validation_status == "missing: alpaca_sip_corp_actions"
+
+
+def test_non_alpaca_placeholder_status_does_not_call_manifest_service(
+    rate_limiter: AsyncMock,
+) -> None:
+    manifest_service = MagicMock()
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        data_manifest_service=manifest_service,
+    )
+    now = datetime(2026, 4, 30, 12, tzinfo=UTC)
+
+    status = service._mock_or_manifest_status("crsp", now)  # noqa: SLF001
+
+    assert status.dataset == "crsp"
+    assert status.last_sync == now
+    manifest_service.get_alpaca_sip_summary.assert_not_called()
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from libs.data.data_quality.manifest import SyncManifest
 from libs.platform.web_console_auth.permissions import Role
+from libs.web_console_services import data_sync_service as data_sync_module
 from libs.web_console_services.data_sync_service import DataSyncService, RateLimitExceeded
 from libs.web_console_services.schemas.data_management import SyncScheduleUpdateDTO
 
@@ -66,6 +68,27 @@ async def test_get_sync_status_filters_by_dataset_permission(
 
     datasets = {item.dataset for item in results}
     assert datasets == {"crsp", "compustat", "fama_french", "taq", "alpaca_sip"}
+
+
+@pytest.mark.asyncio()
+async def test_get_sync_status_offloads_manifest_reads(
+    service: DataSyncService,
+    operator_user: DummyUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def fake_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        nonlocal called
+        called = True
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(data_sync_module.asyncio, "to_thread", fake_to_thread)
+
+    results = await service.get_sync_status(operator_user)
+
+    assert called is True
+    assert results
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -21,6 +21,7 @@ import pytest
 from libs.data.data_quality.manifest import SyncManifest
 from libs.platform.web_console_auth.permissions import Role
 from libs.web_console_services import data_sync_service as data_sync_module
+from libs.web_console_services.data_manifest_service import DataManifestService
 from libs.web_console_services.data_sync_service import DataSyncService, RateLimitExceeded
 from libs.web_console_services.schemas.data_management import SyncScheduleUpdateDTO
 
@@ -93,10 +94,8 @@ async def test_get_sync_status_offloads_manifest_reads(
 
 @pytest.mark.asyncio()
 async def test_get_sync_status_uses_alpaca_sip_manifests(
-    service: DataSyncService,
     operator_user: DummyUser,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_root = tmp_path / "data"
     manifest_dir = data_root / "manifests"
@@ -116,7 +115,7 @@ async def test_get_sync_status_uses_alpaca_sip_manifests(
             validation_status="passed",
         )
         (manifest_dir / f"{dataset}.json").write_text(manifest.model_dump_json())
-    monkeypatch.setenv("DATA_ROOT", str(data_root))
+    service = DataSyncService(data_manifest_service=DataManifestService(data_root=data_root))
 
     results = await service.get_sync_status(operator_user)
 
@@ -128,10 +127,8 @@ async def test_get_sync_status_uses_alpaca_sip_manifests(
 
 @pytest.mark.asyncio()
 async def test_get_sync_status_marks_partial_alpaca_sip_manifests_missing(
-    service: DataSyncService,
     operator_user: DummyUser,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_root = tmp_path / "data"
     manifest_dir = data_root / "manifests"
@@ -150,7 +147,7 @@ async def test_get_sync_status_marks_partial_alpaca_sip_manifests_missing(
         validation_status="passed",
     )
     (manifest_dir / "alpaca_sip_daily.json").write_text(manifest.model_dump_json())
-    monkeypatch.setenv("DATA_ROOT", str(data_root))
+    service = DataSyncService(data_manifest_service=DataManifestService(data_root=data_root))
 
     results = await service.get_sync_status(operator_user)
 


### PR DESCRIPTION
## Summary
- add a manifest-backed Alpaca SIP read model and provider-signature sanitizer for data-page transparency
- wire Alpaca SIP sync/source status to the manifest summary instead of placeholder state
- split the data page into denser reusable components: context ribbon, operations grid, detail drawer, manifest panel, and extracted sync section
- add Phase 1 plan docs for the UI optimization and service boundary work

## PR order
This is based on current `master` after PR #218 (`Harden Alpaca SIP raw semantics`) merged.

## Validation
- `make ci-local` (`12782 passed, 24 skipped, 3 xfailed, 2146 warnings`)
- focused pytest for data page/service changes (`128 passed, 1 warning`)
- Gemini review: `NO ACTIONABLE CONCERNS`
- Codex review: no discrete correctness issues
- Claude review: no remaining implementation concerns
