### PR TITLE
[codex] Add data acquisition preflight workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -72,9 +72,7 @@ docker-compose*.yml
 .dockerignore
 
 # Scripts (only web-console data acquisition adapters are needed in containers)
-scripts/*
-!scripts/data/
-scripts/data/*
+scripts/**
 !scripts/data/__init__.py
 !scripts/data/alpaca_sip_sync.py
 !scripts/data/alpaca_corp_actions_sync.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -71,8 +71,13 @@ Dockerfile*
 docker-compose*.yml
 .dockerignore
 
-# Scripts (not needed in containers)
-scripts/
+# Scripts (only web-console data acquisition adapters are needed in containers)
+scripts/*
+!scripts/data/
+scripts/data/*
+!scripts/data/__init__.py
+!scripts/data/alpaca_sip_sync.py
+!scripts/data/alpaca_corp_actions_sync.py
 
 # Tests (not needed in production containers)
 tests/

--- a/apps/web_console_ng/Dockerfile
+++ b/apps/web_console_ng/Dockerfile
@@ -6,12 +6,17 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 # Use web console specific requirements (excludes ML dependencies)
 COPY apps/web_console_ng/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-# Create a non-root user and group for security
-RUN groupadd -r appuser && useradd --no-create-home -r -g appuser appuser
+# Create a non-root user and group for security. Allow non-unique IDs so
+# host-aligned APP_UID/APP_GID values can reuse IDs already present in Debian.
+RUN groupadd --gid "${APP_GID}" --non-unique appuser \
+    && useradd --uid "${APP_UID}" --gid appuser --no-create-home --non-unique appuser
 
 # Create .nicegui directory for NiceGUI persistence (user storage, etc.)
 RUN mkdir -p /app/.nicegui && chown appuser:appuser /app/.nicegui
@@ -19,6 +24,7 @@ RUN mkdir -p /app/data/universes && chown -R appuser:appuser /app/data
 
 COPY --chown=appuser:appuser apps/web_console_ng /app/apps/web_console_ng
 COPY --chown=appuser:appuser libs /app/libs
+COPY --chown=appuser:appuser scripts/data/__init__.py scripts/data/alpaca_sip_sync.py scripts/data/alpaca_corp_actions_sync.py /app/scripts/data/
 COPY --chown=appuser:appuser config /app/config
 COPY --chown=appuser:appuser strategies /app/strategies
 

--- a/apps/web_console_ng/components/data_sync_section.py
+++ b/apps/web_console_ng/components/data_sync_section.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from datetime import date
+from typing import Any, Literal
 
 from nicegui import ui
 
@@ -13,11 +14,26 @@ from apps.web_console_ng.components.data_management_common import (
     get_user_id_safe,
 )
 from libs.platform.web_console_auth.permissions import Permission, has_permission
-from libs.web_console_services.data_sync_service import DataSyncService
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+)
+from libs.web_console_services.data_sync_service import (
+    DataSyncService,
+)
+from libs.web_console_services.data_sync_service import (
+    PreflightRequired as SyncPreflightRequired,
+)
 from libs.web_console_services.data_sync_service import (
     RateLimitExceeded as SyncRateLimitExceeded,
 )
-from libs.web_console_services.schemas.data_management import SyncScheduleUpdateDTO
+from libs.web_console_services.schemas.data_management import (
+    DataAcquisitionJobDTO,
+    DataAcquisitionPreflightDTO,
+    DataAcquisitionRequestDTO,
+    DataAcquisitionSubmitDTO,
+    SyncScheduleUpdateDTO,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -96,14 +112,12 @@ async def render_sync_status(
     """Render sync status table and manual trigger. Returns container for refresh."""
     ui_ctx, logger_ctx = _resolve_dependencies(ui_module, logger_obj)
     status_container: ui.column | None = None
-    dataset_names: list[str] = []
 
     if has_view:
         ui_ctx.label("Dataset Sync Status").classes("font-bold mb-2")
         status_container = ui_ctx.column().classes("w-full")
         try:
             statuses = await sync_service.get_sync_status(user)
-            dataset_names = [s.dataset for s in statuses]
             with status_container:
                 build_sync_status_table(statuses, ui_module=ui_ctx)
         except PermissionError as e:
@@ -123,40 +137,210 @@ async def render_sync_status(
 
     if has_trigger:
         ui_ctx.separator().classes("my-4")
-        ui_ctx.label("Manual Sync").classes("font-bold mb-2")
+        ui_ctx.label("Data Acquisition").classes("font-bold mb-2")
+        preflight_state: dict[str, DataAcquisitionPreflightDTO | None] = {"value": None}
+        preflight_generation = {"value": 0}
 
         with ui_ctx.row().classes("gap-4 items-end"):
-            dataset_input: Any
-            if dataset_names:
-                dataset_input = ui_ctx.select(
-                    label="Dataset",
-                    options=dataset_names,
-                    value=dataset_names[0],
-                ).classes("w-48")
-            else:
-                dataset_input = ui_ctx.input(
-                    label="Dataset Name",
-                    placeholder="Enter dataset name",
-                ).classes("w-48")
+            dataset_input = ui_ctx.select(
+                label="Dataset",
+                options=[ALPACA_SIP_DAILY_DATASET, ALPACA_SIP_CORP_ACTIONS_DATASET],
+                value=ALPACA_SIP_DAILY_DATASET,
+            ).classes("w-56")
+            start_input = ui_ctx.input(
+                label="Start Date",
+                placeholder="YYYY-MM-DD",
+            ).classes("w-36")
+            end_input = ui_ctx.input(
+                label="End Date",
+                placeholder="YYYY-MM-DD",
+            ).classes("w-36")
+            symbol_source_input = ui_ctx.input(
+                label="Symbols",
+                placeholder="AAPL,MSFT or file:data/symbols/core.txt",
+            ).classes("w-40")
+            mode_input = ui_ctx.select(
+                label="Mode",
+                options=["backfill"],
+                value="backfill",
+            ).classes("w-36")
+            dry_run_input = ui_ctx.switch("Dry Run", value=True)
 
             reason_input = ui_ctx.input(
                 label="Reason",
-                placeholder="Why run this sync now?",
+                placeholder="Why grab this data now?",
             ).classes("w-64")
 
-            async def trigger_sync() -> None:
-                dataset_val = dataset_input.value
+        preflight_container = ui_ctx.column().classes("w-full mt-3")
+        job_container = ui_ctx.column().classes("w-full mt-3")
+
+        with ui_ctx.row().classes("gap-2 mt-2"):
+            suppress_invalidation = {"value": False}
+
+            def invalidate_preflight(_: Any = None) -> None:
+                if suppress_invalidation["value"]:
+                    return
+                preflight_generation["value"] += 1
+                if preflight_state["value"] is None:
+                    return
+                preflight_state["value"] = None
+                preflight_container.clear()
+                job_container.clear()
+
+            def reset_acquisition_form() -> None:
+                suppress_invalidation["value"] = True
+                try:
+                    start_input.value = ""
+                    end_input.value = ""
+                    symbol_source_input.value = ""
+                    mode_input.value = "backfill"
+                    dry_run_input.value = True
+                    reason_input.value = ""
+                finally:
+                    suppress_invalidation["value"] = False
+
+            async def run_preflight() -> None:
+                invalidate_preflight()
+                request_generation = preflight_generation["value"]
+                dataset_value = str(dataset_input.value or "")
                 reason_value = _normalize_sync_reason(reason_input.value)
-                if not dataset_val:
+                if not dataset_value:
                     ui_ctx.notify("Please select a dataset", type="warning")
                     return
                 if not reason_value:
                     ui_ctx.notify("Please provide a reason for audit logging", type="warning")
                     return
                 try:
-                    job = await sync_service.trigger_sync(user, str(dataset_val), reason_value)
+                    request = DataAcquisitionRequestDTO(
+                        dataset=dataset_value,
+                        start_date=_parse_date_input(start_input.value, "start date"),
+                        end_date=_parse_date_input(end_input.value, "end date"),
+                        symbol_source=str(symbol_source_input.value or "").strip(),
+                        mode=_normalize_acquisition_mode(mode_input.value),
+                        adjustment_mode=(
+                            "raw" if dataset_value == ALPACA_SIP_DAILY_DATASET else None
+                        ),
+                        reason=reason_value,
+                        dry_run=bool(dry_run_input.value),
+                    )
+                    preflight = await sync_service.preflight_acquisition(user, request)
+                    if request_generation != preflight_generation["value"]:
+                        ui_ctx.notify("Acquisition inputs changed; rerun preflight", type="warning")
+                        return
+                    preflight_state["value"] = preflight
+                    preflight_container.clear()
+                    with preflight_container:
+                        render_acquisition_preflight(preflight, ui_module=ui_ctx)
+                    job_container.clear()
+                    ui_ctx.notify("Acquisition preflight ready", type="positive")
+                except ValueError as e:
+                    ui_ctx.notify(str(e), type="warning")
+                except SyncRateLimitExceeded:
+                    ui_ctx.notify("Rate limit reached; wait before retrying", type="warning")
+                except PermissionError as e:
+                    ui_ctx.notify(str(e), type="negative")
+                except Exception:
+                    logger_ctx.exception(
+                        "service_call_failed",
+                        extra={
+                            "method": "preflight_acquisition",
+                            "service": "DataSyncService",
+                            "dataset": dataset_value,
+                            "user_id": get_user_id_safe(user),
+                        },
+                    )
+                    ui_ctx.notify("Service temporarily unavailable", type="warning")
+
+            async def submit_preflight() -> None:
+                preflight = preflight_state["value"]
+                if preflight is None:
+                    ui_ctx.notify("Run preflight before submitting", type="warning")
+                    return
+                try:
+                    job = await sync_service.submit_acquisition(
+                        user,
+                        DataAcquisitionSubmitDTO(
+                            idempotency_key=preflight.idempotency_key,
+                            submit_token=preflight.submit_token,
+                        ),
+                    )
+                    job_container.clear()
+                    with job_container:
+                        render_acquisition_job(job, ui_module=ui_ctx)
+                    preflight_state["value"] = None
+                    preflight_container.clear()
+                    reset_acquisition_form()
+                    notification = (
+                        f"Acquisition scope already covered by job {job.id} ({job.status})"
+                        if "duplicate_submission_reused_existing_job" in job.logs
+                        else f"Acquisition job {job.id} {job.status}"
+                    )
+                    ui_ctx.notify(notification, type="positive")
+                except SyncPreflightRequired as e:
+                    preflight_state["value"] = None
+                    preflight_container.clear()
+                    ui_ctx.notify(str(e), type="warning")
+                except SyncRateLimitExceeded:
+                    preflight_state["value"] = None
+                    preflight_container.clear()
+                    ui_ctx.notify("Rate limit reached; wait before retrying", type="warning")
+                except PermissionError as e:
+                    preflight_state["value"] = None
+                    preflight_container.clear()
+                    ui_ctx.notify(str(e), type="negative")
+                except Exception:
+                    preflight_state["value"] = None
+                    preflight_container.clear()
+                    logger_ctx.exception(
+                        "service_call_failed",
+                        extra={
+                            "method": "submit_acquisition",
+                            "service": "DataSyncService",
+                            "dataset": preflight.dataset,
+                            "user_id": get_user_id_safe(user),
+                        },
+                    )
+                    ui_ctx.notify("Service temporarily unavailable", type="warning")
+
+            ui_ctx.button("Preflight", on_click=run_preflight, color="primary")
+            ui_ctx.button("Submit Job", on_click=submit_preflight).props("outline")
+            for acquisition_input in (
+                dataset_input,
+                start_input,
+                end_input,
+                symbol_source_input,
+                mode_input,
+                dry_run_input,
+                reason_input,
+            ):
+                acquisition_input.on_value_change(invalidate_preflight)
+
+        ui_ctx.separator().classes("my-4")
+        ui_ctx.label("Manual Sync").classes("font-bold mb-2")
+        with ui_ctx.row().classes("gap-4 items-end"):
+            manual_dataset_input = ui_ctx.select(
+                label="Sync Dataset",
+                options=list(TREND_DATASETS),
+                value=TREND_DATASETS[0],
+            ).classes("w-48")
+            manual_reason_input = ui_ctx.input(
+                label="Sync Reason",
+                placeholder="Why run this sync now?",
+            ).classes("w-64")
+
+            async def trigger_sync() -> None:
+                dataset_value = str(manual_dataset_input.value or "")
+                reason_value = _normalize_sync_reason(manual_reason_input.value)
+                if not dataset_value:
+                    ui_ctx.notify("Please select a dataset", type="warning")
+                    return
+                if not reason_value:
+                    ui_ctx.notify("Please provide a reason for audit logging", type="warning")
+                    return
+                try:
+                    job = await sync_service.trigger_sync(user, dataset_value, reason_value)
                     ui_ctx.notify(f"Sync job {job.id} queued for {job.dataset}", type="positive")
-                    reason_input.value = ""
+                    manual_reason_input.value = ""
                 except SyncRateLimitExceeded:
                     ui_ctx.notify("Rate limit: 1 sync per minute", type="warning")
                 except PermissionError as e:
@@ -167,7 +351,7 @@ async def render_sync_status(
                         extra={
                             "method": "trigger_sync",
                             "service": "DataSyncService",
-                            "dataset": str(dataset_val),
+                            "dataset": dataset_value,
                             "user_id": get_user_id_safe(user),
                         },
                     )
@@ -176,6 +360,25 @@ async def render_sync_status(
             ui_ctx.button("Trigger Sync", on_click=trigger_sync, color="primary")
 
     return status_container
+
+
+def _parse_date_input(value: Any, label: str) -> date:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"Please provide a {label}")
+    if len(text) != 10 or text[4] != "-" or text[7] != "-":
+        raise ValueError(f"Invalid {label}; expected YYYY-MM-DD")
+    try:
+        return date.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {label}; expected YYYY-MM-DD") from exc
+
+
+def _normalize_acquisition_mode(value: Any) -> Literal["backfill"]:
+    text = str(value or "backfill").strip()
+    if text == "backfill":
+        return "backfill"
+    raise ValueError("Mode must be backfill")
 
 
 def build_sync_status_table(
@@ -297,6 +500,98 @@ def build_sync_logs_table(
         for log in logs
     ]
     ui_ctx.table(columns=columns, rows=rows).classes("w-full")
+
+
+def build_acquisition_preflight_rows(
+    preflight: DataAcquisitionPreflightDTO,
+) -> list[dict[str, str]]:
+    """Build UI-safe preflight rows without exposing the submit token value."""
+    requested_start = preflight.requested_start_date or preflight.start_date
+    requested_end = preflight.requested_end_date or preflight.end_date
+    return [
+        {"field": "Dataset", "value": preflight.dataset},
+        {"field": "Requested date range", "value": f"{requested_start} to {requested_end}"},
+        {
+            "field": "Effective acquisition scope",
+            "value": f"{preflight.start_date} to {preflight.end_date}",
+        },
+        {"field": "Symbols", "value": preflight.symbol_source},
+        {"field": "Mode", "value": preflight.mode},
+        {"field": "Dry run", "value": str(preflight.dry_run).lower()},
+        {"field": "Provider", "value": preflight.provider_id},
+        {"field": "Source feed", "value": preflight.source_feed},
+        {"field": "Canonical storage", "value": preflight.canonical_storage_mode},
+        {
+            "field": "Read-time adjustment",
+            "value": preflight.read_time_adjustment_mode or "-",
+        },
+        {"field": "Adjustment mode", "value": preflight.adjustment_mode or "-"},
+        {"field": "Idempotency key", "value": preflight.idempotency_key},
+        {"field": "Submit token status", "value": preflight.submit_token_status},
+        {
+            "field": "Submit token expires",
+            "value": format_datetime(preflight.submit_token_expires_at),
+        },
+        {
+            "field": "Supported semantics",
+            "value": "; ".join(preflight.supported_semantics),
+        },
+        {"field": "Warnings", "value": "; ".join(preflight.warnings) or "-"},
+        {"field": "Preflight logs", "value": "; ".join(preflight.logs)},
+    ]
+
+
+def render_acquisition_preflight(
+    preflight: DataAcquisitionPreflightDTO,
+    *,
+    ui_module: Any | None = None,
+) -> None:
+    """Render acquisition preflight details without exposing the submit token."""
+    ui_ctx, _ = _resolve_dependencies(ui_module, None)
+    columns = [
+        {"name": "field", "label": "Field", "field": "field"},
+        {"name": "value", "label": "Value", "field": "value"},
+    ]
+    ui_ctx.table(
+        columns=columns,
+        rows=build_acquisition_preflight_rows(preflight),
+    ).classes("w-full")
+
+
+def build_acquisition_job_rows(job: DataAcquisitionJobDTO) -> list[dict[str, str]]:
+    """Build UI-safe acquisition job rows."""
+    return [
+        {"field": "Job ID", "value": job.id},
+        {"field": "Dataset", "value": job.dataset},
+        {"field": "Status", "value": job.status},
+        {"field": "Idempotency key", "value": job.idempotency_key},
+        {"field": "Mode", "value": job.mode},
+        {"field": "Dry run", "value": str(job.dry_run).lower()},
+        {"field": "Provider", "value": job.provider_id},
+        {"field": "Source feed", "value": job.source_feed},
+        {"field": "Canonical storage", "value": job.canonical_storage_mode},
+        {"field": "Adjustment mode", "value": job.adjustment_mode or "-"},
+        {"field": "Submit token status", "value": job.submit_token_status},
+        {"field": "Adapter", "value": job.adapter},
+        {"field": "Started", "value": format_datetime(job.started_at)},
+        {"field": "Produced manifests", "value": "; ".join(job.produced_manifest_ids) or "-"},
+        {"field": "Validation", "value": "; ".join(job.validation_output)},
+        {"field": "Logs", "value": "; ".join(job.logs)},
+    ]
+
+
+def render_acquisition_job(
+    job: DataAcquisitionJobDTO,
+    *,
+    ui_module: Any | None = None,
+) -> None:
+    """Render acquisition job state and logs."""
+    ui_ctx, _ = _resolve_dependencies(ui_module, None)
+    columns = [
+        {"name": "field", "label": "Field", "field": "field"},
+        {"name": "value", "label": "Value", "field": "value"},
+    ]
+    ui_ctx.table(columns=columns, rows=build_acquisition_job_rows(job)).classes("w-full")
 
 
 async def render_sync_schedule(

--- a/apps/web_console_ng/components/data_sync_section.py
+++ b/apps/web_console_ng/components/data_sync_section.py
@@ -256,6 +256,16 @@ async def render_sync_status(
                 if preflight is None:
                     ui_ctx.notify("Run preflight before submitting", type="warning")
                     return
+
+                def clear_preflight_after_submit_error(
+                    message: str,
+                    *,
+                    msg_type: str = "warning",
+                ) -> None:
+                    preflight_state["value"] = None
+                    preflight_container.clear()
+                    ui_ctx.notify(message, type=msg_type)
+
                 try:
                     job = await sync_service.submit_acquisition(
                         user,
@@ -277,20 +287,12 @@ async def render_sync_status(
                     )
                     ui_ctx.notify(notification, type="positive")
                 except SyncPreflightRequired as e:
-                    preflight_state["value"] = None
-                    preflight_container.clear()
-                    ui_ctx.notify(str(e), type="warning")
+                    clear_preflight_after_submit_error(str(e))
                 except SyncRateLimitExceeded:
-                    preflight_state["value"] = None
-                    preflight_container.clear()
-                    ui_ctx.notify("Rate limit reached; wait before retrying", type="warning")
+                    clear_preflight_after_submit_error("Rate limit reached; wait before retrying")
                 except PermissionError as e:
-                    preflight_state["value"] = None
-                    preflight_container.clear()
-                    ui_ctx.notify(str(e), type="negative")
+                    clear_preflight_after_submit_error(str(e), msg_type="negative")
                 except Exception:
-                    preflight_state["value"] = None
-                    preflight_container.clear()
                     logger_ctx.exception(
                         "service_call_failed",
                         extra={
@@ -300,7 +302,7 @@ async def render_sync_status(
                             "user_id": get_user_id_safe(user),
                         },
                     )
-                    ui_ctx.notify("Service temporarily unavailable", type="warning")
+                    clear_preflight_after_submit_error("Service temporarily unavailable")
 
             ui_ctx.button("Preflight", on_click=run_preflight, color="primary")
             ui_ctx.button("Submit Job", on_click=submit_preflight).props("outline")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -376,6 +376,9 @@ services:
     build:
       context: .
       dockerfile: apps/web_console_ng/Dockerfile
+      args:
+        APP_UID: ${WEB_CONSOLE_UID:-1000}
+        APP_GID: ${WEB_CONSOLE_GID:-1000}
     container_name: trading_platform_web_console
     # SECURITY: Create .env file with credentials (see .env.example)
     # Required: WEB_CONSOLE_USER, WEB_CONSOLE_PASSWORD
@@ -434,6 +437,7 @@ services:
       - default
       - trading_platform
     volumes:
+      - ./data:/app/data  # Data acquisition output and symbol-source files; align WEB_CONSOLE_UID/GID with host ownership when needed.
       - backtest_data:/app/data/backtest_results:ro
     profiles:
       - manual  # Prevent auto-start, require explicit profile selection

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -20,7 +20,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from functools import partial
-from inspect import isawaitable
+from inspect import isawaitable, iscoroutinefunction
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 from uuid import uuid4
@@ -71,6 +71,10 @@ _ACQUISITION_BACKGROUND_CONCURRENCY = max(
 _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS = max(
     1,
     int(os.getenv("DATA_ACQUISITION_HEARTBEAT_INTERVAL_SECONDS", "30")),
+)
+_ACQUISITION_EXECUTION_TIMEOUT_SECONDS = max(
+    _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS,
+    int(os.getenv("DATA_ACQUISITION_EXECUTION_TIMEOUT_SECONDS", "21600")),
 )
 _ACQUISITION_ACTIVE_JOB_STALE_SECONDS = max(
     _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS * 3,
@@ -318,6 +322,19 @@ class _InMemoryAcquisitionStore:
             del self.acquisition_jobs[key]
 
 
+def _is_async_redis_client(redis_client: Any) -> bool:
+    with suppress(ImportError):
+        from redis.asyncio import Redis as AsyncRedis
+
+        if isinstance(redis_client, AsyncRedis):
+            return True
+
+    return any(
+        iscoroutinefunction(getattr(redis_client, method_name, None))
+        for method_name in ("eval", "get", "hget", "delete")
+    )
+
+
 class _RedisAcquisitionStore:
     _CONSUME_TOKEN_SCRIPT = """
 local token_hash = redis.call("HGET", KEYS[1], "token_hash")
@@ -380,7 +397,7 @@ return 1
 
     def __init__(self, redis_client: Any) -> None:
         self._redis = redis_client
-        self._redis_is_async = type(redis_client).__module__.startswith("redis.asyncio")
+        self._redis_is_async = _is_async_redis_client(redis_client)
 
     @classmethod
     def from_env(cls) -> _RedisAcquisitionStore:
@@ -471,9 +488,7 @@ return 1
             payload,
             str(_ACQUISITION_JOB_RETENTION_SECONDS),
             str(
-                _datetime_epoch_us(
-                    _now - timedelta(seconds=_ACQUISITION_ACTIVE_JOB_STALE_SECONDS)
-                )
+                _datetime_epoch_us(_now - timedelta(seconds=_ACQUISITION_ACTIVE_JOB_STALE_SECONDS))
             ),
         )
         if existing is None:
@@ -635,7 +650,7 @@ class _ScriptBackedAcquisitionExecutor:
                 ["dry_run_completed", f"adapter={_adapter_for_dataset(preflight.dataset)}"],
             )
 
-        command = _build_acquisition_command(preflight)
+        command = await asyncio.to_thread(_build_acquisition_command, preflight)
         proc = await asyncio.create_subprocess_exec(
             *command,
             cwd=_REPO_ROOT,
@@ -1510,7 +1525,10 @@ class DataSyncService:
         try:
             heartbeat_task = asyncio.create_task(self._heartbeat_acquisition_job(job))
             async with _background_acquisition_semaphore():
-                updated_job = await self._run_acquisition_job(job, preflight)
+                updated_job = await asyncio.wait_for(
+                    self._run_acquisition_job(job, preflight),
+                    timeout=_ACQUISITION_EXECUTION_TIMEOUT_SECONDS,
+                )
             if heartbeat_task is not None:
                 heartbeat_task.cancel()
                 with suppress(asyncio.CancelledError):
@@ -1564,16 +1582,22 @@ class DataSyncService:
             raise
 
     async def _heartbeat_acquisition_job(self, job: DataAcquisitionJobDTO) -> None:
+        loop = asyncio.get_running_loop()
+        next_heartbeat_at = loop.time() + _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS
         while True:
-            await asyncio.sleep(_ACQUISITION_HEARTBEAT_INTERVAL_SECONDS)
-            heartbeat_job = job.model_copy(update={"heartbeat_at": datetime.now(UTC)})
+            await asyncio.sleep(max(0.0, next_heartbeat_at - loop.time()))
+            heartbeat_started_at = datetime.now(UTC)
+            heartbeat_job = job.model_copy(update={"heartbeat_at": heartbeat_started_at})
             try:
-                await self._acquisition_store.update_job(heartbeat_job, datetime.now(UTC))
+                await self._acquisition_store.update_job(heartbeat_job, heartbeat_started_at)
             except Exception:
                 logger.exception(
                     "background_acquisition_heartbeat_failed",
                     extra={"job_id": job.id, "dataset": job.dataset},
                 )
+            next_heartbeat_at += _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS
+            if next_heartbeat_at <= loop.time():
+                next_heartbeat_at = loop.time() + _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS
 
     async def _run_acquisition_job(
         self,

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -401,7 +401,7 @@ return 1
 
     @classmethod
     def from_env(cls) -> _RedisAcquisitionStore:
-        from redis import Redis
+        from redis.asyncio import Redis
 
         redis_url = os.getenv("DATA_ACQUISITION_REDIS_URL")
         if redis_url:
@@ -635,6 +635,12 @@ class _AcquisitionExecutor(Protocol):
         """Execute an acquisition and return manifests, validation output, and logs."""
 
 
+@dataclass(frozen=True)
+class _ProcessStreamCapture:
+    log_lines: list[str]
+    manifest_ids: list[str]
+
+
 class _ScriptBackedAcquisitionExecutor:
     def __init__(self, data_manifest_service: DataManifestService) -> None:
         self._data_manifest_service = data_manifest_service
@@ -657,9 +663,25 @@ class _ScriptBackedAcquisitionExecutor:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        stdout_task = asyncio.create_task(
+            self._capture_process_stream(
+                proc.stdout,
+                prefix="stdout",
+                dataset=preflight.dataset,
+            )
+        )
+        stderr_task = asyncio.create_task(
+            self._capture_process_stream(proc.stderr, prefix="stderr")
+        )
         try:
-            stdout, stderr = await proc.communicate()
+            stdout_capture, stderr_capture = await asyncio.gather(
+                stdout_task,
+                stderr_task,
+            )
+            returncode = await proc.wait()
         except asyncio.CancelledError:
+            stdout_task.cancel()
+            stderr_task.cancel()
             with suppress(ProcessLookupError):
                 proc.terminate()
             try:
@@ -668,19 +690,21 @@ class _ScriptBackedAcquisitionExecutor:
                 with suppress(ProcessLookupError):
                     proc.kill()
                 await proc.wait()
+            with suppress(asyncio.CancelledError):
+                await asyncio.gather(stdout_task, stderr_task)
             raise
         logs = [
             f"command={' '.join(_truncate_command_for_log(command))}",
-            *_decode_process_lines(stdout, prefix="stdout"),
-            *_decode_process_lines(stderr, prefix="stderr"),
+            *stdout_capture.log_lines,
+            *stderr_capture.log_lines,
         ]
-        if proc.returncode != 0:
+        if returncode != 0:
             raise _AcquisitionExecutionError(
-                f"Acquisition adapter failed with exit code {proc.returncode}",
+                f"Acquisition adapter failed with exit code {returncode}",
                 logs,
             )
 
-        manifest_ids = self._manifest_ids_from_stdout(preflight.dataset, stdout)
+        manifest_ids = stdout_capture.manifest_ids
         return (
             manifest_ids or self._produced_manifest_ids(preflight.dataset),
             ["preflight_passed", "adapter_completed", "manifest_validation_pending"],
@@ -688,26 +712,63 @@ class _ScriptBackedAcquisitionExecutor:
         )
 
     @staticmethod
+    async def _capture_process_stream(
+        stream: asyncio.StreamReader | None,
+        *,
+        prefix: str,
+        dataset: str | None = None,
+    ) -> _ProcessStreamCapture:
+        if stream is None:
+            return _ProcessStreamCapture(log_lines=[], manifest_ids=[])
+
+        log_lines: list[str] = []
+        manifest_ids: list[str] = []
+        while line := await stream.readline():
+            decoded_line = line.decode(errors="replace").rstrip("\r\n")
+            if dataset is not None and not manifest_ids:
+                manifest_ids = _ScriptBackedAcquisitionExecutor._manifest_ids_from_stdout_line(
+                    dataset,
+                    decoded_line,
+                )
+            if not decoded_line:
+                continue
+            log_lines.append(f"{prefix}:{_sanitize_log_message(decoded_line)[:500]}")
+            if len(log_lines) > 20:
+                del log_lines[: len(log_lines) - 20]
+
+        return _ProcessStreamCapture(log_lines=log_lines, manifest_ids=manifest_ids)
+
+    @staticmethod
     def _manifest_ids_from_stdout(dataset: str, stdout: bytes) -> list[str]:
         for line in stdout.decode(errors="replace").splitlines():
-            if not line.startswith(_MANIFEST_OUTPUT_PREFIX):
-                continue
-            try:
-                payload = json.loads(line.removeprefix(_MANIFEST_OUTPUT_PREFIX))
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(payload, dict) or str(payload.get("dataset", "")) != dataset:
-                continue
-            manifest_id = str(payload.get("manifest_id") or "").strip()
-            if manifest_id:
-                return [manifest_id]
-            try:
-                version = int(payload["manifest_version"])
-            except (KeyError, TypeError, ValueError):
-                continue
-            checksum = str(payload.get("checksum") or "").strip()
-            if checksum:
-                return [f"{dataset}@v{version}:{checksum}"]
+            manifest_ids = _ScriptBackedAcquisitionExecutor._manifest_ids_from_stdout_line(
+                dataset,
+                line,
+            )
+            if manifest_ids:
+                return manifest_ids
+        return []
+
+    @staticmethod
+    def _manifest_ids_from_stdout_line(dataset: str, line: str) -> list[str]:
+        if not line.startswith(_MANIFEST_OUTPUT_PREFIX):
+            return []
+        try:
+            payload = json.loads(line.removeprefix(_MANIFEST_OUTPUT_PREFIX))
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(payload, dict) or str(payload.get("dataset", "")) != dataset:
+            return []
+        manifest_id = str(payload.get("manifest_id") or "").strip()
+        if manifest_id:
+            return [manifest_id]
+        try:
+            version = int(payload["manifest_version"])
+        except (KeyError, TypeError, ValueError):
+            return []
+        checksum = str(payload.get("checksum") or "").strip()
+        if checksum:
+            return [f"{dataset}@v{version}:{checksum}"]
         return []
 
     def _produced_manifest_ids(self, dataset: str) -> list[str]:
@@ -925,13 +986,6 @@ def _format_exception_for_log(exc: BaseException) -> str:
     message = _sanitize_log_message(str(exc))
     detail = f"{type(exc).__name__}:{message}" if message else type(exc).__name__
     return detail if len(detail) <= 320 else f"{detail[:317]}..."
-
-
-def _decode_process_lines(payload: bytes, *, prefix: str) -> list[str]:
-    text = payload.decode(errors="replace").strip()
-    if not text:
-        return []
-    return [f"{prefix}:{_sanitize_log_message(line)[:500]}" for line in text.splitlines()[-20:]]
 
 
 class DataSyncService:

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -15,6 +15,7 @@ import re
 import secrets
 import sys
 import weakref
+from collections import deque
 from collections.abc import Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -738,7 +739,7 @@ class _ScriptBackedAcquisitionExecutor:
         if stream is None:
             return _ProcessStreamCapture(log_lines=[], manifest_ids=[])
 
-        log_lines: list[str] = []
+        log_lines: deque[str] = deque(maxlen=20)
         manifest_ids: list[str] = []
         while line := await stream.readline():
             decoded_line = line.decode(errors="replace").rstrip("\r\n")
@@ -750,10 +751,8 @@ class _ScriptBackedAcquisitionExecutor:
             if not decoded_line:
                 continue
             log_lines.append(f"{prefix}:{_sanitize_log_message(decoded_line)[:500]}")
-            if len(log_lines) > 20:
-                del log_lines[: len(log_lines) - 20]
 
-        return _ProcessStreamCapture(log_lines=log_lines, manifest_ids=manifest_ids)
+        return _ProcessStreamCapture(log_lines=list(log_lines), manifest_ids=manifest_ids)
 
     @staticmethod
     def _manifest_ids_from_stdout(dataset: str, stdout: bytes) -> list[str]:

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -6,10 +6,27 @@ Enforces RBAC, dataset-level access, and rate limiting at server-side.
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
-from typing import Any
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import secrets
+import sys
+import weakref
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from functools import partial
+from inspect import isawaitable
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
 from uuid import uuid4
 
+from config.settings import get_settings
+from libs.data.data_providers.registry import ProviderType, get_provider_spec
 from libs.platform.web_console_auth.helpers import get_user_id
 from libs.platform.web_console_auth.permissions import (
     Permission,
@@ -17,9 +34,17 @@ from libs.platform.web_console_auth.permissions import (
     has_permission,
 )
 from libs.platform.web_console_auth.rate_limiter import RateLimiter, get_rate_limiter
-from libs.web_console_services.data_manifest_service import DataManifestService
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    DataManifestService,
+)
 
 from .schemas.data_management import (
+    DataAcquisitionJobDTO,
+    DataAcquisitionPreflightDTO,
+    DataAcquisitionRequestDTO,
+    DataAcquisitionSubmitDTO,
     SyncJobDTO,
     SyncLogEntry,
     SyncScheduleDTO,
@@ -28,10 +53,870 @@ from .schemas.data_management import (
 )
 
 _SUPPORTED_DATASETS = ("crsp", "compustat", "taq", "fama_french", "alpaca_sip")
+_SUPPORTED_ACQUISITION_DATASETS = (
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+)
+_ACQUISITION_TOKEN_TTL_SECONDS = 300
+_ACQUISITION_JOB_RETENTION_SECONDS = 86_400
+_ACQUISITION_MAX_PREFLIGHT_TOKENS = 512
+_ACQUISITION_MAX_JOBS = 256
+_ACQUISITION_MAX_DATE_RANGE_DAYS = 5_500
+_ACQUISITION_REUSABLE_JOB_STATUSES = frozenset({"queued", "running", "completed"})
+_ACQUISITION_TERMINAL_JOB_STATUSES = frozenset({"completed", "failed"})
+_ACQUISITION_BACKGROUND_CONCURRENCY = max(
+    1,
+    int(os.getenv("DATA_ACQUISITION_BACKGROUND_CONCURRENCY", "1")),
+)
+_ACQUISITION_HEARTBEAT_INTERVAL_SECONDS = max(
+    1,
+    int(os.getenv("DATA_ACQUISITION_HEARTBEAT_INTERVAL_SECONDS", "30")),
+)
+_ACQUISITION_ACTIVE_JOB_STALE_SECONDS = max(
+    _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS * 3,
+    int(os.getenv("DATA_ACQUISITION_ACTIVE_JOB_STALE_SECONDS", "300")),
+)
+_ACQUISITION_MAX_SYMBOLS_FROM_FILE = 5_000
+_SYMBOL_FILE_PREFIX = "data/symbols/"
+_SYMBOL_FILE_EXTENSIONS = (".csv", ".txt")
+_SYMBOL_FILE_FINGERPRINT_SEPARATOR = "#sha256="
+_SYMBOL_TOKEN_PATTERN = re.compile(r"^[A-Z][A-Z0-9.-]{0,14}$")
+_SOURCE_VALUE_PATTERN = re.compile(r"^[A-Za-z0-9_./,-]{1,200}$")
+_SYMBOL_SOURCE_PREFIXES = ("file:", "universe:", "ids:")
+_ACQUISITION_REDIS_PREFIX = "web-console:data-acquisition"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|secret[_-]?key|token|"
+    r"APCA-API-KEY-ID|APCA-API-SECRET-KEY)(=|:)\s*(?:Bearer\s+)?[^,\s]+"
+)
+_SENSITIVE_BEARER_PATTERN = re.compile(r"(?i)(Bearer\s+)[A-Za-z0-9._~+/=-]+")
+_MANIFEST_OUTPUT_PREFIX = "MANIFEST_JSON:"
+
+logger = logging.getLogger(__name__)
+_BACKGROUND_ACQUISITION_SEMAPHORES: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Semaphore
+] = weakref.WeakKeyDictionary()
 
 
 class RateLimitExceeded(RuntimeError):
     """Raised when a rate limit is exceeded."""
+
+
+class PreflightRequired(RuntimeError):
+    """Raised when an acquisition submit lacks a current one-use preflight token."""
+
+
+@dataclass
+class _SubmitTokenRecord:
+    user_id: str
+    token_hash: str
+    expires_at: datetime
+    preflight: DataAcquisitionPreflightDTO
+    reason: str
+    consumed: bool = False
+
+
+@dataclass
+class _AcquisitionState:
+    lock: asyncio.Lock
+    preflight_tokens: dict[tuple[str, str], _SubmitTokenRecord]
+    acquisition_jobs: dict[str, DataAcquisitionJobDTO]
+
+
+class _AcquisitionStore(Protocol):
+    async def save_preflight_token(
+        self,
+        key: tuple[str, str],
+        record: _SubmitTokenRecord,
+        now: datetime,
+    ) -> None:
+        """Persist a one-use preflight token record."""
+
+    async def consume_preflight_token(
+        self,
+        *,
+        user_id: str,
+        idempotency_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> _SubmitTokenRecord | None:
+        """Atomically validate and consume a preflight token."""
+
+    async def get_preflight_token(
+        self,
+        *,
+        user_id: str,
+        idempotency_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> _SubmitTokenRecord | None:
+        """Validate a preflight token without consuming it."""
+
+    async def get_reusable_job(
+        self,
+        idempotency_key: str,
+        now: datetime,
+    ) -> DataAcquisitionJobDTO | None:
+        """Return a retained job that should satisfy duplicate submits."""
+
+    async def reserve_job(
+        self,
+        job: DataAcquisitionJobDTO,
+        now: datetime,
+    ) -> DataAcquisitionJobDTO | None:
+        """Persist a new job if absent; return an existing retained job on conflict."""
+
+    async def update_job(self, job: DataAcquisitionJobDTO, now: datetime) -> None:
+        """Persist updated job state."""
+
+    async def sweep(self, now: datetime) -> None:
+        """Remove expired local state when the backend requires explicit cleanup."""
+
+
+class _InMemoryAcquisitionStore:
+    def __init__(self, state: _AcquisitionState) -> None:
+        self.lock = state.lock
+        self.preflight_tokens = state.preflight_tokens
+        self.acquisition_jobs = state.acquisition_jobs
+
+    async def save_preflight_token(
+        self,
+        key: tuple[str, str],
+        record: _SubmitTokenRecord,
+        now: datetime,
+    ) -> None:
+        async with self.lock:
+            self._sweep_locked(now)
+            self.preflight_tokens[key] = record
+            self._trim_preflight_tokens_locked()
+
+    async def consume_preflight_token(
+        self,
+        *,
+        user_id: str,
+        idempotency_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> _SubmitTokenRecord | None:
+        async with self.lock:
+            self._sweep_locked(now)
+            record = self.preflight_tokens.get((user_id, idempotency_key))
+            if (
+                record is None
+                or record.user_id != user_id
+                or record.consumed
+                or record.expires_at <= now
+                or not hmac.compare_digest(record.token_hash, token_hash)
+            ):
+                return None
+            record.consumed = True
+            return record
+
+    async def get_preflight_token(
+        self,
+        *,
+        user_id: str,
+        idempotency_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> _SubmitTokenRecord | None:
+        async with self.lock:
+            self._sweep_locked(now)
+            record = self.preflight_tokens.get((user_id, idempotency_key))
+            if (
+                record is None
+                or record.user_id != user_id
+                or record.consumed
+                or record.expires_at <= now
+                or not hmac.compare_digest(record.token_hash, token_hash)
+            ):
+                return None
+            return record
+
+    async def get_reusable_job(
+        self,
+        idempotency_key: str,
+        now: datetime,
+    ) -> DataAcquisitionJobDTO | None:
+        async with self.lock:
+            self._sweep_locked(now)
+            job = self.acquisition_jobs.get(idempotency_key)
+            return job if job is not None and _is_reusable_acquisition_job(job, now) else None
+
+    async def reserve_job(
+        self,
+        job: DataAcquisitionJobDTO,
+        now: datetime,
+    ) -> DataAcquisitionJobDTO | None:
+        async with self.lock:
+            self._sweep_locked(now)
+            existing = self.acquisition_jobs.get(job.idempotency_key)
+            if existing is not None and _is_reusable_acquisition_job(existing, now):
+                return existing
+            self.acquisition_jobs[job.idempotency_key] = job
+            self._trim_acquisition_jobs_locked()
+            return None
+
+    async def update_job(self, job: DataAcquisitionJobDTO, now: datetime) -> None:
+        async with self.lock:
+            self._sweep_locked(now)
+            existing = self.acquisition_jobs.get(job.idempotency_key)
+            if existing is not None and existing.id != job.id:
+                return
+            if (
+                existing is not None
+                and existing.status in _ACQUISITION_TERMINAL_JOB_STATUSES
+                and job.status not in _ACQUISITION_TERMINAL_JOB_STATUSES
+            ):
+                return
+            self.acquisition_jobs[job.idempotency_key] = job
+            self._trim_acquisition_jobs_locked()
+
+    async def sweep(self, now: datetime) -> None:
+        async with self.lock:
+            self._sweep_locked(now)
+
+    def _sweep_locked(self, now: datetime) -> None:
+        expired_token_keys = [
+            key for key, record in self.preflight_tokens.items() if record.expires_at <= now
+        ]
+        for token_key in expired_token_keys:
+            del self.preflight_tokens[token_key]
+
+        job_cutoff = now - timedelta(seconds=_ACQUISITION_JOB_RETENTION_SECONDS)
+        stale_job_keys = [
+            key
+            for key, job in self.acquisition_jobs.items()
+            if _retention_anchor_for_acquisition_job(job, now) <= job_cutoff
+        ]
+        for job_key in stale_job_keys:
+            del self.acquisition_jobs[job_key]
+
+        self._trim_acquisition_jobs_locked()
+
+    def _trim_preflight_tokens_locked(self) -> None:
+        overflow = len(self.preflight_tokens) - _ACQUISITION_MAX_PREFLIGHT_TOKENS
+        if overflow <= 0:
+            return
+        oldest_keys = sorted(
+            self.preflight_tokens,
+            key=lambda key: self.preflight_tokens[key].expires_at,
+        )[:overflow]
+        for key in oldest_keys:
+            del self.preflight_tokens[key]
+
+    def _trim_acquisition_jobs_locked(self) -> None:
+        overflow = len(self.acquisition_jobs) - _ACQUISITION_MAX_JOBS
+        if overflow <= 0:
+            return
+        oldest_keys = sorted(
+            self.acquisition_jobs,
+            key=lambda key: self.acquisition_jobs[key].started_at
+            or datetime.min.replace(tzinfo=UTC),
+        )[:overflow]
+        for key in oldest_keys:
+            del self.acquisition_jobs[key]
+
+
+class _RedisAcquisitionStore:
+    _CONSUME_TOKEN_SCRIPT = """
+local token_hash = redis.call("HGET", KEYS[1], "token_hash")
+if not token_hash then
+  return nil
+end
+if token_hash ~= ARGV[1] then
+  return nil
+end
+local expires_at_epoch = tonumber(redis.call("HGET", KEYS[1], "expires_at_epoch") or "0")
+if expires_at_epoch <= tonumber(ARGV[2]) then
+  redis.call("DEL", KEYS[1])
+  return nil
+end
+local payload = redis.call("HGET", KEYS[1], "payload")
+redis.call("DEL", KEYS[1])
+return payload
+"""
+    _RESERVE_JOB_SCRIPT = """
+local existing = redis.call("GET", KEYS[1])
+if not existing then
+  redis.call("SET", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
+  return nil
+end
+
+local decoded = cjson.decode(existing)
+local status = decoded["status"]
+if status == "completed" then
+  return existing
+end
+if status == "queued" or status == "running" then
+  local active_epoch_us = tonumber(decoded["heartbeat_at_epoch_us"] or decoded["started_at_epoch_us"] or "0")
+  if active_epoch_us >= tonumber(ARGV[3]) then
+    return existing
+  end
+end
+
+redis.call("SET", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
+return nil
+"""
+    _UPDATE_JOB_IF_CURRENT_SCRIPT = """
+-- update-if-current-job-id
+local existing = redis.call("GET", KEYS[1])
+if existing then
+  local decoded = cjson.decode(existing)
+  if decoded["id"] ~= ARGV[2] then
+    return 0
+  end
+  local replacement = cjson.decode(ARGV[1])
+  local existing_status = decoded["status"]
+  local replacement_status = replacement["status"]
+  if (existing_status == "completed" or existing_status == "failed") and
+     replacement_status ~= "completed" and replacement_status ~= "failed" then
+    return 0
+  end
+end
+redis.call("SET", KEYS[1], ARGV[1], "EX", tonumber(ARGV[3]))
+return 1
+"""
+
+    def __init__(self, redis_client: Any) -> None:
+        self._redis = redis_client
+        self._redis_is_async = type(redis_client).__module__.startswith("redis.asyncio")
+
+    @classmethod
+    def from_env(cls) -> _RedisAcquisitionStore:
+        from redis import Redis
+
+        redis_url = os.getenv("DATA_ACQUISITION_REDIS_URL")
+        if redis_url:
+            return cls(Redis.from_url(redis_url, decode_responses=True))
+
+        redis_url = os.getenv("REDIS_URL") or get_settings().redis_url
+        return cls(Redis.from_url(redis_url, decode_responses=True))
+
+    async def save_preflight_token(
+        self,
+        key: tuple[str, str],
+        record: _SubmitTokenRecord,
+        _now: datetime,
+    ) -> None:
+        redis_key = self._token_key(*key)
+        payload = _serialize_token_record(record)
+        await self._save_token(redis_key, payload, record.token_hash, record.expires_at)
+
+    async def consume_preflight_token(
+        self,
+        *,
+        user_id: str,
+        idempotency_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> _SubmitTokenRecord | None:
+        redis_key = self._token_key(user_id, idempotency_key)
+        payload = await self._call_redis(
+            "eval",
+            self._CONSUME_TOKEN_SCRIPT,
+            1,
+            redis_key,
+            token_hash,
+            str(int(now.timestamp())),
+        )
+        if not payload:
+            return None
+        record = _deserialize_token_record(str(payload))
+        if record.expires_at <= now:
+            return None
+        record.consumed = True
+        return record
+
+    async def get_preflight_token(
+        self,
+        *,
+        user_id: str,
+        idempotency_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> _SubmitTokenRecord | None:
+        redis_key = self._token_key(user_id, idempotency_key)
+        payload = await self._get_token_payload(redis_key, token_hash, now)
+        if payload is None:
+            return None
+        record = _deserialize_token_record(payload)
+        if record.expires_at <= now:
+            return None
+        return record
+
+    async def get_reusable_job(
+        self,
+        idempotency_key: str,
+        now: datetime,
+    ) -> DataAcquisitionJobDTO | None:
+        payload = await self._call_redis("get", self._job_key(idempotency_key))
+        if payload is None:
+            return None
+        job = DataAcquisitionJobDTO.model_validate_json(str(payload))
+        return job if _is_reusable_acquisition_job(job, now) else None
+
+    async def reserve_job(
+        self,
+        job: DataAcquisitionJobDTO,
+        _now: datetime,
+    ) -> DataAcquisitionJobDTO | None:
+        redis_key = self._job_key(job.idempotency_key)
+        payload = _serialize_acquisition_job(job)
+        existing = await self._call_redis(
+            "eval",
+            self._RESERVE_JOB_SCRIPT,
+            1,
+            redis_key,
+            payload,
+            str(_ACQUISITION_JOB_RETENTION_SECONDS),
+            str(
+                _datetime_epoch_us(
+                    _now - timedelta(seconds=_ACQUISITION_ACTIVE_JOB_STALE_SECONDS)
+                )
+            ),
+        )
+        if existing is None:
+            return None
+        existing_job = DataAcquisitionJobDTO.model_validate_json(str(existing))
+        return existing_job if _is_reusable_acquisition_job(existing_job, _now) else None
+
+    async def update_job(self, job: DataAcquisitionJobDTO, _now: datetime) -> None:
+        await self._call_redis(
+            "eval",
+            self._UPDATE_JOB_IF_CURRENT_SCRIPT,
+            1,
+            self._job_key(job.idempotency_key),
+            _serialize_acquisition_job(job),
+            job.id,
+            str(_ACQUISITION_JOB_RETENTION_SECONDS),
+        )
+
+    async def sweep(self, _now: datetime) -> None:
+        return None
+
+    async def _call_redis(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        method = getattr(self._redis, method_name)
+        if not self._redis_is_async:
+            return await asyncio.to_thread(method, *args, **kwargs)
+
+        result = method(*args, **kwargs)
+        if isawaitable(result):
+            return await result
+        return result
+
+    async def _save_token(
+        self,
+        redis_key: str,
+        payload: str,
+        token_hash: str,
+        expires_at: datetime,
+    ) -> None:
+        if not self._redis_is_async:
+            await asyncio.to_thread(
+                self._save_token_sync,
+                redis_key,
+                payload,
+                token_hash,
+                expires_at,
+            )
+            return
+
+        pipe = self._redis.pipeline()
+        pipe.hset(
+            redis_key,
+            mapping={
+                "payload": payload,
+                "token_hash": token_hash,
+                "expires_at_epoch": str(int(expires_at.timestamp())),
+            },
+        )
+        pipe.expire(redis_key, _ACQUISITION_TOKEN_TTL_SECONDS)
+        result = pipe.execute()
+        if isawaitable(result):
+            await result
+
+    async def _get_token_payload(
+        self,
+        redis_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> str | None:
+        if not self._redis_is_async:
+            return await asyncio.to_thread(
+                self._get_token_payload_sync,
+                redis_key,
+                token_hash,
+                now,
+            )
+
+        stored_hash = await self._call_redis("hget", redis_key, "token_hash")
+        if stored_hash is None or not hmac.compare_digest(str(stored_hash), token_hash):
+            return None
+        expires_at_epoch = int(
+            str(await self._call_redis("hget", redis_key, "expires_at_epoch") or "0")
+        )
+        if expires_at_epoch <= int(now.timestamp()):
+            await self._call_redis("delete", redis_key)
+            return None
+        payload = await self._call_redis("hget", redis_key, "payload")
+        return str(payload) if payload is not None else None
+
+    def _save_token_sync(
+        self,
+        redis_key: str,
+        payload: str,
+        token_hash: str,
+        expires_at: datetime,
+    ) -> None:
+        pipe = self._redis.pipeline()
+        pipe.hset(
+            redis_key,
+            mapping={
+                "payload": payload,
+                "token_hash": token_hash,
+                "expires_at_epoch": str(int(expires_at.timestamp())),
+            },
+        )
+        pipe.expire(redis_key, _ACQUISITION_TOKEN_TTL_SECONDS)
+        pipe.execute()
+
+    def _get_token_payload_sync(
+        self,
+        redis_key: str,
+        token_hash: str,
+        now: datetime,
+    ) -> str | None:
+        stored_hash = self._redis.hget(redis_key, "token_hash")
+        if stored_hash is None or not hmac.compare_digest(str(stored_hash), token_hash):
+            return None
+        expires_at_epoch = int(str(self._redis.hget(redis_key, "expires_at_epoch") or "0"))
+        if expires_at_epoch <= int(now.timestamp()):
+            self._redis.delete(redis_key)
+            return None
+        payload = self._redis.hget(redis_key, "payload")
+        return str(payload) if payload is not None else None
+
+    @staticmethod
+    def _token_key(user_id: str, idempotency_key: str) -> str:
+        return f"{_ACQUISITION_REDIS_PREFIX}:token:{user_id}:{idempotency_key}"
+
+    @staticmethod
+    def _job_key(idempotency_key: str) -> str:
+        return f"{_ACQUISITION_REDIS_PREFIX}:job:{idempotency_key}"
+
+
+class _AcquisitionExecutionError(RuntimeError):
+    def __init__(self, message: str, logs: list[str]) -> None:
+        super().__init__(message)
+        self.logs = logs
+
+
+class _AcquisitionExecutor(Protocol):
+    async def run(
+        self,
+        preflight: DataAcquisitionPreflightDTO,
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Execute an acquisition and return manifests, validation output, and logs."""
+
+
+class _ScriptBackedAcquisitionExecutor:
+    def __init__(self, data_manifest_service: DataManifestService) -> None:
+        self._data_manifest_service = data_manifest_service
+
+    async def run(
+        self,
+        preflight: DataAcquisitionPreflightDTO,
+    ) -> tuple[list[str], list[str], list[str]]:
+        if preflight.dry_run:
+            return (
+                [],
+                ["preflight_passed", "dry_run_completed_without_external_fetch"],
+                ["dry_run_completed", f"adapter={_adapter_for_dataset(preflight.dataset)}"],
+            )
+
+        command = _build_acquisition_command(preflight)
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=_REPO_ROOT,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await proc.communicate()
+        except asyncio.CancelledError:
+            with suppress(ProcessLookupError):
+                proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except TimeoutError:
+                with suppress(ProcessLookupError):
+                    proc.kill()
+                await proc.wait()
+            raise
+        logs = [
+            f"command={' '.join(_truncate_command_for_log(command))}",
+            *_decode_process_lines(stdout, prefix="stdout"),
+            *_decode_process_lines(stderr, prefix="stderr"),
+        ]
+        if proc.returncode != 0:
+            raise _AcquisitionExecutionError(
+                f"Acquisition adapter failed with exit code {proc.returncode}",
+                logs,
+            )
+
+        manifest_ids = self._manifest_ids_from_stdout(preflight.dataset, stdout)
+        return (
+            manifest_ids or self._produced_manifest_ids(preflight.dataset),
+            ["preflight_passed", "adapter_completed", "manifest_validation_pending"],
+            logs,
+        )
+
+    @staticmethod
+    def _manifest_ids_from_stdout(dataset: str, stdout: bytes) -> list[str]:
+        for line in stdout.decode(errors="replace").splitlines():
+            if not line.startswith(_MANIFEST_OUTPUT_PREFIX):
+                continue
+            try:
+                payload = json.loads(line.removeprefix(_MANIFEST_OUTPUT_PREFIX))
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict) or str(payload.get("dataset", "")) != dataset:
+                continue
+            manifest_id = str(payload.get("manifest_id") or "").strip()
+            if manifest_id:
+                return [manifest_id]
+            try:
+                version = int(payload["manifest_version"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            checksum = str(payload.get("checksum") or "").strip()
+            if checksum:
+                return [f"{dataset}@v{version}:{checksum}"]
+        return []
+
+    def _produced_manifest_ids(self, dataset: str) -> list[str]:
+        summary = self._data_manifest_service.get_manifest_summary(dataset)
+        if summary is None:
+            return []
+        return [
+            summary.manifest_id
+            or f"{summary.dataset}@v{summary.manifest_version}:{summary.manifest_checksum}"
+        ]
+
+
+def _serialize_token_record(record: _SubmitTokenRecord) -> str:
+    return json.dumps(
+        {
+            "user_id": record.user_id,
+            "token_hash": record.token_hash,
+            "expires_at": record.expires_at.isoformat(),
+            "preflight": record.preflight.model_copy(update={"submit_token": ""}).model_dump(
+                mode="json"
+            ),
+            "reason": record.reason,
+            "consumed": record.consumed,
+        },
+        sort_keys=True,
+    )
+
+
+def _deserialize_token_record(payload: str) -> _SubmitTokenRecord:
+    data = json.loads(payload)
+    return _SubmitTokenRecord(
+        user_id=str(data["user_id"]),
+        token_hash=str(data["token_hash"]),
+        expires_at=datetime.fromisoformat(str(data["expires_at"])),
+        preflight=DataAcquisitionPreflightDTO.model_validate(data["preflight"]),
+        reason=str(data["reason"]),
+        consumed=bool(data.get("consumed", False)),
+    )
+
+
+def _adapter_for_dataset(dataset: str) -> str:
+    return (
+        "script:scripts/data/alpaca_sip_sync.py"
+        if dataset == ALPACA_SIP_DAILY_DATASET
+        else "script:scripts/data/alpaca_corp_actions_sync.py"
+    )
+
+
+def _build_acquisition_command(preflight: DataAcquisitionPreflightDTO) -> list[str]:
+    if preflight.dataset == ALPACA_SIP_DAILY_DATASET:
+        command = [
+            sys.executable,
+            "scripts/data/alpaca_sip_sync.py",
+            "full-sync",
+            "--start-year",
+            str(preflight.start_date.year),
+            "--end-year",
+            str(preflight.end_date.year),
+            "--feed",
+            preflight.source_feed,
+            "--adjustment",
+            preflight.adjustment_mode or "raw",
+        ]
+        source_type, source_value = _split_symbol_source(preflight.symbol_source)
+        if source_type == "file":
+            command.extend(["--symbols", ",".join(_read_symbol_source_file(source_value))])
+        elif source_type == "symbols":
+            command.extend(["--symbols", source_value])
+        else:
+            raise ValueError(f"Unsupported daily symbol source: {source_type}")
+        return command
+
+    command = [
+        sys.executable,
+        "scripts/data/alpaca_corp_actions_sync.py",
+        "full-sync",
+        "--start-date",
+        preflight.start_date.isoformat(),
+        "--end-date",
+        preflight.end_date.isoformat(),
+    ]
+    source_type, source_value = _split_symbol_source(preflight.symbol_source)
+    if source_type == "ids":
+        command.extend(["--ids", source_value])
+    elif source_type == "file":
+        command.extend(["--symbols", ",".join(_read_symbol_source_file(source_value))])
+    elif source_type == "symbols":
+        command.extend(["--symbols", source_value])
+    else:
+        raise ValueError(f"Unsupported corporate-actions symbol source: {source_type}")
+    return command
+
+
+def _split_symbol_source(symbol_source: str) -> tuple[str, str]:
+    if ":" in symbol_source:
+        prefix, value = symbol_source.split(":", 1)
+        return prefix.lower(), value
+    return "symbols", symbol_source
+
+
+def _read_symbol_source_file(value: str) -> list[str]:
+    path_value, expected_hash = _split_symbol_file_fingerprint(value)
+    path = (_REPO_ROOT / path_value).resolve()
+    symbol_source_base = (_REPO_ROOT / "data" / "symbols").resolve()
+    if not path.is_relative_to(symbol_source_base):
+        raise ValueError("File symbol sources must stay under data/symbols/")
+    if not path.is_file():
+        raise ValueError("File symbol source does not exist")
+    symbols = [
+        line.strip().upper()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if not symbols:
+        raise ValueError("File symbol source is empty")
+    if any(not _SYMBOL_TOKEN_PATTERN.fullmatch(symbol) for symbol in symbols):
+        raise ValueError("File symbol source contains unsupported symbols")
+    canonical_symbols = sorted(set(symbols))
+    if len(canonical_symbols) > _ACQUISITION_MAX_SYMBOLS_FROM_FILE:
+        raise ValueError("File symbol source contains too many symbols")
+    actual_hash = _hash_symbol_list(canonical_symbols)
+    if expected_hash is not None and not hmac.compare_digest(actual_hash, expected_hash):
+        raise ValueError("File symbol source changed after preflight")
+    return canonical_symbols
+
+
+def _fingerprinted_symbol_file_source(value: str) -> str:
+    path_value, _expected_hash = _split_symbol_file_fingerprint(value)
+    symbols = _read_symbol_source_file(value)
+    return f"{path_value}{_SYMBOL_FILE_FINGERPRINT_SEPARATOR}{_hash_symbol_list(symbols)}"
+
+
+def _split_symbol_file_fingerprint(value: str) -> tuple[str, str | None]:
+    if _SYMBOL_FILE_FINGERPRINT_SEPARATOR not in value:
+        return value, None
+    path_value, fingerprint = value.split(_SYMBOL_FILE_FINGERPRINT_SEPARATOR, 1)
+    if not re.fullmatch(r"[0-9a-f]{16}", fingerprint):
+        raise ValueError("File symbol source fingerprint is unsupported")
+    return path_value, fingerprint
+
+
+def _hash_symbol_list(symbols: Sequence[str]) -> str:
+    # Short fingerprint is for idempotency/change detection, not secret validation.
+    payload = "\n".join(symbols).encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _is_reusable_acquisition_job(job: DataAcquisitionJobDTO, _now: datetime) -> bool:
+    if job.status == "completed":
+        return True
+    if job.status not in _ACQUISITION_REUSABLE_JOB_STATUSES:
+        return False
+    active_at = job.heartbeat_at or job.started_at
+    if active_at is None:
+        return False
+    return (_now - active_at.astimezone(UTC)) <= timedelta(
+        seconds=_ACQUISITION_ACTIVE_JOB_STALE_SECONDS
+    )
+
+
+def _retention_anchor_for_acquisition_job(job: DataAcquisitionJobDTO, now: datetime) -> datetime:
+    if job.status in {"queued", "running"}:
+        return (job.heartbeat_at or job.started_at or now).astimezone(UTC)
+    return (job.completed_at or job.started_at or now).astimezone(UTC)
+
+
+def _acquisition_store_backend_name(store: _AcquisitionStore) -> str:
+    if isinstance(store, _InMemoryAcquisitionStore):
+        return "in_memory"
+    if isinstance(store, _RedisAcquisitionStore):
+        return "redis"
+    return type(store).__name__
+
+
+def _background_acquisition_semaphore() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    semaphore = _BACKGROUND_ACQUISITION_SEMAPHORES.get(loop)
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(_ACQUISITION_BACKGROUND_CONCURRENCY)
+        _BACKGROUND_ACQUISITION_SEMAPHORES[loop] = semaphore
+    return semaphore
+
+
+def _datetime_epoch_us(value: datetime) -> int:
+    return int(value.astimezone(UTC).timestamp() * 1_000_000)
+
+
+def _serialize_acquisition_job(job: DataAcquisitionJobDTO) -> str:
+    payload = job.model_dump(mode="json")
+    if job.started_at is not None:
+        payload["started_at_epoch_us"] = _datetime_epoch_us(job.started_at)
+    if job.heartbeat_at is not None:
+        payload["heartbeat_at_epoch_us"] = _datetime_epoch_us(job.heartbeat_at)
+    if job.completed_at is not None:
+        payload["completed_at_epoch_us"] = _datetime_epoch_us(job.completed_at)
+    return json.dumps(payload, sort_keys=True)
+
+
+def _sanitize_log_message(value: str) -> str:
+    sanitized = value.strip().replace("\n", " ")
+    sanitized = _SENSITIVE_ASSIGNMENT_PATTERN.sub(r"\1\2<redacted>", sanitized)
+    return _SENSITIVE_BEARER_PATTERN.sub(r"\1<redacted>", sanitized)
+
+
+def _truncate_command_for_log(command: Sequence[str]) -> list[str]:
+    sanitized_parts = [_sanitize_log_message(part) for part in command]
+    return [part if len(part) <= 160 else f"{part[:157]}..." for part in sanitized_parts]
+
+
+def _sanitize_log_lines(lines: Sequence[str]) -> list[str]:
+    return [_sanitize_log_message(line)[:500] for line in lines]
+
+
+def _format_exception_for_log(exc: BaseException) -> str:
+    message = _sanitize_log_message(str(exc))
+    detail = f"{type(exc).__name__}:{message}" if message else type(exc).__name__
+    return detail if len(detail) <= 320 else f"{detail[:317]}..."
+
+
+def _decode_process_lines(payload: bytes, *, prefix: str) -> list[str]:
+    text = payload.decode(errors="replace").strip()
+    if not text:
+        return []
+    return [f"{prefix}:{_sanitize_log_message(line)[:500]}" for line in text.splitlines()[-20:]]
 
 
 class DataSyncService:
@@ -53,9 +938,41 @@ class DataSyncService:
         self,
         rate_limiter: RateLimiter | None = None,
         data_manifest_service: DataManifestService | None = None,
+        acquisition_state: _AcquisitionState | None = None,
+        acquisition_store: _AcquisitionStore | None = None,
+        acquisition_executor: _AcquisitionExecutor | None = None,
     ) -> None:
         self._rate_limiter = rate_limiter or get_rate_limiter()
         self._data_manifest_service = data_manifest_service or DataManifestService()
+        selected_store: _AcquisitionStore
+        if acquisition_store is not None:
+            selected_store = acquisition_store
+            self._acquisition_store = selected_store
+            self._acquisition_lock = asyncio.Lock()
+            self._preflight_tokens: dict[tuple[str, str], _SubmitTokenRecord] = {}
+            self._acquisition_jobs: dict[str, DataAcquisitionJobDTO] = {}
+        else:
+            if acquisition_state is not None:
+                selected_store = _InMemoryAcquisitionStore(acquisition_state)
+            else:
+                selected_store = _RedisAcquisitionStore.from_env()
+            self._acquisition_store = selected_store
+            if isinstance(selected_store, _InMemoryAcquisitionStore):
+                self._acquisition_lock = selected_store.lock
+                self._preflight_tokens = selected_store.preflight_tokens
+                self._acquisition_jobs = selected_store.acquisition_jobs
+            else:
+                self._acquisition_lock = asyncio.Lock()
+                self._preflight_tokens = {}
+                self._acquisition_jobs = {}
+        logger.info(
+            "data_acquisition_store_selected",
+            extra={"backend": _acquisition_store_backend_name(self._acquisition_store)},
+        )
+        self._acquisition_executor = acquisition_executor or _ScriptBackedAcquisitionExecutor(
+            self._data_manifest_service
+        )
+        self._background_acquisition_tasks: set[asyncio.Task[None]] = set()
 
     async def get_sync_status(self, user: Any) -> list[SyncStatusDTO]:
         """Get sync status for datasets user has access to.
@@ -176,6 +1093,167 @@ class DataSyncService:
             started_at=now,
         )
 
+    async def preflight_acquisition(
+        self,
+        user: Any,
+        request: DataAcquisitionRequestDTO,
+    ) -> DataAcquisitionPreflightDTO:
+        """Validate a UI acquisition request and mint a one-use submit token."""
+        self._require_permission(user, Permission.TRIGGER_DATA_SYNC)
+        self._require_dataset_access(user, request.dataset)
+        symbol_source = await asyncio.to_thread(self._validate_acquisition_request, request)
+        await self._enforce_rate_limit(
+            user,
+            action="preflight_data_acquisition",
+            max_requests=10,
+            window=60,
+        )
+
+        user_id = get_user_id(user)
+        reason = request.reason.strip()
+        idempotency_key = self._build_acquisition_idempotency_key(
+            request.model_copy(
+                update={
+                    "reason": reason,
+                    "symbol_source": symbol_source,
+                }
+            )
+        )
+        now = datetime.now(UTC)
+        submit_token = secrets.token_urlsafe(32)
+        expires_at = now + timedelta(seconds=_ACQUISITION_TOKEN_TTL_SECONDS)
+        preflight = self._build_acquisition_preflight(
+            request,
+            idempotency_key=idempotency_key,
+            submit_token=submit_token,
+            expires_at=expires_at,
+            reason=reason,
+            symbol_source=symbol_source,
+        )
+        record = _SubmitTokenRecord(
+            user_id=user_id,
+            token_hash=self._hash_submit_token(submit_token),
+            expires_at=expires_at,
+            preflight=preflight.model_copy(update={"submit_token": ""}),
+            reason=reason,
+        )
+        await self._acquisition_store.save_preflight_token((user_id, idempotency_key), record, now)
+        return preflight
+
+    async def submit_acquisition(
+        self,
+        user: Any,
+        submission: DataAcquisitionSubmitDTO,
+    ) -> DataAcquisitionJobDTO:
+        """Submit an acquisition job using a current one-use preflight token."""
+        self._require_permission(user, Permission.TRIGGER_DATA_SYNC)
+
+        user_id = get_user_id(user)
+        now = datetime.now(UTC)
+        token_hash = self._hash_submit_token(submission.submit_token)
+        token_record = await self._acquisition_store.get_preflight_token(
+            user_id=user_id,
+            idempotency_key=submission.idempotency_key,
+            token_hash=token_hash,
+            now=now,
+        )
+        if token_record is None:
+            raise PreflightRequired("Current acquisition preflight required")
+        self._require_dataset_access(user, token_record.preflight.dataset)
+
+        existing = await self._acquisition_store.get_reusable_job(
+            submission.idempotency_key,
+            now,
+        )
+        if existing is not None:
+            record = await self._acquisition_store.consume_preflight_token(
+                user_id=user_id,
+                idempotency_key=submission.idempotency_key,
+                token_hash=token_hash,
+                now=now,
+            )
+            if record is None:
+                raise PreflightRequired("Current acquisition preflight required")
+            duplicate_job = self._duplicate_job_view(existing)
+            self._log_acquisition_submission(
+                job=duplicate_job,
+                record=record,
+                user_id=user_id,
+                deduplicated=True,
+            )
+            return duplicate_job
+
+        try:
+            await self._enforce_rate_limit(
+                user, action="trigger_data_sync", max_requests=1, window=60
+            )
+        except RateLimitExceeded:
+            preview_job = self._build_acquisition_job(token_record.preflight, now)
+            rate_limited_job = preview_job.model_copy(
+                update={
+                    "status": "failed",
+                    "completed_at": datetime.now(UTC),
+                    "validation_output": [
+                        *preview_job.validation_output,
+                        "rate_limited_before_start",
+                    ],
+                    "logs": [*preview_job.logs, "job_not_started_rate_limited"],
+                }
+            )
+            self._log_acquisition_submission_blocked(
+                job=rate_limited_job,
+                record=token_record,
+                user_id=user_id,
+                block_reason="rate_limited",
+            )
+            raise
+
+        record = await self._acquisition_store.consume_preflight_token(
+            user_id=user_id,
+            idempotency_key=submission.idempotency_key,
+            token_hash=token_hash,
+            now=now,
+        )
+        if record is None:
+            raise PreflightRequired("Current acquisition preflight required")
+
+        job = self._build_acquisition_job(record.preflight, now)
+        reserved_existing = await self._acquisition_store.reserve_job(job, now)
+        if reserved_existing is not None:
+            duplicate_job = self._duplicate_job_view(reserved_existing)
+            self._log_acquisition_submission(
+                job=duplicate_job,
+                record=record,
+                user_id=user_id,
+                deduplicated=True,
+            )
+            return duplicate_job
+
+        started_job = await self._start_acquisition_execution(job, record.preflight)
+        self._log_acquisition_submission(
+            job=started_job,
+            record=record,
+            user_id=user_id,
+            deduplicated=False,
+        )
+        return started_job
+
+    async def close(self, *, cancel_running: bool = False) -> None:
+        """Wait for background acquisition tasks, optionally cancelling active work."""
+        tasks = tuple(self._background_acquisition_tasks)
+        if not tasks:
+            return
+        if cancel_running:
+            for task in tasks:
+                task.cancel()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError):
+                logger.warning(
+                    "background_acquisition_task_failed",
+                    extra={"error": str(result), "error_type": type(result).__name__},
+                )
+
     def _require_permission(self, user: Any, permission: Permission) -> None:
         if not has_permission(user, permission):
             raise PermissionError(f"Permission {permission.value} required")
@@ -231,5 +1309,474 @@ class DataSyncService:
     def _build_sync_statuses(self, now: datetime) -> list[SyncStatusDTO]:
         return [self._mock_or_manifest_status(name, now) for name in _SUPPORTED_DATASETS]
 
+    def _validate_acquisition_request(self, request: DataAcquisitionRequestDTO) -> str:
+        if request.dataset not in _SUPPORTED_ACQUISITION_DATASETS:
+            raise ValueError(f"Unsupported acquisition dataset: {request.dataset}")
+        if request.mode != "backfill":
+            raise ValueError("Only backfill acquisition mode is currently supported")
+        if request.start_date > request.end_date:
+            raise ValueError("Start date must be before or equal to end date")
+        self._validate_acquisition_date_bounds(request)
+        normalized_start, normalized_end = self._normalized_acquisition_dates(request)
+        if (normalized_end - normalized_start).days > _ACQUISITION_MAX_DATE_RANGE_DAYS:
+            raise ValueError("Date range exceeds the maximum acquisition window")
+        if not request.symbol_source.strip():
+            raise ValueError("Symbol source is required")
+        symbol_source = self._canonical_symbol_source(request)
+        if request.dataset == ALPACA_SIP_DAILY_DATASET and request.adjustment_mode != "raw":
+            raise ValueError("Daily Alpaca SIP acquisition requires adjustment_mode=raw")
+        if (
+            request.dataset == ALPACA_SIP_CORP_ACTIONS_DATASET
+            and request.adjustment_mode is not None
+        ):
+            raise ValueError("Corporate actions acquisition does not accept adjustment metadata")
+        if not request.reason.strip():
+            raise ValueError("Reason is required for audit logging")
+        return symbol_source
 
-__all__ = ["DataSyncService", "RateLimitExceeded"]
+    def _build_acquisition_idempotency_key(
+        self,
+        request: DataAcquisitionRequestDTO,
+    ) -> str:
+        start_date, end_date = self._normalized_acquisition_dates(request)
+        payload = {
+            "dataset": request.dataset,
+            "provider_id": "alpaca_sip",
+            "source_feed": "sip",
+            "adjustment_mode": request.adjustment_mode,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "symbol_source": request.symbol_source,
+            "mode": request.mode,
+            "dry_run": request.dry_run,
+        }
+        digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+        return f"acq_{digest[:32]}"
+
+    def _build_acquisition_preflight(
+        self,
+        request: DataAcquisitionRequestDTO,
+        *,
+        idempotency_key: str,
+        submit_token: str,
+        expires_at: datetime,
+        reason: str,
+        symbol_source: str,
+    ) -> DataAcquisitionPreflightDTO:
+        is_daily = request.dataset == ALPACA_SIP_DAILY_DATASET
+        effective_start, effective_end = self._normalized_acquisition_dates(request)
+        supported_semantics = (
+            [
+                "alpaca_sip_daily_sync_uses_calendar_year_partitions",
+                f"requested_date_range={request.start_date.isoformat()}:{request.end_date.isoformat()}",
+                f"effective_date_range={effective_start.isoformat()}:{effective_end.isoformat()}",
+                "canonical_storage=raw_ohlc",
+                "adj_close_and_ret_remain_unavailable",
+            ]
+            if is_daily
+            else [
+                "alpaca_sip_corp_actions_sync_uses_date_range_scope",
+                "corporate_actions_feed_has_no_price_adjustment_mode",
+            ]
+        )
+        warnings = (
+            [
+                "daily_bar_requests_are_expanded_to_supported_year_based_sync_semantics",
+                "raw_sip_returns_unavailable",
+            ]
+            if is_daily
+            else []
+        )
+        logs = [
+            "preflight_validated",
+            "submit_token_active_until_expiry",
+            "submit_token_value_hidden_from_ui_logs",
+            f"reason_recorded:{reason}",
+        ]
+        return DataAcquisitionPreflightDTO(
+            dataset=request.dataset,
+            start_date=effective_start,
+            end_date=effective_end,
+            requested_start_date=request.start_date,
+            requested_end_date=request.end_date,
+            symbol_source=symbol_source,
+            mode=request.mode,
+            dry_run=request.dry_run,
+            provider_id="alpaca_sip",
+            source_feed="sip",
+            canonical_storage_mode="raw" if is_daily else "not_price_bars",
+            read_time_adjustment_mode="unavailable" if is_daily else None,
+            adjustment_mode=request.adjustment_mode,
+            idempotency_key=idempotency_key,
+            submit_token=submit_token,
+            submit_token_expires_at=expires_at,
+            supported_semantics=supported_semantics,
+            warnings=warnings,
+            logs=logs,
+        )
+
+    def _build_acquisition_job(
+        self,
+        preflight: DataAcquisitionPreflightDTO,
+        now: datetime,
+    ) -> DataAcquisitionJobDTO:
+        adapter = _adapter_for_dataset(preflight.dataset)
+        return DataAcquisitionJobDTO(
+            id=str(uuid4()),
+            dataset=preflight.dataset,
+            status="queued",
+            idempotency_key=preflight.idempotency_key,
+            mode=preflight.mode,
+            dry_run=preflight.dry_run,
+            provider_id=preflight.provider_id,
+            source_feed=preflight.source_feed,
+            canonical_storage_mode=preflight.canonical_storage_mode,
+            read_time_adjustment_mode=preflight.read_time_adjustment_mode,
+            adjustment_mode=preflight.adjustment_mode,
+            started_at=now,
+            heartbeat_at=now,
+            submit_token_status="consumed",
+            adapter=adapter,
+            produced_manifest_ids=[],
+            validation_output=["preflight_passed", "manifest_validation_pending"],
+            logs=[
+                "job_queued",
+                f"adapter={adapter}",
+                "duplicate_submissions_reuse_idempotency_key",
+            ],
+        )
+
+    @staticmethod
+    def _duplicate_job_view(job: DataAcquisitionJobDTO) -> DataAcquisitionJobDTO:
+        return job.model_copy(
+            update={
+                "logs": [*job.logs, "duplicate_submission_reused_existing_job"],
+            }
+        )
+
+    async def _start_acquisition_execution(
+        self,
+        job: DataAcquisitionJobDTO,
+        preflight: DataAcquisitionPreflightDTO,
+    ) -> DataAcquisitionJobDTO:
+        now = datetime.now(UTC)
+        if preflight.dry_run:
+            completed_job = await self._run_acquisition_job(job, preflight)
+            await self._acquisition_store.update_job(completed_job, datetime.now(UTC))
+            return completed_job
+
+        running_job = job.model_copy(
+            update={
+                "status": "running",
+                "heartbeat_at": now,
+                "logs": [*job.logs, "job_started"],
+            }
+        )
+        await self._acquisition_store.update_job(running_job, now)
+        task = asyncio.create_task(self._run_and_store_acquisition_job(running_job, preflight))
+        self._background_acquisition_tasks.add(task)
+        task.add_done_callback(partial(self._observe_background_acquisition_task, job=running_job))
+        return running_job
+
+    def _observe_background_acquisition_task(
+        self,
+        task: asyncio.Task[None],
+        *,
+        job: DataAcquisitionJobDTO,
+    ) -> None:
+        self._background_acquisition_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return
+        logger.warning(
+            "background_acquisition_task_failed",
+            extra={
+                "job_id": job.id,
+                "dataset": job.dataset,
+                "error": _format_exception_for_log(exc),
+                "error_type": type(exc).__name__,
+            },
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+    async def _run_and_store_acquisition_job(
+        self,
+        job: DataAcquisitionJobDTO,
+        preflight: DataAcquisitionPreflightDTO,
+    ) -> None:
+        heartbeat_task: asyncio.Task[None] | None = None
+        try:
+            heartbeat_task = asyncio.create_task(self._heartbeat_acquisition_job(job))
+            async with _background_acquisition_semaphore():
+                updated_job = await self._run_acquisition_job(job, preflight)
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat_task
+            await self._acquisition_store.update_job(updated_job, datetime.now(UTC))
+        except asyncio.CancelledError:
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat_task
+            cancelled_job = job.model_copy(
+                update={
+                    "status": "failed",
+                    "completed_at": datetime.now(UTC),
+                    "validation_output": [*job.validation_output, "acquisition_cancelled"],
+                    "logs": [*job.logs, "job_cancelled_during_shutdown"],
+                }
+            )
+            try:
+                await self._acquisition_store.update_job(cancelled_job, datetime.now(UTC))
+            except Exception:
+                logger.exception(
+                    "background_acquisition_cancel_status_update_failed",
+                    extra={"job_id": job.id, "dataset": job.dataset},
+                )
+            raise
+        except Exception as exc:
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat_task
+            failed_job = job.model_copy(
+                update={
+                    "status": "failed",
+                    "completed_at": datetime.now(UTC),
+                    "validation_output": [
+                        *job.validation_output,
+                        "background_acquisition_failed",
+                        type(exc).__name__,
+                    ],
+                    "logs": [*job.logs, f"error={_format_exception_for_log(exc)}"],
+                }
+            )
+            try:
+                await self._acquisition_store.update_job(failed_job, datetime.now(UTC))
+            except Exception:
+                logger.exception(
+                    "background_acquisition_failure_status_update_failed",
+                    extra={"job_id": job.id, "dataset": job.dataset},
+                )
+            raise
+
+    async def _heartbeat_acquisition_job(self, job: DataAcquisitionJobDTO) -> None:
+        while True:
+            await asyncio.sleep(_ACQUISITION_HEARTBEAT_INTERVAL_SECONDS)
+            heartbeat_job = job.model_copy(update={"heartbeat_at": datetime.now(UTC)})
+            try:
+                await self._acquisition_store.update_job(heartbeat_job, datetime.now(UTC))
+            except Exception:
+                logger.exception(
+                    "background_acquisition_heartbeat_failed",
+                    extra={"job_id": job.id, "dataset": job.dataset},
+                )
+
+    async def _run_acquisition_job(
+        self,
+        job: DataAcquisitionJobDTO,
+        preflight: DataAcquisitionPreflightDTO,
+    ) -> DataAcquisitionJobDTO:
+        try:
+            (
+                produced_manifest_ids,
+                validation_output,
+                execution_logs,
+            ) = await self._acquisition_executor.run(preflight)
+        except _AcquisitionExecutionError as exc:
+            return job.model_copy(
+                update={
+                    "status": "failed",
+                    "completed_at": datetime.now(UTC),
+                    "validation_output": [
+                        "preflight_passed",
+                        "adapter_failed",
+                        type(exc).__name__,
+                    ],
+                    "logs": [
+                        *job.logs,
+                        *_sanitize_log_lines(exc.logs),
+                        f"error={_format_exception_for_log(exc)}",
+                    ],
+                }
+            )
+        except Exception as exc:
+            return job.model_copy(
+                update={
+                    "status": "failed",
+                    "completed_at": datetime.now(UTC),
+                    "validation_output": [
+                        "preflight_passed",
+                        "adapter_failed",
+                        type(exc).__name__,
+                    ],
+                    "logs": [*job.logs, f"error={_format_exception_for_log(exc)}"],
+                }
+            )
+
+        return job.model_copy(
+            update={
+                "status": "completed",
+                "completed_at": datetime.now(UTC),
+                "produced_manifest_ids": produced_manifest_ids,
+                "validation_output": validation_output,
+                "logs": [*job.logs, *_sanitize_log_lines(execution_logs), "job_completed"],
+            }
+        )
+
+    @staticmethod
+    def _hash_submit_token(submit_token: str) -> str:
+        return hashlib.sha256(submit_token.encode()).hexdigest()
+
+    @staticmethod
+    def _normalized_acquisition_dates(request: DataAcquisitionRequestDTO) -> tuple[date, date]:
+        if request.dataset == ALPACA_SIP_DAILY_DATASET:
+            # The daily sync adapter accepts year partitions, so requested in-year gaps
+            # are validated as typed but executed against the containing calendar years.
+            return (
+                date(request.start_date.year, 1, 1),
+                date(request.end_date.year, 12, 31),
+            )
+        return request.start_date, request.end_date
+
+    @staticmethod
+    def _validate_acquisition_date_bounds(request: DataAcquisitionRequestDTO) -> None:
+        spec = get_provider_spec(ProviderType.ALPACA_SIP)
+        history_start = spec.capabilities.history_start or date(2016, 1, 1)
+        if request.start_date < history_start:
+            raise ValueError("Alpaca SIP acquisition starts at " f"{history_start.isoformat()}")
+        today = datetime.now(UTC).date()
+        if request.end_date > today:
+            raise ValueError("End date cannot be in the future")
+
+    def _canonical_symbol_source(self, request: DataAcquisitionRequestDTO) -> str:
+        symbol_source = request.symbol_source.strip()
+        if len(symbol_source) > 256:
+            raise ValueError("Symbol source is too long")
+        if any(ord(char) < 32 for char in symbol_source):
+            raise ValueError("Symbol source contains unsupported control characters")
+
+        normalized = symbol_source.lower()
+        if normalized == "all":
+            if request.dataset == ALPACA_SIP_CORP_ACTIONS_DATASET:
+                raise ValueError("Corporate actions acquisition requires symbols or ids")
+            raise ValueError("Alpaca SIP acquisition requires explicit symbols or a source prefix")
+        if normalized.startswith(_SYMBOL_SOURCE_PREFIXES):
+            prefix, raw_value = symbol_source.split(":", 1)
+            value = raw_value.strip()
+            prefix = prefix.lower()
+            if not value:
+                raise ValueError("Symbol source prefix requires a value")
+            if prefix == "ids":
+                if request.dataset != ALPACA_SIP_CORP_ACTIONS_DATASET:
+                    raise ValueError("Daily acquisition does not accept corporate-action ids")
+                ids = [part.strip() for part in value.split(",") if part.strip()]
+                if not ids or any(
+                    not _SOURCE_VALUE_PATTERN.fullmatch(identifier)
+                    or ".." in identifier
+                    or identifier.startswith("/")
+                    for identifier in ids
+                ):
+                    raise ValueError("Corporate-action id source is unsupported")
+                return f"{prefix}:{','.join(sorted(set(ids)))}"
+            if prefix == "universe":
+                raise ValueError("Universe symbol sources are not executable yet")
+            if prefix == "file":
+                self._validate_symbol_file_source(value)
+                return f"{prefix}:{_fingerprinted_symbol_file_source(value)}"
+            if not _SOURCE_VALUE_PATTERN.fullmatch(value) or ".." in value or value.startswith("/"):
+                raise ValueError("Symbol source prefix value is unsupported")
+            return f"{prefix}:{value}"
+
+        symbols = [part.strip().upper() for part in symbol_source.split(",")]
+        if not symbols or any(not _SYMBOL_TOKEN_PATTERN.fullmatch(symbol) for symbol in symbols):
+            raise ValueError("Symbol source must be all, a supported source prefix, or symbols")
+        return ",".join(sorted(set(symbols)))
+
+    @staticmethod
+    def _validate_symbol_file_source(value: str) -> None:
+        value, _fingerprint = _split_symbol_file_fingerprint(value)
+        path = PurePosixPath(value)
+        if (
+            not value.startswith(_SYMBOL_FILE_PREFIX)
+            or path.is_absolute()
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or path.suffix.lower() not in _SYMBOL_FILE_EXTENSIONS
+        ):
+            raise ValueError(
+                "File symbol sources must be relative CSV/TXT files under data/symbols/"
+            )
+
+    def _log_acquisition_submission(
+        self,
+        *,
+        job: DataAcquisitionJobDTO,
+        record: _SubmitTokenRecord,
+        user_id: str,
+        deduplicated: bool,
+    ) -> None:
+        logger.info(
+            "acquisition_submitted",
+            extra={
+                "dataset": job.dataset,
+                "job_id": job.id,
+                "user_id": user_id,
+                "reason": record.reason,
+                "idempotency_key": job.idempotency_key,
+                "deduplicated": deduplicated,
+                "mode": job.mode,
+                "dry_run": job.dry_run,
+                "start_date": record.preflight.start_date.isoformat(),
+                "end_date": record.preflight.end_date.isoformat(),
+                "requested_start_date": (
+                    record.preflight.requested_start_date or record.preflight.start_date
+                ).isoformat(),
+                "requested_end_date": (
+                    record.preflight.requested_end_date or record.preflight.end_date
+                ).isoformat(),
+                "symbol_source": record.preflight.symbol_source,
+                "adjustment_mode": record.preflight.adjustment_mode,
+                "provider_id": job.provider_id,
+                "source_feed": job.source_feed,
+            },
+        )
+
+    def _log_acquisition_submission_blocked(
+        self,
+        *,
+        job: DataAcquisitionJobDTO,
+        record: _SubmitTokenRecord,
+        user_id: str,
+        block_reason: str,
+    ) -> None:
+        logger.info(
+            "acquisition_submission_blocked",
+            extra={
+                "dataset": job.dataset,
+                "job_id": job.id,
+                "user_id": user_id,
+                "reason": record.reason,
+                "idempotency_key": job.idempotency_key,
+                "block_reason": block_reason,
+                "mode": job.mode,
+                "dry_run": job.dry_run,
+                "start_date": record.preflight.start_date.isoformat(),
+                "end_date": record.preflight.end_date.isoformat(),
+                "requested_start_date": (
+                    record.preflight.requested_start_date or record.preflight.start_date
+                ).isoformat(),
+                "requested_end_date": (
+                    record.preflight.requested_end_date or record.preflight.end_date
+                ).isoformat(),
+                "symbol_source": record.preflight.symbol_source,
+                "adjustment_mode": record.preflight.adjustment_mode,
+                "provider_id": job.provider_id,
+                "source_feed": job.source_feed,
+            },
+        )
+
+
+__all__ = ["DataSyncService", "PreflightRequired", "RateLimitExceeded"]

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -1016,24 +1016,19 @@ class DataSyncService:
         selected_store: _AcquisitionStore
         if acquisition_store is not None:
             selected_store = acquisition_store
-            self._acquisition_store = selected_store
-            self._acquisition_lock = asyncio.Lock()
-            self._preflight_tokens: dict[tuple[str, str], _SubmitTokenRecord] = {}
-            self._acquisition_jobs: dict[str, DataAcquisitionJobDTO] = {}
+        elif acquisition_state is not None:
+            selected_store = _InMemoryAcquisitionStore(acquisition_state)
         else:
-            if acquisition_state is not None:
-                selected_store = _InMemoryAcquisitionStore(acquisition_state)
-            else:
-                selected_store = _RedisAcquisitionStore.from_env()
-            self._acquisition_store = selected_store
-            if isinstance(selected_store, _InMemoryAcquisitionStore):
-                self._acquisition_lock = selected_store.lock
-                self._preflight_tokens = selected_store.preflight_tokens
-                self._acquisition_jobs = selected_store.acquisition_jobs
-            else:
-                self._acquisition_lock = asyncio.Lock()
-                self._preflight_tokens = {}
-                self._acquisition_jobs = {}
+            selected_store = _RedisAcquisitionStore.from_env()
+        self._acquisition_store = selected_store
+        self._preflight_tokens: dict[tuple[str, str], _SubmitTokenRecord]
+        self._acquisition_jobs: dict[str, DataAcquisitionJobDTO]
+        if isinstance(selected_store, _InMemoryAcquisitionStore):
+            self._preflight_tokens = selected_store.preflight_tokens
+            self._acquisition_jobs = selected_store.acquisition_jobs
+        else:
+            self._preflight_tokens = {}
+            self._acquisition_jobs = {}
         logger.info(
             "data_acquisition_store_selected",
             extra={"backend": _acquisition_store_backend_name(self._acquisition_store)},

--- a/libs/web_console_services/data_sync_service.py
+++ b/libs/web_console_services/data_sync_service.py
@@ -62,7 +62,6 @@ _ACQUISITION_JOB_RETENTION_SECONDS = 86_400
 _ACQUISITION_MAX_PREFLIGHT_TOKENS = 512
 _ACQUISITION_MAX_JOBS = 256
 _ACQUISITION_MAX_DATE_RANGE_DAYS = 5_500
-_ACQUISITION_REUSABLE_JOB_STATUSES = frozenset({"queued", "running", "completed"})
 _ACQUISITION_TERMINAL_JOB_STATUSES = frozenset({"completed", "failed"})
 _ACQUISITION_BACKGROUND_CONCURRENCY = max(
     1,
@@ -79,6 +78,15 @@ _ACQUISITION_EXECUTION_TIMEOUT_SECONDS = max(
 _ACQUISITION_ACTIVE_JOB_STALE_SECONDS = max(
     _ACQUISITION_HEARTBEAT_INTERVAL_SECONDS * 3,
     int(os.getenv("DATA_ACQUISITION_ACTIVE_JOB_STALE_SECONDS", "300")),
+)
+_ACQUISITION_QUEUED_JOB_STALE_SECONDS = max(
+    _ACQUISITION_ACTIVE_JOB_STALE_SECONDS,
+    int(
+        os.getenv(
+            "DATA_ACQUISITION_QUEUED_JOB_STALE_SECONDS",
+            str(_ACQUISITION_EXECUTION_TIMEOUT_SECONDS),
+        )
+    ),
 )
 _ACQUISITION_MAX_SYMBOLS_FROM_FILE = 5_000
 _SYMBOL_FILE_PREFIX = "data/symbols/"
@@ -365,7 +373,13 @@ local status = decoded["status"]
 if status == "completed" then
   return existing
 end
-if status == "queued" or status == "running" then
+if status == "queued" then
+  local queued_epoch_us = tonumber(decoded["started_at_epoch_us"] or "0")
+  if queued_epoch_us >= tonumber(ARGV[4]) then
+    return existing
+  end
+end
+if status == "running" then
   local active_epoch_us = tonumber(decoded["heartbeat_at_epoch_us"] or decoded["started_at_epoch_us"] or "0")
   if active_epoch_us >= tonumber(ARGV[3]) then
     return existing
@@ -489,6 +503,9 @@ return 1
             str(_ACQUISITION_JOB_RETENTION_SECONDS),
             str(
                 _datetime_epoch_us(_now - timedelta(seconds=_ACQUISITION_ACTIVE_JOB_STALE_SECONDS))
+            ),
+            str(
+                _datetime_epoch_us(_now - timedelta(seconds=_ACQUISITION_QUEUED_JOB_STALE_SECONDS))
             ),
         )
         if existing is None:
@@ -919,7 +936,14 @@ def _hash_symbol_list(symbols: Sequence[str]) -> str:
 def _is_reusable_acquisition_job(job: DataAcquisitionJobDTO, _now: datetime) -> bool:
     if job.status == "completed":
         return True
-    if job.status not in _ACQUISITION_REUSABLE_JOB_STATUSES:
+    if job.status == "queued":
+        queued_at = job.started_at
+        if queued_at is None:
+            return False
+        return (_now - queued_at.astimezone(UTC)) <= timedelta(
+            seconds=_ACQUISITION_QUEUED_JOB_STALE_SECONDS
+        )
+    if job.status != "running":
         return False
     active_at = job.heartbeat_at or job.started_at
     if active_at is None:
@@ -1523,24 +1547,15 @@ class DataSyncService:
         job: DataAcquisitionJobDTO,
         preflight: DataAcquisitionPreflightDTO,
     ) -> DataAcquisitionJobDTO:
-        now = datetime.now(UTC)
         if preflight.dry_run:
             completed_job = await self._run_acquisition_job(job, preflight)
             await self._acquisition_store.update_job(completed_job, datetime.now(UTC))
             return completed_job
 
-        running_job = job.model_copy(
-            update={
-                "status": "running",
-                "heartbeat_at": now,
-                "logs": [*job.logs, "job_started"],
-            }
-        )
-        await self._acquisition_store.update_job(running_job, now)
-        task = asyncio.create_task(self._run_and_store_acquisition_job(running_job, preflight))
+        task = asyncio.create_task(self._run_and_store_acquisition_job(job, preflight))
         self._background_acquisition_tasks.add(task)
-        task.add_done_callback(partial(self._observe_background_acquisition_task, job=running_job))
-        return running_job
+        task.add_done_callback(partial(self._observe_background_acquisition_task, job=job))
+        return job
 
     def _observe_background_acquisition_task(
         self,
@@ -1571,11 +1586,22 @@ class DataSyncService:
         preflight: DataAcquisitionPreflightDTO,
     ) -> None:
         heartbeat_task: asyncio.Task[None] | None = None
+        active_job = job
         try:
-            heartbeat_task = asyncio.create_task(self._heartbeat_acquisition_job(job))
             async with _background_acquisition_semaphore():
+                now = datetime.now(UTC)
+                active_job = job.model_copy(
+                    update={
+                        "status": "running",
+                        "started_at": now,
+                        "heartbeat_at": now,
+                        "logs": [*job.logs, "job_started"],
+                    }
+                )
+                await self._acquisition_store.update_job(active_job, now)
+                heartbeat_task = asyncio.create_task(self._heartbeat_acquisition_job(active_job))
                 updated_job = await asyncio.wait_for(
-                    self._run_acquisition_job(job, preflight),
+                    self._run_acquisition_job(active_job, preflight),
                     timeout=_ACQUISITION_EXECUTION_TIMEOUT_SECONDS,
                 )
             if heartbeat_task is not None:
@@ -1588,12 +1614,12 @@ class DataSyncService:
                 heartbeat_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await heartbeat_task
-            cancelled_job = job.model_copy(
+            cancelled_job = active_job.model_copy(
                 update={
                     "status": "failed",
                     "completed_at": datetime.now(UTC),
-                    "validation_output": [*job.validation_output, "acquisition_cancelled"],
-                    "logs": [*job.logs, "job_cancelled_during_shutdown"],
+                    "validation_output": [*active_job.validation_output, "acquisition_cancelled"],
+                    "logs": [*active_job.logs, "job_cancelled_during_shutdown"],
                 }
             )
             try:
@@ -1609,16 +1635,16 @@ class DataSyncService:
                 heartbeat_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await heartbeat_task
-            failed_job = job.model_copy(
+            failed_job = active_job.model_copy(
                 update={
                     "status": "failed",
                     "completed_at": datetime.now(UTC),
                     "validation_output": [
-                        *job.validation_output,
+                        *active_job.validation_output,
                         "background_acquisition_failed",
                         type(exc).__name__,
                     ],
-                    "logs": [*job.logs, f"error={_format_exception_for_log(exc)}"],
+                    "logs": [*active_job.logs, f"error={_format_exception_for_log(exc)}"],
                 }
             )
             try:

--- a/libs/web_console_services/schemas/data_management.py
+++ b/libs/web_console_services/schemas/data_management.py
@@ -6,7 +6,8 @@ Covers data sync, dataset exploration, and data quality reporting.
 
 from __future__ import annotations
 
-from typing import Any
+from datetime import date
+from typing import Any, Literal
 
 from pydantic import AwareDatetime, BaseModel
 
@@ -120,6 +121,75 @@ class SyncJobDTO(BaseModel):
     completed_at: AwareDatetime | None = None
     row_count: int | None = None
     error: str | None = None
+
+
+class DataAcquisitionRequestDTO(BaseModel):
+    """Preflight request for UI-triggered data acquisition."""
+
+    dataset: str
+    start_date: date
+    end_date: date
+    symbol_source: str
+    mode: Literal["backfill"] = "backfill"
+    adjustment_mode: Literal["raw"] | None = None
+    reason: str
+    dry_run: bool = True
+
+
+class DataAcquisitionPreflightDTO(BaseModel):
+    """Preflight result with a one-use submit token."""
+
+    dataset: str
+    start_date: date
+    end_date: date
+    requested_start_date: date | None = None
+    requested_end_date: date | None = None
+    symbol_source: str
+    mode: str
+    dry_run: bool
+    provider_id: str
+    source_feed: str
+    canonical_storage_mode: str
+    read_time_adjustment_mode: str | None = None
+    adjustment_mode: str | None = None
+    idempotency_key: str
+    submit_token: str
+    submit_token_expires_at: AwareDatetime
+    submit_token_status: Literal["active", "expired", "consumed"] = "active"
+    supported_semantics: list[str]
+    warnings: list[str]
+    logs: list[str]
+
+
+class DataAcquisitionSubmitDTO(BaseModel):
+    """Submit payload bound to a prior acquisition preflight."""
+
+    idempotency_key: str
+    submit_token: str
+
+
+class DataAcquisitionJobDTO(BaseModel):
+    """Acquisition job state safe for UI/log display."""
+
+    id: str
+    dataset: str
+    status: Literal["queued", "running", "completed", "failed"]
+    idempotency_key: str
+    mode: str
+    dry_run: bool
+    provider_id: str
+    source_feed: str
+    canonical_storage_mode: str
+    read_time_adjustment_mode: str | None = None
+    adjustment_mode: str | None = None
+    started_at: AwareDatetime | None = None
+    heartbeat_at: AwareDatetime | None = None
+    completed_at: AwareDatetime | None = None
+    submit_token_status: Literal["consumed", "expired"]
+    adapter: str
+    produced_manifest_ids: list[str]
+    validation_output: list[str]
+    logs: list[str]
 
 
 class DatasetInfoDTO(BaseModel):

--- a/scripts/data/alpaca_corp_actions_sync.py
+++ b/scripts/data/alpaca_corp_actions_sync.py
@@ -97,6 +97,18 @@ def _run_full_sync(args: argparse.Namespace) -> int:
     )
     print(f"Manifest version: {manifest.manifest_version}")
     print(f"Checksum: {manifest.checksum[:16]}...")
+    print(
+        "MANIFEST_JSON:"
+        + json.dumps(
+            {
+                "dataset": manifest.dataset,
+                "manifest_id": manifest.manifest_id,
+                "manifest_version": manifest.manifest_version,
+                "checksum": manifest.checksum,
+            },
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/scripts/data/alpaca_sip_sync.py
+++ b/scripts/data/alpaca_sip_sync.py
@@ -114,6 +114,18 @@ def _run_full_sync(args: argparse.Namespace) -> int:
     )
     print(f"Manifest version: {manifest.manifest_version}")
     print(f"Checksum: {manifest.checksum[:16]}...")
+    print(
+        "MANIFEST_JSON:"
+        + json.dumps(
+            {
+                "dataset": manifest.dataset,
+                "manifest_id": manifest.manifest_id,
+                "manifest_version": manifest.manifest_version,
+                "checksum": manifest.checksum,
+            },
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/tests/apps/web_console_ng/components/test_data_sync_section.py
+++ b/tests/apps/web_console_ng/components/test_data_sync_section.py
@@ -2,11 +2,100 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, date, datetime
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from apps.web_console_ng.components import data_sync_section
+from libs.web_console_services.data_manifest_service import ALPACA_SIP_DAILY_DATASET
+from libs.web_console_services.data_sync_service import PreflightRequired, RateLimitExceeded
+from libs.web_console_services.schemas.data_management import (
+    DataAcquisitionJobDTO,
+    DataAcquisitionPreflightDTO,
+)
+
+
+class _FakeElement:
+    def __init__(self, value: Any = None) -> None:
+        self.value = value
+        self.cleared = False
+        self.clear_count = 0
+        self.on_value_change_cb: Any | None = None
+
+    def classes(self, *_args: Any) -> _FakeElement:
+        return self
+
+    def props(self, *_args: Any) -> _FakeElement:
+        return self
+
+    def on_value_change(self, cb: Any) -> _FakeElement:
+        self.on_value_change_cb = cb
+        return self
+
+    def clear(self) -> None:
+        self.cleared = True
+        self.clear_count += 1
+
+    def __enter__(self) -> _FakeElement:
+        return self
+
+    def __exit__(self, *_args: Any) -> Literal[False]:
+        return False
+
+
+class _FakeUI:
+    def __init__(self, *, input_values: dict[str, Any] | None = None) -> None:
+        self.input_values = input_values or {}
+        self.buttons: dict[str, Any] = {}
+        self.notifications: list[tuple[str, str | None]] = []
+        self.tables: list[dict[str, Any]] = []
+        self.elements: dict[str, _FakeElement] = {}
+        self.columns: list[_FakeElement] = []
+        self.select_options: dict[str, tuple[Any, ...]] = {}
+
+    def label(self, *_args: Any, **_kwargs: Any) -> _FakeElement:
+        return _FakeElement()
+
+    def separator(self, *_args: Any, **_kwargs: Any) -> _FakeElement:
+        return _FakeElement()
+
+    def row(self, *_args: Any, **_kwargs: Any) -> _FakeElement:
+        return _FakeElement()
+
+    def column(self, *_args: Any, **_kwargs: Any) -> _FakeElement:
+        element = _FakeElement()
+        self.columns.append(element)
+        return element
+
+    def select(self, *, label: str, value: Any, **_kwargs: Any) -> _FakeElement:
+        element = _FakeElement(self.input_values.get(label, value))
+        self.elements[label] = element
+        self.select_options[label] = tuple(_kwargs.get("options", ()))
+        return element
+
+    def input(self, *, label: str, value: Any = "", **_kwargs: Any) -> _FakeElement:
+        element = _FakeElement(self.input_values.get(label, value))
+        self.elements[label] = element
+        return element
+
+    def switch(self, _label: str, *, value: bool) -> _FakeElement:
+        element = _FakeElement(value)
+        self.elements[_label] = element
+        return element
+
+    def button(self, label: str, *, on_click: Any, **_kwargs: Any) -> _FakeElement:
+        self.buttons[label] = on_click
+        return _FakeElement()
+
+    def notify(self, message: str, *, type: str | None = None) -> None:
+        self.notifications.append((message, type))
+
+    def table(self, **kwargs: Any) -> _FakeElement:
+        self.tables.append(kwargs)
+        return _FakeElement()
 
 
 @pytest.mark.asyncio()
@@ -29,6 +118,488 @@ async def test_render_sync_status_without_view_permission_skips_service(
     sync_service.get_sync_status.assert_not_awaited()
 
 
+@pytest.mark.asyncio()
+async def test_render_sync_status_submit_before_preflight_warns() -> None:
+    ui_module = _FakeUI()
+    sync_service = MagicMock()
+    sync_service.submit_acquisition = AsyncMock()
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Submit Job"]()
+
+    assert ("Run preflight before submitting", "warning") in ui_module.notifications
+    sync_service.submit_acquisition.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_preflight_passes_raw_adjustment() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    sync_service = MagicMock()
+    captured: dict[str, Any] = {}
+
+    async def preflight_side_effect(_user: Any, request: Any) -> DataAcquisitionPreflightDTO:
+        captured["request"] = request
+        return DataAcquisitionPreflightDTO(
+            dataset=request.dataset,
+            start_date=request.start_date,
+            end_date=request.end_date,
+            symbol_source=request.symbol_source,
+            mode=request.mode,
+            dry_run=request.dry_run,
+            provider_id="alpaca_sip",
+            source_feed="sip",
+            canonical_storage_mode="raw",
+            read_time_adjustment_mode="unavailable",
+            adjustment_mode="raw",
+            idempotency_key="acq_abc",
+            submit_token="secret-submit-token",
+            submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+            supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+            warnings=[],
+            logs=[],
+        )
+
+    sync_service.preflight_acquisition = AsyncMock(side_effect=preflight_side_effect)
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Preflight"]()
+
+    assert captured["request"].dataset == ALPACA_SIP_DAILY_DATASET
+    assert captured["request"].adjustment_mode == "raw"
+    assert ("Acquisition preflight ready", "positive") in ui_module.notifications
+    assert ui_module.tables
+    assert ui_module.select_options["Mode"] == ("backfill",)
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_preserves_manual_sync_trigger() -> None:
+    ui_module = _FakeUI(input_values={"Sync Reason": "operator rerun"})
+    sync_job = MagicMock(id="sync-1", dataset="crsp")
+    sync_service = MagicMock()
+    sync_service.trigger_sync = AsyncMock(return_value=sync_job)
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Trigger Sync"]()
+
+    assert "crsp" in ui_module.select_options["Sync Dataset"]
+    sync_service.trigger_sync.assert_awaited_once_with(
+        {"user_id": "operator"},
+        "crsp",
+        "operator rerun",
+    )
+    assert ("Sync job sync-1 queued for crsp", "positive") in ui_module.notifications
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_successful_submit_clears_preflight_display() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 4, 30),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=[],
+        logs=[],
+    )
+    job = DataAcquisitionJobDTO(
+        id="job-1",
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        status="completed",
+        idempotency_key="acq_abc",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        started_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        submit_token_status="consumed",
+        adapter="script:scripts/data/alpaca_sip_sync.py",
+        produced_manifest_ids=[],
+        validation_output=["preflight_passed"],
+        logs=["job_queued"],
+    )
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(return_value=preflight)
+    sync_service.submit_acquisition = AsyncMock(return_value=job)
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    preflight_container = ui_module.columns[0]
+    await ui_module.buttons["Preflight"]()
+    clear_count_before_submit = preflight_container.clear_count
+    await ui_module.buttons["Submit Job"]()
+
+    assert preflight_container.clear_count == clear_count_before_submit + 1
+    assert ui_module.elements["Start Date"].value == ""
+    assert ui_module.elements["End Date"].value == ""
+    assert ui_module.elements["Symbols"].value == ""
+    assert ui_module.elements["Reason"].value == ""
+    assert ui_module.elements["Mode"].value == "backfill"
+    assert ui_module.elements["Dry Run"].value is True
+    assert ("Acquisition job job-1 completed", "positive") in ui_module.notifications
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_duplicate_submit_uses_scope_message() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 4, 30),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=[],
+        logs=[],
+    )
+    job = DataAcquisitionJobDTO(
+        id="job-1",
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        status="completed",
+        idempotency_key="acq_abc",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        started_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        submit_token_status="consumed",
+        adapter="script:scripts/data/alpaca_sip_sync.py",
+        produced_manifest_ids=[],
+        validation_output=["preflight_passed"],
+        logs=["job_queued", "duplicate_submission_reused_existing_job"],
+    )
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(return_value=preflight)
+    sync_service.submit_acquisition = AsyncMock(return_value=job)
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Preflight"]()
+    await ui_module.buttons["Submit Job"]()
+
+    assert (
+        "Acquisition scope already covered by job job-1 (completed)",
+        "positive",
+    ) in ui_module.notifications
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_submit_error_clears_stale_preflight() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 4, 30),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=[],
+        logs=[],
+    )
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(return_value=preflight)
+    sync_service.submit_acquisition = AsyncMock(
+        side_effect=PreflightRequired("Current acquisition preflight required")
+    )
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    preflight_container = ui_module.columns[0]
+    await ui_module.buttons["Preflight"]()
+    clear_count_before_submit = preflight_container.clear_count
+    await ui_module.buttons["Submit Job"]()
+    await ui_module.buttons["Submit Job"]()
+
+    assert preflight_container.clear_count == clear_count_before_submit + 1
+    assert ("Current acquisition preflight required", "warning") in ui_module.notifications
+    assert ("Run preflight before submitting", "warning") in ui_module.notifications
+    sync_service.submit_acquisition.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_preflight_rate_limit_notifies() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Reason": "fill gap",
+        }
+    )
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(side_effect=RateLimitExceeded("blocked"))
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Preflight"]()
+
+    assert ("Rate limit reached; wait before retrying", "warning") in ui_module.notifications
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_input_change_invalidates_preflight() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 4, 30),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=[],
+        logs=[],
+    )
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(return_value=preflight)
+    sync_service.submit_acquisition = AsyncMock()
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Preflight"]()
+    ui_module.elements["Symbols"].value = "GOOG"
+    on_value_change_cb = ui_module.elements["Symbols"].on_value_change_cb
+    assert on_value_change_cb is not None
+    on_value_change_cb(None)
+    await ui_module.buttons["Submit Job"]()
+
+    assert ("Run preflight before submitting", "warning") in ui_module.notifications
+    sync_service.submit_acquisition.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_ignores_stale_inflight_preflight_after_edit() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 4, 30),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=[],
+        logs=[],
+    )
+
+    async def preflight_side_effect(_user: Any, _request: Any) -> DataAcquisitionPreflightDTO:
+        started.set()
+        await release.wait()
+        return preflight
+
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(side_effect=preflight_side_effect)
+    sync_service.submit_acquisition = AsyncMock()
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    preflight_task = asyncio.create_task(ui_module.buttons["Preflight"]())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    ui_module.elements["Symbols"].value = "GOOG"
+    on_value_change_cb = ui_module.elements["Symbols"].on_value_change_cb
+    assert on_value_change_cb is not None
+    on_value_change_cb(None)
+    release.set()
+    await preflight_task
+    await ui_module.buttons["Submit Job"]()
+
+    assert ("Acquisition inputs changed; rerun preflight", "warning") in ui_module.notifications
+    assert ("Acquisition preflight ready", "positive") not in ui_module.notifications
+    assert not ui_module.tables
+    assert ("Run preflight before submitting", "warning") in ui_module.notifications
+    sync_service.submit_acquisition.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_render_sync_status_failed_preflight_clears_previous_token() -> None:
+    ui_module = _FakeUI(
+        input_values={
+            "Start Date": "2026-01-03",
+            "End Date": "2026-04-30",
+            "Symbols": "MSFT,AAPL",
+            "Reason": "fill gap",
+        }
+    )
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 4, 30),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=[],
+        logs=[],
+    )
+    sync_service = MagicMock()
+    sync_service.preflight_acquisition = AsyncMock(side_effect=[preflight, ValueError("bad dates")])
+    sync_service.submit_acquisition = AsyncMock()
+
+    await data_sync_section.render_sync_status(
+        {"user_id": "operator"},
+        sync_service,
+        has_view=False,
+        has_trigger=True,
+        ui_module=ui_module,
+    )
+    await ui_module.buttons["Preflight"]()
+    await ui_module.buttons["Preflight"]()
+    await ui_module.buttons["Submit Job"]()
+
+    assert ("bad dates", "warning") in ui_module.notifications
+    assert ("Run preflight before submitting", "warning") in ui_module.notifications
+    sync_service.submit_acquisition.assert_not_awaited()
+
+
 def test_build_sync_status_table_accepts_explicit_ui_module() -> None:
     ui_module = MagicMock()
     status = MagicMock(
@@ -46,3 +617,82 @@ def test_build_sync_status_table_accepts_explicit_ui_module() -> None:
 def test_normalize_sync_reason_strips_whitespace() -> None:
     assert data_sync_section._normalize_sync_reason("  backfill gap  ") == "backfill gap"
     assert data_sync_section._normalize_sync_reason("   ") == ""
+
+
+def test_parse_date_input_validates_iso_dates() -> None:
+    assert data_sync_section._parse_date_input("2026-05-01", "start date") == date(2026, 5, 1)
+
+    with pytest.raises(ValueError, match="Invalid start date"):
+        data_sync_section._parse_date_input("05/01/2026", "start date")
+    with pytest.raises(ValueError, match="Invalid start date"):
+        data_sync_section._parse_date_input("20260501", "start date")
+
+
+def test_normalize_acquisition_mode_rejects_unknown_values() -> None:
+    assert data_sync_section._normalize_acquisition_mode("backfill") == "backfill"
+
+    for unsupported in ("incremental", "full"):
+        with pytest.raises(ValueError, match="Mode must be backfill"):
+            data_sync_section._normalize_acquisition_mode(unsupported)
+
+
+def test_acquisition_preflight_rows_hide_submit_token() -> None:
+    preflight = DataAcquisitionPreflightDTO(
+        dataset="alpaca_sip_daily",
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        symbol_source="all",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_abc",
+        submit_token="secret-submit-token",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=["alpaca_sip_daily_sync_uses_calendar_year_partitions"],
+        warnings=["raw_sip_returns_unavailable"],
+        logs=["submit_token_value_hidden_from_ui_logs"],
+    )
+
+    rows = data_sync_section.build_acquisition_preflight_rows(preflight)
+    values = " ".join(row["value"] for row in rows)
+    fields = [row["field"] for row in rows]
+
+    assert "secret-submit-token" not in values
+    assert "active" in values
+    assert "acq_abc" in values
+    assert "Requested date range" in fields
+    assert "Effective acquisition scope" in fields
+
+
+def test_acquisition_job_rows_expose_state_without_token_value() -> None:
+    job = DataAcquisitionJobDTO(
+        id="job-1",
+        dataset="alpaca_sip_daily",
+        status="queued",
+        idempotency_key="acq_abc",
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        started_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        submit_token_status="consumed",
+        adapter="script:scripts/data/alpaca_sip_sync.py",
+        produced_manifest_ids=[],
+        validation_output=["preflight_passed"],
+        logs=["job_queued"],
+    )
+
+    rows = data_sync_section.build_acquisition_job_rows(job)
+    values = " ".join(row["value"] for row in rows)
+
+    assert "consumed" in values
+    assert "true" in values
+    assert "script:scripts/data/alpaca_sip_sync.py" in values
+    assert "submit-token" not in values

--- a/tests/apps/web_console_ng/test_dockerfile.py
+++ b/tests/apps/web_console_ng/test_dockerfile.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_web_console_image_includes_data_acquisition_adapters() -> None:
+    repo_root = Path(__file__).parents[3]
+    dockerfile = (repo_root / "apps/web_console_ng/Dockerfile").read_text()
+    dockerignore = (repo_root / ".dockerignore").read_text()
+    compose = (repo_root / "docker-compose.yml").read_text()
+
+    assert "scripts/data/alpaca_sip_sync.py" in dockerfile
+    assert "scripts/data/alpaca_corp_actions_sync.py" in dockerfile
+    assert "/app/scripts/data/" in dockerfile
+    assert "ARG APP_UID=1000" in dockerfile
+    assert "ARG APP_GID=1000" in dockerfile
+    assert "groupadd --gid \"${APP_GID}\" --non-unique appuser" in dockerfile
+    assert "useradd --uid \"${APP_UID}\" --gid appuser --no-create-home --non-unique appuser" in dockerfile
+
+    assert "!scripts/data/" in dockerignore
+    assert "scripts/data/*" in dockerignore
+    assert "!scripts/data/alpaca_sip_sync.py" in dockerignore
+    assert "!scripts/data/alpaca_corp_actions_sync.py" in dockerignore
+
+    assert "./data:/app/data" in compose
+    assert "APP_UID: ${WEB_CONSOLE_UID:-1000}" in compose
+    assert "APP_GID: ${WEB_CONSOLE_GID:-1000}" in compose

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -271,34 +271,42 @@ class _CancellableProcess:
         self.terminated = False
         self.killed = False
         self.wait_calls = 0
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
         self._release = asyncio.Event()
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        await self._release.wait()
-        return b"", b""
 
     def terminate(self) -> None:
         self.terminated = True
+        self.stdout.feed_eof()
+        self.stderr.feed_eof()
         self._release.set()
 
     def kill(self) -> None:
         self.killed = True
+        self.stdout.feed_eof()
+        self.stderr.feed_eof()
         self._release.set()
 
     async def wait(self) -> int:
         self.wait_calls += 1
+        await self._release.wait()
         return self.returncode
 
 
 class _CompletedProcess:
-    returncode = 0
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        return (
+    def __init__(self) -> None:
+        self.returncode = 0
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.stdout.feed_data(
             b'MANIFEST_JSON:{"dataset": "alpaca_sip_daily", '
-            b'"manifest_id": "alpaca_sip_daily@v2:test"}\n',
-            b"",
+            b'"manifest_id": "alpaca_sip_daily@v2:test"}\n'
         )
+        self.stdout.feed_eof()
+        self.stderr.feed_eof()
+
+    async def wait(self) -> int:
+        return self.returncode
 
 
 @pytest.fixture()

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -173,7 +173,15 @@ class _FakeRedis:
             existing_job = DataAcquisitionJobDTO.model_validate_json(existing)
             if existing_job.status == "completed":
                 return existing
-            if existing_job.status in {"queued", "running"}:
+            if existing_job.status == "queued":
+                queued_epoch_us = (
+                    int(data_sync_module._datetime_epoch_us(existing_job.started_at))  # noqa: SLF001
+                    if existing_job.started_at is not None
+                    else 0
+                )
+                if queued_epoch_us >= int(args[3]):
+                    return existing
+            if existing_job.status == "running":
                 active_epoch_us = max(
                     int(data_sync_module._datetime_epoch_us(existing_job.started_at))  # noqa: SLF001
                     if existing_job.started_at is not None
@@ -766,7 +774,7 @@ async def test_submit_acquisition_runs_non_dry_job_and_updates_state(
         await asyncio.gather(*service._background_acquisition_tasks)  # noqa: SLF001
 
     stored = service._acquisition_jobs[preflight.idempotency_key]  # noqa: SLF001
-    assert job.status == "running"
+    assert job.status == "queued"
     assert stored.status == "completed"
     assert stored.produced_manifest_ids == ["alpaca_sip_daily@v2:checksum"]
     assert "executor_completed" in stored.logs
@@ -805,7 +813,7 @@ async def test_background_acquisition_observes_store_update_failure(
             break
         await asyncio.sleep(0)
 
-    assert job.status == "running"
+    assert job.status == "queued"
     assert not service._background_acquisition_tasks  # noqa: SLF001
     failure_records = [
         record
@@ -1639,6 +1647,33 @@ async def test_in_memory_acquisition_store_reuses_fresh_heartbeat_job() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_in_memory_acquisition_store_keeps_queued_job_reusable_beyond_active_stale() -> None:
+    state = _fresh_acquisition_state()
+    store = data_sync_module._InMemoryAcquisitionStore(state)  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_in_memory_queued"
+    queued_at = now - timedelta(
+        seconds=data_sync_module._ACQUISITION_ACTIVE_JOB_STALE_SECONDS + 1  # noqa: SLF001
+    )
+    queued = _daily_acquisition_job(
+        job_id="job-queued",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": queued_at, "heartbeat_at": queued_at})
+
+    assert await store.reserve_job(queued, queued_at) is None
+    retry = _daily_acquisition_job(
+        job_id="job-retry",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+    duplicate = await store.reserve_job(retry, now)
+
+    assert duplicate is not None
+    assert duplicate.id == "job-queued"
+
+
+@pytest.mark.asyncio()
 async def test_in_memory_acquisition_store_rejects_late_heartbeat_after_terminal() -> None:
     state = _fresh_acquisition_state()
     store = data_sync_module._InMemoryAcquisitionStore(state)  # noqa: SLF001
@@ -1698,6 +1733,32 @@ async def test_redis_acquisition_store_reuses_fresh_heartbeat_job() -> None:
     stored_after_mismatched_update = await store.get_reusable_job(idempotency_key, now)
     assert stored_after_mismatched_update is not None
     assert stored_after_mismatched_update.id == "job-long-running"
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_keeps_queued_job_reusable_beyond_active_stale() -> None:
+    store = data_sync_module._RedisAcquisitionStore(_FakeRedis())  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_redis_queued"
+    queued_at = now - timedelta(
+        seconds=data_sync_module._ACQUISITION_ACTIVE_JOB_STALE_SECONDS + 1  # noqa: SLF001
+    )
+    queued = _daily_acquisition_job(
+        job_id="job-queued",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": queued_at, "heartbeat_at": queued_at})
+
+    assert await store.reserve_job(queued, queued_at) is None
+    retry = _daily_acquisition_job(
+        job_id="job-retry",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+    duplicate = await store.reserve_job(retry, now)
+
+    assert duplicate is not None
+    assert duplicate.id == "job-queued"
 
 
 @pytest.mark.asyncio()
@@ -1924,7 +1985,7 @@ async def test_background_acquisition_concurrency_is_shared_across_services(
             ),
         )
         await first_executor.started.wait()
-        await second_service.submit_acquisition(
+        second_job = await second_service.submit_acquisition(
             operator_user,
             DataAcquisitionSubmitDTO(
                 idempotency_key=second_preflight.idempotency_key,
@@ -1933,11 +1994,22 @@ async def test_background_acquisition_concurrency_is_shared_across_services(
         )
         await asyncio.sleep(0.05)
 
+        queued_second = second_service._acquisition_jobs[  # noqa: SLF001
+            second_preflight.idempotency_key
+        ]
+        assert second_job.status == "queued"
+        assert queued_second.status == "queued"
+        assert "job_started" not in queued_second.logs
         assert not second_executor.started.is_set()
 
         first_executor.release.set()
         await first_service.close()
         await asyncio.wait_for(second_executor.started.wait(), timeout=1)
+        running_second = second_service._acquisition_jobs[  # noqa: SLF001
+            second_preflight.idempotency_key
+        ]
+        assert running_second.status == "running"
+        assert "job_started" in running_second.logs
     finally:
         first_executor.release.set()
         second_executor.release.set()

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -365,6 +365,17 @@ def test_data_sync_service_logs_acquisition_backend(
     assert backend_records[-1].__dict__["backend"] == "in_memory"
 
 
+def test_data_sync_service_binds_direct_in_memory_store_state(
+    rate_limiter: AsyncMock,
+) -> None:
+    state = _fresh_acquisition_state()
+    store = data_sync_module._InMemoryAcquisitionStore(state)  # noqa: SLF001
+    service = DataSyncService(rate_limiter=rate_limiter, acquisition_store=store)
+
+    assert service._preflight_tokens is state.preflight_tokens  # noqa: SLF001
+    assert service._acquisition_jobs is state.acquisition_jobs  # noqa: SLF001
+
+
 @pytest.mark.asyncio()
 async def test_redis_acquisition_store_supports_async_redis_clients(
     rate_limiter: AsyncMock,

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -245,8 +246,6 @@ class _AsyncFakeRedisPipeline:
 
 
 class _AsyncFakeRedis:
-    __module__ = "redis.asyncio.client"
-
     def __init__(self) -> None:
         self._sync = _FakeRedis()
 
@@ -289,6 +288,17 @@ class _CancellableProcess:
     async def wait(self) -> int:
         self.wait_calls += 1
         return self.returncode
+
+
+class _CompletedProcess:
+    returncode = 0
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return (
+            b'MANIFEST_JSON:{"dataset": "alpaca_sip_daily", '
+            b'"manifest_id": "alpaca_sip_daily@v2:test"}\n',
+            b"",
+        )
 
 
 @pytest.fixture()
@@ -779,7 +789,9 @@ async def test_background_acquisition_observes_store_update_failure(
     assert job.status == "running"
     assert not service._background_acquisition_tasks  # noqa: SLF001
     failure_records = [
-        record for record in caplog.records if record.message == "background_acquisition_task_failed"
+        record
+        for record in caplog.records
+        if record.message == "background_acquisition_task_failed"
     ]
     assert failure_records
     assert failure_records[-1].__dict__["job_id"] == job.id
@@ -790,12 +802,59 @@ async def test_background_acquisition_observes_store_update_failure(
 
 
 @pytest.mark.asyncio()
+async def test_script_executor_builds_command_off_event_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    loop_thread_id = threading.get_ident()
+    build_thread_id: int | None = None
+
+    def fake_build_acquisition_command(
+        _preflight: DataAcquisitionPreflightDTO,
+    ) -> list[str]:
+        nonlocal build_thread_id
+        build_thread_id = threading.get_ident()
+        return ["python", "-c", "pass"]
+
+    async def fake_create_subprocess_exec(*_args: Any, **_kwargs: Any) -> _CompletedProcess:
+        return _CompletedProcess()
+
+    monkeypatch.setattr(
+        data_sync_module,
+        "_build_acquisition_command",
+        fake_build_acquisition_command,
+    )
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    service = DataSyncService(rate_limiter=rate_limiter)
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False),
+    )
+    executor = data_sync_module._ScriptBackedAcquisitionExecutor(DataManifestService())  # noqa: SLF001
+
+    manifest_ids, validation_output, logs = await executor.run(preflight)
+
+    assert build_thread_id is not None
+    assert build_thread_id != loop_thread_id
+    assert manifest_ids == ["alpaca_sip_daily@v2:test"]
+    assert "adapter_completed" in validation_output
+    assert "command=python -c pass" in logs
+
+
+@pytest.mark.asyncio()
 async def test_script_executor_terminates_subprocess_on_cancellation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     proc = _CancellableProcess()
+    proc_created = asyncio.Event()
 
     async def fake_create_subprocess_exec(*_args: Any, **_kwargs: Any) -> _CancellableProcess:
+        proc_created.set()
         return proc
 
     monkeypatch.setattr(
@@ -825,7 +884,7 @@ async def test_script_executor_terminates_subprocess_on_cancellation(
     )
 
     task = asyncio.create_task(executor.run(preflight))
-    await asyncio.sleep(0)
+    await asyncio.wait_for(proc_created.wait(), timeout=1)
     task.cancel()
 
     with pytest.raises(asyncio.CancelledError):
@@ -1525,6 +1584,7 @@ async def test_redis_acquisition_store_reuses_only_active_or_successful_jobs() -
     assert stored_retry is not None
     assert stored_retry.id == "job-retry"
 
+
 @pytest.mark.asyncio()
 async def test_in_memory_acquisition_store_reuses_fresh_heartbeat_job() -> None:
     state = _fresh_acquisition_state()
@@ -1551,9 +1611,7 @@ async def test_in_memory_acquisition_store_reuses_fresh_heartbeat_job() -> None:
     assert duplicate is not None
     assert duplicate.id == "job-long-running"
 
-    mismatched_completion = retry.model_copy(
-        update={"status": "completed", "completed_at": now}
-    )
+    mismatched_completion = retry.model_copy(update={"status": "completed", "completed_at": now})
     await store.update_job(mismatched_completion, now)
 
     stored = state.acquisition_jobs[idempotency_key]
@@ -1582,9 +1640,7 @@ async def test_in_memory_acquisition_store_rejects_late_heartbeat_after_terminal
         }
     )
     await store.update_job(completed, now)
-    late_heartbeat = running.model_copy(
-        update={"heartbeat_at": now + timedelta(seconds=1)}
-    )
+    late_heartbeat = running.model_copy(update={"heartbeat_at": now + timedelta(seconds=1)})
     await store.update_job(late_heartbeat, now + timedelta(seconds=1))
 
     stored = state.acquisition_jobs[idempotency_key]
@@ -1618,9 +1674,7 @@ async def test_redis_acquisition_store_reuses_fresh_heartbeat_job() -> None:
     assert duplicate is not None
     assert duplicate.id == "job-long-running"
 
-    mismatched_completion = retry.model_copy(
-        update={"status": "completed", "completed_at": now}
-    )
+    mismatched_completion = retry.model_copy(update={"status": "completed", "completed_at": now})
     await store.update_job(mismatched_completion, now)
     stored_after_mismatched_update = await store.get_reusable_job(idempotency_key, now)
     assert stored_after_mismatched_update is not None
@@ -1647,9 +1701,7 @@ async def test_redis_acquisition_store_rejects_late_heartbeat_after_terminal() -
         }
     )
     await store.update_job(completed, now)
-    late_heartbeat = running.model_copy(
-        update={"heartbeat_at": now + timedelta(seconds=1)}
-    )
+    late_heartbeat = running.model_copy(update={"heartbeat_at": now + timedelta(seconds=1)})
     await store.update_job(late_heartbeat, now + timedelta(seconds=1))
 
     stored = await store.get_reusable_job(idempotency_key, now + timedelta(seconds=1))
@@ -1745,6 +1797,44 @@ async def test_acquisition_state_cleanup_removes_expired_tokens_and_bounds_jobs(
     assert token_key not in service._preflight_tokens  # noqa: SLF001
     assert stale_key not in service._acquisition_jobs  # noqa: SLF001
     assert len(service._acquisition_jobs) == data_sync_module._ACQUISITION_MAX_JOBS  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_background_acquisition_times_out_hung_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    monkeypatch.setattr(data_sync_module, "_ACQUISITION_EXECUTION_TIMEOUT_SECONDS", 0.01)
+    executor = _BlockingAcquisitionExecutor()
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=executor,
+    )
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False),
+    )
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    await executor.started.wait()
+
+    await asyncio.gather(
+        *list(service._background_acquisition_tasks),  # noqa: SLF001
+        return_exceptions=True,
+    )
+
+    stored = service._acquisition_jobs[preflight.idempotency_key]  # noqa: SLF001
+    assert stored.id == job.id
+    assert stored.status == "failed"
+    assert "TimeoutError" in stored.validation_output
+    assert not service._background_acquisition_tasks  # noqa: SLF001
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_sync_service.py
+++ b/tests/libs/web_console_services/test_data_sync_service.py
@@ -10,20 +10,37 @@ Coverage focus:
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any, Literal
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
+from pydantic import ValidationError
 
 from libs.data.data_quality.manifest import SyncManifest
 from libs.platform.web_console_auth.permissions import Role
 from libs.web_console_services import data_sync_service as data_sync_module
-from libs.web_console_services.data_manifest_service import DataManifestService
-from libs.web_console_services.data_sync_service import DataSyncService, RateLimitExceeded
-from libs.web_console_services.schemas.data_management import SyncScheduleUpdateDTO
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    DataManifestService,
+)
+from libs.web_console_services.data_sync_service import (
+    DataSyncService,
+    PreflightRequired,
+    RateLimitExceeded,
+)
+from libs.web_console_services.schemas.data_management import (
+    DataAcquisitionJobDTO,
+    DataAcquisitionPreflightDTO,
+    DataAcquisitionRequestDTO,
+    DataAcquisitionSubmitDTO,
+    SyncScheduleUpdateDTO,
+)
 
 
 @dataclass(frozen=True)
@@ -32,6 +49,246 @@ class DummyUser:
 
     user_id: str
     role: Role
+
+
+class _RecordingAcquisitionExecutor:
+    def __init__(self) -> None:
+        self.preflights: list[Any] = []
+
+    async def run(self, preflight: Any) -> tuple[list[str], list[str], list[str]]:
+        self.preflights.append(preflight)
+        return (
+            ["alpaca_sip_daily@v2:checksum"],
+            ["preflight_passed", "adapter_completed"],
+            ["executor_completed"],
+        )
+
+
+class _FailingAcquisitionExecutor:
+    async def run(self, _preflight: Any) -> tuple[list[str], list[str], list[str]]:
+        raise RuntimeError("transient provider failure")
+
+
+class _SensitiveFailingAcquisitionExecutor:
+    async def run(self, _preflight: Any) -> tuple[list[str], list[str], list[str]]:
+        raise data_sync_module._AcquisitionExecutionError(  # noqa: SLF001
+            "provider failed token=secret-token Authorization: Bearer abc.def",
+            [
+                "stdout:api_key=secret-key",
+                "stderr:APCA-API-SECRET-KEY: broker-secret",
+            ],
+        )
+
+
+class _BlockingAcquisitionExecutor:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def run(self, _preflight: Any) -> tuple[list[str], list[str], list[str]]:
+        self.started.set()
+        await self.release.wait()
+        return (
+            ["alpaca_sip_daily@v2:checksum"],
+            ["preflight_passed", "adapter_completed"],
+            ["executor_completed"],
+        )
+
+
+class _FailingCompletionStore(data_sync_module._InMemoryAcquisitionStore):  # noqa: SLF001
+    def __init__(self, state: data_sync_module._AcquisitionState) -> None:  # noqa: SLF001
+        super().__init__(state)
+        self.update_calls = 0
+
+    async def update_job(self, job: DataAcquisitionJobDTO, now: datetime) -> None:
+        self.update_calls += 1
+        if self.update_calls > 1:
+            raise RuntimeError("store unavailable")
+        await super().update_job(job, now)
+
+
+class _FakeRedisPipeline:
+    def __init__(self, redis_client: _FakeRedis) -> None:
+        self._redis = redis_client
+        self._ops: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def hset(self, *args: Any, **kwargs: Any) -> _FakeRedisPipeline:
+        self._ops.append(("hset", args, kwargs))
+        return self
+
+    def expire(self, *args: Any, **kwargs: Any) -> _FakeRedisPipeline:
+        self._ops.append(("expire", args, kwargs))
+        return self
+
+    def execute(self) -> list[bool]:
+        results: list[bool] = []
+        for name, args, kwargs in self._ops:
+            if name == "hset":
+                key = str(args[0])
+                mapping = dict(kwargs["mapping"])
+                self._redis.hashes[key] = {str(k): str(v) for k, v in mapping.items()}
+            elif name == "expire":
+                self._redis.expirations[str(args[0])] = int(args[1])
+            results.append(True)
+        return results
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.values: dict[str, str] = {}
+        self.expirations: dict[str, int] = {}
+
+    def pipeline(self) -> _FakeRedisPipeline:
+        return _FakeRedisPipeline(self)
+
+    def eval(self, script: str, _key_count: int, key: str, *args: str) -> str | None:
+        if "update-if-current-job-id" in script:
+            new_payload = args[0]
+            job_id = args[1]
+            existing = self.values.get(key)
+            if existing is not None:
+                existing_job = DataAcquisitionJobDTO.model_validate_json(existing)
+                if existing_job.id != job_id:
+                    return "0"
+                replacement_job = DataAcquisitionJobDTO.model_validate_json(new_payload)
+                if (
+                    existing_job.status in data_sync_module._ACQUISITION_TERMINAL_JOB_STATUSES  # noqa: SLF001
+                    and replacement_job.status
+                    not in data_sync_module._ACQUISITION_TERMINAL_JOB_STATUSES  # noqa: SLF001
+                ):
+                    return "0"
+            self.values[key] = new_payload
+            self.expirations[key] = int(args[2])
+            return "1"
+
+        if "cjson.decode" in script:
+            new_payload = args[0]
+            existing = self.values.get(key)
+            if existing is None:
+                self.values[key] = new_payload
+                self.expirations[key] = int(args[1])
+                return None
+            existing_job = DataAcquisitionJobDTO.model_validate_json(existing)
+            if existing_job.status == "completed":
+                return existing
+            if existing_job.status in {"queued", "running"}:
+                active_epoch_us = max(
+                    int(data_sync_module._datetime_epoch_us(existing_job.started_at))  # noqa: SLF001
+                    if existing_job.started_at is not None
+                    else 0,
+                    int(data_sync_module._datetime_epoch_us(existing_job.heartbeat_at))  # noqa: SLF001
+                    if existing_job.heartbeat_at is not None
+                    else 0,
+                )
+                if active_epoch_us >= int(args[2]):
+                    return existing
+            self.values[key] = new_payload
+            self.expirations[key] = int(args[1])
+            return None
+
+        token_hash = args[0]
+        now_epoch = int(args[1])
+        payload = self.hashes.get(key)
+        if payload is None or payload.get("token_hash") != token_hash:
+            return None
+        expires_at_epoch = int(payload.get("expires_at_epoch", "0"))
+        if expires_at_epoch <= now_epoch:
+            self.hashes.pop(key, None)
+            return None
+        self.hashes.pop(key, None)
+        return payload.get("payload")
+
+    def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def hget(self, key: str, field: str) -> str | None:
+        payload = self.hashes.get(key)
+        return None if payload is None else payload.get(field)
+
+    def delete(self, key: str) -> int:
+        removed = int(key in self.hashes) + int(key in self.values)
+        self.hashes.pop(key, None)
+        self.values.pop(key, None)
+        return removed
+
+    def set(
+        self,
+        key: str,
+        value: str,
+        *,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> bool:
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        if ex is not None:
+            self.expirations[key] = ex
+        return True
+
+
+class _AsyncFakeRedisPipeline:
+    def __init__(self, redis_client: _FakeRedis) -> None:
+        self._pipeline = _FakeRedisPipeline(redis_client)
+
+    def hset(self, *args: Any, **kwargs: Any) -> _AsyncFakeRedisPipeline:
+        self._pipeline.hset(*args, **kwargs)
+        return self
+
+    def expire(self, *args: Any, **kwargs: Any) -> _AsyncFakeRedisPipeline:
+        self._pipeline.expire(*args, **kwargs)
+        return self
+
+    async def execute(self) -> list[bool]:
+        return self._pipeline.execute()
+
+
+class _AsyncFakeRedis:
+    __module__ = "redis.asyncio.client"
+
+    def __init__(self) -> None:
+        self._sync = _FakeRedis()
+
+    def pipeline(self) -> _AsyncFakeRedisPipeline:
+        return _AsyncFakeRedisPipeline(self._sync)
+
+    async def eval(self, script: str, _key_count: int, key: str, *args: str) -> str | None:
+        return self._sync.eval(script, _key_count, key, *args)
+
+    async def get(self, key: str) -> str | None:
+        return self._sync.get(key)
+
+    async def hget(self, key: str, field: str) -> str | None:
+        return self._sync.hget(key, field)
+
+    async def delete(self, key: str) -> int:
+        return self._sync.delete(key)
+
+
+class _CancellableProcess:
+    def __init__(self) -> None:
+        self.returncode = 0
+        self.terminated = False
+        self.killed = False
+        self.wait_calls = 0
+        self._release = asyncio.Event()
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await self._release.wait()
+        return b"", b""
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._release.set()
+
+    def kill(self) -> None:
+        self.killed = True
+        self._release.set()
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        return self.returncode
 
 
 @pytest.fixture()
@@ -56,9 +313,59 @@ def rate_limiter() -> AsyncMock:
     return limiter
 
 
+def _fresh_acquisition_state() -> data_sync_module._AcquisitionState:  # noqa: SLF001
+    return data_sync_module._AcquisitionState(  # noqa: SLF001
+        lock=asyncio.Lock(),
+        preflight_tokens={},
+        acquisition_jobs={},
+    )
+
+
 @pytest.fixture()
 def service(rate_limiter: AsyncMock) -> DataSyncService:
-    return DataSyncService(rate_limiter=rate_limiter)
+    return DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
+
+
+def test_data_sync_service_logs_acquisition_backend(
+    rate_limiter: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger=data_sync_module.__name__)
+
+    DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
+
+    backend_records = [
+        record for record in caplog.records if record.message == "data_acquisition_store_selected"
+    ]
+    assert backend_records
+    assert backend_records[-1].__dict__["backend"] == "in_memory"
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_supports_async_redis_clients(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    store = data_sync_module._RedisAcquisitionStore(_AsyncFakeRedis())  # noqa: SLF001
+    service = DataSyncService(rate_limiter=rate_limiter, acquisition_store=store)
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    assert job.status == "completed"
 
 
 @pytest.mark.asyncio()
@@ -84,7 +391,7 @@ async def test_get_sync_status_offloads_manifest_reads(
         called = True
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(data_sync_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
     results = await service.get_sync_status(operator_user)
 
@@ -115,7 +422,10 @@ async def test_get_sync_status_uses_alpaca_sip_manifests(
             validation_status="passed",
         )
         (manifest_dir / f"{dataset}.json").write_text(manifest.model_dump_json())
-    service = DataSyncService(data_manifest_service=DataManifestService(data_root=data_root))
+    service = DataSyncService(
+        data_manifest_service=DataManifestService(data_root=data_root),
+        acquisition_state=_fresh_acquisition_state(),
+    )
 
     results = await service.get_sync_status(operator_user)
 
@@ -147,7 +457,10 @@ async def test_get_sync_status_marks_partial_alpaca_sip_manifests_missing(
         validation_status="passed",
     )
     (manifest_dir / "alpaca_sip_daily.json").write_text(manifest.model_dump_json())
-    service = DataSyncService(data_manifest_service=DataManifestService(data_root=data_root))
+    service = DataSyncService(
+        data_manifest_service=DataManifestService(data_root=data_root),
+        acquisition_state=_fresh_acquisition_state(),
+    )
 
     results = await service.get_sync_status(operator_user)
 
@@ -164,6 +477,7 @@ def test_non_alpaca_placeholder_status_does_not_call_manifest_service(
     service = DataSyncService(
         rate_limiter=rate_limiter,
         data_manifest_service=manifest_service,
+        acquisition_state=_fresh_acquisition_state(),
     )
     now = datetime(2026, 4, 30, 12, tzinfo=UTC)
 
@@ -253,12 +567,1308 @@ async def test_update_sync_schedule_success(
 async def test_trigger_sync_success_calls_rate_limiter(
     rate_limiter: AsyncMock, operator_user: DummyUser
 ) -> None:
-    service = DataSyncService(rate_limiter=rate_limiter)
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
 
     job = await service.trigger_sync(operator_user, dataset="crsp", reason="manual")
 
     assert job.dataset == "crsp"
     rate_limiter.check_rate_limit.assert_awaited_once()
+
+
+def _daily_acquisition_request(**overrides: Any) -> DataAcquisitionRequestDTO:
+    data: dict[str, Any] = {
+        "dataset": ALPACA_SIP_DAILY_DATASET,
+        "start_date": date(2026, 1, 3),
+        "end_date": date(2026, 4, 30),
+        "symbol_source": "AAPL,MSFT",
+        "mode": "backfill",
+        "adjustment_mode": "raw",
+        "reason": "fill missing SIP daily bars",
+        "dry_run": True,
+    }
+    data.update(overrides)
+    return DataAcquisitionRequestDTO(**data)
+
+
+def _daily_acquisition_job(
+    *,
+    job_id: str,
+    idempotency_key: str,
+    status: Literal["queued", "running", "completed", "failed"],
+) -> DataAcquisitionJobDTO:
+    started_at = datetime(2026, 5, 1, 12, tzinfo=UTC)
+    return DataAcquisitionJobDTO(
+        id=job_id,
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        status=status,
+        idempotency_key=idempotency_key,
+        mode="backfill",
+        dry_run=False,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        started_at=started_at,
+        heartbeat_at=started_at if status in {"queued", "running"} else None,
+        completed_at=(
+            datetime(2026, 5, 1, 12, 5, tzinfo=UTC) if status in {"completed", "failed"} else None
+        ),
+        submit_token_status="consumed",
+        adapter="script:scripts/data/alpaca_sip_sync.py",
+        produced_manifest_ids=[],
+        validation_output=["preflight_passed"],
+        logs=["job_queued"],
+    )
+
+
+@pytest.mark.asyncio()
+async def test_preflight_acquisition_builds_daily_policy_and_token(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+
+    assert preflight.dataset == ALPACA_SIP_DAILY_DATASET
+    assert preflight.provider_id == "alpaca_sip"
+    assert preflight.source_feed == "sip"
+    assert preflight.start_date == date(2026, 1, 1)
+    assert preflight.end_date == date(2026, 12, 31)
+    assert preflight.adjustment_mode == "raw"
+    assert preflight.canonical_storage_mode == "raw"
+    assert preflight.read_time_adjustment_mode == "unavailable"
+    assert preflight.idempotency_key.startswith("acq_")
+    assert preflight.submit_token
+    assert "alpaca_sip_daily_sync_uses_calendar_year_partitions" in (preflight.supported_semantics)
+    assert "raw_sip_returns_unavailable" in preflight.warnings
+
+
+@pytest.mark.asyncio()
+async def test_preflight_acquisition_builds_corp_actions_policy(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(
+            dataset=ALPACA_SIP_CORP_ACTIONS_DATASET,
+            symbol_source="AAPL,MSFT",
+            adjustment_mode=None,
+            reason="fill corporate actions",
+        ),
+    )
+
+    assert preflight.dataset == ALPACA_SIP_CORP_ACTIONS_DATASET
+    assert preflight.provider_id == "alpaca_sip"
+    assert preflight.source_feed == "sip"
+    assert preflight.adjustment_mode is None
+    assert preflight.canonical_storage_mode == "not_price_bars"
+    assert preflight.read_time_adjustment_mode is None
+    assert "corporate_actions_feed_has_no_price_adjustment_mode" in (preflight.supported_semantics)
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_consumes_token_and_hides_token_from_job(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    token_record = service._preflight_tokens[
+        (  # noqa: SLF001
+            operator_user.user_id,
+            preflight.idempotency_key,
+        )
+    ]
+    assert token_record.preflight.submit_token == ""
+    assert token_record.token_hash != preflight.submit_token
+
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+
+    serialized_job = job.model_dump_json()
+    assert job.status == "completed"
+    assert job.submit_token_status == "consumed"
+    assert job.dry_run is True
+    assert job.idempotency_key == preflight.idempotency_key
+    assert job.adapter == "script:scripts/data/alpaca_sip_sync.py"
+    assert "preflight_passed" in job.validation_output
+    assert "dry_run_completed_without_external_fetch" in job.validation_output
+    assert preflight.submit_token not in serialized_job
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_runs_non_dry_job_and_updates_state(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    executor = _RecordingAcquisitionExecutor()
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=executor,
+    )
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False),
+    )
+
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    if service._background_acquisition_tasks:  # noqa: SLF001
+        await asyncio.gather(*service._background_acquisition_tasks)  # noqa: SLF001
+
+    stored = service._acquisition_jobs[preflight.idempotency_key]  # noqa: SLF001
+    assert job.status == "running"
+    assert stored.status == "completed"
+    assert stored.produced_manifest_ids == ["alpaca_sip_daily@v2:checksum"]
+    assert "executor_completed" in stored.logs
+    assert len(executor.preflights) == 1
+    assert executor.preflights[0].idempotency_key == preflight.idempotency_key
+    assert executor.preflights[0].submit_token == ""
+
+
+@pytest.mark.asyncio()
+async def test_background_acquisition_observes_store_update_failure(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _FailingCompletionStore(_fresh_acquisition_state())
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_store=store,
+        acquisition_executor=_RecordingAcquisitionExecutor(),
+    )
+    caplog.set_level(logging.WARNING, logger=data_sync_module.__name__)
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False),
+    )
+
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    for _ in range(20):
+        if not service._background_acquisition_tasks:  # noqa: SLF001
+            break
+        await asyncio.sleep(0)
+
+    assert job.status == "running"
+    assert not service._background_acquisition_tasks  # noqa: SLF001
+    failure_records = [
+        record for record in caplog.records if record.message == "background_acquisition_task_failed"
+    ]
+    assert failure_records
+    assert failure_records[-1].__dict__["job_id"] == job.id
+    assert any(
+        record.message == "background_acquisition_failure_status_update_failed"
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio()
+async def test_script_executor_terminates_subprocess_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc = _CancellableProcess()
+
+    async def fake_create_subprocess_exec(*_args: Any, **_kwargs: Any) -> _CancellableProcess:
+        return proc
+
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    executor = data_sync_module._ScriptBackedAcquisitionExecutor(DataManifestService())  # noqa: SLF001
+    preflight = DataAcquisitionPreflightDTO(
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        symbol_source="AAPL,MSFT",
+        mode="backfill",
+        dry_run=False,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        idempotency_key="acq_cancel",
+        submit_token="",
+        submit_token_expires_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        supported_semantics=[],
+        warnings=[],
+        logs=[],
+    )
+
+    task = asyncio.create_task(executor.run(preflight))
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proc.terminated is True
+    assert proc.wait_calls == 1
+
+
+def test_script_executor_extracts_manifest_id_from_stdout() -> None:
+    payload = (
+        b"Sync complete\n"
+        b'MANIFEST_JSON:{"checksum": "abc123", "dataset": "alpaca_sip_daily", '
+        b'"manifest_id": "alpaca_sip_daily@v7:abc123", "manifest_version": 7}\n'
+    )
+
+    assert data_sync_module._ScriptBackedAcquisitionExecutor._manifest_ids_from_stdout(  # noqa: SLF001
+        ALPACA_SIP_DAILY_DATASET,
+        payload,
+    ) == ["alpaca_sip_daily@v7:abc123"]
+
+
+def test_script_executor_builds_manifest_id_from_stdout_fields() -> None:
+    payload = (
+        b"Corporate actions sync complete\n"
+        b'MANIFEST_JSON:{"checksum": "def456", "dataset": "alpaca_sip_corp_actions", '
+        b'"manifest_id": null, "manifest_version": 3}\n'
+    )
+
+    assert data_sync_module._ScriptBackedAcquisitionExecutor._manifest_ids_from_stdout(  # noqa: SLF001
+        ALPACA_SIP_CORP_ACTIONS_DATASET,
+        payload,
+    ) == ["alpaca_sip_corp_actions@v3:def456"]
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_reuses_existing_inflight_job_for_same_scope(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    request = _daily_acquisition_request()
+    first_preflight = await service.preflight_acquisition(operator_user, request)
+    first_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=first_preflight.idempotency_key,
+            submit_token=first_preflight.submit_token,
+        ),
+    )
+    second_preflight = await service.preflight_acquisition(operator_user, request)
+
+    second_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=second_preflight.idempotency_key,
+            submit_token=second_preflight.submit_token,
+        ),
+    )
+
+    assert second_job.id == first_job.id
+    assert second_job.submit_token_status == "consumed"
+    assert "duplicate_submission_reused_existing_job" in second_job.logs
+
+
+@pytest.mark.asyncio()
+async def test_duplicate_submit_reuses_job_without_charging_trigger_rate_limit(
+    operator_user: DummyUser,
+) -> None:
+    rate_limiter = AsyncMock()
+    rate_limiter.check_rate_limit = AsyncMock(
+        side_effect=[
+            (True, 0),
+            (True, 0),
+            (True, 0),
+            (False, 0),
+        ]
+    )
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
+    request = _daily_acquisition_request()
+    first_preflight = await service.preflight_acquisition(operator_user, request)
+    first_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=first_preflight.idempotency_key,
+            submit_token=first_preflight.submit_token,
+        ),
+    )
+    second_preflight = await service.preflight_acquisition(operator_user, request)
+
+    second_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=second_preflight.idempotency_key,
+            submit_token=second_preflight.submit_token,
+        ),
+    )
+
+    assert second_job.id == first_job.id
+    assert rate_limiter.check_rate_limit.await_count == 3
+    actions = [
+        call_kwargs.kwargs["action"]
+        for call_kwargs in rate_limiter.check_rate_limit.await_args_list
+    ]
+    assert actions == [
+        "preflight_data_acquisition",
+        "trigger_data_sync",
+        "preflight_data_acquisition",
+    ]
+
+
+@pytest.mark.asyncio()
+async def test_failed_acquisition_job_can_be_retried_with_same_scope(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=_FailingAcquisitionExecutor(),
+    )
+    request = _daily_acquisition_request(dry_run=False)
+    first_preflight = await service.preflight_acquisition(operator_user, request)
+    first_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=first_preflight.idempotency_key,
+            submit_token=first_preflight.submit_token,
+        ),
+    )
+    await service.close()
+    stored_failed = service._acquisition_jobs[first_preflight.idempotency_key]  # noqa: SLF001
+    assert stored_failed.status == "failed"
+
+    service._acquisition_executor = _RecordingAcquisitionExecutor()  # noqa: SLF001
+    second_preflight = await service.preflight_acquisition(operator_user, request)
+    second_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=second_preflight.idempotency_key,
+            submit_token=second_preflight.submit_token,
+        ),
+    )
+    await service.close()
+
+    assert second_job.id != first_job.id
+    assert "duplicate_submission_reused_existing_job" not in second_job.logs
+    stored_retry = service._acquisition_jobs[second_preflight.idempotency_key]  # noqa: SLF001
+    assert stored_retry.status == "completed"
+    assert any("RuntimeError:transient provider failure" in log for log in stored_failed.logs)
+
+
+@pytest.mark.asyncio()
+async def test_failed_acquisition_job_redacts_sensitive_logs(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=_SensitiveFailingAcquisitionExecutor(),
+    )
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False),
+    )
+
+    await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    await service.close()
+
+    stored = service._acquisition_jobs[preflight.idempotency_key]  # noqa: SLF001
+    serialized_logs = "\n".join(stored.logs)
+    assert stored.status == "failed"
+    assert "secret-token" not in serialized_logs
+    assert "secret-key" not in serialized_logs
+    assert "broker-secret" not in serialized_logs
+    assert "abc.def" not in serialized_logs
+    assert "<redacted>" in serialized_logs
+
+
+@pytest.mark.asyncio()
+async def test_daily_acquisition_idempotency_uses_year_scope(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    today = datetime.now(UTC).date()
+    year_start = date(today.year, 1, 1)
+    first_end = min(today, date(today.year, 4, 30))
+    first_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(
+            start_date=year_start,
+            end_date=first_end,
+        ),
+    )
+    second_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(
+            start_date=year_start,
+            end_date=today,
+        ),
+    )
+
+    assert second_preflight.idempotency_key == first_preflight.idempotency_key
+
+
+@pytest.mark.asyncio()
+async def test_same_scope_acquisition_jobs_are_deduplicated_across_users(
+    service: DataSyncService,
+    operator_user: DummyUser,
+    admin_user: DummyUser,
+) -> None:
+    request = _daily_acquisition_request()
+    operator_preflight = await service.preflight_acquisition(operator_user, request)
+    admin_preflight = await service.preflight_acquisition(admin_user, request)
+
+    operator_job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=operator_preflight.idempotency_key,
+            submit_token=operator_preflight.submit_token,
+        ),
+    )
+    admin_job = await service.submit_acquisition(
+        admin_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=admin_preflight.idempotency_key,
+            submit_token=admin_preflight.submit_token,
+        ),
+    )
+
+    assert admin_job.id == operator_job.id
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_rejects_cross_user_token(
+    service: DataSyncService,
+    operator_user: DummyUser,
+    admin_user: DummyUser,
+) -> None:
+    admin_preflight = await service.preflight_acquisition(
+        admin_user,
+        _daily_acquisition_request(),
+    )
+
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=admin_preflight.idempotency_key,
+                submit_token=admin_preflight.submit_token,
+            ),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_keeps_token_when_dataset_access_is_denied(
+    service: DataSyncService,
+    operator_user: DummyUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    submission = DataAcquisitionSubmitDTO(
+        idempotency_key=preflight.idempotency_key,
+        submit_token=preflight.submit_token,
+    )
+
+    monkeypatch.setattr(data_sync_module, "has_dataset_permission", lambda *_args: False)
+    with pytest.raises(PermissionError):
+        await service.submit_acquisition(operator_user, submission)
+
+    monkeypatch.setattr(data_sync_module, "has_dataset_permission", lambda *_args: True)
+    job = await service.submit_acquisition(operator_user, submission)
+
+    assert job.status == "completed"
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_requires_current_one_use_token(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    submission = DataAcquisitionSubmitDTO(
+        idempotency_key=preflight.idempotency_key,
+        submit_token=preflight.submit_token,
+    )
+    await service.submit_acquisition(operator_user, submission)
+
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(operator_user, submission)
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=preflight.idempotency_key,
+                submit_token="forged",
+            ),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_rejects_expired_token(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    service._preflight_tokens[(operator_user.user_id, preflight.idempotency_key)].expires_at = (  # noqa: SLF001
+        datetime.now(UTC) - timedelta(seconds=1)
+    )
+
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=preflight.idempotency_key,
+                submit_token=preflight.submit_token,
+            ),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_preflight_acquisition_validates_request_policy(
+    service: DataSyncService,
+    operator_user: DummyUser,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="Reason is required"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(reason="   "),
+        )
+    with pytest.raises(ValueError, match="Start date"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(
+                start_date=date(2026, 5, 1),
+                end_date=date(2026, 4, 30),
+            ),
+        )
+    with pytest.raises(ValidationError, match="Input should be 'backfill'"):
+        _daily_acquisition_request(mode="incremental")
+    with pytest.raises(ValueError, match="starts at"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(
+                start_date=date(2015, 12, 31),
+                end_date=date(2026, 1, 1),
+            ),
+        )
+    tomorrow = datetime.now(UTC).date() + timedelta(days=1)
+    with pytest.raises(ValueError, match="cannot be in the future"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(
+                start_date=tomorrow,
+                end_date=tomorrow,
+            ),
+        )
+    with monkeypatch.context() as patched:
+        patched.setattr(data_sync_module, "_ACQUISITION_MAX_DATE_RANGE_DAYS", 1)
+        with pytest.raises(ValueError, match="maximum acquisition window"):
+            await service.preflight_acquisition(
+                operator_user,
+                _daily_acquisition_request(
+                    start_date=date(2026, 1, 1),
+                    end_date=date(2026, 1, 2),
+                ),
+            )
+    with pytest.raises(ValueError, match="requires adjustment_mode=raw"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(adjustment_mode=None),
+        )
+    with pytest.raises(ValueError, match="does not accept adjustment metadata"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(
+                dataset=ALPACA_SIP_CORP_ACTIONS_DATASET,
+                symbol_source="AAPL",
+            ),
+        )
+    with pytest.raises(ValueError, match="requires symbols or ids"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(
+                dataset=ALPACA_SIP_CORP_ACTIONS_DATASET,
+                adjustment_mode=None,
+                symbol_source="all",
+            ),
+        )
+    with pytest.raises(ValueError, match="requires explicit symbols"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(symbol_source="all"),
+        )
+    with pytest.raises(ValueError, match="Symbol source must be"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(symbol_source="DROP TABLE"),
+        )
+    with pytest.raises(ValueError, match="File symbol sources"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(symbol_source="file:../../etc/passwd"),
+        )
+    with pytest.raises(ValueError, match="File symbol sources"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(symbol_source="file:./config/secrets.env"),
+        )
+    with pytest.raises(ValueError, match="Universe symbol sources"):
+        await service.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(symbol_source="universe:sp500"),
+        )
+
+    symbol_file = tmp_path / "data" / "symbols" / "core.txt"
+    symbol_file.parent.mkdir(parents=True)
+    symbol_file.write_text("MSFT\nAAPL\nAAPL\n")
+    monkeypatch.setattr(data_sync_module, "_REPO_ROOT", tmp_path)
+    file_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(symbol_source="file:data/symbols/core.txt"),
+    )
+    assert file_preflight.symbol_source.startswith("file:data/symbols/core.txt#sha256=")
+
+    original_key = file_preflight.idempotency_key
+    command = data_sync_module._build_acquisition_command(file_preflight)  # noqa: SLF001
+    assert "--symbols" in command
+    assert "AAPL,MSFT" in command
+
+    symbol_file.write_text("AAPL\nGOOG\n")
+    changed_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(symbol_source="file:data/symbols/core.txt"),
+    )
+    assert changed_preflight.idempotency_key != original_key
+    with pytest.raises(ValueError, match="changed after preflight"):
+        data_sync_module._build_acquisition_command(file_preflight)  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_symbol_list_idempotency_uses_canonical_scope(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    first_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(symbol_source="AAPL, MSFT"),
+    )
+    second_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(symbol_source="msft,aapl,AAPL"),
+    )
+
+    assert first_preflight.symbol_source == "AAPL,MSFT"
+    assert second_preflight.idempotency_key == first_preflight.idempotency_key
+
+
+@pytest.mark.asyncio()
+async def test_corp_action_ids_idempotency_uses_canonical_scope(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    base_request = {
+        "dataset": ALPACA_SIP_CORP_ACTIONS_DATASET,
+        "adjustment_mode": None,
+        "reason": "fill corporate actions",
+    }
+    first_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(symbol_source="ids:B,A", **base_request),
+    )
+    second_preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(symbol_source="ids:A,B,A", **base_request),
+    )
+
+    assert first_preflight.symbol_source == "ids:A,B"
+    assert second_preflight.idempotency_key == first_preflight.idempotency_key
+    command = data_sync_module._build_acquisition_command(first_preflight)  # noqa: SLF001
+    assert "--ids" in command
+    assert "A,B" in command
+    assert "--symbols" not in command
+
+
+@pytest.mark.asyncio()
+async def test_acquisition_preflight_and_submit_are_rate_limited(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
+
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+
+    rate_limiter.check_rate_limit.assert_has_awaits(
+        [
+            call(
+                user_id=operator_user.user_id,
+                action="preflight_data_acquisition",
+                max_requests=10,
+                window_seconds=60,
+            ),
+            call(
+                user_id=operator_user.user_id,
+                action="trigger_data_sync",
+                max_requests=1,
+                window_seconds=60,
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio()
+async def test_acquisition_rate_limits_block_preflight_and_submit(
+    operator_user: DummyUser,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    preflight_limiter = AsyncMock()
+    preflight_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
+    preflight_blocked = DataSyncService(
+        rate_limiter=preflight_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
+
+    with pytest.raises(RateLimitExceeded):
+        await preflight_blocked.preflight_acquisition(
+            operator_user,
+            _daily_acquisition_request(),
+        )
+
+    submit_limiter = AsyncMock()
+    submit_limiter.check_rate_limit = AsyncMock(side_effect=[(True, 0), (False, 0), (True, 0)])
+    submit_blocked = DataSyncService(
+        rate_limiter=submit_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
+    preflight = await submit_blocked.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger=data_sync_module.__name__)
+    with pytest.raises(RateLimitExceeded):
+        await submit_blocked.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=preflight.idempotency_key,
+                submit_token=preflight.submit_token,
+            ),
+        )
+    blocked_records = [
+        record for record in caplog.records if record.message == "acquisition_submission_blocked"
+    ]
+    assert blocked_records
+    assert blocked_records[-1].__dict__["dataset"] == ALPACA_SIP_DAILY_DATASET
+    assert blocked_records[-1].__dict__["user_id"] == operator_user.user_id
+    assert blocked_records[-1].__dict__["block_reason"] == "rate_limited"
+    assert submit_blocked._acquisition_jobs == {}  # noqa: SLF001
+
+    retry_job = await submit_blocked.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    assert retry_job.status == "completed"
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_consumes_preflight_token_once(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    fake_redis = _FakeRedis()
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_store=data_sync_module._RedisAcquisitionStore(fake_redis),  # noqa: SLF001
+    )
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    forged = DataAcquisitionSubmitDTO(
+        idempotency_key=preflight.idempotency_key,
+        submit_token="forged",
+    )
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(operator_user, forged)
+
+    submission = DataAcquisitionSubmitDTO(
+        idempotency_key=preflight.idempotency_key,
+        submit_token=preflight.submit_token,
+    )
+    job = await service.submit_acquisition(operator_user, submission)
+
+    assert job.status == "completed"
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(operator_user, submission)
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_rejects_expired_token_in_lua(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    fake_redis = _FakeRedis()
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_store=data_sync_module._RedisAcquisitionStore(fake_redis),  # noqa: SLF001
+    )
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    for payload in fake_redis.hashes.values():
+        payload["expires_at_epoch"] = "0"
+
+    with pytest.raises(PreflightRequired):
+        await service.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=preflight.idempotency_key,
+                submit_token=preflight.submit_token,
+            ),
+        )
+    assert not fake_redis.hashes
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_reuses_only_active_or_successful_jobs() -> None:
+    store = data_sync_module._RedisAcquisitionStore(_FakeRedis())  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_redis"
+    running = _daily_acquisition_job(
+        job_id="job-running",
+        idempotency_key=idempotency_key,
+        status="running",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+
+    assert await store.reserve_job(running, now) is None
+    duplicate = await store.reserve_job(
+        _daily_acquisition_job(
+            job_id="job-duplicate",
+            idempotency_key=idempotency_key,
+            status="queued",
+        ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None}),
+        now,
+    )
+    assert duplicate is not None
+    assert duplicate.id == "job-running"
+
+    failed = running.model_copy(update={"status": "failed", "completed_at": now})
+    await store.update_job(failed, now)
+    assert await store.get_reusable_job(idempotency_key, now) is None
+
+    retry = _daily_acquisition_job(
+        job_id="job-retry",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+    assert await store.reserve_job(retry, now) is None
+    stored_retry = await store.get_reusable_job(idempotency_key, now)
+    assert stored_retry is not None
+    assert stored_retry.id == "job-retry"
+
+@pytest.mark.asyncio()
+async def test_in_memory_acquisition_store_reuses_fresh_heartbeat_job() -> None:
+    state = _fresh_acquisition_state()
+    store = data_sync_module._InMemoryAcquisitionStore(state)  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_in_memory_long_running"
+    old_started_at = now - timedelta(
+        seconds=data_sync_module._ACQUISITION_JOB_RETENTION_SECONDS + 1  # noqa: SLF001
+    )
+    long_running = _daily_acquisition_job(
+        job_id="job-long-running",
+        idempotency_key=idempotency_key,
+        status="running",
+    ).model_copy(update={"started_at": old_started_at, "heartbeat_at": now, "completed_at": None})
+
+    assert await store.reserve_job(long_running, old_started_at) is None
+    retry = _daily_acquisition_job(
+        job_id="job-retry",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+    duplicate = await store.reserve_job(retry, now)
+
+    assert duplicate is not None
+    assert duplicate.id == "job-long-running"
+
+    mismatched_completion = retry.model_copy(
+        update={"status": "completed", "completed_at": now}
+    )
+    await store.update_job(mismatched_completion, now)
+
+    stored = state.acquisition_jobs[idempotency_key]
+    assert stored.id == "job-long-running"
+    assert stored.status == "running"
+
+
+@pytest.mark.asyncio()
+async def test_in_memory_acquisition_store_rejects_late_heartbeat_after_terminal() -> None:
+    state = _fresh_acquisition_state()
+    store = data_sync_module._InMemoryAcquisitionStore(state)  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_in_memory_late_heartbeat"
+    running = _daily_acquisition_job(
+        job_id="job-terminal",
+        idempotency_key=idempotency_key,
+        status="running",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+
+    assert await store.reserve_job(running, now) is None
+    completed = running.model_copy(
+        update={
+            "status": "completed",
+            "completed_at": now,
+            "produced_manifest_ids": ["manifest-1"],
+        }
+    )
+    await store.update_job(completed, now)
+    late_heartbeat = running.model_copy(
+        update={"heartbeat_at": now + timedelta(seconds=1)}
+    )
+    await store.update_job(late_heartbeat, now + timedelta(seconds=1))
+
+    stored = state.acquisition_jobs[idempotency_key]
+    assert stored.status == "completed"
+    assert stored.produced_manifest_ids == ["manifest-1"]
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_reuses_fresh_heartbeat_job() -> None:
+    store = data_sync_module._RedisAcquisitionStore(_FakeRedis())  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_long_running"
+    old_started_at = now - timedelta(hours=8)
+    long_running = _daily_acquisition_job(
+        job_id="job-long-running",
+        idempotency_key=idempotency_key,
+        status="running",
+    ).model_copy(update={"started_at": old_started_at, "heartbeat_at": now, "completed_at": None})
+
+    assert await store.reserve_job(long_running, old_started_at) is None
+    stored_long_running = await store.get_reusable_job(idempotency_key, now)
+    assert stored_long_running is not None
+    assert stored_long_running.id == "job-long-running"
+    retry = _daily_acquisition_job(
+        job_id="job-retry",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+
+    duplicate = await store.reserve_job(retry, now)
+    assert duplicate is not None
+    assert duplicate.id == "job-long-running"
+
+    mismatched_completion = retry.model_copy(
+        update={"status": "completed", "completed_at": now}
+    )
+    await store.update_job(mismatched_completion, now)
+    stored_after_mismatched_update = await store.get_reusable_job(idempotency_key, now)
+    assert stored_after_mismatched_update is not None
+    assert stored_after_mismatched_update.id == "job-long-running"
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_rejects_late_heartbeat_after_terminal() -> None:
+    store = data_sync_module._RedisAcquisitionStore(_FakeRedis())  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_redis_late_heartbeat"
+    running = _daily_acquisition_job(
+        job_id="job-terminal",
+        idempotency_key=idempotency_key,
+        status="running",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+
+    assert await store.reserve_job(running, now) is None
+    completed = running.model_copy(
+        update={
+            "status": "completed",
+            "completed_at": now,
+            "produced_manifest_ids": ["manifest-1"],
+        }
+    )
+    await store.update_job(completed, now)
+    late_heartbeat = running.model_copy(
+        update={"heartbeat_at": now + timedelta(seconds=1)}
+    )
+    await store.update_job(late_heartbeat, now + timedelta(seconds=1))
+
+    stored = await store.get_reusable_job(idempotency_key, now + timedelta(seconds=1))
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.produced_manifest_ids == ["manifest-1"]
+
+
+@pytest.mark.asyncio()
+async def test_redis_acquisition_store_replaces_stale_active_job() -> None:
+    store = data_sync_module._RedisAcquisitionStore(_FakeRedis())  # noqa: SLF001
+    now = datetime.now(UTC)
+    idempotency_key = "acq_stale_running"
+    stale_at = now - timedelta(seconds=data_sync_module._ACQUISITION_ACTIVE_JOB_STALE_SECONDS + 1)  # noqa: SLF001
+    stale_running = _daily_acquisition_job(
+        job_id="job-stale-running",
+        idempotency_key=idempotency_key,
+        status="running",
+    ).model_copy(update={"started_at": stale_at, "heartbeat_at": stale_at, "completed_at": None})
+
+    assert await store.reserve_job(stale_running, stale_at) is None
+    assert await store.get_reusable_job(idempotency_key, now) is None
+    retry = _daily_acquisition_job(
+        job_id="job-retry",
+        idempotency_key=idempotency_key,
+        status="queued",
+    ).model_copy(update={"started_at": now, "heartbeat_at": now, "completed_at": None})
+
+    duplicate = await store.reserve_job(retry, now)
+    assert duplicate is None
+    stored_retry = await store.get_reusable_job(idempotency_key, now)
+    assert stored_retry is not None
+    assert stored_retry.id == "job-retry"
+
+
+@pytest.mark.asyncio()
+async def test_acquisition_state_cleanup_removes_expired_tokens_and_bounds_jobs(
+    service: DataSyncService,
+    operator_user: DummyUser,
+) -> None:
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(),
+    )
+    token_key = (operator_user.user_id, preflight.idempotency_key)
+    service._preflight_tokens[token_key].expires_at = datetime.now(UTC) - timedelta(  # noqa: SLF001
+        seconds=1
+    )
+    for index in range(data_sync_module._ACQUISITION_MAX_JOBS + 1):  # noqa: SLF001
+        service._acquisition_jobs[f"job-{index}"] = DataAcquisitionJobDTO(  # noqa: SLF001
+            id=f"job-{index}",
+            dataset=ALPACA_SIP_DAILY_DATASET,
+            status="queued",
+            idempotency_key=f"job-{index}",
+            mode="backfill",
+            dry_run=True,
+            provider_id="alpaca_sip",
+            source_feed="sip",
+            canonical_storage_mode="raw",
+            read_time_adjustment_mode="unavailable",
+            adjustment_mode="raw",
+            started_at=datetime.now(UTC) - timedelta(seconds=index),
+            submit_token_status="consumed",
+            adapter="script:scripts/data/alpaca_sip_sync.py",
+            produced_manifest_ids=[],
+            validation_output=[],
+            logs=[],
+        )
+    stale_key = "stale-queued"
+    service._acquisition_jobs[stale_key] = DataAcquisitionJobDTO(  # noqa: SLF001
+        id=stale_key,
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        status="queued",
+        idempotency_key=stale_key,
+        mode="backfill",
+        dry_run=True,
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        adjustment_mode="raw",
+        started_at=datetime.now(UTC)
+        - timedelta(seconds=data_sync_module._ACQUISITION_JOB_RETENTION_SECONDS + 1),  # noqa: SLF001
+        submit_token_status="consumed",
+        adapter="script:scripts/data/alpaca_sip_sync.py",
+        produced_manifest_ids=[],
+        validation_output=[],
+        logs=[],
+    )
+
+    await service._acquisition_store.sweep(datetime.now(UTC))  # noqa: SLF001
+
+    assert token_key not in service._preflight_tokens  # noqa: SLF001
+    assert stale_key not in service._acquisition_jobs  # noqa: SLF001
+    assert len(service._acquisition_jobs) == data_sync_module._ACQUISITION_MAX_JOBS  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_close_can_cancel_running_background_acquisition(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    executor = _BlockingAcquisitionExecutor()
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=executor,
+    )
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False),
+    )
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+    await executor.started.wait()
+
+    await service.close(cancel_running=True)
+
+    stored = service._acquisition_jobs[preflight.idempotency_key]  # noqa: SLF001
+    assert stored.id == job.id
+    assert stored.status == "failed"
+    assert "job_cancelled_during_shutdown" in stored.logs
+    assert not service._background_acquisition_tasks  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_background_acquisition_concurrency_is_shared_across_services(
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
+) -> None:
+    first_executor = _BlockingAcquisitionExecutor()
+    second_executor = _BlockingAcquisitionExecutor()
+    first_service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=first_executor,
+    )
+    second_service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+        acquisition_executor=second_executor,
+    )
+    first_preflight = await first_service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False, symbol_source="AAPL"),
+    )
+    second_preflight = await second_service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(dry_run=False, symbol_source="MSFT"),
+    )
+
+    try:
+        await first_service.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=first_preflight.idempotency_key,
+                submit_token=first_preflight.submit_token,
+            ),
+        )
+        await first_executor.started.wait()
+        await second_service.submit_acquisition(
+            operator_user,
+            DataAcquisitionSubmitDTO(
+                idempotency_key=second_preflight.idempotency_key,
+                submit_token=second_preflight.submit_token,
+            ),
+        )
+        await asyncio.sleep(0.05)
+
+        assert not second_executor.started.is_set()
+
+        first_executor.release.set()
+        await first_service.close()
+        await asyncio.wait_for(second_executor.started.wait(), timeout=1)
+    finally:
+        first_executor.release.set()
+        second_executor.release.set()
+        await first_service.close()
+        await second_service.close()
+
+
+@pytest.mark.asyncio()
+async def test_submit_acquisition_logs_audit_event(
+    service: DataSyncService,
+    operator_user: DummyUser,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger=data_sync_module.__name__)
+    preflight = await service.preflight_acquisition(
+        operator_user,
+        _daily_acquisition_request(reason="audit trail"),
+    )
+
+    job = await service.submit_acquisition(
+        operator_user,
+        DataAcquisitionSubmitDTO(
+            idempotency_key=preflight.idempotency_key,
+            submit_token=preflight.submit_token,
+        ),
+    )
+
+    audit_records = [
+        record for record in caplog.records if record.message == "acquisition_submitted"
+    ]
+    assert audit_records
+    assert audit_records[-1].__dict__["dataset"] == ALPACA_SIP_DAILY_DATASET
+    assert audit_records[-1].__dict__["job_id"] == job.id
+    assert audit_records[-1].__dict__["user_id"] == operator_user.user_id
+    assert audit_records[-1].__dict__["reason"] == "audit trail"
+    assert audit_records[-1].__dict__["dry_run"] is True
+    assert audit_records[-1].__dict__["start_date"] == "2026-01-01"
+    assert audit_records[-1].__dict__["end_date"] == "2026-12-31"
+    assert audit_records[-1].__dict__["symbol_source"] == "AAPL,MSFT"
+    assert audit_records[-1].__dict__["adjustment_mode"] == "raw"
 
 
 @pytest.mark.asyncio()
@@ -267,7 +1877,10 @@ async def test_trigger_sync_rate_limited_raises(
 ) -> None:
     rate_limiter = AsyncMock()
     rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
-    service = DataSyncService(rate_limiter=rate_limiter)
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
 
     with pytest.raises(RateLimitExceeded):
         await service.trigger_sync(operator_user, dataset="crsp", reason="manual")
@@ -277,7 +1890,10 @@ async def test_trigger_sync_rate_limited_raises(
 async def test_rate_limit_check_delegates(
     rate_limiter: AsyncMock, operator_user: DummyUser
 ) -> None:
-    service = DataSyncService(rate_limiter=rate_limiter)
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
 
     allowed, remaining = await service._rate_limit_check(
         operator_user.user_id,
@@ -300,7 +1916,10 @@ async def test_rate_limit_check_delegates(
 async def test_enforce_rate_limit_uses_user_id_lookup(
     rate_limiter: AsyncMock,
 ) -> None:
-    service = DataSyncService(rate_limiter=rate_limiter)
+    service = DataSyncService(
+        rate_limiter=rate_limiter,
+        acquisition_state=_fresh_acquisition_state(),
+    )
 
     class UserObj:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

- Adds the Phase 2 Alpaca SIP data acquisition flow: preflight DTOs, one-use submit tokens, idempotent job submission, Redis/in-memory acquisition state, and script-backed execution.
- Adds a denser web-console acquisition panel with preflight-first validation, submit-token handling, stale preflight response protection, and job result rendering.
- Wires container support for exact data adapter scripts and mounted `./data`, and emits `MANIFEST_JSON` from the Alpaca SIP daily and corporate-actions sync scripts.
- Hardens job lifecycle handling so duplicate submissions reuse active/completed work while stale active jobs can recover, and late heartbeats cannot overwrite terminal job state.

## Validation

- `python scripts/dev/generate_architecture.py --check`
- `ruff check apps/web_console_ng/components/data_sync_section.py tests/apps/web_console_ng/components/test_data_sync_section.py tests/apps/web_console_ng/test_dockerfile.py libs/web_console_services/data_sync_service.py libs/web_console_services/schemas/data_management.py scripts/data/alpaca_sip_sync.py scripts/data/alpaca_corp_actions_sync.py tests/libs/web_console_services/test_data_sync_service.py`
- `mypy --strict libs/web_console_services/data_sync_service.py libs/web_console_services/schemas/data_management.py apps/web_console_ng/components/data_sync_section.py tests/libs/web_console_services/test_data_sync_service.py tests/apps/web_console_ng/components/test_data_sync_section.py tests/apps/web_console_ng/test_dockerfile.py scripts/data/alpaca_sip_sync.py scripts/data/alpaca_corp_actions_sync.py`
- `pytest -q tests/apps/web_console_ng/test_dockerfile.py tests/libs/web_console_services/test_data_sync_service.py tests/apps/web_console_ng/components/test_data_sync_section.py tests/apps/web_console/services/test_data_sync_service.py tests/apps/web_console/services/test_data_sync_rate_limit.py tests/apps/web_console_ng/pages/test_data_management.py tests/apps/web_console_ng/components/test_data_manifest_components.py tests/libs/web_console_services/test_data_manifest_service.py tests/libs/web_console_services/test_data_source_status_service.py`
- `make ci-local` (12,837 passed, 24 skipped, 3 xfailed)

## Review Loop

- Gemini: no blocking issues after final heartbeat-race fix.
- Claude: no blocking issues after final heartbeat-race fix.
- Codex: initially flagged async Redis handling and late heartbeat terminal overwrite; both were fixed and Codex final review reported no discrete correctness, security, or maintainability issues.
