### PR TITLE
[codex] Back data explorer with trusted SQL previews

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -73,6 +73,8 @@ docker-compose*.yml
 
 # Scripts (only web-console data acquisition adapters are needed in containers)
 scripts/**
+!scripts/data/
+scripts/data/*
 !scripts/data/__init__.py
 !scripts/data/alpaca_sip_sync.py
 !scripts/data/alpaca_corp_actions_sync.py

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -24,7 +24,7 @@ import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import plotly.graph_objects as go
 from nicegui import ui
@@ -57,7 +57,10 @@ from libs.platform.web_console_auth.permissions import (
     has_dataset_permission,
     has_permission,
 )
-from libs.web_console_services.data_explorer_service import DataExplorerService
+from libs.web_console_services.data_explorer_service import (
+    DATA_EXPORT_RATE_LIMIT,
+    DataExplorerService,
+)
 from libs.web_console_services.data_explorer_service import (
     RateLimitExceeded as ExplorerRateLimitExceeded,
 )
@@ -69,7 +72,8 @@ logger = logging.getLogger(__name__)
 
 # Rate limits (displayed in UI messages)
 MAX_QUERIES_PER_MINUTE = 10
-MAX_EXPORTS_PER_HOUR = 5
+INLINE_QUERY_RESULT_ROW_LIMIT = 500
+_EXPORT_FORMAT_OPTIONS = {"csv": "CSV", "parquet": "Parquet"}
 
 # Dataset name pattern for quarantine drill-down (64-char cap aligns with typical naming)
 _DATASET_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
@@ -385,6 +389,8 @@ async def _render_data_explorer_section(
 
     # Track selected dataset
     selected_dataset: dict[str, str | None] = {"value": None}
+    dataset_map: dict[str, Any] = {}
+    refresh_query_controls: Callable[[], None] | None = None
 
     with ui.row().classes("w-full gap-4"):
         # Dataset browser sidebar
@@ -410,7 +416,8 @@ async def _render_data_explorer_section(
                     datasets = []
 
                 dataset_names = [d.name for d in datasets]
-                dataset_map = {d.name: d for d in datasets}
+                dataset_map.clear()
+                dataset_map.update({d.name: d for d in datasets})
 
                 if dataset_names:
                     selected_dataset["value"] = dataset_names[0]
@@ -437,6 +444,14 @@ async def _render_data_explorer_section(
                         ui.label("Dataset Info").classes("font-bold mb-1")
                         if info.description:
                             ui.label(info.description).classes("text-sm text-gray-600")
+                        queryable_state = getattr(info, "queryable_state", None)
+                        if queryable_state:
+                            ui.label(f"State: {queryable_state}").classes("text-sm text-gray-600")
+                        tables = getattr(info, "tables", None)
+                        if tables:
+                            ui.label(f"Tables: {', '.join(tables)}").classes(
+                                "text-sm text-gray-600"
+                            )
                         if info.row_count is not None:
                             ui.label(f"Rows: {info.row_count:,}").classes("text-sm text-gray-600")
                         if info.symbol_count is not None:
@@ -447,6 +462,9 @@ async def _render_data_explorer_section(
                             start = info.date_range.get("start", "?")
                             end = info.date_range.get("end", "?")
                             ui.label(f"Range: {start} to {end}").classes("text-sm text-gray-600")
+                        availability_reason = getattr(info, "availability_reason", None)
+                        if availability_reason:
+                            ui.label(availability_reason).classes("text-xs text-amber-600")
 
                 async def _load_schema(ds_name: str | None) -> None:
                     """Load schema preview for dataset (requires QUERY_DATA)."""
@@ -464,6 +482,9 @@ async def _render_data_explorer_section(
                             ui.label("Schema Preview").classes("font-bold mb-1")
                             for col in preview.columns:
                                 ui.label(f"  {col}").classes("text-sm text-gray-600 font-mono")
+                    except ValueError as e:
+                        with schema_container:
+                            ui.label(str(e)).classes("text-sm text-amber-600")
                     except PermissionError:
                         with schema_container:
                             ui.label("Schema requires query permission").classes(
@@ -485,6 +506,8 @@ async def _render_data_explorer_section(
                     selected_dataset["value"] = ds
                     _show_dataset_info(ds)
                     await _load_schema(ds)
+                    if refresh_query_controls is not None:
+                        refresh_query_controls()
 
                 dataset_select.on_value_change(on_dataset_change)
 
@@ -511,7 +534,114 @@ async def _render_data_explorer_section(
 
                     results_container = ui.column().classes("w-full mt-4")
 
+                    def _selected_dataset_info() -> Any | None:
+                        ds = selected_dataset["value"]
+                        if ds is None:
+                            return None
+                        return dataset_map.get(ds)
+
+                    template_items: dict[str, Any] = {}
+                    template_select = ui.select(
+                        label="Query Template",
+                        options={},
+                        value=None,
+                    ).classes("w-full max-w-md")
+                    export_format_select = None
+                    if has_export:
+                        export_format_select = ui.select(
+                            label="Export Format",
+                            options=_EXPORT_FORMAT_OPTIONS,
+                            value="csv",
+                        ).classes("w-36")
+
+                    def refresh_query_templates() -> None:
+                        info = _selected_dataset_info()
+                        templates = list(getattr(info, "query_templates", []) or [])
+                        template_items.clear()
+                        options: dict[str, str] = {}
+                        for idx, template in enumerate(templates):
+                            key = str(idx)
+                            template_items[key] = template
+                            options[key] = str(template.label)
+                        _set_select_options(template_select, options, next(iter(options), None))
+
+                    refresh_query_controls = refresh_query_templates
+                    refresh_query_templates()
+
                     with ui.row().classes("gap-2 mt-2"):
+
+                        def load_query_template() -> None:
+                            selected_key = (
+                                str(template_select.value)
+                                if template_select.value is not None
+                                else None
+                            )
+                            template = (
+                                template_items.get(selected_key)
+                                if selected_key is not None
+                                else None
+                            )
+                            if template is None:
+                                ui.notify("No trusted query template available", type="warning")
+                                return
+                            query_textarea.value = str(template.sql)
+
+                        def open_sql_explorer() -> None:
+                            info = _selected_dataset_info()
+                            handoff_url = getattr(info, "sql_handoff_url", None) if info else None
+                            if not handoff_url:
+                                ui.notify(
+                                    "SQL Explorer handoff requires trusted local data",
+                                    type="warning",
+                                )
+                                return
+                            ui.navigate.to(
+                                resolve_rooted_path_from_ui(str(handoff_url), ui_module=ui)
+                            )
+
+                        async def export_query() -> None:
+                            ds = selected_dataset["value"]
+                            if not ds:
+                                ui.notify("Please select a dataset", type="warning")
+                                return
+                            query_val = str(query_textarea.value).strip()
+                            if not query_val:
+                                ui.notify("Please enter a query", type="warning")
+                                return
+                            export_format = _export_format_value(
+                                export_format_select.value if export_format_select else None
+                            )
+                            if export_format is None:
+                                ui.notify("Please select a valid export format", type="warning")
+                                return
+                            try:
+                                job = await explorer_service.export_data(
+                                    user,
+                                    ds,
+                                    query_val,
+                                    export_format,
+                                )
+                                ui.notify(f"Export queued: {job.id}", type="positive")
+                            except ValueError as e:
+                                ui.notify(f"Export error: {e}", type="negative")
+                            except ExplorerRateLimitExceeded:
+                                ui.notify(
+                                    f"Rate limit: {DATA_EXPORT_RATE_LIMIT} exports/hour",
+                                    type="warning",
+                                )
+                            except PermissionError as e:
+                                ui.notify(str(e), type="negative")
+                            except Exception:
+                                logger.exception(
+                                    "service_call_failed",
+                                    extra={
+                                        "method": "export_data",
+                                        "service": "DataExplorerService",
+                                        "dataset": ds,
+                                        "user_id": _get_user_id_safe(user),
+                                    },
+                                )
+                                ui.notify("Export temporarily unavailable", type="warning")
 
                         async def run_query() -> None:
                             ds = selected_dataset["value"]
@@ -523,7 +653,12 @@ async def _render_data_explorer_section(
                                 ui.notify("Please enter a query", type="warning")
                                 return
                             try:
-                                result = await explorer_service.execute_query(user, ds, query_val)
+                                result = await explorer_service.execute_query(
+                                    user,
+                                    ds,
+                                    query_val,
+                                    max_rows=INLINE_QUERY_RESULT_ROW_LIMIT,
+                                )
                                 results_container.clear()
                                 with results_container:
                                     _build_query_results(result)
@@ -549,66 +684,34 @@ async def _render_data_explorer_section(
                                 ui.notify("Service temporarily unavailable", type="warning")
 
                         ui.button("Run Query", on_click=run_query, color="primary")
-
+                        ui.button("Use Template", on_click=load_query_template).props("flat")
+                        ui.button("Open in SQL Explorer", on_click=open_sql_explorer).props("flat")
                         if has_export:
-                            export_format: dict[str, str] = {"value": "csv"}
-                            ui.radio(
-                                ["csv", "parquet"],
-                                value="csv",
-                                on_change=lambda e: export_format.update({"value": str(e.value)}),
-                            ).props("inline")
-
-                            async def export_data() -> None:
-                                ds = selected_dataset["value"]
-                                if not ds:
-                                    ui.notify("Please select a dataset", type="warning")
-                                    return
-                                query_val = str(query_textarea.value).strip()
-                                if not query_val:
-                                    ui.notify(
-                                        "Please enter a query to export",
-                                        type="warning",
-                                    )
-                                    return
-                                fmt = cast(
-                                    Literal["csv", "parquet"],
-                                    export_format["value"],
-                                )
-                                try:
-                                    job = await explorer_service.export_data(
-                                        user, ds, query_val, fmt
-                                    )
-                                    ui.notify(
-                                        f"Export job {job.id} queued ({fmt})",
-                                        type="positive",
-                                    )
-                                except ExplorerRateLimitExceeded:
-                                    ui.notify(
-                                        f"Rate limit: {MAX_EXPORTS_PER_HOUR} exports/hour",
-                                        type="warning",
-                                    )
-                                except PermissionError as e:
-                                    ui.notify(str(e), type="negative")
-                                except Exception:
-                                    logger.exception(
-                                        "service_call_failed",
-                                        extra={
-                                            "method": "export_data",
-                                            "service": "DataExplorerService",
-                                            "dataset": ds,
-                                            "user_id": _get_user_id_safe(user),
-                                        },
-                                    )
-                                    ui.notify(
-                                        "Service temporarily unavailable",
-                                        type="warning",
-                                    )
-
-                            ui.button("Export Results", on_click=export_data).props("flat")
+                            ui.button("Export Results", on_click=export_query).props("flat")
                 else:
                     ui.label("Query execution requires QUERY_DATA permission").classes(
                         "text-gray-400"
                     )
+
+
+def _export_format_value(value: Any) -> Literal["csv", "parquet"] | None:
+    text = str(value).strip().lower() if value is not None else ""
+    if text == "csv":
+        return "csv"
+    if text == "parquet":
+        return "parquet"
+    return None
+
+
+def _set_select_options(select: Any, options: dict[str, str], value: str | None) -> None:
+    """Update NiceGUI select options across supported versions."""
+    set_options = getattr(select, "set_options", None)
+    if callable(set_options):
+        set_options(options, value=value)
+        return
+    select.options = options
+    select.value = value
+    select.update()
 
 
 def _build_query_results(result: Any) -> None:
@@ -623,7 +726,7 @@ def _build_query_results(result: Any) -> None:
     ui.table(columns=columns, rows=result.rows).classes("w-full")
 
     with ui.row().classes("gap-4 mt-2"):
-        ui.label(f"Total: {result.total_count} rows").classes("text-sm text-gray-600")
+        ui.label(f"Showing: {len(result.rows)} rows").classes("text-sm text-gray-600")
         if result.has_more:
             ui.label("(more results available)").classes("text-sm text-amber-600")
 

--- a/apps/web_console_ng/pages/sql_explorer.py
+++ b/apps/web_console_ng/pages/sql_explorer.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 from nicegui import ui
 
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.core.redis_ha import get_redis_store
+from apps.web_console_ng.core.request_query import get_request_query_param
 from apps.web_console_ng.ui.layout import main_layout
 from apps.web_console_ng.ui.root_path import render_client_redirect, resolve_rooted_path_from_ui
 from apps.web_console_ng.ui.trading_layout import apply_compact_grid_options
@@ -24,21 +25,22 @@ from libs.web_console_services.sql_explorer_service import (
     RateLimitExceededError,
     SqlExplorerService,
     can_query_dataset,
+    validate_sql_table_paths,
 )
 from libs.web_console_services.sql_validator import DATASET_TABLES
 
 logger = logging.getLogger(__name__)
 
+_NotifyType = Literal["positive", "negative", "warning", "info", "ongoing"]
 _PATH_CACHE_TTL = 120
 _LARGE_RESULT_THRESHOLD = 200_000
+_MAX_PREFILL_QUERY_CHARS = 8_192
 _path_cache: tuple[dict[str, set[str]], list[str]] | None = None
 _path_cache_ts: float = 0.0
 _path_cache_lock = asyncio.Lock()
 
 
 async def _get_validated_paths() -> tuple[dict[str, set[str]], list[str]]:
-    from libs.web_console_services.sql_explorer_service import _validate_table_paths
-
     global _path_cache, _path_cache_ts
     now = time.monotonic()
     if _path_cache is not None and (now - _path_cache_ts) < _PATH_CACHE_TTL:
@@ -48,10 +50,66 @@ async def _get_validated_paths() -> tuple[dict[str, set[str]], list[str]]:
         now = time.monotonic()
         if _path_cache is not None and (now - _path_cache_ts) < _PATH_CACHE_TTL:
             return _path_cache
-        result = await asyncio.to_thread(_validate_table_paths)
+        result = await asyncio.to_thread(validate_sql_table_paths)
         _path_cache = result
         _path_cache_ts = now
         return result
+
+
+def _get_sql_explorer_prefill_from_request() -> dict[str, str | None]:
+    """Extract optional `/data` handoff parameters from the current request."""
+    try:
+        request = ui.context.client.request
+    except (AttributeError, LookupError, RuntimeError):
+        logger.debug("sql_explorer_prefill_request_unavailable", exc_info=True)
+        return {"dataset": None, "query": None}
+    dataset = get_request_query_param(request=request, key="dataset")
+    query = get_request_query_param(request=request, key="query")
+    return {
+        "dataset": dataset.strip() if dataset else None,
+        "query": query.strip() if query else None,
+    }
+
+
+def _resolve_sql_explorer_prefill(
+    *,
+    allowed_datasets: list[str],
+    requested_dataset: str | None,
+    requested_query: str | None,
+) -> tuple[str, str, list[tuple[str, _NotifyType]]]:
+    """Resolve request handoff state without executing a linked query."""
+    initial_dataset = (
+        requested_dataset if requested_dataset in allowed_datasets else allowed_datasets[0]
+    )
+    prefill_query = ""
+    notifications: list[tuple[str, _NotifyType]] = []
+    if requested_dataset in allowed_datasets and requested_query:
+        prefill_query = requested_query[:_MAX_PREFILL_QUERY_CHARS]
+        notifications.append(("Query editor prefilled from link; review before running", "info"))
+        if len(requested_query) > _MAX_PREFILL_QUERY_CHARS:
+            notifications.append(
+                (
+                    f"Linked query was truncated to {_MAX_PREFILL_QUERY_CHARS:,} characters",
+                    "warning",
+                )
+            )
+    elif requested_query:
+        if requested_dataset:
+            notifications.append(
+                (
+                    "Requested dataset is unavailable or not authorized; "
+                    "linked query was not loaded",
+                    "warning",
+                )
+            )
+        else:
+            notifications.append(
+                ("Linked query was not loaded because no dataset was provided", "warning")
+            )
+    elif requested_dataset:
+        notifications.append(("Requested dataset is unavailable or not authorized", "warning"))
+
+    return initial_dataset, prefill_query, notifications
 
 
 @ui.page("/data/sql-explorer")
@@ -114,6 +172,17 @@ async def sql_explorer_page() -> None:
             ui.label("No queryable datasets available for your account.").classes("text-gray-400")
         return
 
+    prefill = _get_sql_explorer_prefill_from_request()
+    requested_dataset = prefill["dataset"]
+    requested_query = prefill["query"]
+    initial_dataset, prefill_query, prefill_notifications = _resolve_sql_explorer_prefill(
+        allowed_datasets=allowed_datasets,
+        requested_dataset=requested_dataset,
+        requested_query=requested_query,
+    )
+    for message, level in prefill_notifications:
+        ui.notify(message, type=level)
+
     dataset_options = {
         dataset: (
             dataset.upper()
@@ -131,7 +200,7 @@ async def sql_explorer_page() -> None:
         dataset_select = ui.select(
             label="Dataset",
             options=dataset_options,
-            value=allowed_datasets[0],
+            value=initial_dataset,
         ).classes("w-56")
         timeout_select = ui.select(
             label="Timeout",
@@ -185,6 +254,7 @@ async def sql_explorer_page() -> None:
     query_editor = ui.textarea(
         label="SQL Query",
         placeholder="SELECT * FROM crsp_daily WHERE symbol = 'AAPL' LIMIT 100",
+        value=prefill_query,
     ).classes("w-full font-mono")
 
     status_label = ui.label("Run a query to see results").classes("text-sm text-gray-400 mt-1")
@@ -235,7 +305,12 @@ async def sql_explorer_page() -> None:
                             ui.button("Use in editor", on_click=_replay_query).props("flat dense")
 
             def _add_history(
-                fingerprint: str, dataset: str, status: str, rows: int, *, original_sql: str = "",
+                fingerprint: str,
+                dataset: str,
+                status: str,
+                rows: int,
+                *,
+                original_sql: str = "",
             ) -> None:
                 history.insert(
                     0,
@@ -281,8 +356,7 @@ async def sql_explorer_page() -> None:
                 extra={"dataset": dataset, "user_id": user.get("user_id")},
             )
             ui.notify(
-                "No local parquet files found for selected dataset. "
-                "Sync data before querying.",
+                "No local parquet files found for selected dataset. Sync data before querying.",
                 type="warning",
             )
             return

--- a/apps/web_console_ng/requirements.txt
+++ b/apps/web_console_ng/requirements.txt
@@ -60,5 +60,5 @@ scipy==1.14.1
 statsmodels==0.14.4
 scikit-learn==1.5.2
 cvxpy==1.6.0
-duckdb==1.2.0
+duckdb==1.4.4
 sqlglot==26.10.0

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -40,9 +40,8 @@ from .sql_explorer_service import (
     SqlTableResolution,
     TablePathSpec,
     check_sensitive_tables,
-    create_scoped_query_connection,
     ensure_sql_explorer_execution_allowed,
-    execute_scoped_query_with_timeout,
+    execute_scoped_query_frame_with_timeout,
     fingerprint_sql_query,
     log_sql_query_audit,
     resolve_sql_table_availability,
@@ -939,16 +938,13 @@ class DataExplorerService:
         timeout_seconds: int,
     ) -> Any:
         await asyncio.to_thread(ensure_sql_explorer_execution_allowed)
-        conn = await asyncio.to_thread(
-            create_scoped_query_connection,
+        return await execute_scoped_query_frame_with_timeout(
             dataset,
+            sql,
+            timeout_seconds,
             available_tables=set(table_paths),
             table_paths=table_paths,
         )
-        try:
-            return await execute_scoped_query_with_timeout(conn, sql, timeout_seconds)
-        finally:
-            await asyncio.to_thread(conn.close)
 
 
 def _trusted_table_paths_for_dataset(
@@ -998,11 +994,13 @@ def _queryable_state_for_table(resolution: SqlTableResolution) -> str:
 
 
 def _trusted_alpaca_summary_manifests(alpaca_summary: Any, trusted_tables: list[str]) -> list[Any]:
-    trusted_table_set = set(trusted_tables)
+    trusted_manifest_datasets = {
+        _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table) for table in trusted_tables
+    }
     return [
         manifest
         for manifest in alpaca_summary.manifests
-        if getattr(manifest, "dataset", None) in trusted_table_set
+        if getattr(manifest, "dataset", None) in trusted_manifest_datasets
         and str(getattr(manifest, "validation_status", "")).lower() == "passed"
     ]
 

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -5,8 +5,12 @@ Enforces query validation, RBAC, and rate limiting.
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
 from datetime import UTC, datetime
 from typing import Any, Literal
+from urllib.parse import urlencode
 from uuid import uuid4
 
 from libs.platform.web_console_auth.helpers import get_user_id
@@ -17,15 +21,77 @@ from libs.platform.web_console_auth.permissions import (
 )
 from libs.platform.web_console_auth.rate_limiter import RateLimiter, get_rate_limiter
 
+from .data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_DATASET_KEY,
+    DataManifestService,
+)
 from .schemas.data_management import (
     DataPreviewDTO,
     DatasetInfoDTO,
     ExportJobDTO,
     QueryResultDTO,
+    QueryTemplateDTO,
 )
-from .sql_validator import SQLValidator
+from .sql_explorer_service import (
+    ConcurrencyLimitError,
+    SensitiveTableAccessError,
+    SqlTableResolution,
+    TablePathSpec,
+    check_sensitive_tables,
+    create_scoped_query_connection,
+    ensure_sql_explorer_execution_allowed,
+    execute_scoped_query_with_timeout,
+    fingerprint_sql_query,
+    log_sql_query_audit,
+    resolve_sql_table_availability,
+)
+from .sql_validator import DATASET_TABLES, SQLValidator
 
-_SUPPORTED_DATASETS = ("crsp", "compustat", "taq", "fama_french", "alpaca_sip")
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_DATASETS = tuple(DATASET_TABLES)
+_PREVIEW_TIMEOUT_SECONDS = 10
+_PREVIEW_RATE_LIMIT = 30
+_INTERACTIVE_ROW_LIMIT = 10_000
+_INTERACTIVE_FETCH_LIMIT = _INTERACTIVE_ROW_LIMIT + 1
+DATA_EXPORT_RATE_LIMIT = 5
+DATA_EXPORT_WINDOW_SECONDS = 3600
+_EXPORT_ROW_LIMIT = 100_000
+# Keep availability scans cached while allowing fresh sync/manifest states to surface quickly.
+_TABLE_AVAILABILITY_CACHE_TTL_SECONDS = 30
+_MANIFEST_SUMMARY_CACHE_TTL_SECONDS = 30
+_MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS = 5
+_MANIFEST_SUMMARY_TIMEOUT_SECONDS = 5.0
+
+_DATASET_DESCRIPTIONS: dict[str, str] = {
+    "crsp": "CRSP stock and index history",
+    "compustat": "Compustat fundamentals",
+    "taq": "TAQ intraday market data",
+    "fama_french": "Fama-French factor datasets",
+    ALPACA_SIP_DATASET_KEY: "Alpaca SIP local canonical data",
+}
+_PREFERRED_PREVIEW_TABLES: dict[str, tuple[str, ...]] = {
+    ALPACA_SIP_DATASET_KEY: ("alpaca_sip_daily", "alpaca_sip_corp_actions"),
+}
+_ALPACA_SIP_TABLE_MANIFEST_DATASETS: dict[str, str] = {
+    "alpaca_sip_daily": ALPACA_SIP_DAILY_DATASET,
+    "alpaca_sip_corp_actions": ALPACA_SIP_CORP_ACTIONS_DATASET,
+}
+_PREFERRED_HANDOFF_QUERY_LABELS: dict[str, tuple[str, ...]] = {
+    "crsp": ("Preview crsp_daily",),
+    "compustat": ("Preview compustat_annual",),
+    "fama_french": ("Preview ff_factors_daily",),
+    "taq": ("Preview taq_trades",),
+    ALPACA_SIP_DATASET_KEY: ("Latest daily bars", "Recent corporate actions"),
+}
+_NULL_COLUMN_REASONS_BY_TABLE: dict[str, dict[str, str]] = {
+    "alpaca_sip_daily": {
+        "adj_close": "raw_sip_returns_unavailable",
+        "ret": "raw_sip_returns_unavailable",
+    }
+}
 
 
 class RateLimitExceeded(RuntimeError):
@@ -42,9 +108,19 @@ class DataExplorerService:
         self,
         rate_limiter: RateLimiter | None = None,
         sql_validator: SQLValidator | None = None,
+        manifest_service: DataManifestService | None = None,
+        table_paths: dict[str, TablePathSpec] | None = None,
     ) -> None:
         self._rate_limiter = rate_limiter or get_rate_limiter()
         self._sql_validator = sql_validator or SQLValidator()
+        self._manifest_service = manifest_service or DataManifestService()
+        self._table_paths = table_paths
+        self._table_availability_cache: (
+            tuple[float, tuple[dict[str, SqlTableResolution], list[str]]] | None
+        ) = None
+        self._table_availability_lock = asyncio.Lock()
+        self._alpaca_summary_cache: tuple[float, Any | None, bool] | None = None
+        self._alpaca_summary_lock = asyncio.Lock()
 
     async def list_datasets(self, user: Any) -> list[DatasetInfoDTO]:
         """List available datasets with metadata.
@@ -54,37 +130,237 @@ class DataExplorerService:
         """
         self._require_permission(user, Permission.VIEW_DATA_SYNC)
 
-        now = datetime.now(UTC)
-        mock = [
-            DatasetInfoDTO(
-                name=dataset,
-                description="Placeholder dataset",
-                row_count=1000,
-                date_range={"start": "2000-01-01", "end": "2024-12-31"},
-                symbol_count=500,
-                last_sync=now,
+        (
+            (table_resolutions, _warnings),
+            (
+                alpaca_summary,
+                alpaca_summary_error,
+            ),
+        ) = await asyncio.gather(
+            self._resolve_table_availability(),
+            self._get_alpaca_summary(),
+        )
+
+        datasets: list[DatasetInfoDTO] = []
+        for dataset in _SUPPORTED_DATASETS:
+            if not has_dataset_permission(user, dataset):
+                continue
+            dataset_resolutions = [
+                resolution
+                for resolution in table_resolutions.values()
+                if resolution.dataset == dataset
+            ]
+            available_tables = sorted(
+                resolution.table
+                for resolution in dataset_resolutions
+                if resolution.available and not resolution.manifest_invalid
             )
-            for dataset in _SUPPORTED_DATASETS
-        ]
-        return [item for item in mock if has_dataset_permission(user, item.name)]
+            trusted_tables = sorted(
+                resolution.table
+                for resolution in dataset_resolutions
+                if resolution.trusted_for_data_page
+            )
+            fallback_tables = sorted(
+                resolution.table
+                for resolution in dataset_resolutions
+                if resolution.available and resolution.fallback_only and not resolution.manifest_invalid
+            )
+            invalid_manifest_tables = sorted(
+                resolution.table
+                for resolution in dataset_resolutions
+                if resolution.manifest_invalid
+            )
+            queryable_state = _queryable_state(
+                available_tables=available_tables,
+                trusted_tables=trusted_tables,
+                fallback_tables=fallback_tables,
+                manifest_required=any(
+                    resolution.manifest_required for resolution in dataset_resolutions
+                ),
+            )
+            row_count: int | None = None
+            date_range: dict[str, str] | None = None
+            last_sync = None
+            if (
+                dataset == ALPACA_SIP_DATASET_KEY
+                and alpaca_summary is not None
+                and alpaca_summary.has_any_manifest
+                and trusted_tables
+            ):
+                trusted_manifests = _trusted_alpaca_summary_manifests(
+                    alpaca_summary,
+                    trusted_tables,
+                )
+                if trusted_manifests:
+                    row_count = sum(
+                        int(getattr(manifest, "row_count", 0) or 0)
+                        for manifest in trusted_manifests
+                    )
+                    sync_timestamps = [
+                        sync_timestamp
+                        for manifest in trusted_manifests
+                        if (sync_timestamp := getattr(manifest, "sync_timestamp", None))
+                        is not None
+                    ]
+                    last_sync = max(sync_timestamps, default=None)
+                    starts = [manifest.start_date for manifest in trusted_manifests]
+                    ends = [manifest.end_date for manifest in trusted_manifests]
+                    if starts and ends:
+                        date_range = {
+                            "start": min(starts).isoformat(),
+                            "end": max(ends).isoformat(),
+                        }
+
+            datasets.append(
+                DatasetInfoDTO(
+                    name=dataset,
+                    description=_dataset_description(dataset, queryable_state),
+                    row_count=row_count,
+                    date_range=date_range,
+                    symbol_count=None,
+                    last_sync=last_sync,
+                    tables=trusted_tables or available_tables,
+                    queryable_state=queryable_state,
+                    trusted_manifest_backed=any(
+                        resolution.trusted_for_data_page and resolution.manifest_backed
+                        for resolution in dataset_resolutions
+                    ),
+                    manifest_required=any(
+                        resolution.manifest_required for resolution in dataset_resolutions
+                    ),
+                    availability_reason=_availability_reason(
+                        queryable_state=queryable_state,
+                        fallback_tables=fallback_tables,
+                        invalid_manifest_tables=invalid_manifest_tables,
+                        alpaca_summary_unavailable=(
+                            dataset == ALPACA_SIP_DATASET_KEY and alpaca_summary_error
+                        ),
+                    ),
+                    sql_handoff_url=_sql_handoff_url(dataset, trusted_tables),
+                    query_templates=_query_templates_for_dataset(dataset, trusted_tables),
+                )
+            )
+
+        return datasets
 
     async def get_dataset_preview(
         self,
         user: Any,
         dataset: str,
         limit: int = 100,
+        table: str | None = None,
     ) -> DataPreviewDTO:
         """Get first N rows of dataset.
 
         Permission: QUERY_DATA + dataset-level access
         Limit: Max 1000 rows
         """
-        self._require_permission(user, Permission.QUERY_DATA)
-        self._require_dataset_access(user, dataset)
-        if limit > 1000:
-            raise ValueError("Preview limit cannot exceed 1000 rows")
+        started = time.monotonic()
+        query = ""
+        try:
+            self._require_permission(user, Permission.QUERY_DATA)
+            self._require_dataset_access(user, dataset)
+            if limit > 1000:
+                raise ValueError("Preview limit cannot exceed 1000 rows")
+            if limit <= 0:
+                raise ValueError("Preview limit must be positive")
 
-        return DataPreviewDTO(columns=[], rows=[], total_count=0)
+            table_name, trusted_table_paths, resolution = await self._select_preview_table(
+                dataset,
+                requested_table=table,
+            )
+            await self._enforce_rate_limit(
+                user,
+                action="data_preview",
+                max_requests=_PREVIEW_RATE_LIMIT,
+                window=60,
+            )
+            fetch_limit = limit + 1
+            query = f"SELECT * FROM {table_name} LIMIT {fetch_limit}"
+            frame = await self._execute_sql_frame(
+                dataset=dataset,
+                sql=query,
+                table_paths=trusted_table_paths,
+                timeout_seconds=_PREVIEW_TIMEOUT_SECONDS,
+            )
+            fetched_row_count = len(frame)
+            has_more = fetched_row_count > limit
+            if has_more:
+                frame = frame.head(limit)
+            preview_provenance = await self._preview_provenance_for_table(table_name)
+            execution_ms = int((time.monotonic() - started) * 1000)
+            log_sql_query_audit(
+                user,
+                dataset,
+                query,
+                query,
+                len(frame),
+                execution_ms,
+                "success",
+                None,
+            )
+
+            return DataPreviewDTO(
+                columns=list(frame.columns),
+                rows=frame.to_dicts(),
+                total_count=fetched_row_count,
+                has_more=has_more,
+                table=table_name,
+                queryable_state=_queryable_state_for_table(resolution),
+                trusted_manifest_backed=resolution.manifest_backed,
+                sql_handoff_url=_sql_handoff_url(dataset, [table_name]),
+                **preview_provenance,
+            )
+        except PermissionError:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                None,
+                started,
+                "authorization_denied",
+                None,
+            )
+            raise
+        except RateLimitExceeded as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                None,
+                started,
+                "rate_limited",
+                str(exc),
+            )
+            raise
+        except ValueError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                None,
+                started,
+                "validation_error",
+                str(exc),
+            )
+            raise
+        except TimeoutError:
+            self._audit_query_failure(user, dataset, query, None, started, "timeout", None)
+            raise
+        except ConcurrencyLimitError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                None,
+                started,
+                "concurrency_limit",
+                str(exc),
+            )
+            raise
+        except Exception as exc:
+            self._audit_query_failure(user, dataset, query, None, started, "error", str(exc))
+            raise
 
     async def execute_query(
         self,
@@ -92,8 +368,8 @@ class DataExplorerService:
         dataset: str,
         query: str,
         timeout_seconds: int = 30,
+        max_rows: int = _INTERACTIVE_ROW_LIMIT,
     ) -> QueryResultDTO:
-        # TODO: Pass timeout_seconds to DuckDB client when query execution is implemented
         """Execute read-only SQL query against a SINGLE dataset.
 
         Permission: QUERY_DATA + dataset-level access for specified dataset
@@ -105,21 +381,143 @@ class DataExplorerService:
         CRITICAL: Query is scoped to specified dataset only.
         Cross-dataset queries are rejected at validation time.
         """
-        self._require_permission(user, Permission.QUERY_DATA)
-        self._require_dataset_access(user, dataset)
+        started = time.monotonic()
+        limited_query: str | None = None
+        try:
+            self._require_permission(user, Permission.QUERY_DATA)
+            self._require_dataset_access(user, dataset)
 
-        # Validate SQL before rate limiting to fail fast on invalid queries
-        valid, error = self._sql_validator.validate(query, dataset)
-        if not valid:
-            raise ValueError(f"Invalid query: {error}")
+            if max_rows <= 0:
+                raise ValueError("Query row limit must be positive")
 
-        # Enforce row limit for interactive queries (10,000 max)
-        query = self._sql_validator.enforce_row_limit(query, max_rows=10000)
+            # Validate SQL before rate limiting to fail fast on invalid queries
+            valid, error = self._sql_validator.validate(query, dataset)
+            if not valid:
+                raise ValueError(f"Invalid query: {error}")
+            result_row_limit = min(max_rows, _INTERACTIVE_ROW_LIMIT)
 
-        await self._enforce_rate_limit(user, action="data_query", max_requests=10, window=60)
+            tables = list(self._sql_validator.extract_tables(query) or [])
+            check_sensitive_tables(tables)
+            self._require_literal_smoke_query_when_tableless(query, tables)
 
-        # TODO: Execute query against DuckDB and return actual results
-        return QueryResultDTO(columns=[], rows=[], total_count=0, has_more=False, cursor=None)
+            trusted_table_paths = await self._trusted_available_tables_for_query(dataset, tables)
+
+            await self._enforce_rate_limit(user, action="data_query", max_requests=10, window=60)
+
+            fetch_limit = min(result_row_limit + 1, _INTERACTIVE_FETCH_LIMIT)
+            limited_query = self._sql_validator.enforce_row_limit(
+                query,
+                max_rows=fetch_limit,
+            )
+
+            frame = await self._execute_sql_frame(
+                dataset=dataset,
+                sql=limited_query,
+                table_paths=trusted_table_paths,
+                timeout_seconds=timeout_seconds,
+            )
+            fetched_row_count = len(frame)
+            has_more = fetched_row_count > result_row_limit
+            if has_more:
+                frame = frame.head(result_row_limit)
+            execution_ms = int((time.monotonic() - started) * 1000)
+            log_sql_query_audit(
+                user,
+                dataset,
+                query,
+                limited_query,
+                fetched_row_count,
+                execution_ms,
+                "success",
+                None,
+            )
+            return QueryResultDTO(
+                columns=list(frame.columns),
+                rows=frame.to_dicts(),
+                total_count=fetched_row_count,
+                has_more=has_more,
+                cursor=None,
+                execution_ms=execution_ms,
+                fingerprint=fingerprint_sql_query(query),
+            )
+        except PermissionError:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "authorization_denied",
+                None,
+            )
+            raise
+        # SensitiveTableAccessError subclasses ValueError; keep this branch first.
+        except SensitiveTableAccessError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "security_blocked",
+                str(exc),
+            )
+            raise
+        except RateLimitExceeded as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "rate_limited",
+                str(exc),
+            )
+            raise
+        except TimeoutError:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "timeout",
+                None,
+            )
+            raise
+        except ConcurrencyLimitError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "concurrency_limit",
+                str(exc),
+            )
+            raise
+        except ValueError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "validation_error",
+                str(exc),
+            )
+            raise
+        except Exception as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "error",
+                str(exc),
+            )
+            raise
 
     async def export_data(
         self,
@@ -136,29 +534,110 @@ class DataExplorerService:
         Audit: Logged with user, dataset, query_fingerprint, row_count, format
         Storage: Temp directory with 24-hour TTL, auto-cleanup via cron job
         """
-        self._require_permission(user, Permission.EXPORT_DATA)
-        self._require_dataset_access(user, dataset)
+        started = time.monotonic()
+        limited_query: str | None = None
+        try:
+            self._require_permission(user, Permission.EXPORT_DATA)
+            self._require_dataset_access(user, dataset)
 
-        # Validate SQL before rate limiting to fail fast on invalid queries
-        valid, error = self._sql_validator.validate(query, dataset)
-        if not valid:
-            raise ValueError(f"Invalid query: {error}")
+            # Validate SQL before rate limiting to fail fast on invalid queries
+            valid, error = self._sql_validator.validate(query, dataset)
+            if not valid:
+                raise ValueError(f"Invalid query: {error}")
 
-        # Enforce row limit for exports (100,000 max)
-        query = self._sql_validator.enforce_row_limit(query, max_rows=100000)
+            tables = list(self._sql_validator.extract_tables(query) or [])
+            check_sensitive_tables(tables)
+            self._require_literal_smoke_query_when_tableless(query, tables)
 
-        await self._enforce_rate_limit(user, action="data_export", max_requests=5, window=3600)
+            await self._trusted_available_tables_for_query(dataset, tables)
 
-        # TODO: Queue export job to background worker
-        now = datetime.now(UTC)
-        return ExportJobDTO(
-            id=str(uuid4()),
-            status="queued",
-            format=format,
-            row_count=None,
-            file_path=None,
-            expires_at=now,
-        )
+            await self._enforce_rate_limit(
+                user,
+                action="data_export",
+                max_requests=DATA_EXPORT_RATE_LIMIT,
+                window=DATA_EXPORT_WINDOW_SECONDS,
+            )
+
+            limited_query = self._sql_validator.enforce_row_limit(query, max_rows=_EXPORT_ROW_LIMIT)
+
+            execution_ms = int((time.monotonic() - started) * 1000)
+            log_sql_query_audit(
+                user,
+                dataset,
+                query,
+                limited_query,
+                0,
+                execution_ms,
+                "queued",
+                None,
+            )
+
+            # TODO: Queue export job to background worker
+            now = datetime.now(UTC)
+            return ExportJobDTO(
+                id=str(uuid4()),
+                status="queued",
+                format=format,
+                row_count=None,
+                file_path=None,
+                expires_at=now,
+            )
+        except PermissionError:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "authorization_denied",
+                None,
+            )
+            raise
+        # SensitiveTableAccessError subclasses ValueError; keep this branch first.
+        except SensitiveTableAccessError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "security_blocked",
+                str(exc),
+            )
+            raise
+        except RateLimitExceeded as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "rate_limited",
+                str(exc),
+            )
+            raise
+        except ValueError as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "validation_error",
+                str(exc),
+            )
+            raise
+        except Exception as exc:
+            self._audit_query_failure(
+                user,
+                dataset,
+                query,
+                limited_query,
+                started,
+                "error",
+                str(exc),
+            )
+            raise
 
     def _require_permission(self, user: Any, permission: Permission) -> None:
         if not has_permission(user, permission):
@@ -200,5 +679,448 @@ class DataExplorerService:
             window_seconds=window,
         )
 
+    async def _resolve_table_availability(
+        self,
+    ) -> tuple[dict[str, SqlTableResolution], list[str]]:
+        now = time.monotonic()
+        if (
+            self._table_availability_cache is not None
+            and now - self._table_availability_cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
+        ):
+            return self._table_availability_cache[1]
 
-__all__ = ["DataExplorerService", "RateLimitExceeded"]
+        async with self._table_availability_lock:
+            now = time.monotonic()
+            if (
+                self._table_availability_cache is not None
+                and now - self._table_availability_cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
+            ):
+                return self._table_availability_cache[1]
+
+            result = await asyncio.to_thread(resolve_sql_table_availability, self._table_paths)
+            self._table_availability_cache = (now, result)
+            return result
+
+    async def _get_alpaca_summary(self) -> tuple[Any | None, bool]:
+        now = time.monotonic()
+        cache_ttl = (
+            _MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS
+            if self._alpaca_summary_cache is not None and self._alpaca_summary_cache[2]
+            else _MANIFEST_SUMMARY_CACHE_TTL_SECONDS
+        )
+        if (
+            self._alpaca_summary_cache is not None
+            and now - self._alpaca_summary_cache[0] < cache_ttl
+        ):
+            return self._alpaca_summary_cache[1], self._alpaca_summary_cache[2]
+
+        async with self._alpaca_summary_lock:
+            now = time.monotonic()
+            cache_ttl = (
+                _MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS
+                if self._alpaca_summary_cache is not None and self._alpaca_summary_cache[2]
+                else _MANIFEST_SUMMARY_CACHE_TTL_SECONDS
+            )
+            if (
+                self._alpaca_summary_cache is not None
+                and now - self._alpaca_summary_cache[0] < cache_ttl
+            ):
+                return self._alpaca_summary_cache[1], self._alpaca_summary_cache[2]
+
+            try:
+                alpaca_summary = await asyncio.wait_for(
+                    asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary),
+                    timeout=_MANIFEST_SUMMARY_TIMEOUT_SECONDS,
+                )
+                self._alpaca_summary_cache = (time.monotonic(), alpaca_summary, False)
+                return alpaca_summary, False
+            except Exception as exc:
+                logger.warning(
+                    "data_explorer_alpaca_manifest_summary_unavailable",
+                    extra={"error_type": type(exc).__name__},
+                    exc_info=True,
+                )
+                self._alpaca_summary_cache = (time.monotonic(), None, True)
+                return None, True
+
+    async def _preview_provenance_for_table(self, table_name: str) -> dict[str, Any]:
+        null_column_reasons = dict(_NULL_COLUMN_REASONS_BY_TABLE.get(table_name, {}))
+        warnings = sorted(set(null_column_reasons.values()))
+        manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table_name)
+        if manifest_dataset is None:
+            return {
+                "null_column_reasons": null_column_reasons,
+                "warnings": warnings,
+            }
+
+        alpaca_summary, summary_unavailable = await self._get_alpaca_summary()
+        if alpaca_summary is None or summary_unavailable:
+            return {
+                "null_column_reasons": null_column_reasons,
+                "warnings": [*warnings, "alpaca_sip_manifest_summary_unavailable"],
+            }
+
+        manifest = next(
+            (
+                candidate
+                for candidate in getattr(alpaca_summary, "manifests", [])
+                if getattr(candidate, "dataset", None) == manifest_dataset
+            ),
+            None,
+        )
+        if manifest is None:
+            return {
+                "null_column_reasons": null_column_reasons,
+                "warnings": [*warnings, f"alpaca_sip_missing_manifest:{manifest_dataset}"],
+            }
+
+        manifest_version = getattr(manifest, "manifest_version", None)
+        return {
+            "manifest_id": getattr(manifest, "manifest_id", None),
+            "manifest_reference": getattr(manifest, "manifest_reference", None),
+            "manifest_checksum": getattr(manifest, "manifest_checksum", None),
+            "manifest_version": str(manifest_version) if manifest_version is not None else None,
+            "provider_id": getattr(manifest, "provider_id", None),
+            "provider_version": getattr(manifest, "provider_version", None),
+            "source_feed": getattr(manifest, "source_feed", None),
+            "adjustment_mode": getattr(manifest, "adjustment_mode", None),
+            "canonical_storage_mode": getattr(manifest, "canonical_storage_mode", None),
+            "read_time_adjustment_mode": getattr(
+                manifest,
+                "read_time_adjustment_mode",
+                None,
+            ),
+            "provider_signature": getattr(manifest, "provider_signature", None),
+            "null_column_reasons": null_column_reasons,
+            "warnings": warnings,
+        }
+
+    def _audit_query_failure(
+        self,
+        user: Any,
+        dataset: str,
+        query: str,
+        limited_query: str | None,
+        started: float,
+        status: str,
+        error_message: str | None,
+    ) -> None:
+        execution_ms = int((time.monotonic() - started) * 1000)
+        log_sql_query_audit(
+            user,
+            dataset,
+            query,
+            limited_query,
+            0,
+            execution_ms,
+            status,
+            error_message,
+        )
+
+    async def _select_preview_table(
+        self,
+        dataset: str,
+        *,
+        requested_table: str | None,
+    ) -> tuple[str, dict[str, TablePathSpec], SqlTableResolution]:
+        table_resolutions, _warnings = await self._resolve_table_availability()
+        allowed_tables = DATASET_TABLES.get(dataset)
+        if not allowed_tables:
+            raise ValueError(f"Unknown dataset: {dataset}")
+        candidate_tables = (
+            [requested_table]
+            if requested_table
+            else _preview_candidate_tables(dataset, allowed_tables)
+        )
+        trusted_table_paths = _trusted_table_paths_for_dataset(table_resolutions, dataset)
+        saw_fallback_only = False
+        saw_manifest_invalid = False
+        saw_available = False
+        for table in candidate_tables:
+            if table not in allowed_tables:
+                raise ValueError(f"Table {table} is not available for dataset {dataset}")
+            resolution = table_resolutions.get(table)
+            if resolution is None or not resolution.available:
+                if resolution is not None and resolution.manifest_invalid:
+                    saw_manifest_invalid = True
+                    if requested_table is not None:
+                        raise ValueError(
+                            f"Trusted manifest is invalid for table {table}; re-run validation"
+                        )
+                if requested_table is not None:
+                    raise ValueError(f"No local data available for table {table}")
+                continue
+            saw_available = True
+            if not resolution.trusted_for_data_page:
+                saw_fallback_only = saw_fallback_only or resolution.fallback_only
+                saw_manifest_invalid = saw_manifest_invalid or resolution.manifest_invalid
+                if requested_table is not None:
+                    if resolution.manifest_invalid:
+                        raise ValueError(
+                            f"Trusted manifest is invalid for table {table}; re-run validation"
+                        )
+                    if resolution.fallback_only:
+                        raise ValueError(
+                            f"{table} is queryable fallback only; trusted manifest required for /data"
+                        )
+                    raise ValueError(
+                        f"No trusted local data available for table {table}"
+                    )
+                continue
+            return table, {table: trusted_table_paths[table]}, resolution
+
+        if saw_manifest_invalid:
+            raise ValueError(f"Trusted manifest is invalid for {dataset}; re-run validation")
+        if saw_fallback_only:
+            raise ValueError(f"Fallback parquet exists for {dataset}; trusted manifest required")
+        if saw_available:
+            raise ValueError(f"No trusted local data available for {dataset}")
+        raise ValueError(f"No trusted local data available for {dataset}")
+
+    async def _trusted_available_tables_for_query(
+        self,
+        dataset: str,
+        referenced_tables: list[str],
+    ) -> dict[str, TablePathSpec]:
+        if not referenced_tables:
+            return {}
+
+        table_resolutions, _warnings = await self._resolve_table_availability()
+        trusted_table_paths = _trusted_table_paths_for_dataset(table_resolutions, dataset)
+
+        for table in referenced_tables:
+            resolution = table_resolutions.get(table)
+            if resolution is None or resolution.dataset != dataset:
+                raise ValueError(f"Table {table} is not available for dataset {dataset}")
+            if not resolution.available:
+                if resolution.manifest_invalid:
+                    raise ValueError(
+                        f"Trusted manifest is invalid for table {table}; re-run validation"
+                    )
+                raise ValueError(f"No local data available for table {table}")
+            if not resolution.trusted_for_data_page:
+                if resolution.manifest_invalid:
+                    raise ValueError(
+                        f"Trusted manifest is invalid for table {table}; re-run validation"
+                    )
+                if resolution.fallback_only:
+                    raise ValueError(
+                        f"{table} is queryable fallback only; trusted manifest required for /data"
+                    )
+                raise ValueError(
+                    f"No trusted local data available for table {table}"
+                )
+        missing_trusted = sorted(set(referenced_tables) - set(trusted_table_paths))
+        if missing_trusted:
+            raise ValueError(
+                "Trusted local data required for tables: " + ", ".join(missing_trusted)
+            )
+        return {table: trusted_table_paths[table] for table in sorted(set(referenced_tables))}
+
+    def _require_literal_smoke_query_when_tableless(
+        self,
+        query: str,
+        referenced_tables: list[str],
+    ) -> None:
+        if referenced_tables:
+            return
+        if not self._sql_validator.is_literal_smoke_query(query):
+            raise ValueError(
+                "Tableless queries must be a single literal SELECT, such as SELECT 1; "
+                "reference an approved dataset table for data access"
+            )
+
+    async def _execute_sql_frame(
+        self,
+        *,
+        dataset: str,
+        sql: str,
+        table_paths: dict[str, TablePathSpec],
+        timeout_seconds: int,
+    ) -> Any:
+        await asyncio.to_thread(ensure_sql_explorer_execution_allowed)
+        conn = await asyncio.to_thread(
+            create_scoped_query_connection,
+            dataset,
+            available_tables=set(table_paths),
+            table_paths=table_paths,
+        )
+        try:
+            return await execute_scoped_query_with_timeout(conn, sql, timeout_seconds)
+        finally:
+            await asyncio.to_thread(conn.close)
+
+
+def _trusted_table_paths_for_dataset(
+    table_resolutions: dict[str, SqlTableResolution],
+    dataset: str,
+) -> dict[str, TablePathSpec]:
+    trusted_paths: dict[str, TablePathSpec] = {}
+    for item in table_resolutions.values():
+        if item.dataset != dataset or not item.trusted_for_data_page or item.path_spec is None:
+            continue
+        trusted_paths[item.table] = item.path_spec
+    return trusted_paths
+
+
+def _preview_candidate_tables(dataset: str, allowed_tables: list[str]) -> list[str]:
+    allowed_set = set(allowed_tables)
+    preferred = _PREFERRED_PREVIEW_TABLES.get(dataset, ())
+    ordered = [table for table in preferred if table in allowed_set]
+    ordered.extend(sorted(allowed_set - set(ordered)))
+    return ordered
+
+
+def _queryable_state(
+    *,
+    available_tables: list[str],
+    trusted_tables: list[str],
+    fallback_tables: list[str],
+    manifest_required: bool,
+) -> str:
+    if trusted_tables:
+        return "trusted_manifest_backed" if manifest_required else "queryable"
+    if fallback_tables:
+        return "queryable_fallback_only"
+    if available_tables:
+        return "queryable"
+    return "missing"
+
+
+def _queryable_state_for_table(resolution: SqlTableResolution) -> str:
+    if resolution.manifest_backed:
+        return "trusted_manifest_backed"
+    if resolution.fallback_only:
+        return "queryable_fallback_only"
+    if resolution.available:
+        return "queryable"
+    return "missing"
+
+
+def _trusted_alpaca_summary_manifests(alpaca_summary: Any, trusted_tables: list[str]) -> list[Any]:
+    trusted_table_set = set(trusted_tables)
+    return [
+        manifest
+        for manifest in alpaca_summary.manifests
+        if getattr(manifest, "dataset", None) in trusted_table_set
+        and str(getattr(manifest, "validation_status", "")).lower() == "passed"
+    ]
+
+
+def _dataset_description(dataset: str, queryable_state: str) -> str:
+    base = _DATASET_DESCRIPTIONS.get(dataset, dataset)
+    return f"{base}; state={queryable_state}"
+
+
+def _availability_reason(
+    *,
+    queryable_state: str,
+    fallback_tables: list[str],
+    invalid_manifest_tables: list[str],
+    alpaca_summary_unavailable: bool = False,
+) -> str | None:
+    if invalid_manifest_tables:
+        return (
+            "Trusted manifest is invalid or has no valid parquet files "
+            f"({', '.join(invalid_manifest_tables)})"
+        )
+    if queryable_state == "queryable_fallback_only":
+        return (
+            "Fallback parquet exists without a trusted manifest; use standalone SQL Explorer "
+            f"for local inspection only ({', '.join(fallback_tables)})"
+        )
+    if alpaca_summary_unavailable:
+        return (
+            "Manifest summary temporarily unavailable; row count and date range may be incomplete"
+        )
+    if queryable_state == "missing":
+        return "No local parquet files discovered"
+    return None
+
+
+def _sql_handoff_url(dataset: str, tables: list[str]) -> str | None:
+    if not tables:
+        return None
+    query = _handoff_query_for_dataset(dataset, tables)
+    return "/data/sql-explorer?" + urlencode({"dataset": dataset, "query": query})
+
+
+def _handoff_query_for_dataset(dataset: str, tables: list[str]) -> str:
+    templates = _query_templates_for_dataset(dataset, tables)
+    preferred_labels = _PREFERRED_HANDOFF_QUERY_LABELS.get(dataset, ())
+    for label in preferred_labels:
+        for template in templates:
+            if template.label == label:
+                return template.sql
+    for table in tables:
+        for template in templates:
+            if template.table == table:
+                return template.sql
+    return templates[0].sql
+
+
+def _query_templates_for_dataset(dataset: str, tables: list[str]) -> list[QueryTemplateDTO]:
+    if not tables:
+        return []
+    templates: list[QueryTemplateDTO] = []
+    table_set = set(tables)
+    if "alpaca_sip_daily" in table_set:
+        templates.extend(
+            [
+                QueryTemplateDTO(
+                    label="Latest daily bars",
+                    table="alpaca_sip_daily",
+                    sql="SELECT * FROM alpaca_sip_daily ORDER BY date DESC, symbol LIMIT 100",
+                ),
+                QueryTemplateDTO(
+                    label="Date coverage by symbol",
+                    table="alpaca_sip_daily",
+                    sql=(
+                        "SELECT symbol, min(date) AS start_date, max(date) AS end_date, "
+                        "count(*) AS rows FROM alpaca_sip_daily "
+                        "GROUP BY symbol ORDER BY symbol LIMIT 100"
+                    ),
+                ),
+                QueryTemplateDTO(
+                    label="Rows by partition year",
+                    table="alpaca_sip_daily",
+                    sql=(
+                        "SELECT year(date) AS year, count(*) AS rows "
+                        "FROM alpaca_sip_daily GROUP BY year ORDER BY year"
+                    ),
+                ),
+                QueryTemplateDTO(
+                    label="Null adjusted-return columns",
+                    table="alpaca_sip_daily",
+                    sql=(
+                        "SELECT date, symbol, adj_close, ret FROM alpaca_sip_daily "
+                        "WHERE adj_close IS NULL OR ret IS NULL LIMIT 100"
+                    ),
+                ),
+            ]
+        )
+    if "alpaca_sip_corp_actions" in table_set:
+        templates.append(
+            QueryTemplateDTO(
+                label="Recent corporate actions",
+                table="alpaca_sip_corp_actions",
+                sql=(
+                    "SELECT * FROM alpaca_sip_corp_actions "
+                    "ORDER BY ex_date DESC, symbol LIMIT 100"
+                ),
+            )
+        )
+    for table in tables:
+        if table in {"alpaca_sip_daily", "alpaca_sip_corp_actions"}:
+            continue
+        templates.append(
+            QueryTemplateDTO(
+                label=f"Preview {table}",
+                table=table,
+                sql=f"SELECT * FROM {table} LIMIT 100",
+            )
+        )
+    return templates
+
+
+__all__ = ["DATA_EXPORT_RATE_LIMIT", "DataExplorerService", "RateLimitExceeded"]

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -63,6 +63,12 @@ _TABLE_AVAILABILITY_CACHE_TTL_SECONDS = 30
 _MANIFEST_SUMMARY_CACHE_TTL_SECONDS = 30
 _MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS = 5
 _MANIFEST_SUMMARY_TIMEOUT_SECONDS = 5.0
+_TableAvailabilityCache = tuple[float, tuple[dict[str, SqlTableResolution], list[str]]]
+_AlpacaSummaryCache = tuple[float, Any | None, bool]
+_SHARED_TABLE_AVAILABILITY_CACHE: _TableAvailabilityCache | None = None
+_SHARED_TABLE_AVAILABILITY_LOCK = asyncio.Lock()
+_SHARED_ALPACA_SUMMARY_CACHE: _AlpacaSummaryCache | None = None
+_SHARED_ALPACA_SUMMARY_LOCK = asyncio.Lock()
 
 _DATASET_DESCRIPTIONS: dict[str, str] = {
     "crsp": "CRSP stock and index history",
@@ -112,13 +118,13 @@ class DataExplorerService:
     ) -> None:
         self._rate_limiter = rate_limiter or get_rate_limiter()
         self._sql_validator = sql_validator or SQLValidator()
+        self._uses_shared_alpaca_summary_cache = manifest_service is None
         self._manifest_service = manifest_service or DataManifestService()
         self._table_paths = table_paths
-        self._table_availability_cache: (
-            tuple[float, tuple[dict[str, SqlTableResolution], list[str]]] | None
-        ) = None
+        self._uses_shared_table_availability_cache = table_paths is None
+        self._table_availability_cache: _TableAvailabilityCache | None = None
         self._table_availability_lock = asyncio.Lock()
-        self._alpaca_summary_cache: tuple[float, Any | None, bool] | None = None
+        self._alpaca_summary_cache: _AlpacaSummaryCache | None = None
         self._alpaca_summary_lock = asyncio.Lock()
 
     async def list_datasets(self, user: Any) -> list[DatasetInfoDTO]:
@@ -681,57 +687,92 @@ class DataExplorerService:
     async def _resolve_table_availability(
         self,
     ) -> tuple[dict[str, SqlTableResolution], list[str]]:
-        now = time.monotonic()
-        if (
-            self._table_availability_cache is not None
-            and now - self._table_availability_cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
-        ):
-            return self._table_availability_cache[1]
+        global _SHARED_TABLE_AVAILABILITY_CACHE
 
-        async with self._table_availability_lock:
+        now = time.monotonic()
+        cache = (
+            _SHARED_TABLE_AVAILABILITY_CACHE
+            if self._uses_shared_table_availability_cache
+            else self._table_availability_cache
+        )
+        if (
+            cache is not None
+            and now - cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
+        ):
+            return cache[1]
+
+        lock = (
+            _SHARED_TABLE_AVAILABILITY_LOCK
+            if self._uses_shared_table_availability_cache
+            else self._table_availability_lock
+        )
+        async with lock:
             now = time.monotonic()
+            cache = (
+                _SHARED_TABLE_AVAILABILITY_CACHE
+                if self._uses_shared_table_availability_cache
+                else self._table_availability_cache
+            )
             if (
-                self._table_availability_cache is not None
-                and now - self._table_availability_cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
+                cache is not None
+                and now - cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
             ):
-                return self._table_availability_cache[1]
+                return cache[1]
 
             result = await asyncio.to_thread(resolve_sql_table_availability, self._table_paths)
-            self._table_availability_cache = (now, result)
+            if self._uses_shared_table_availability_cache:
+                _SHARED_TABLE_AVAILABILITY_CACHE = (now, result)
+            else:
+                self._table_availability_cache = (now, result)
             return result
 
     async def _get_alpaca_summary(self) -> tuple[Any | None, bool]:
+        global _SHARED_ALPACA_SUMMARY_CACHE
+
         now = time.monotonic()
+        cache = (
+            _SHARED_ALPACA_SUMMARY_CACHE
+            if self._uses_shared_alpaca_summary_cache
+            else self._alpaca_summary_cache
+        )
         cache_ttl = (
             _MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS
-            if self._alpaca_summary_cache is not None and self._alpaca_summary_cache[2]
+            if cache is not None and cache[2]
             else _MANIFEST_SUMMARY_CACHE_TTL_SECONDS
         )
-        if (
-            self._alpaca_summary_cache is not None
-            and now - self._alpaca_summary_cache[0] < cache_ttl
-        ):
-            return self._alpaca_summary_cache[1], self._alpaca_summary_cache[2]
+        if cache is not None and now - cache[0] < cache_ttl:
+            return cache[1], cache[2]
 
-        async with self._alpaca_summary_lock:
+        lock = (
+            _SHARED_ALPACA_SUMMARY_LOCK
+            if self._uses_shared_alpaca_summary_cache
+            else self._alpaca_summary_lock
+        )
+        async with lock:
             now = time.monotonic()
+            cache = (
+                _SHARED_ALPACA_SUMMARY_CACHE
+                if self._uses_shared_alpaca_summary_cache
+                else self._alpaca_summary_cache
+            )
             cache_ttl = (
                 _MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS
-                if self._alpaca_summary_cache is not None and self._alpaca_summary_cache[2]
+                if cache is not None and cache[2]
                 else _MANIFEST_SUMMARY_CACHE_TTL_SECONDS
             )
-            if (
-                self._alpaca_summary_cache is not None
-                and now - self._alpaca_summary_cache[0] < cache_ttl
-            ):
-                return self._alpaca_summary_cache[1], self._alpaca_summary_cache[2]
+            if cache is not None and now - cache[0] < cache_ttl:
+                return cache[1], cache[2]
 
             try:
                 alpaca_summary = await asyncio.wait_for(
                     asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary),
                     timeout=_MANIFEST_SUMMARY_TIMEOUT_SECONDS,
                 )
-                self._alpaca_summary_cache = (time.monotonic(), alpaca_summary, False)
+                next_cache: _AlpacaSummaryCache = (time.monotonic(), alpaca_summary, False)
+                if self._uses_shared_alpaca_summary_cache:
+                    _SHARED_ALPACA_SUMMARY_CACHE = next_cache
+                else:
+                    self._alpaca_summary_cache = next_cache
                 return alpaca_summary, False
             except Exception as exc:
                 logger.warning(
@@ -739,7 +780,11 @@ class DataExplorerService:
                     extra={"error_type": type(exc).__name__},
                     exc_info=True,
                 )
-                self._alpaca_summary_cache = (time.monotonic(), None, True)
+                next_cache = (time.monotonic(), None, True)
+                if self._uses_shared_alpaca_summary_cache:
+                    _SHARED_ALPACA_SUMMARY_CACHE = next_cache
+                else:
+                    self._alpaca_summary_cache = next_cache
                 return None, True
 
     async def _preview_provenance_for_table(self, table_name: str) -> dict[str, Any]:
@@ -834,7 +879,6 @@ class DataExplorerService:
         trusted_table_paths = _trusted_table_paths_for_dataset(table_resolutions, dataset)
         saw_fallback_only = False
         saw_manifest_invalid = False
-        saw_available = False
         for table in candidate_tables:
             if table not in allowed_tables:
                 raise ValueError(f"Table {table} is not available for dataset {dataset}")
@@ -849,7 +893,6 @@ class DataExplorerService:
                 if requested_table is not None:
                     raise ValueError(f"No local data available for table {table}")
                 continue
-            saw_available = True
             if not resolution.trusted_for_data_page:
                 saw_fallback_only = saw_fallback_only or resolution.fallback_only
                 saw_manifest_invalid = saw_manifest_invalid or resolution.manifest_invalid
@@ -872,8 +915,6 @@ class DataExplorerService:
             raise ValueError(f"Trusted manifest is invalid for {dataset}; re-run validation")
         if saw_fallback_only:
             raise ValueError(f"Fallback parquet exists for {dataset}; trusted manifest required")
-        if saw_available:
-            raise ValueError(f"No trusted local data available for {dataset}")
         raise ValueError(f"No trusted local data available for {dataset}")
 
     async def _trusted_available_tables_for_query(
@@ -999,7 +1040,7 @@ def _trusted_alpaca_summary_manifests(alpaca_summary: Any, trusted_tables: list[
     }
     return [
         manifest
-        for manifest in alpaca_summary.manifests
+        for manifest in getattr(alpaca_summary, "manifests", [])
         if getattr(manifest, "dataset", None) in trusted_manifest_datasets
         and str(getattr(manifest, "validation_status", "")).lower() == "passed"
     ]

--- a/libs/web_console_services/schemas/data_management.py
+++ b/libs/web_console_services/schemas/data_management.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel
+from pydantic import AwareDatetime, BaseModel, Field
+
+from libs.web_console_services.provider_signature import ProviderSignatureDTO
 
 
 class SyncStatusDTO(BaseModel):
@@ -192,6 +194,14 @@ class DataAcquisitionJobDTO(BaseModel):
     logs: list[str]
 
 
+class QueryTemplateDTO(BaseModel):
+    """Curated query template for one dataset/table."""
+
+    label: str
+    table: str
+    sql: str
+
+
 class DatasetInfoDTO(BaseModel):
     """High-level metadata for a dataset in the explorer."""
 
@@ -201,6 +211,13 @@ class DatasetInfoDTO(BaseModel):
     date_range: dict[str, str] | None = None
     symbol_count: int | None = None
     last_sync: AwareDatetime | None = None
+    tables: list[str] = Field(default_factory=list)
+    queryable_state: str = "unknown"
+    trusted_manifest_backed: bool = False
+    manifest_required: bool = False
+    availability_reason: str | None = None
+    sql_handoff_url: str | None = None
+    query_templates: list[QueryTemplateDTO] = Field(default_factory=list)
 
 
 class DataPreviewDTO(BaseModel):
@@ -208,7 +225,27 @@ class DataPreviewDTO(BaseModel):
 
     columns: list[str]
     rows: list[dict[str, Any]]
-    total_count: int
+    total_count: int = Field(
+        description="Fetched row count, including at most one sentinel row when has_more is true.",
+    )
+    has_more: bool = False
+    table: str | None = None
+    queryable_state: str = "unknown"
+    trusted_manifest_backed: bool = False
+    sql_handoff_url: str | None = None
+    manifest_id: str | None = None
+    manifest_reference: str | None = None
+    manifest_checksum: str | None = None
+    manifest_version: str | None = None
+    provider_id: str | None = None
+    provider_version: str | None = None
+    source_feed: str | None = None
+    adjustment_mode: str | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+    provider_signature: ProviderSignatureDTO | None = None
+    null_column_reasons: dict[str, str] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
 
 
 class QueryResultDTO(BaseModel):
@@ -216,9 +253,13 @@ class QueryResultDTO(BaseModel):
 
     columns: list[str]
     rows: list[dict[str, Any]]
-    total_count: int
+    total_count: int = Field(
+        description="Fetched row count, including at most one sentinel row when has_more is true.",
+    )
     has_more: bool
     cursor: str | None = None
+    execution_ms: int | None = None
+    fingerprint: str | None = None
 
 
 class ExportJobDTO(BaseModel):

--- a/libs/web_console_services/sql_explorer_service.py
+++ b/libs/web_console_services/sql_explorer_service.py
@@ -47,6 +47,7 @@ _QUERY_RATE_LIMIT = 10
 _EXPORT_RATE_LIMIT = 5
 _MAX_CELLS = 1_000_000
 _MAX_ALPACA_SIP_MANIFEST_PATH_CACHE_ENTRIES = 64
+_ALPACA_SIP_MANIFEST_FAILURE_CACHE_TTL_SECONDS = 5.0
 _DUCKDB_LOCKDOWN_MIN_VERSION = (1, 4, 0)
 _SANDBOX_PROBE_CACHE_TTL_SECONDS = 60.0
 _DUCKDB_LOADABLE_EXTENSIONS = frozenset({"core_functions", "icu", "json", "parquet"})
@@ -79,6 +80,7 @@ class _ManifestPathCacheEntry(BaseModel, frozen=True):
     mtime_ns: int
     size: int
     path_spec: _TablePathSpec
+    failure_cached_at: float | None = None
 
 
 class SqlTableResolution(BaseModel, frozen=True):
@@ -115,6 +117,8 @@ def _cache_resolved_alpaca_sip_manifest_path(
     cache_key: str,
     manifest_stat: os.stat_result,
     path_spec: _TablePathSpec,
+    *,
+    failure_cache: bool = False,
 ) -> _TablePathSpec:
     _cache_alpaca_sip_manifest_path(
         cache_key,
@@ -122,6 +126,7 @@ def _cache_resolved_alpaca_sip_manifest_path(
             mtime_ns=manifest_stat.st_mtime_ns,
             size=manifest_stat.st_size,
             path_spec=path_spec,
+            failure_cached_at=time.monotonic() if failure_cache else None,
         ),
     )
     return path_spec
@@ -423,8 +428,15 @@ def _resolve_alpaca_sip_snapshot_paths(
                     and cached.mtime_ns == manifest_stat.st_mtime_ns
                     and cached.size == manifest_stat.st_size
                 ):
-                    _ALPACA_SIP_MANIFEST_PATH_CACHE.move_to_end(cache_key)
-                    return cached.path_spec
+                    failure_expired = (
+                        cached.failure_cached_at is not None
+                        and time.monotonic() - cached.failure_cached_at
+                        >= _ALPACA_SIP_MANIFEST_FAILURE_CACHE_TTL_SECONDS
+                    )
+                    if not failure_expired:
+                        _ALPACA_SIP_MANIFEST_PATH_CACHE.move_to_end(cache_key)
+                        return cached.path_spec
+                    _ALPACA_SIP_MANIFEST_PATH_CACHE.pop(cache_key, None)
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             if not isinstance(manifest, dict):
                 logger.warning(
@@ -479,6 +491,7 @@ def _resolve_alpaca_sip_snapshot_paths(
                 cache_key,
                 manifest_stat,
                 ResolvedTablePathSpec(path_spec=(), manifest_invalid=True),
+                failure_cache=True,
             )
         else:
             resolved_paths: list[str] = []
@@ -941,6 +954,17 @@ async def _execute_query_callable_with_timeout(
 
     clamped_timeout = min(timeout_seconds, _MAX_TIMEOUT_SECONDS)
 
+    async def _release_slot_after_cleanup(task: asyncio.Task[pl.DataFrame]) -> None:
+        global _active_queries
+
+        try:
+            await asyncio.shield(task)
+        except Exception:
+            pass
+        finally:
+            async with _active_queries_lock:
+                _active_queries -= 1
+
     try:
         task = asyncio.create_task(asyncio.to_thread(run_query))
         try:
@@ -951,10 +975,8 @@ async def _execute_query_callable_with_timeout(
                     interrupt()
                 except Exception:
                     logger.warning("duckdb_interrupt_failed", extra={"timeout": clamped_timeout})
-            try:
-                await asyncio.shield(task)
-            except Exception:
-                pass
+                asyncio.create_task(_release_slot_after_cleanup(task))
+                acquired_slot = False
             raise TimeoutError("SQL query timed out") from exc
     finally:
         if acquired_slot:

--- a/libs/web_console_services/sql_explorer_service.py
+++ b/libs/web_console_services/sql_explorer_service.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import socket
+import threading
 import time
 from collections import OrderedDict
 from datetime import UTC, datetime
@@ -45,7 +46,32 @@ _QUERY_RATE_LIMIT = 10
 _EXPORT_RATE_LIMIT = 5
 _MAX_CELLS = 1_000_000
 _MAX_ALPACA_SIP_MANIFEST_PATH_CACHE_ENTRIES = 64
-_TablePathSpec = str | tuple[str, ...]
+_DUCKDB_LOCKDOWN_MIN_VERSION = (1, 4, 0)
+_SANDBOX_PROBE_CACHE_TTL_SECONDS = 60.0
+_DUCKDB_LOADABLE_EXTENSIONS = frozenset({"core_functions", "icu", "json", "parquet"})
+_DUCKDB_ALLOWED_LOADED_EXTENSIONS = _DUCKDB_LOADABLE_EXTENSIONS | frozenset({"jemalloc"})
+_DUCKDB_DENIED_EXTENSIONS = frozenset(
+    {"httpfs", "postgres_scanner", "sqlite_scanner", "mysql_scanner", "azure", "aws"}
+)
+_RawTablePathSpec = str | tuple[str, ...]
+
+
+class ResolvedTablePathSpec(BaseModel, frozen=True):
+    """Physical table path plus explicit provenance for trust decisions."""
+
+    path_spec: _RawTablePathSpec
+    manifest_backed: bool = False
+    fallback_only: bool = False
+    manifest_invalid: bool = False
+
+
+_TablePathSpec = _RawTablePathSpec | ResolvedTablePathSpec
+TablePathSpec = _TablePathSpec
+
+_ALPACA_SIP_TABLE_MANIFESTS: dict[str, str] = {
+    "alpaca_sip_daily": "alpaca_sip_daily.json",
+    "alpaca_sip_corp_actions": "alpaca_sip_corp_actions.json",
+}
 
 
 class _ManifestPathCacheEntry(BaseModel, frozen=True):
@@ -54,7 +80,22 @@ class _ManifestPathCacheEntry(BaseModel, frozen=True):
     path_spec: _TablePathSpec
 
 
+class SqlTableResolution(BaseModel, frozen=True):
+    """Resolved local table state for SQL-backed data surfaces."""
+
+    dataset: str
+    table: str
+    path_spec: TablePathSpec | None
+    available: bool
+    manifest_required: bool
+    manifest_backed: bool
+    manifest_invalid: bool
+    fallback_only: bool
+    trusted_for_data_page: bool
+
+
 _ALPACA_SIP_MANIFEST_PATH_CACHE: OrderedDict[str, _ManifestPathCacheEntry] = OrderedDict()
+_ALPACA_SIP_MANIFEST_PATH_CACHE_LOCK = threading.Lock()
 
 
 def _cache_alpaca_sip_manifest_path(
@@ -62,13 +103,28 @@ def _cache_alpaca_sip_manifest_path(
     entry: _ManifestPathCacheEntry,
 ) -> None:
     """Store a manifest cache entry while bounding global cache growth."""
-    _ALPACA_SIP_MANIFEST_PATH_CACHE[cache_key] = entry
-    _ALPACA_SIP_MANIFEST_PATH_CACHE.move_to_end(cache_key)
-    while (
-        len(_ALPACA_SIP_MANIFEST_PATH_CACHE)
-        > _MAX_ALPACA_SIP_MANIFEST_PATH_CACHE_ENTRIES
-    ):
-        _ALPACA_SIP_MANIFEST_PATH_CACHE.popitem(last=False)
+    with _ALPACA_SIP_MANIFEST_PATH_CACHE_LOCK:
+        _ALPACA_SIP_MANIFEST_PATH_CACHE[cache_key] = entry
+        _ALPACA_SIP_MANIFEST_PATH_CACHE.move_to_end(cache_key)
+        while len(_ALPACA_SIP_MANIFEST_PATH_CACHE) > _MAX_ALPACA_SIP_MANIFEST_PATH_CACHE_ENTRIES:
+            _ALPACA_SIP_MANIFEST_PATH_CACHE.popitem(last=False)
+
+
+def _cache_resolved_alpaca_sip_manifest_path(
+    cache_key: str,
+    manifest_stat: os.stat_result,
+    path_spec: _TablePathSpec,
+) -> _TablePathSpec:
+    _cache_alpaca_sip_manifest_path(
+        cache_key,
+        _ManifestPathCacheEntry(
+            mtime_ns=manifest_stat.st_mtime_ns,
+            size=manifest_stat.st_size,
+            path_spec=path_spec,
+        ),
+    )
+    return path_spec
+
 
 _KNOWN_ENVS = {"production", "staging", "development", "test", "local"}
 
@@ -81,6 +137,7 @@ _ERROR_CODES: dict[str, str] = {
     "concurrency_limit": "Too many concurrent queries",
     "error": "Query execution failed",
 }
+_NON_ERROR_AUDIT_STATUSES = {"success", "queued"}
 
 _SENSITIVE_TABLES_EXACT = frozenset(
     {
@@ -189,6 +246,8 @@ if _AUDIT_LOG_RAW_SQL:
 
 _active_queries = 0
 _active_queries_lock = asyncio.Lock()
+_sandbox_probe_result: tuple[float, bool, tuple[str, ...]] | None = None
+_sandbox_probe_lock = threading.Lock()
 
 
 class SensitiveTableAccessError(ValueError):
@@ -216,15 +275,20 @@ class QueryResult(BaseModel, frozen=True):
 def _safe_error_message(status: str, _raw_error: str | None = None) -> str | None:
     """Return canonical, non-sensitive error messages only.
 
-    Returns None for success status to avoid misleading audit log entries.
+    Returns None for non-error statuses to avoid misleading audit log entries.
     The _raw_error parameter is intentionally unused — it exists in the
     signature so callers pass it for documentation/audit purposes, but
     its value is never included in the returned message to prevent
     leaking SQL fragments or internal details.
     """
-    if status == "success":
+    if status in _NON_ERROR_AUDIT_STATUSES:
         return None
     return _ERROR_CODES.get(status, "Internal execution error")
+
+
+def safe_sql_error_message(status: str) -> str | None:
+    """Return canonical, non-sensitive SQL Explorer audit error text."""
+    return _safe_error_message(status)
 
 
 def _fingerprint_query(sql: str) -> str:
@@ -298,10 +362,17 @@ def _glob_has_match(pattern: str) -> bool:
     return bool(_glob_module.glob(pattern, recursive=True))
 
 
+def _raw_path_spec(path_spec: _TablePathSpec) -> _RawTablePathSpec:
+    if isinstance(path_spec, ResolvedTablePathSpec):
+        return path_spec.path_spec
+    return path_spec
+
+
 def _path_spec_has_match(path_spec: _TablePathSpec) -> bool:
-    if isinstance(path_spec, str):
-        return _glob_has_match(path_spec)
-    return any(_Path(path).exists() for path in path_spec)
+    raw_path_spec = _raw_path_spec(path_spec)
+    if isinstance(raw_path_spec, str):
+        return _glob_has_match(raw_path_spec)
+    return any(_Path(path).exists() for path in raw_path_spec)
 
 
 def _validate_path_safe(path: str) -> None:
@@ -337,19 +408,22 @@ def _resolve_alpaca_sip_snapshot_paths(
     data_root_path = _Path(data_root).resolve()
     storage_root = (data_root_path / "alpaca" / "sip" / storage_leaf).resolve()
     manifest_path = (data_root_path / "manifests" / manifest_name).resolve()
+    fallback_path_spec = f"{storage_root}/snapshots/*/*.parquet"
 
     if manifest_path.exists():
         cache_key = str(manifest_path.resolve())
+        manifest_stat: os.stat_result | None = None
         try:
             manifest_stat = manifest_path.stat()
-            cached = _ALPACA_SIP_MANIFEST_PATH_CACHE.get(cache_key)
-            if (
-                cached is not None
-                and cached.mtime_ns == manifest_stat.st_mtime_ns
-                and cached.size == manifest_stat.st_size
-            ):
-                _ALPACA_SIP_MANIFEST_PATH_CACHE.move_to_end(cache_key)
-                return cached.path_spec
+            with _ALPACA_SIP_MANIFEST_PATH_CACHE_LOCK:
+                cached = _ALPACA_SIP_MANIFEST_PATH_CACHE.get(cache_key)
+                if (
+                    cached is not None
+                    and cached.mtime_ns == manifest_stat.st_mtime_ns
+                    and cached.size == manifest_stat.st_size
+                ):
+                    _ALPACA_SIP_MANIFEST_PATH_CACHE.move_to_end(cache_key)
+                    return cached.path_spec
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             if not isinstance(manifest, dict):
                 logger.warning(
@@ -359,14 +433,52 @@ def _resolve_alpaca_sip_snapshot_paths(
                         "error": "Manifest JSON is not an object",
                     },
                 )
-                return ()
+                return _cache_resolved_alpaca_sip_manifest_path(
+                    cache_key,
+                    manifest_stat,
+                    ResolvedTablePathSpec(path_spec=(), manifest_invalid=True),
+                )
+            raw_validation_status = manifest.get("validation_status")
+            validation_status = (
+                str(raw_validation_status).lower()
+                if raw_validation_status is not None
+                else "unknown"
+            )
+            if validation_status != "passed":
+                logger.warning(
+                    "sql_explorer_alpaca_sip_manifest_untrusted",
+                    extra={
+                        "manifest_path": str(manifest_path),
+                        "validation_status": validation_status,
+                    },
+                )
+                if raw_validation_status is None:
+                    return _cache_resolved_alpaca_sip_manifest_path(
+                        cache_key,
+                        manifest_stat,
+                        ResolvedTablePathSpec(
+                            path_spec=fallback_path_spec,
+                            fallback_only=True,
+                        ),
+                    )
+                return _cache_resolved_alpaca_sip_manifest_path(
+                    cache_key,
+                    manifest_stat,
+                    ResolvedTablePathSpec(path_spec=(), manifest_invalid=True),
+                )
             file_paths = manifest.get("file_paths", [])
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning(
                 unreadable_log_event,
                 extra={"manifest_path": str(manifest_path), "error": str(exc)},
             )
-            return ()
+            if manifest_stat is None:
+                return ResolvedTablePathSpec(path_spec=(), manifest_invalid=True)
+            return _cache_resolved_alpaca_sip_manifest_path(
+                cache_key,
+                manifest_stat,
+                ResolvedTablePathSpec(path_spec=(), manifest_invalid=True),
+            )
         else:
             resolved_paths: list[str] = []
             if isinstance(file_paths, list):
@@ -396,33 +508,40 @@ def _resolve_alpaca_sip_snapshot_paths(
                             "invalid_paths": invalid_paths,
                         },
                     )
+                    path_spec = ResolvedTablePathSpec(path_spec=(), manifest_invalid=True)
+                    return _cache_resolved_alpaca_sip_manifest_path(
+                        cache_key,
+                        manifest_stat,
+                        path_spec,
+                    )
 
-                path_spec: _TablePathSpec = tuple(sorted(resolved_paths))
-                _cache_alpaca_sip_manifest_path(
-                    cache_key,
-                    _ManifestPathCacheEntry(
-                        mtime_ns=manifest_stat.st_mtime_ns,
-                        size=manifest_stat.st_size,
-                        path_spec=path_spec,
-                    ),
+                raw_path_spec = tuple(sorted(resolved_paths))
+                path_spec = ResolvedTablePathSpec(
+                    path_spec=raw_path_spec,
+                    manifest_backed=bool(raw_path_spec),
+                    manifest_invalid=not raw_path_spec,
                 )
-                return path_spec
+                return _cache_resolved_alpaca_sip_manifest_path(
+                    cache_key,
+                    manifest_stat,
+                    path_spec,
+                )
 
             logger.warning(
                 "sql_explorer_alpaca_sip_manifest_invalid_file_paths",
                 extra={"manifest_path": str(manifest_path)},
             )
-            _cache_alpaca_sip_manifest_path(
+            path_spec = ResolvedTablePathSpec(path_spec=(), manifest_invalid=True)
+            return _cache_resolved_alpaca_sip_manifest_path(
                 cache_key,
-                _ManifestPathCacheEntry(
-                    mtime_ns=manifest_stat.st_mtime_ns,
-                    size=manifest_stat.st_size,
-                    path_spec=(),
-                ),
+                manifest_stat,
+                path_spec,
             )
-            return ()
 
-    return f"{storage_root}/snapshots/*/*.parquet"
+    return ResolvedTablePathSpec(
+        path_spec=fallback_path_spec,
+        fallback_only=True,
+    )
 
 
 def _resolve_alpaca_sip_daily_paths(data_root: str) -> _TablePathSpec:
@@ -447,16 +566,52 @@ def _resolve_alpaca_sip_corp_actions_paths(data_root: str) -> _TablePathSpec:
 
 def _duckdb_read_parquet_arg(path_spec: _TablePathSpec) -> str:
     """Build a safe DuckDB read_parquet argument from validated path specs."""
-    paths = (path_spec,) if isinstance(path_spec, str) else path_spec
+    raw_path_spec = _raw_path_spec(path_spec)
+    paths = (raw_path_spec,) if isinstance(raw_path_spec, str) else raw_path_spec
     for path in paths:
         _validate_path_safe(path)
 
-    if isinstance(path_spec, str):
-        return f"'{path_spec}'"
-    if not path_spec:
+    if isinstance(raw_path_spec, str):
+        return f"'{raw_path_spec}'"
+    if not raw_path_spec:
         raise ValueError("Empty path list rejected")
-    quoted_paths = ", ".join(f"'{path}'" for path in path_spec)
+    quoted_paths = ", ".join(f"'{path}'" for path in raw_path_spec)
     return f"[{quoted_paths}]"
+
+
+def _set_duckdb_option(
+    conn: duckdb.DuckDBPyConnection,
+    sql: str,
+    *,
+    option_name: str,
+    allow_unrecognized: bool = False,
+) -> None:
+    try:
+        conn.execute(sql)
+    except duckdb.CatalogException as exc:
+        if allow_unrecognized and "unrecognized configuration parameter" in str(exc):
+            logger.warning(
+                "duckdb_option_unavailable",
+                extra={"option": option_name},
+            )
+            return
+        raise
+
+
+def _duckdb_version_tuple(version: str) -> tuple[int, int, int]:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        return (0, 0, 0)
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _ensure_duckdb_lockdown_supported() -> None:
+    version = _duckdb_version_tuple(str(getattr(duckdb, "__version__", "")))
+    if version < _DUCKDB_LOCKDOWN_MIN_VERSION:
+        raise RuntimeError(
+            "SQL Explorer requires DuckDB >= 1.4.0 for hardened extension lockdown "
+            f"(found {getattr(duckdb, '__version__', 'unknown')})."
+        )
 
 
 def _resolve_table_paths() -> dict[str, _TablePathSpec]:
@@ -482,7 +637,7 @@ def _validate_table_paths(
 ) -> tuple[dict[str, set[str]], list[str]]:
     """Validate discovered table paths and return per-dataset availability."""
 
-    paths = table_paths or _resolve_table_paths()
+    paths = _resolve_table_paths() if table_paths is None else table_paths
     available_tables_by_dataset: dict[str, set[str]] = {}
     warnings: list[str] = []
 
@@ -503,32 +658,141 @@ def _validate_table_paths(
     return available_tables_by_dataset, warnings
 
 
-def _create_query_connection(dataset: str, available_tables: set[str]) -> duckdb.DuckDBPyConnection:
+def resolve_sql_table_paths() -> dict[str, TablePathSpec]:
+    """Resolve logical SQL Explorer tables to local parquet path specs."""
+    return _resolve_table_paths()
+
+
+def validate_sql_table_paths(
+    table_paths: dict[str, TablePathSpec] | None = None,
+) -> tuple[dict[str, set[str]], list[str]]:
+    """Return queryable local tables grouped by dataset."""
+    return _validate_table_paths(table_paths)
+
+
+def resolve_sql_table_availability(
+    table_paths: dict[str, TablePathSpec] | None = None,
+) -> tuple[dict[str, SqlTableResolution], list[str]]:
+    """Return table availability with Data-page trust metadata.
+
+    SQL Explorer can inspect fallback Alpaca SIP parquet files, but the main
+    data page requires manifest-pinned paths for preview and handoff actions.
+    """
+
+    paths = resolve_sql_table_paths() if table_paths is None else table_paths
+    resolutions: dict[str, SqlTableResolution] = {}
+    warnings: list[str] = []
+
+    for dataset, tables in DATASET_TABLES.items():
+        for table in tables:
+            path_spec = paths.get(table)
+            available = bool(path_spec and _path_spec_has_match(path_spec))
+            manifest_required = table in _ALPACA_SIP_TABLE_MANIFESTS
+            if isinstance(path_spec, ResolvedTablePathSpec):
+                manifest_backed = bool(path_spec.manifest_backed and available)
+                fallback_only = bool(path_spec.fallback_only)
+                manifest_invalid = bool(path_spec.manifest_invalid)
+            else:
+                manifest_backed = bool(
+                    manifest_required and isinstance(path_spec, tuple) and available
+                )
+                fallback_only = bool(manifest_required and isinstance(path_spec, str))
+                manifest_invalid = False
+            trusted_for_data_page = bool(
+                available
+                and not manifest_invalid
+                and (not manifest_required or manifest_backed)
+            )
+            if manifest_invalid:
+                warnings.append(
+                    f"{table} manifest is invalid or has no valid parquet files; /data disabled"
+                )
+            if fallback_only:
+                warnings.append(
+                    f"{table} is queryable fallback only; manifest-backed /data preview disabled"
+                )
+            elif not available and not manifest_invalid:
+                warnings.append(f"No Parquet files found for {table}: {path_spec}")
+
+            resolutions[table] = SqlTableResolution(
+                dataset=dataset,
+                table=table,
+                path_spec=path_spec,
+                available=available,
+                manifest_required=manifest_required,
+                manifest_backed=manifest_backed,
+                manifest_invalid=manifest_invalid,
+                fallback_only=fallback_only,
+                trusted_for_data_page=trusted_for_data_page,
+            )
+
+    return resolutions, warnings
+
+
+def _create_query_connection(
+    dataset: str,
+    available_tables: set[str],
+    table_paths: dict[str, TablePathSpec] | None = None,
+) -> duckdb.DuckDBPyConnection:
     """Create hardened DuckDB connection scoped to available dataset tables."""
 
+    _ensure_duckdb_lockdown_supported()
     conn = duckdb.connect()
     try:
-        conn.execute("SET enable_extension_autoloading = false")
-        conn.execute("SET enable_extension_loading = false")
-
-        _allowed_extensions = frozenset({"core_functions", "icu", "json", "parquet"})
-        _denied_extensions = frozenset(
-            {"httpfs", "postgres_scanner", "sqlite_scanner", "mysql_scanner", "azure", "aws"}
-        )
         _strict_extensions = os.getenv("SQL_EXPLORER_STRICT_EXTENSIONS", "true").lower() == "true"
         if not _strict_extensions and _APP_ENV == "production":
             raise RuntimeError(
                 "SQL_EXPLORER_STRICT_EXTENSIONS=false is forbidden when APP_ENV=production."
             )
 
+        _set_duckdb_option(
+            conn,
+            "SET autoinstall_known_extensions = false",
+            option_name="autoinstall_known_extensions",
+        )
+        _set_duckdb_option(
+            conn,
+            "SET autoload_known_extensions = false",
+            option_name="autoload_known_extensions",
+        )
+        _set_duckdb_option(
+            conn,
+            "SET allow_unsigned_extensions = false",
+            option_name="allow_unsigned_extensions",
+        )
+        _set_duckdb_option(
+            conn,
+            "SET allow_community_extensions = false",
+            option_name="allow_community_extensions",
+        )
+
+        for extension in sorted(_DUCKDB_LOADABLE_EXTENSIONS):
+            conn.execute(f"LOAD {extension}")
+
+        # Legacy aliases are removed in the locked DuckDB 1.4.4 build, so they
+        # are advisory only. Apply them after loading the required built-ins for
+        # builds that still support the broader extension-loading switch.
+        _set_duckdb_option(
+            conn,
+            "SET enable_extension_loading = false",
+            option_name="enable_extension_loading",
+            allow_unrecognized=True,
+        )
+        _set_duckdb_option(
+            conn,
+            "SET enable_extension_autoloading = false",
+            option_name="enable_extension_autoloading",
+            allow_unrecognized=True,
+        )
+
         loaded_extensions = conn.execute(
             "SELECT extension_name FROM duckdb_extensions() WHERE loaded = true"
         ).fetchall()
 
         for (ext_name,) in loaded_extensions:
-            if ext_name in _denied_extensions:
+            if ext_name in _DUCKDB_DENIED_EXTENSIONS:
                 raise RuntimeError(f"Denied DuckDB extension loaded: {ext_name}")
-            if ext_name not in _allowed_extensions:
+            if ext_name not in _DUCKDB_ALLOWED_LOADED_EXTENSIONS:
                 if _strict_extensions:
                     raise RuntimeError(f"Unknown DuckDB extension loaded: {ext_name}")
                 logger.warning("duckdb_unknown_extension_advisory", extra={"extension": ext_name})
@@ -547,14 +811,14 @@ def _create_query_connection(dataset: str, available_tables: set[str]) -> duckdb
         conn.execute(f"SET max_memory = '{max_memory_mb}MB'")
         conn.execute("SET threads = 1")
 
-        table_paths = _resolve_table_paths()
+        resolved_table_paths = _resolve_table_paths() if table_paths is None else table_paths
         for table_name in DATASET_TABLES[dataset]:
             if table_name not in available_tables:
                 continue
             if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", table_name):
                 raise ValueError(f"Invalid table identifier: {table_name}")
 
-            parquet_path_spec = table_paths.get(table_name)
+            parquet_path_spec = resolved_table_paths.get(table_name)
             if parquet_path_spec is None:
                 continue
             parquet_arg = _duckdb_read_parquet_arg(parquet_path_spec)
@@ -567,6 +831,18 @@ def _create_query_connection(dataset: str, available_tables: set[str]) -> duckdb
     except Exception:
         conn.close()
         raise
+
+
+def create_scoped_query_connection(
+    dataset: str,
+    available_tables: set[str],
+    table_paths: dict[str, TablePathSpec] | None = None,
+) -> duckdb.DuckDBPyConnection:
+    """Create a hardened DuckDB connection scoped to approved tables."""
+    ensure_sql_explorer_execution_allowed()
+    if table_paths is None:
+        return _create_query_connection(dataset, available_tables)
+    return _create_query_connection(dataset, available_tables, table_paths=table_paths)
 
 
 def _verify_sandbox() -> tuple[bool, list[str]]:
@@ -675,19 +951,84 @@ async def _execute_query_with_timeout(
                 _active_queries -= 1
 
 
+async def execute_scoped_query_with_timeout(
+    conn: duckdb.DuckDBPyConnection,
+    sql: str,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+) -> pl.DataFrame:
+    """Execute a scoped DuckDB query with shared timeout/concurrency limits."""
+    return await _execute_query_with_timeout(conn, sql, timeout_seconds)
+
+
+def check_sensitive_tables(tables: list[str]) -> None:
+    """Raise if a query references obviously sensitive tables."""
+    _check_sensitive_tables(tables)
+
+
+def fingerprint_sql_query(sql: str) -> str:
+    """Return a normalized audit/display fingerprint for SQL text."""
+    return _fingerprint_query(sql)
+
+
+def ensure_sql_explorer_execution_allowed() -> None:
+    """Enforce SQL Explorer production attestation and sandbox checks."""
+    global _sandbox_probe_result
+
+    if _APP_ENV == "production":
+        if os.getenv("SQL_EXPLORER_DEPLOY_ATTESTED", "false").lower() != "true":
+            raise RuntimeError("SQL Explorer requires deploy-attested sandbox in production")
+
+    if _IS_DEV_MODE and _APP_ENV == "production":
+        raise RuntimeError("SQL_EXPLORER_DEV_MODE=true is forbidden when APP_ENV=production.")
+
+    now = time.monotonic()
+    with _sandbox_probe_lock:
+        if (
+            _sandbox_probe_result is None
+            or now - _sandbox_probe_result[0] >= _SANDBOX_PROBE_CACHE_TTL_SECONDS
+        ):
+            safe, failures = _verify_sandbox()
+            _sandbox_probe_result = (now, safe, tuple(failures))
+        else:
+            _checked_at, safe, failures_tuple = _sandbox_probe_result
+            failures = list(failures_tuple)
+
+    if not safe:
+        if _APP_ENV == "production":
+            raise RuntimeError(
+                f"SQL Explorer sandbox probe failed in production: {', '.join(failures)}. "
+                "Ensure network egress is blocked and filesystem is read-only."
+            )
+        logger.warning("sql_explorer_sandbox_probe_failed", extra={"failures": failures})
+
+
+def log_sql_query_audit(
+    user: Any,
+    dataset: str,
+    original_query: str,
+    executed_query: str | None,
+    row_count: int,
+    execution_ms: int,
+    status: str,
+    error_message: str | None,
+) -> None:
+    """Write a SQL Explorer-compatible query audit record."""
+    _log_query(
+        user,
+        dataset,
+        original_query,
+        executed_query,
+        row_count,
+        execution_ms,
+        status,
+        error_message,
+    )
+
+
 class SqlExplorerService:
     """Service encapsulating SQL Explorer security and execution pipeline."""
 
     def __init__(self, rate_limiter: RateLimiter | None = None) -> None:
-        app_env = _APP_ENV
-
-        if app_env == "production":
-            if os.getenv("SQL_EXPLORER_DEPLOY_ATTESTED", "false").lower() != "true":
-                raise RuntimeError("SQL Explorer requires deploy-attested sandbox in production")
-
-        if _IS_DEV_MODE and app_env == "production":
-            raise RuntimeError("SQL_EXPLORER_DEV_MODE=true is forbidden when APP_ENV=production.")
-
         if rate_limiter is None:
             if not _IS_DEV_MODE:
                 raise ValueError(
@@ -700,15 +1041,7 @@ class SqlExplorerService:
 
         self._rate_limiter = rate_limiter
         self._validator = SQLValidator()
-
-        safe, failures = _verify_sandbox()
-        if not safe:
-            if app_env == "production":
-                raise RuntimeError(
-                    f"SQL Explorer sandbox probe failed in production: {', '.join(failures)}. "
-                    "Ensure network egress is blocked and filesystem is read-only."
-                )
-            logger.warning("sql_explorer_sandbox_probe_failed", extra={"failures": failures})
+        ensure_sql_explorer_execution_allowed()
 
     async def execute_query(
         self,
@@ -751,11 +1084,15 @@ class SqlExplorerService:
             resolved_tables = (
                 available_tables if available_tables is not None else set(DATASET_TABLES[dataset])
             )
-            conn = _create_query_connection(dataset, available_tables=resolved_tables)
+            conn = await asyncio.to_thread(
+                create_scoped_query_connection,
+                dataset,
+                available_tables=resolved_tables,
+            )
             try:
-                result = await _execute_query_with_timeout(conn, limited_sql, timeout_seconds)
+                result = await execute_scoped_query_with_timeout(conn, limited_sql, timeout_seconds)
             finally:
-                conn.close()
+                await asyncio.to_thread(conn.close)
 
             execution_ms = int((time.monotonic() - start) * 1000)
             fingerprint = _fingerprint_query(query)
@@ -885,10 +1222,23 @@ class SqlExplorerService:
 __all__ = [
     "SqlExplorerService",
     "QueryResult",
+    "SqlTableResolution",
+    "TablePathSpec",
+    "ResolvedTablePathSpec",
     "SensitiveTableAccessError",
     "ConcurrencyLimitError",
     "RateLimitExceededError",
     "can_query_dataset",
+    "check_sensitive_tables",
+    "create_scoped_query_connection",
+    "ensure_sql_explorer_execution_allowed",
+    "execute_scoped_query_with_timeout",
+    "fingerprint_sql_query",
+    "log_sql_query_audit",
+    "safe_sql_error_message",
+    "resolve_sql_table_availability",
+    "resolve_sql_table_paths",
+    "validate_sql_table_paths",
     "_DEFAULT_TIMEOUT_SECONDS",
     "_MAX_TIMEOUT_SECONDS",
     "_DEFAULT_MAX_ROWS",

--- a/libs/web_console_services/sql_explorer_service.py
+++ b/libs/web_console_services/sql_explorer_service.py
@@ -12,6 +12,7 @@ import socket
 import threading
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path as _Path
 from typing import Any
@@ -907,12 +908,27 @@ def can_query_dataset(user: Any, dataset: str) -> bool:
     return has_dataset_permission(user, permission)
 
 
-async def _execute_query_with_timeout(
+def _query_frame_from_connection(
     conn: duckdb.DuckDBPyConnection,
     sql: str,
-    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
 ) -> pl.DataFrame:
-    """Execute query with bounded concurrency and hard timeout."""
+    result = conn.execute(sql)
+    df = result.pl()
+    cell_count = len(df) * len(df.columns)
+    if cell_count > _MAX_CELLS:
+        raise ValueError(
+            f"Result too large: {cell_count:,} cells exceeds limit of {_MAX_CELLS:,}. "
+            "Add filters or reduce columns."
+        )
+    return df
+
+
+async def _execute_query_callable_with_timeout(
+    run_query: Callable[[], pl.DataFrame],
+    timeout_seconds: int,
+    interrupt: Callable[[], None],
+) -> pl.DataFrame:
+    """Execute query work with bounded concurrency and cooperative timeout cleanup."""
 
     global _active_queries
 
@@ -926,29 +942,108 @@ async def _execute_query_with_timeout(
     clamped_timeout = min(timeout_seconds, _MAX_TIMEOUT_SECONDS)
 
     try:
-
-        def _run() -> pl.DataFrame:
-            result = conn.execute(sql)
-            df = result.pl()
-            cell_count = len(df) * len(df.columns)
-            if cell_count > _MAX_CELLS:
-                raise ValueError(
-                    f"Result too large: {cell_count:,} cells exceeds limit of {_MAX_CELLS:,}. "
-                    "Add filters or reduce columns."
-                )
-            return df
-
-        return await asyncio.wait_for(asyncio.to_thread(_run), timeout=clamped_timeout)
-    except TimeoutError:
+        task = asyncio.create_task(asyncio.to_thread(run_query))
         try:
-            conn.interrupt()
-        except Exception:
-            logger.warning("duckdb_interrupt_failed", extra={"timeout": clamped_timeout})
-        raise
+            return await asyncio.wait_for(asyncio.shield(task), timeout=clamped_timeout)
+        except TimeoutError as exc:
+            if not task.done():
+                try:
+                    interrupt()
+                except Exception:
+                    logger.warning("duckdb_interrupt_failed", extra={"timeout": clamped_timeout})
+            try:
+                await asyncio.shield(task)
+            except Exception:
+                pass
+            raise TimeoutError("SQL query timed out") from exc
     finally:
         if acquired_slot:
             async with _active_queries_lock:
                 _active_queries -= 1
+
+
+async def _execute_query_with_timeout(
+    conn: duckdb.DuckDBPyConnection,
+    sql: str,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+) -> pl.DataFrame:
+    """Execute query with bounded concurrency and timeout-safe cleanup."""
+
+    return await _execute_query_callable_with_timeout(
+        lambda: _query_frame_from_connection(conn, sql),
+        timeout_seconds,
+        conn.interrupt,
+    )
+
+
+class _ScopedQueryRunner:
+    """Own a scoped DuckDB connection inside the worker thread that executes it."""
+
+    def __init__(
+        self,
+        *,
+        dataset: str,
+        available_tables: set[str],
+        table_paths: dict[str, TablePathSpec] | None,
+        sql: str,
+    ) -> None:
+        self._dataset = dataset
+        self._available_tables = available_tables
+        self._table_paths = table_paths
+        self._sql = sql
+        self._conn: duckdb.DuckDBPyConnection | None = None
+        self._conn_lock = threading.Lock()
+        self._interrupt_requested = threading.Event()
+
+    def run(self) -> pl.DataFrame:
+        conn = create_scoped_query_connection(
+            self._dataset,
+            available_tables=self._available_tables,
+            table_paths=self._table_paths,
+        )
+        with self._conn_lock:
+            self._conn = conn
+        try:
+            if self._interrupt_requested.is_set():
+                conn.interrupt()
+            return _query_frame_from_connection(conn, self._sql)
+        finally:
+            try:
+                conn.close()
+            finally:
+                with self._conn_lock:
+                    if self._conn is conn:
+                        self._conn = None
+
+    def interrupt(self) -> None:
+        self._interrupt_requested.set()
+        with self._conn_lock:
+            conn = self._conn
+        if conn is not None:
+            conn.interrupt()
+
+
+async def execute_scoped_query_frame_with_timeout(
+    dataset: str,
+    sql: str,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    *,
+    available_tables: set[str],
+    table_paths: dict[str, TablePathSpec] | None = None,
+) -> pl.DataFrame:
+    """Execute a scoped DuckDB query while owning close in the query worker thread."""
+
+    runner = _ScopedQueryRunner(
+        dataset=dataset,
+        available_tables=available_tables,
+        table_paths=table_paths,
+        sql=sql,
+    )
+    return await _execute_query_callable_with_timeout(
+        runner.run,
+        timeout_seconds,
+        runner.interrupt,
+    )
 
 
 async def execute_scoped_query_with_timeout(
@@ -1041,7 +1136,6 @@ class SqlExplorerService:
 
         self._rate_limiter = rate_limiter
         self._validator = SQLValidator()
-        ensure_sql_explorer_execution_allowed()
 
     async def execute_query(
         self,
@@ -1084,15 +1178,12 @@ class SqlExplorerService:
             resolved_tables = (
                 available_tables if available_tables is not None else set(DATASET_TABLES[dataset])
             )
-            conn = await asyncio.to_thread(
-                create_scoped_query_connection,
+            result = await execute_scoped_query_frame_with_timeout(
                 dataset,
+                limited_sql,
+                timeout_seconds,
                 available_tables=resolved_tables,
             )
-            try:
-                result = await execute_scoped_query_with_timeout(conn, limited_sql, timeout_seconds)
-            finally:
-                await asyncio.to_thread(conn.close)
 
             execution_ms = int((time.monotonic() - start) * 1000)
             fingerprint = _fingerprint_query(query)
@@ -1232,6 +1323,7 @@ __all__ = [
     "check_sensitive_tables",
     "create_scoped_query_connection",
     "ensure_sql_explorer_execution_allowed",
+    "execute_scoped_query_frame_with_timeout",
     "execute_scoped_query_with_timeout",
     "fingerprint_sql_query",
     "log_sql_query_audit",

--- a/libs/web_console_services/sql_validator.py
+++ b/libs/web_console_services/sql_validator.py
@@ -95,6 +95,20 @@ class SQLValidator:
         expression = sqlglot.parse_one(query, read="duckdb")
         return list(self._extract_tables_from_expression(expression))
 
+    def is_literal_smoke_query(self, query: str) -> bool:
+        """Return whether a tableless query is limited to literal smoke output."""
+        try:
+            expressions = sqlglot.parse(query, read="duckdb")
+        except sqlglot.errors.ParseError:
+            return False
+
+        if len(expressions) != 1:
+            return False
+        expression = expressions[0]
+        if expression is None:
+            return False
+        return self._is_literal_smoke_select(expression)
+
     def enforce_row_limit(self, query: str, max_rows: int) -> str:
         """Add or clamp LIMIT clause to enforce a maximum row count.
 
@@ -144,6 +158,34 @@ class SQLValidator:
     def _extract_tables_from_expression(self, expression: exp.Expression) -> list[str]:
         """Extract table names only (for backward compatibility)."""
         return [name for name, _, _ in self._extract_tables_with_schema(expression)]
+
+    @classmethod
+    def _is_literal_smoke_select(cls, expression: exp.Expression) -> bool:
+        if not isinstance(expression, exp.Select):
+            return False
+        if any(
+            key != "expressions" and value is not None
+            for key, value in expression.args.items()
+        ):
+            return False
+        if any(
+            expression.find(node_type) is not None
+            for node_type in (exp.From, exp.Join, exp.Subquery, exp.CTE, exp.SetOperation)
+        ):
+            return False
+        return bool(expression.expressions) and all(
+            cls._is_literal_projection(projection) for projection in expression.expressions
+        )
+
+    @classmethod
+    def _is_literal_projection(cls, expression: exp.Expression) -> bool:
+        if isinstance(expression, exp.Alias | exp.Paren):
+            return cls._is_literal_projection(expression.this)
+        if isinstance(expression, exp.Cast):
+            return cls._is_literal_projection(expression.this)
+        if isinstance(expression, exp.Neg):
+            return cls._is_literal_projection(expression.this)
+        return isinstance(expression, exp.Literal | exp.Null | exp.Boolean)
 
     def _first_blocked_function(self, expression: exp.Expression) -> str | None:
         for func in expression.find_all(exp.Func):

--- a/tests/apps/web_console/services/test_data_explorer_service.py
+++ b/tests/apps/web_console/services/test_data_explorer_service.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
+import polars as pl
 import pytest
 
 from libs.platform.web_console_auth.permissions import Role
+from libs.web_console_services import sql_explorer_service as sql_module
 from libs.web_console_services.data_explorer_service import DataExplorerService
+from libs.web_console_services.sql_explorer_service import TablePathSpec
 
 
 @dataclass(frozen=True)
@@ -27,8 +32,21 @@ async def rate_limiter() -> AsyncMock:
 
 
 @pytest.fixture()
-async def service(rate_limiter: AsyncMock) -> DataExplorerService:
-    return DataExplorerService(rate_limiter=rate_limiter)
+async def table_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, TablePathSpec]:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    return {"crsp_daily": str(partition)}
+
+
+@pytest.fixture()
+async def service(
+    rate_limiter: AsyncMock,
+    table_paths: dict[str, TablePathSpec],
+) -> DataExplorerService:
+    return DataExplorerService(rate_limiter=rate_limiter, table_paths=table_paths)
 
 
 @pytest.fixture()
@@ -39,6 +57,14 @@ async def operator_user() -> DummyUser:
 @pytest.fixture()
 async def viewer_user() -> DummyUser:
     return DummyUser(user_id="user-viewer", role=Role.VIEWER)
+
+
+@pytest.fixture(autouse=True)
+def no_sql_explorer_sandbox_probe() -> Generator[None, None, None]:
+    with patch(
+        "libs.web_console_services.data_explorer_service.ensure_sql_explorer_execution_allowed"
+    ):
+        yield
 
 
 @pytest.mark.asyncio()
@@ -57,8 +83,30 @@ async def test_execute_query_viewer_allowed_single_admin(
     service: DataExplorerService, viewer_user: DummyUser
 ) -> None:
     """P6T19: Viewer can execute queries — single-admin model."""
-    result = await service.execute_query(viewer_user, dataset="fama_french", query="select 1")
+    result = await service.execute_query(
+        viewer_user,
+        dataset="crsp",
+        query="select * from crsp_daily",
+    )
     assert result is not None
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_rejects_tableless_table_function(
+    rate_limiter: AsyncMock,
+    viewer_user: DummyUser,
+) -> None:
+    """Table functions cannot use the tableless smoke-query path."""
+    service = DataExplorerService(rate_limiter=rate_limiter, table_paths={})
+
+    with pytest.raises(ValueError, match="Tableless queries"):
+        await service.execute_query(
+            viewer_user,
+            dataset="crsp",
+            query="select count(*) from range(1000000)",
+        )
+
+    rate_limiter.check_rate_limit.assert_not_awaited()
 
 
 @pytest.mark.asyncio()
@@ -66,7 +114,6 @@ async def test_export_data_any_dataset_allowed_single_admin(
     service: DataExplorerService, operator_user: DummyUser
 ) -> None:
     """P6T19: All datasets accessible — single-admin model."""
-    # Use crsp dataset with crsp_daily table (valid combination)
     result = await service.export_data(
         operator_user,
         dataset="crsp",
@@ -77,16 +124,27 @@ async def test_export_data_any_dataset_allowed_single_admin(
 
 
 @pytest.mark.asyncio()
-async def test_execute_query_alpaca_sip_table_allowed(
-    service: DataExplorerService, operator_user: DummyUser
+async def test_execute_query_alpaca_sip_table_requires_trusted_manifest(
+    tmp_path: Path,
+    rate_limiter: AsyncMock,
+    operator_user: DummyUser,
 ) -> None:
-    result = await service.execute_query(
-        operator_user,
-        dataset="alpaca_sip",
-        query="select * from alpaca_sip_daily",
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": str(partition)},
     )
 
-    assert result is not None
+    with pytest.raises(ValueError, match="local data|trusted manifest"):
+        await service.execute_query(
+            operator_user,
+            dataset="alpaca_sip",
+            query="select * from alpaca_sip_daily",
+        )
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console/services/test_query_rate_limit.py
+++ b/tests/apps/web_console/services/test_query_rate_limit.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
+import polars as pl
 import pytest
 
 from libs.platform.web_console_auth.permissions import Role
+from libs.web_console_services import sql_explorer_service as sql_module
 from libs.web_console_services.data_explorer_service import DataExplorerService, RateLimitExceeded
+from libs.web_console_services.sql_explorer_service import TablePathSpec
 
 
 @dataclass(frozen=True)
@@ -24,36 +29,71 @@ async def operator_user() -> DummyUser:
     return DummyUser(user_id="user-operator", role=Role.OPERATOR)
 
 
+@pytest.fixture()
+async def table_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, TablePathSpec]:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    return {"crsp_daily": str(partition)}
+
+
+@pytest.fixture(autouse=True)
+def no_sql_explorer_sandbox_probe() -> Generator[None, None, None]:
+    with patch(
+        "libs.web_console_services.data_explorer_service.ensure_sql_explorer_execution_allowed"
+    ):
+        yield
+
+
 @pytest.mark.asyncio()
-async def test_execute_query_rate_limit_allows(operator_user: DummyUser) -> None:
+async def test_execute_query_rate_limit_allows(
+    operator_user: DummyUser,
+    table_paths: dict[str, TablePathSpec],
+) -> None:
     """Allowed rate limit should return query results."""
     rate_limiter = AsyncMock()
     rate_limiter.check_rate_limit = AsyncMock(return_value=(True, 0))
-    service = DataExplorerService(rate_limiter=rate_limiter)
+    service = DataExplorerService(rate_limiter=rate_limiter, table_paths=table_paths)
 
-    result = await service.execute_query(operator_user, dataset="crsp", query="select 1")
+    result = await service.execute_query(
+        operator_user,
+        dataset="crsp",
+        query="select * from crsp_daily",
+    )
 
-    assert result.total_count == 0
+    assert result.total_count == 1
     rate_limiter.check_rate_limit.assert_awaited_once()
 
 
 @pytest.mark.asyncio()
-async def test_execute_query_rate_limit_blocks(operator_user: DummyUser) -> None:
+async def test_execute_query_rate_limit_blocks(
+    operator_user: DummyUser,
+    table_paths: dict[str, TablePathSpec],
+) -> None:
     """Blocked rate limit should raise RateLimitExceeded."""
     rate_limiter = AsyncMock()
     rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
-    service = DataExplorerService(rate_limiter=rate_limiter)
+    service = DataExplorerService(rate_limiter=rate_limiter, table_paths=table_paths)
 
     with pytest.raises(RateLimitExceeded):
-        await service.execute_query(operator_user, dataset="crsp", query="select 1")
+        await service.execute_query(
+            operator_user,
+            dataset="crsp",
+            query="select * from crsp_daily",
+        )
 
 
 @pytest.mark.asyncio()
-async def test_export_data_rate_limit_allows(operator_user: DummyUser) -> None:
+async def test_export_data_rate_limit_allows(
+    operator_user: DummyUser,
+    table_paths: dict[str, TablePathSpec],
+) -> None:
     """Allowed export rate limit should return export job."""
     rate_limiter = AsyncMock()
     rate_limiter.check_rate_limit = AsyncMock(return_value=(True, 0))
-    service = DataExplorerService(rate_limiter=rate_limiter)
+    service = DataExplorerService(rate_limiter=rate_limiter, table_paths=table_paths)
 
     job = await service.export_data(
         operator_user,
@@ -67,11 +107,14 @@ async def test_export_data_rate_limit_allows(operator_user: DummyUser) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_export_data_rate_limit_blocks(operator_user: DummyUser) -> None:
+async def test_export_data_rate_limit_blocks(
+    operator_user: DummyUser,
+    table_paths: dict[str, TablePathSpec],
+) -> None:
     """Blocked export rate limit should raise RateLimitExceeded."""
     rate_limiter = AsyncMock()
     rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
-    service = DataExplorerService(rate_limiter=rate_limiter)
+    service = DataExplorerService(rate_limiter=rate_limiter, table_paths=table_paths)
 
     with pytest.raises(RateLimitExceeded):
         await service.export_data(

--- a/tests/apps/web_console/services/test_sql_validator.py
+++ b/tests/apps/web_console/services/test_sql_validator.py
@@ -63,6 +63,32 @@ class TestTableAccess:
         assert valid
         assert error is None
 
+    def test_literal_smoke_query_allows_select_literal(self, validator: SQLValidator) -> None:
+        """Tableless smoke queries are limited to literal output."""
+        assert validator.is_literal_smoke_query("SELECT 1") is True
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT count(*) FROM range(1000000)",
+            "SELECT * FROM generate_series(1, 10)",
+            "SELECT * FROM (SELECT 1) AS t",
+            "SELECT unnest([1, 2, 3])",
+            "SELECT 1 WHERE random() > 0",
+            "SELECT 1 ORDER BY random()",
+            "SELECT 1 LIMIT 1 OFFSET random()",
+            "SELECT 1 HAVING random() > 0",
+            "SELECT 1 QUALIFY random() > 0",
+        ],
+    )
+    def test_literal_smoke_query_rejects_computed_sources(
+        self,
+        validator: SQLValidator,
+        query: str,
+    ) -> None:
+        """Synthetic row sources cannot use the tableless smoke path."""
+        assert validator.is_literal_smoke_query(query) is False
+
     def test_schema_qualified_table_rejected(self, validator: SQLValidator) -> None:
         """Schema-qualified tables (schema.table) should be rejected."""
         valid, error = validator.validate("SELECT * FROM other_schema.crsp_daily", "crsp")

--- a/tests/apps/web_console_ng/pages/test_data_management_wiring.py
+++ b/tests/apps/web_console_ng/pages/test_data_management_wiring.py
@@ -134,6 +134,33 @@ def _make_export_job() -> ExportJobDTO:
     )
 
 
+class _FakeElement:
+    def __init__(self, *, value: Any = None, options: Any = None) -> None:
+        self.value = value
+        self.options = options
+
+    def __enter__(self) -> _FakeElement:
+        return self
+
+    def __exit__(self, *_args: Any) -> bool:
+        return False
+
+    def classes(self, *_args: Any, **_kwargs: Any) -> _FakeElement:
+        return self
+
+    def props(self, *_args: Any, **_kwargs: Any) -> _FakeElement:
+        return self
+
+    def clear(self) -> None:
+        return None
+
+    def update(self) -> None:
+        return None
+
+    def on_value_change(self, _handler: Any) -> None:
+        return None
+
+
 def _make_validation_results() -> list[ValidationResultDTO]:
     return [
         ValidationResultDTO(
@@ -237,9 +264,7 @@ def quality_service() -> MagicMock:
     svc.get_anomaly_alerts = AsyncMock(return_value=_make_anomaly_alerts())
     svc.get_quality_trends = AsyncMock(return_value=_make_quality_trend())
     svc.get_quarantine_status = AsyncMock(return_value=_make_quarantine_entries())
-    svc.acknowledge_alert = AsyncMock(
-        return_value=MagicMock(acknowledged_by="user-1")
-    )
+    svc.acknowledge_alert = AsyncMock(return_value=MagicMock(acknowledged_by="user-1"))
     return svc
 
 
@@ -365,9 +390,7 @@ class TestSyncStatusWiring:
 
     @pytest.mark.asyncio()
     @patch("apps.web_console_ng.pages.data_management.ui")
-    async def test_calls_get_sync_status(
-        self, mock_ui: MagicMock, sync_service: MagicMock
-    ) -> None:
+    async def test_calls_get_sync_status(self, mock_ui: MagicMock, sync_service: MagicMock) -> None:
         mock_ui.column.return_value = MagicMock()
         mock_ui.column.return_value.__enter__ = MagicMock()
         mock_ui.column.return_value.__exit__ = MagicMock(return_value=False)
@@ -430,9 +453,7 @@ class TestSyncTriggerWiring:
     async def test_trigger_sync_rate_limit(
         self, mock_ui: MagicMock, sync_service: MagicMock
     ) -> None:
-        sync_service.trigger_sync = AsyncMock(
-            side_effect=SyncRateLimitExceeded("1 per 60 seconds")
-        )
+        sync_service.trigger_sync = AsyncMock(side_effect=SyncRateLimitExceeded("1 per 60 seconds"))
         # The rate limit is caught in the trigger_sync callback (closured)
         # We can't easily test the closure, but we can test that the exception type is correct
         with pytest.raises(SyncRateLimitExceeded):
@@ -448,9 +469,7 @@ class TestQueryExecutionWiring:
     """Test execute_query calls service correctly."""
 
     @pytest.mark.asyncio()
-    async def test_query_rate_limit_exception_type(
-        self, explorer_service: MagicMock
-    ) -> None:
+    async def test_query_rate_limit_exception_type(self, explorer_service: MagicMock) -> None:
         explorer_service.execute_query = AsyncMock(
             side_effect=ExplorerRateLimitExceeded("10 per 60 seconds")
         )
@@ -458,9 +477,7 @@ class TestQueryExecutionWiring:
             await explorer_service.execute_query(ADMIN_USER, "crsp", "SELECT 1")
 
     @pytest.mark.asyncio()
-    async def test_query_validation_error(
-        self, explorer_service: MagicMock
-    ) -> None:
+    async def test_query_validation_error(self, explorer_service: MagicMock) -> None:
         explorer_service.execute_query = AsyncMock(
             side_effect=ValueError("Invalid query: DROP not allowed")
         )
@@ -533,14 +550,54 @@ class TestBuildQueryResults:
         mock_ui.table.assert_called_once()
 
     @patch("apps.web_console_ng.pages.data_management.ui")
-    def test_empty_results(self, mock_ui: MagicMock) -> None:
+    def test_renders_service_limited_rows_without_extra_trim(self, mock_ui: MagicMock) -> None:
+        mock_ui.table.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+        mock_ui.row.return_value = MagicMock()
+        mock_ui.row.return_value.__enter__ = MagicMock()
+        mock_ui.row.return_value.__exit__ = MagicMock(return_value=False)
         mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
 
         result = QueryResultDTO(
-            columns=[], rows=[], total_count=0, has_more=False, cursor=None
+            columns=["id"],
+            rows=[{"id": i} for i in range(dm_module.INLINE_QUERY_RESULT_ROW_LIMIT)],
+            total_count=dm_module.INLINE_QUERY_RESULT_ROW_LIMIT + 1,
+            has_more=True,
+            cursor=None,
         )
+
+        dm_module._build_query_results(result)
+
+        rows = mock_ui.table.call_args.kwargs.get("rows") or mock_ui.table.call_args[1]["rows"]
+        assert len(rows) == dm_module.INLINE_QUERY_RESULT_ROW_LIMIT
+        labels = [call.args[0] for call in mock_ui.label.call_args_list]
+        assert f"Showing: {dm_module.INLINE_QUERY_RESULT_ROW_LIMIT} rows" in labels
+        assert f"Fetched: {dm_module.INLINE_QUERY_RESULT_ROW_LIMIT + 1} rows" not in labels
+
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    def test_empty_results(self, mock_ui: MagicMock) -> None:
+        mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+
+        result = QueryResultDTO(columns=[], rows=[], total_count=0, has_more=False, cursor=None)
         dm_module._build_query_results(result)
         mock_ui.table.assert_not_called()
+
+    def test_set_select_options_uses_native_helper_when_available(self) -> None:
+        select = MagicMock()
+        options = {"0": "Latest daily bars"}
+
+        dm_module._set_select_options(select, options, "0")
+
+        select.set_options.assert_called_once_with(options, value="0")
+        select.update.assert_not_called()
+
+    def test_set_select_options_falls_back_to_assignment(self) -> None:
+        select = _FakeElement()
+        options = {"0": "Latest daily bars"}
+
+        dm_module._set_select_options(select, options, "0")
+
+        assert select.options == options
+        assert select.value == "0"
 
 
 class TestBuildQualityTrendChart:
@@ -556,10 +613,7 @@ class TestBuildQualityTrendChart:
         trend = _make_quality_trend()
         dm_module._build_quality_trend_chart(trend)
         # Should show "No trend data available yet"
-        labels = [
-            str(call.args[0]) if call.args else ""
-            for call in mock_ui.label.call_args_list
-        ]
+        labels = [str(call.args[0]) if call.args else "" for call in mock_ui.label.call_args_list]
         assert any("No trend data" in label for label in labels)
 
 
@@ -659,6 +713,56 @@ class TestExportPermissionGating:
         from libs.platform.web_console_auth.permissions import Permission
 
         assert hasattr(Permission, "EXPORT_DATA")
+
+    def test_export_format_normalization(self) -> None:
+        assert dm_module._export_format_value("csv") == "csv"
+        assert dm_module._export_format_value("PARQUET") == "parquet"
+        assert dm_module._export_format_value("xlsx") is None
+
+    @pytest.mark.asyncio()
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    async def test_data_explorer_export_button_calls_service(
+        self,
+        mock_ui: MagicMock,
+        explorer_service: MagicMock,
+    ) -> None:
+        buttons: dict[str, Any] = {}
+        textareas_by_label: dict[str, _FakeElement] = {}
+
+        mock_ui.row.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.card.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.column.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.label.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.separator.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.select.side_effect = lambda *_args, **kwargs: _FakeElement(
+            value=kwargs.get("value"),
+            options=kwargs.get("options"),
+        )
+
+        def _textarea(*_args: Any, **kwargs: Any) -> _FakeElement:
+            element = _FakeElement(value=kwargs.get("value", ""))
+            label = str(kwargs.get("label", ""))
+            textareas_by_label[label] = element
+            return element
+
+        def _button(label: str, *_args: Any, **kwargs: Any) -> _FakeElement:
+            buttons[label] = kwargs.get("on_click")
+            return _FakeElement()
+
+        mock_ui.textarea.side_effect = _textarea
+        mock_ui.button.side_effect = _button
+
+        with patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True):
+            await dm_module._render_data_explorer_section(ADMIN_USER, explorer_service)
+        textareas_by_label["SQL Query"].value = "SELECT * FROM crsp_daily LIMIT 10"
+        await buttons["Export Results"]()
+
+        explorer_service.export_data.assert_awaited_once_with(
+            ADMIN_USER,
+            "crsp",
+            "SELECT * FROM crsp_daily LIMIT 10",
+            "csv",
+        )
 
 
 # ============================================================================
@@ -760,8 +864,11 @@ class TestQualityScoreCards:
         quality_service.get_validation_results = AsyncMock(
             return_value=[
                 ValidationResultDTO(
-                    id="v1", dataset="crsp", validation_type="row_count",
-                    status="ok", created_at=NOW,
+                    id="v1",
+                    dataset="crsp",
+                    validation_type="row_count",
+                    status="ok",
+                    created_at=NOW,
                 ),
             ]
         )
@@ -798,9 +905,7 @@ class TestQualityScoreCards:
         mock_ui.notify = MagicMock()
 
         quality_service = MagicMock()
-        quality_service.get_validation_results = AsyncMock(
-            side_effect=PermissionError("No access")
-        )
+        quality_service.get_validation_results = AsyncMock(side_effect=PermissionError("No access"))
 
         await dm_module._build_quality_score_cards(ADMIN_USER, quality_service)
         mock_ui.notify.assert_called_once()

--- a/tests/apps/web_console_ng/pages/test_sql_explorer_prefill.py
+++ b/tests/apps/web_console_ng/pages/test_sql_explorer_prefill.py
@@ -1,0 +1,67 @@
+"""SQL Explorer handoff prefill tests."""
+
+from __future__ import annotations
+
+from apps.web_console_ng.pages import sql_explorer as module
+
+
+def test_resolve_sql_explorer_prefill_warns_when_query_has_no_dataset() -> None:
+    initial_dataset, prefill_query, notifications = module._resolve_sql_explorer_prefill(
+        allowed_datasets=["crsp"],
+        requested_dataset=None,
+        requested_query="SELECT 1",
+    )
+
+    assert initial_dataset == "crsp"
+    assert prefill_query == ""
+    assert notifications == [
+        ("Linked query was not loaded because no dataset was provided", "warning")
+    ]
+
+
+def test_resolve_sql_explorer_prefill_warns_when_query_dataset_not_authorized() -> None:
+    initial_dataset, prefill_query, notifications = module._resolve_sql_explorer_prefill(
+        allowed_datasets=["crsp"],
+        requested_dataset="taq",
+        requested_query="SELECT * FROM taq_trades",
+    )
+
+    assert initial_dataset == "crsp"
+    assert prefill_query == ""
+    assert notifications == [
+        (
+            "Requested dataset is unavailable or not authorized; linked query was not loaded",
+            "warning",
+        )
+    ]
+
+
+def test_resolve_sql_explorer_prefill_loads_authorized_query() -> None:
+    initial_dataset, prefill_query, notifications = module._resolve_sql_explorer_prefill(
+        allowed_datasets=["crsp"],
+        requested_dataset="crsp",
+        requested_query="SELECT * FROM crsp_daily",
+    )
+
+    assert initial_dataset == "crsp"
+    assert prefill_query == "SELECT * FROM crsp_daily"
+    assert notifications == [
+        ("Query editor prefilled from link; review before running", "info")
+    ]
+
+
+def test_resolve_sql_explorer_prefill_warns_when_query_truncated() -> None:
+    long_query = "SELECT '" + ("x" * module._MAX_PREFILL_QUERY_CHARS) + "'"
+
+    initial_dataset, prefill_query, notifications = module._resolve_sql_explorer_prefill(
+        allowed_datasets=["crsp"],
+        requested_dataset="crsp",
+        requested_query=long_query,
+    )
+
+    assert initial_dataset == "crsp"
+    assert prefill_query == long_query[: module._MAX_PREFILL_QUERY_CHARS]
+    assert notifications == [
+        ("Query editor prefilled from link; review before running", "info"),
+        ("Linked query was truncated to 8,192 characters", "warning"),
+    ]

--- a/tests/apps/web_console_ng/test_dockerfile.py
+++ b/tests/apps/web_console_ng/test_dockerfile.py
@@ -6,6 +6,7 @@ def test_web_console_image_includes_data_acquisition_adapters() -> None:
     dockerfile = (repo_root / "apps/web_console_ng/Dockerfile").read_text()
     dockerignore = (repo_root / ".dockerignore").read_text()
     compose = (repo_root / "docker-compose.yml").read_text()
+    requirements = (repo_root / "apps/web_console_ng/requirements.txt").read_text()
 
     assert "scripts/data/alpaca_sip_sync.py" in dockerfile
     assert "scripts/data/alpaca_corp_actions_sync.py" in dockerfile
@@ -19,6 +20,7 @@ def test_web_console_image_includes_data_acquisition_adapters() -> None:
     assert "scripts/data/*" in dockerignore
     assert "!scripts/data/alpaca_sip_sync.py" in dockerignore
     assert "!scripts/data/alpaca_corp_actions_sync.py" in dockerignore
+    assert "duckdb==1.4.4" in requirements
 
     assert "./data:/app/data" in compose
     assert "APP_UID: ${WEB_CONSOLE_UID:-1000}" in compose

--- a/tests/apps/web_console_ng/ui/test_root_path.py
+++ b/tests/apps/web_console_ng/ui/test_root_path.py
@@ -59,6 +59,24 @@ def test_resolve_rooted_path_from_ui_uses_request_root_path() -> None:
     assert resolve_rooted_path_from_ui("/login", ui_module=ui_module) == "/console/login"
 
 
+def test_resolve_rooted_path_from_ui_preserves_query_string() -> None:
+    ui_module = SimpleNamespace(
+        context=SimpleNamespace(
+            client=SimpleNamespace(
+                request=SimpleNamespace(scope={"root_path": "/console"}),
+            ),
+        ),
+    )
+
+    assert (
+        resolve_rooted_path_from_ui(
+            "/data/sql-explorer?dataset=crsp&query=SELECT+1",
+            ui_module=ui_module,
+        )
+        == "/console/data/sql-explorer?dataset=crsp&query=SELECT+1"
+    )
+
+
 def test_resolve_rooted_path_from_ui_handles_missing_context() -> None:
     ui_module = SimpleNamespace()
 

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -945,6 +945,38 @@ async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
     ]
 
 
+def test_trusted_alpaca_summary_manifests_maps_tables_to_manifest_datasets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        data_explorer_module._ALPACA_SIP_TABLE_MANIFEST_DATASETS,
+        "alpaca_sip_daily",
+        "alpaca_sip_daily_v1",
+    )
+    trusted_manifest = SimpleNamespace(
+        dataset="alpaca_sip_daily_v1",
+        validation_status="passed",
+    )
+    stale_manifest = SimpleNamespace(
+        dataset="alpaca_sip_daily",
+        validation_status="passed",
+    )
+    failed_manifest = SimpleNamespace(
+        dataset="alpaca_sip_daily_v1",
+        validation_status="failed",
+    )
+    summary = SimpleNamespace(
+        manifests=[trusted_manifest, stale_manifest, failed_manifest],
+    )
+
+    manifests = data_explorer_module._trusted_alpaca_summary_manifests(
+        summary,
+        ["alpaca_sip_daily"],
+    )
+
+    assert manifests == [trusted_manifest]
+
+
 @pytest.mark.asyncio()
 async def test_list_datasets_isolates_alpaca_manifest_summary_failure(
     rate_limiter: AsyncMock,

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import polars as pl
@@ -62,10 +63,14 @@ def service(
 
 @pytest.fixture(autouse=True)
 def no_sql_explorer_sandbox_probe() -> Generator[None, None, None]:
+    data_explorer_module._SHARED_TABLE_AVAILABILITY_CACHE = None
+    data_explorer_module._SHARED_ALPACA_SUMMARY_CACHE = None
     with patch(
         "libs.web_console_services.data_explorer_service.ensure_sql_explorer_execution_allowed"
     ):
         yield
+    data_explorer_module._SHARED_TABLE_AVAILABILITY_CACHE = None
+    data_explorer_module._SHARED_ALPACA_SUMMARY_CACHE = None
 
 
 @pytest.mark.asyncio()
@@ -977,6 +982,15 @@ def test_trusted_alpaca_summary_manifests_maps_tables_to_manifest_datasets(
     assert manifests == [trusted_manifest]
 
 
+def test_trusted_alpaca_summary_manifests_handles_missing_manifests() -> None:
+    manifests = data_explorer_module._trusted_alpaca_summary_manifests(
+        SimpleNamespace(),
+        ["alpaca_sip_daily"],
+    )
+
+    assert manifests == []
+
+
 @pytest.mark.asyncio()
 async def test_list_datasets_isolates_alpaca_manifest_summary_failure(
     rate_limiter: AsyncMock,
@@ -1005,6 +1019,72 @@ async def test_list_datasets_isolates_alpaca_manifest_summary_failure(
     assert alpaca.availability_reason == (
         "Manifest summary temporarily unavailable; row count and date range may be incomplete"
     )
+
+
+@pytest.mark.asyncio()
+async def test_default_table_availability_cache_shared_across_service_instances(
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    calls = 0
+    expected = (
+        {
+            "crsp_daily": sql_module.SqlTableResolution(
+                dataset="crsp",
+                table="crsp_daily",
+                path_spec=None,
+                available=False,
+                manifest_required=False,
+                manifest_backed=False,
+                manifest_invalid=False,
+                fallback_only=False,
+                trusted_for_data_page=False,
+            )
+        },
+        ["missing"],
+    )
+
+    def resolve(table_paths: dict[str, sql_module.TablePathSpec] | None = None) -> Any:
+        nonlocal calls
+        assert table_paths is None
+        calls += 1
+        return expected
+
+    monkeypatch.setattr(data_explorer_module, "resolve_sql_table_availability", resolve)
+
+    service_one = DataExplorerService(rate_limiter=rate_limiter)
+    service_two = DataExplorerService(rate_limiter=rate_limiter)
+
+    assert await service_one._resolve_table_availability() == expected
+    assert await service_two._resolve_table_availability() == expected
+    assert calls == 1
+
+
+@pytest.mark.asyncio()
+async def test_default_alpaca_summary_cache_shared_across_service_instances(
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    calls = 0
+    summary = SimpleNamespace(manifests=[])
+
+    def get_summary(_service: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return summary
+
+    monkeypatch.setattr(
+        data_explorer_module.DataManifestService,
+        "get_alpaca_sip_summary",
+        get_summary,
+    )
+
+    service_one = DataExplorerService(rate_limiter=rate_limiter)
+    service_two = DataExplorerService(rate_limiter=rate_limiter)
+
+    assert await service_one._get_alpaca_summary() == (summary, False)
+    assert await service_two._get_alpaca_summary() == (summary, False)
+    assert calls == 1
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Generator
 from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import polars as pl
 import pytest
 
+from libs.web_console_services import data_explorer_service as data_explorer_module
+from libs.web_console_services import sql_explorer_service as sql_module
 from libs.web_console_services.data_explorer_service import DataExplorerService, RateLimitExceeded
+from libs.web_console_services.provider_signature import ProviderSignatureDTO
+from libs.web_console_services.sql_validator import SQLValidator
 
 
 @dataclass(frozen=True)
@@ -26,13 +36,36 @@ def rate_limiter() -> AsyncMock:
 def sql_validator() -> MagicMock:
     validator = MagicMock()
     validator.validate.return_value = (True, None)
+    validator.extract_tables.return_value = ["crsp_daily"]
     validator.enforce_row_limit.side_effect = lambda query, max_rows: f"{query} LIMIT {max_rows}"
     return validator
 
 
 @pytest.fixture()
-def service(rate_limiter: AsyncMock, sql_validator: MagicMock) -> DataExplorerService:
-    return DataExplorerService(rate_limiter=rate_limiter, sql_validator=sql_validator)
+def service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+    sql_validator: MagicMock,
+) -> DataExplorerService:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    return DataExplorerService(
+        rate_limiter=rate_limiter,
+        sql_validator=sql_validator,
+        table_paths={"crsp_daily": str(partition)},
+    )
+
+
+@pytest.fixture(autouse=True)
+def no_sql_explorer_sandbox_probe() -> Generator[None, None, None]:
+    with patch(
+        "libs.web_console_services.data_explorer_service.ensure_sql_explorer_execution_allowed"
+    ):
+        yield
 
 
 @pytest.mark.asyncio()
@@ -55,8 +88,19 @@ async def test_list_datasets_filters_by_dataset_permission(
     assert names == {"crsp", "fama_french"}
 
 
+@pytest.mark.parametrize(
+    ("limit", "message"),
+    [
+        (1001, "1000"),
+        (0, "positive"),
+    ],
+)
 @pytest.mark.asyncio()
-async def test_get_dataset_preview_limit_guard(service: DataExplorerService) -> None:
+async def test_get_dataset_preview_limit_guard(
+    service: DataExplorerService,
+    limit: int,
+    message: str,
+) -> None:
     with (
         patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
         patch(
@@ -64,8 +108,65 @@ async def test_get_dataset_preview_limit_guard(service: DataExplorerService) -> 
             return_value=True,
         ),
     ):
-        with pytest.raises(ValueError, match="1000"):
-            await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=1001)
+        with pytest.raises(ValueError, match=message):
+            await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=limit)
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_audits_rate_limit_failure(
+    service: DataExplorerService,
+) -> None:
+    service._rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        with pytest.raises(RateLimitExceeded):
+            await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=5)
+
+    assert audit.call_args.args[6] == "rate_limited"
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_audits_permission_failure(
+    service: DataExplorerService,
+) -> None:
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=False),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        with pytest.raises(PermissionError):
+            await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=5)
+
+    assert audit.call_args.args[6] == "authorization_denied"
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_audits_table_selection_failure(
+    rate_limiter: AsyncMock,
+) -> None:
+    service = DataExplorerService(rate_limiter=rate_limiter, table_paths={})
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        with pytest.raises(ValueError, match="No trusted local data"):
+            await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=5)
+
+    assert audit.call_args.args[6] == "validation_error"
 
 
 @pytest.mark.asyncio()
@@ -89,6 +190,89 @@ async def test_execute_query_invalid_sql_fails_before_rate_limit(
 
 
 @pytest.mark.asyncio()
+async def test_execute_query_tableless_literal_smoke_query_runs(
+    rate_limiter: AsyncMock,
+) -> None:
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        sql_validator=SQLValidator(),
+        table_paths={},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            "SELECT 1 AS ok",
+        )
+
+    assert result.rows == [{"ok": 1}]
+    assert result.has_more is False
+    rate_limiter.check_rate_limit.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_max_rows_guard_fails_before_rate_limit(
+    rate_limiter: AsyncMock,
+    sql_validator: MagicMock,
+) -> None:
+    service = DataExplorerService(rate_limiter=rate_limiter, sql_validator=sql_validator)
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="row limit must be positive"):
+            await service.execute_query(
+                DummyUser(user_id="user-1"),
+                "crsp",
+                "select * from crsp_daily",
+                max_rows=0,
+            )
+
+    rate_limiter.check_rate_limit.assert_not_awaited()
+    sql_validator.validate.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_export_data_table_trust_fails_before_rate_limit(
+    service: DataExplorerService,
+) -> None:
+    service._rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
+    service._resolve_table_availability = AsyncMock(return_value=({}, []))  # type: ignore[method-assign]
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="not available|Trusted local data"):
+            await service.export_data(
+                DummyUser(user_id="user-1"),
+                dataset="crsp",
+                query="select * from crsp_daily",
+                format="csv",
+            )
+
+    service._rate_limiter.check_rate_limit.assert_not_awaited()
+    service._resolve_table_availability.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
 async def test_execute_query_rate_limit_exceeded(service: DataExplorerService) -> None:
     service._rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
 
@@ -105,6 +289,54 @@ async def test_execute_query_rate_limit_exceeded(service: DataExplorerService) -
 
 
 @pytest.mark.asyncio()
+async def test_execute_query_table_trust_fails_before_rate_limit(
+    service: DataExplorerService,
+) -> None:
+    service._rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
+    service._resolve_table_availability = AsyncMock(return_value=({}, []))  # type: ignore[method-assign]
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="not available|Trusted local data"):
+            await service.execute_query(
+                DummyUser(user_id="user-1"),
+                "crsp",
+                "select * from crsp_daily",
+            )
+
+    service._rate_limiter.check_rate_limit.assert_not_awaited()
+    service._resolve_table_availability.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_table_trust_fails_before_rate_limit(
+    service: DataExplorerService,
+) -> None:
+    service._rate_limiter.check_rate_limit = AsyncMock(return_value=(False, 0))
+    service._resolve_table_availability = AsyncMock(return_value=({}, []))  # type: ignore[method-assign]
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="No trusted local data"):
+            await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=5)
+
+    service._rate_limiter.check_rate_limit.assert_not_awaited()
+    service._resolve_table_availability.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
 async def test_execute_query_enforces_row_limit_and_calls_rate_limiter(
     service: DataExplorerService, sql_validator: MagicMock
 ) -> None:
@@ -116,11 +348,135 @@ async def test_execute_query_enforces_row_limit_and_calls_rate_limiter(
         ),
         patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
     ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            "select * from crsp_daily",
+        )
+
+    assert result.total_count == 1
+    sql_validator.enforce_row_limit.assert_called_once_with(
+        "select * from crsp_daily",
+        max_rows=10001,
+    )
+    service._rate_limiter.check_rate_limit.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_accepts_smaller_page_limit(
+    service: DataExplorerService, sql_validator: MagicMock
+) -> None:
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            "select * from crsp_daily",
+            max_rows=500,
+        )
+
+    assert result.total_count == 1
+    sql_validator.enforce_row_limit.assert_called_once_with(
+        "select * from crsp_daily",
+        max_rows=501,
+    )
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_allows_tableless_smoke_query(
+    rate_limiter: AsyncMock,
+    sql_validator: MagicMock,
+) -> None:
+    sql_validator.extract_tables.return_value = []
+    sql_validator.enforce_row_limit.side_effect = lambda query, max_rows: query
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        sql_validator=sql_validator,
+        table_paths={},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
         result = await service.execute_query(DummyUser(user_id="user-1"), "crsp", "select 1")
 
-    assert result.total_count == 0
-    sql_validator.enforce_row_limit.assert_called_once_with("select 1", max_rows=10000)
-    service._rate_limiter.check_rate_limit.assert_awaited_once()
+    assert result.total_count == 1
+    assert result.has_more is False
+    rate_limiter.check_rate_limit.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_rejects_tableless_table_function(
+    rate_limiter: AsyncMock,
+) -> None:
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        sql_validator=SQLValidator(),
+        table_paths={},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="Tableless queries"):
+            await service.execute_query(
+                DummyUser(user_id="user-1"),
+                "crsp",
+                "select count(*) from range(1000000)",
+            )
+
+    rate_limiter.check_rate_limit.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_rejects_cross_dataset_table_after_trust_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+    sql_validator: MagicMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "taq" / "trades" / "taq.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    sql_validator.extract_tables.return_value = ["taq_trades"]
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        sql_validator=sql_validator,
+        table_paths={"taq_trades": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="taq_trades.*crsp"):
+            await service.execute_query(
+                DummyUser(user_id="user-1"),
+                "crsp",
+                "select * from taq_trades",
+            )
 
 
 @pytest.mark.asyncio()
@@ -134,6 +490,7 @@ async def test_export_data_returns_job(
             return_value=True,
         ),
         patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
     ):
         job = await service.export_data(
             DummyUser(user_id="user-1"),
@@ -148,3 +505,1017 @@ async def test_export_data_returns_job(
         "select * from crsp_daily", max_rows=100000
     )
     service._rate_limiter.check_rate_limit.assert_awaited_once()
+    assert audit.call_args.args[6] == "queued"
+
+
+@pytest.mark.asyncio()
+async def test_export_data_audits_sensitive_table_block(
+    service: DataExplorerService,
+    sql_validator: MagicMock,
+) -> None:
+    sql_validator.extract_tables.return_value = ["users"]
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        with pytest.raises(sql_module.SensitiveTableAccessError):
+            await service.export_data(
+                DummyUser(user_id="user-1"),
+                dataset="crsp",
+                query="select * from users",
+                format="csv",
+            )
+
+    assert audit.call_args.args[6] == "security_blocked"
+
+
+@pytest.mark.asyncio()
+async def test_export_data_blocks_alpaca_sip_fallback_without_manifest(
+    tmp_path: Path,
+    rate_limiter: AsyncMock,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(ValueError, match="fallback only"):
+            await service.export_data(
+                DummyUser(user_id="user-1"),
+                dataset="alpaca_sip",
+                query="SELECT * FROM alpaca_sip_daily",
+                format="csv",
+            )
+
+    rate_limiter.check_rate_limit.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_reads_manifest_pinned_alpaca_sip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "date": ["2026-01-02"],
+            "symbol": ["AAPL"],
+            "close": [187.25],
+        }
+    ).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": (str(partition),)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=1,
+            table="alpaca_sip_daily",
+        )
+
+    assert preview.table == "alpaca_sip_daily"
+    assert preview.trusted_manifest_backed is True
+    assert preview.rows == [{"date": "2026-01-02", "symbol": "AAPL", "close": 187.25}]
+    assert preview.sql_handoff_url is not None
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_blocks_alpaca_sip_fallback_without_manifest(
+    tmp_path: Path,
+    rate_limiter: AsyncMock,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(ValueError, match="fallback only"):
+            await service.get_dataset_preview(
+                DummyUser(user_id="user-1"),
+                "alpaca_sip",
+                table="alpaca_sip_daily",
+            )
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_skips_fallback_when_trusted_table_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    fallback_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    fallback_partition.parent.mkdir(parents=True)
+    fallback_partition.write_bytes(b"PAR1")
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame({"ex_date": ["2026-01-02"], "symbol": ["AAPL"]}).write_parquet(corp_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={
+            "alpaca_sip_daily": str(fallback_partition),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=1,
+        )
+
+    assert preview.table == "alpaca_sip_corp_actions"
+    assert preview.trusted_manifest_backed is True
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_labels_alpaca_sip_fallback_only(
+    tmp_path: Path,
+    rate_limiter: AsyncMock,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    alpaca = next(item for item in datasets if item.name == "alpaca_sip")
+    assert alpaca.queryable_state == "queryable_fallback_only"
+    assert alpaca.sql_handoff_url is None
+    assert alpaca.availability_reason is not None
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_hides_untrusted_alpaca_manifest_summary(
+    tmp_path: Path,
+    rate_limiter: AsyncMock,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
+        has_any_manifest=True,
+        row_count=123,
+        latest_sync=datetime(2026, 1, 3, tzinfo=UTC),
+        manifests=[
+            SimpleNamespace(
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 2),
+            )
+        ],
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={"alpaca_sip_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    alpaca = next(item for item in datasets if item.name == "alpaca_sip")
+    assert alpaca.queryable_state == "queryable_fallback_only"
+    assert alpaca.row_count is None
+    assert alpaca.date_range is None
+    assert alpaca.last_sync is None
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_exposes_trusted_alpaca_manifest_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"symbol": ["AAPL"]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    latest_sync = datetime(2026, 1, 3, tzinfo=UTC)
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
+        has_any_manifest=True,
+        row_count=1,
+        latest_sync=latest_sync,
+        manifests=[
+            SimpleNamespace(
+                dataset="alpaca_sip_daily",
+                validation_status="passed",
+                sync_timestamp=latest_sync,
+                start_date=date(2026, 1, 2),
+                end_date=date(2026, 1, 2),
+                row_count=1,
+            )
+        ],
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={"alpaca_sip_daily": (str(partition),)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    alpaca = next(item for item in datasets if item.name == "alpaca_sip")
+    assert alpaca.queryable_state == "trusted_manifest_backed"
+    assert alpaca.tables == ["alpaca_sip_daily"]
+    assert alpaca.row_count == 1
+    assert alpaca.date_range == {"start": "2026-01-02", "end": "2026-01-02"}
+    assert alpaca.last_sync == latest_sync
+    assert alpaca.sql_handoff_url is not None
+    assert alpaca.query_templates
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_does_not_mark_invalid_manifest_path_queryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    failed_sync = datetime(2026, 1, 10, tzinfo=UTC)
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
+        has_any_manifest=True,
+        row_count=100,
+        latest_sync=failed_sync,
+        manifests=[
+            SimpleNamespace(
+                dataset="alpaca_sip_daily",
+                validation_status="failed",
+                sync_timestamp=failed_sync,
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 10),
+                row_count=100,
+            )
+        ],
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={
+            "alpaca_sip_daily": sql_module.ResolvedTablePathSpec(
+                path_spec=(str(partition),),
+                manifest_backed=True,
+                manifest_invalid=True,
+            )
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    alpaca = next(item for item in datasets if item.name == "alpaca_sip")
+    assert alpaca.queryable_state == "missing"
+    assert alpaca.trusted_manifest_backed is False
+    assert alpaca.tables == []
+    assert alpaca.sql_handoff_url is None
+    assert alpaca.row_count is None
+    assert alpaca.availability_reason is not None
+    assert "Trusted manifest is invalid" in alpaca.availability_reason
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame({"ex_date": ["2026-01-02"], "symbol": ["AAPL"]}).write_parquet(corp_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    trusted_sync = datetime(2026, 1, 3, tzinfo=UTC)
+    failed_sync = datetime(2026, 1, 10, tzinfo=UTC)
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
+        has_any_manifest=True,
+        row_count=105,
+        latest_sync=failed_sync,
+        manifests=[
+            SimpleNamespace(
+                dataset="alpaca_sip_daily",
+                validation_status="failed",
+                sync_timestamp=failed_sync,
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 10),
+                row_count=100,
+            ),
+            SimpleNamespace(
+                dataset="alpaca_sip_corp_actions",
+                validation_status="passed",
+                sync_timestamp=trusted_sync,
+                start_date=date(2026, 1, 2),
+                end_date=date(2026, 1, 2),
+                row_count=5,
+            ),
+        ],
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={
+            "alpaca_sip_daily": sql_module.ResolvedTablePathSpec(
+                path_spec=(),
+                manifest_invalid=True,
+            ),
+            "alpaca_sip_corp_actions": sql_module.ResolvedTablePathSpec(
+                path_spec=(str(corp_partition),),
+                manifest_backed=True,
+            ),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    alpaca = next(item for item in datasets if item.name == "alpaca_sip")
+    assert alpaca.tables == ["alpaca_sip_corp_actions"]
+    assert alpaca.row_count == 5
+    assert alpaca.date_range == {"start": "2026-01-02", "end": "2026-01-02"}
+    assert alpaca.last_sync == trusted_sync
+    assert alpaca.sql_handoff_url is not None
+    assert "alpaca_sip_corp_actions" in alpaca.sql_handoff_url
+    assert "alpaca_sip_daily" not in alpaca.sql_handoff_url
+    assert [template.table for template in alpaca.query_templates] == [
+        "alpaca_sip_corp_actions"
+    ]
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_isolates_alpaca_manifest_summary_failure(
+    rate_limiter: AsyncMock,
+) -> None:
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.side_effect = RuntimeError("bad manifest")
+    service = DataExplorerService(rate_limiter=rate_limiter, manifest_service=manifest_service)
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    assert {dataset.name for dataset in datasets} == {
+        "crsp",
+        "compustat",
+        "taq",
+        "fama_french",
+        "alpaca_sip",
+    }
+    alpaca = next(dataset for dataset in datasets if dataset.name == "alpaca_sip")
+    assert alpaca.availability_reason == (
+        "Manifest summary temporarily unavailable; row count and date range may be incomplete"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_alpaca_manifest_summary_timeout_failure_cache_uses_fresh_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.side_effect = (
+        lambda: data_explorer_module.time.sleep(0.12)
+    )
+    service = DataExplorerService(rate_limiter=rate_limiter, manifest_service=manifest_service)
+    monkeypatch.setattr(data_explorer_module, "_MANIFEST_SUMMARY_TIMEOUT_SECONDS", 0.08)
+    monkeypatch.setattr(data_explorer_module, "_MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS", 5.0)
+
+    assert await service._get_alpaca_summary() == (None, True)
+    assert await service._get_alpaca_summary() == (None, True)
+    manifest_service.get_alpaca_sip_summary.assert_called_once_with()
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_rejects_requested_table_outside_dataset(
+    service: DataExplorerService,
+) -> None:
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(ValueError, match="taq_trades.*crsp"):
+            await service.get_dataset_preview(
+                DummyUser(user_id="user-1"),
+                "crsp",
+                table="taq_trades",
+            )
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_rejects_requested_table_without_local_data(
+    service: DataExplorerService,
+) -> None:
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(ValueError, match="No local data available for table crsp_monthly"):
+            await service.get_dataset_preview(
+                DummyUser(user_id="user-1"),
+                "crsp",
+                table="crsp_monthly",
+            )
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_reads_trusted_local_table(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "date": ["2026-01-02"],
+            "symbol": ["AAPL"],
+            "close": [187.25],
+        }
+    ).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": (str(partition),)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            "SELECT symbol, close FROM alpaca_sip_daily",
+        )
+
+    assert result.rows == [{"symbol": "AAPL", "close": 187.25}]
+    assert result.execution_ms is not None
+    assert result.fingerprint is not None
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_only_registers_referenced_trusted_tables(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    monthly = data_root / "wrds" / "crsp" / "monthly" / "crsp.parquet"
+    daily.parent.mkdir(parents=True)
+    monthly.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(daily)
+    monthly.write_text("not parquet", encoding="utf-8")
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={
+            "crsp_daily": str(daily),
+            "crsp_monthly": str(monthly),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            "SELECT * FROM crsp_daily",
+        )
+
+    assert result.rows == [{"id": 1}]
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_only_registers_selected_table(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    monthly = data_root / "wrds" / "crsp" / "monthly" / "crsp.parquet"
+    daily.parent.mkdir(parents=True)
+    monthly.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(daily)
+    monthly.write_text("not parquet", encoding="utf-8")
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={
+            "crsp_daily": str(daily),
+            "crsp_monthly": str(monthly),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        preview = await service.get_dataset_preview(DummyUser(user_id="user-1"), "crsp", limit=1)
+
+    assert preview.table == "crsp_daily"
+    assert preview.rows == [{"id": 1}]
+
+
+@pytest.mark.asyncio()
+async def test_preview_reuses_cached_trusted_manifest_paths_after_manifest_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    project_root = tmp_path
+    data_root = project_root / "data"
+    trusted_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "trusted.parquet"
+    )
+    fallback_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "fallback.parquet"
+    )
+    trusted_partition.parent.mkdir(parents=True)
+    fallback_partition.parent.mkdir(parents=True)
+    pl.DataFrame({"source": ["trusted"]}).write_parquet(trusted_partition)
+    pl.DataFrame({"source": ["fallback"]}).write_parquet(fallback_partition)
+    manifest_dir = data_root / "manifests"
+    manifest_dir.mkdir(parents=True)
+    manifest_path = manifest_dir / "alpaca_sip_daily.json"
+    manifest_path.write_text(
+        json.dumps({"file_paths": [str(trusted_partition)], "validation_status": "passed"}),
+        encoding="utf-8",
+    )
+    sql_module._ALPACA_SIP_MANIFEST_PATH_CACHE.clear()
+    monkeypatch.setattr(sql_module, "_PROJECT_ROOT", project_root)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(rate_limiter=rate_limiter)
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        first_preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=10,
+            table="alpaca_sip_daily",
+        )
+        manifest_path.unlink()
+        second_preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=10,
+            table="alpaca_sip_daily",
+        )
+
+    assert first_preview.rows == [{"source": "trusted"}]
+    assert second_preview.rows == [{"source": "trusted"}]
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_trims_fetch_limit_and_sets_has_more(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": list(range(10001))}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"crsp_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            "SELECT * FROM crsp_daily",
+        )
+
+    assert len(result.rows) == 10000
+    assert result.total_count == 10001
+    assert result.has_more is True
+
+
+@pytest.mark.asyncio()
+async def test_execute_query_uses_sql_explorer_guard_and_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"crsp_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch(
+            "libs.web_console_services.data_explorer_service.ensure_sql_explorer_execution_allowed"
+        ) as guard,
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        result = await service.execute_query(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            "SELECT * FROM crsp_daily",
+        )
+
+    assert result.total_count == 1
+    guard.assert_called_once_with()
+    audit.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_uses_sql_explorer_guard_and_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"crsp_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch(
+            "libs.web_console_services.data_explorer_service.ensure_sql_explorer_execution_allowed"
+        ) as guard,
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            limit=1,
+        )
+
+    assert preview.total_count == 1
+    assert preview.has_more is False
+    guard.assert_called_once_with()
+    audit.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_fetches_sentinel_and_sets_has_more(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "crsp.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"id": [1, 2, 3]}).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"crsp_daily": str(partition)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "crsp",
+            limit=2,
+        )
+
+    assert preview.rows == [{"id": 1}, {"id": 2}]
+    assert preview.total_count == 3
+    assert preview.has_more is True
+    assert audit.call_args.args[4] == 2
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "date": [date(2026, 1, 2)],
+            "close": [100.0],
+            "adj_close": [None],
+            "ret": [None],
+        }
+    ).write_parquet(partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": (str(partition),)},
+    )
+    provider_signature = ProviderSignatureDTO(
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        adjustment_mode="raw",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        manifest_id="alpaca_sip_daily@v1:abc",
+        manifest_reference="manifests://alpaca_sip_daily.json",
+        manifest_checksum="abc",
+    )
+    service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
+        return_value=(
+            SimpleNamespace(
+                manifests=[
+                    SimpleNamespace(
+                        dataset="alpaca_sip_daily",
+                        manifest_id="alpaca_sip_daily@v1:abc",
+                        manifest_reference="manifests://alpaca_sip_daily.json",
+                        manifest_checksum="abc",
+                        manifest_version=1,
+                        provider_id="alpaca_sip",
+                        provider_version="1.0",
+                        source_feed="sip",
+                        adjustment_mode="raw",
+                        canonical_storage_mode="raw",
+                        read_time_adjustment_mode="unavailable",
+                        provider_signature=provider_signature,
+                    )
+                ]
+            ),
+            False,
+        )
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=5,
+            table="alpaca_sip_daily",
+        )
+
+    assert preview.provider_id == "alpaca_sip"
+    assert preview.provider_version == "1.0"
+    assert preview.source_feed == "sip"
+    assert preview.adjustment_mode == "raw"
+    assert preview.canonical_storage_mode == "raw"
+    assert preview.read_time_adjustment_mode == "unavailable"
+    assert preview.manifest_id == "alpaca_sip_daily@v1:abc"
+    assert preview.manifest_reference == "manifests://alpaca_sip_daily.json"
+    assert preview.manifest_checksum == "abc"
+    assert preview.provider_signature == provider_signature
+    assert preview.null_column_reasons == {
+        "adj_close": "raw_sip_returns_unavailable",
+        "ret": "raw_sip_returns_unavailable",
+    }
+    assert preview.warnings == ["raw_sip_returns_unavailable"]
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_requested_table_reports_invalid_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={
+            "alpaca_sip_daily": sql_module.ResolvedTablePathSpec(
+                path_spec=(str(partition),),
+                manifest_backed=True,
+                manifest_invalid=True,
+            )
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="Trusted manifest is invalid"):
+            await service.get_dataset_preview(
+                DummyUser(user_id="user-1"),
+                "alpaca_sip",
+                limit=5,
+                table="alpaca_sip_daily",
+            )
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_requested_table_reports_unavailable_invalid_manifest(
+    rate_limiter: AsyncMock,
+) -> None:
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={
+            "alpaca_sip_daily": sql_module.ResolvedTablePathSpec(
+                path_spec=(),
+                manifest_invalid=True,
+            )
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        with pytest.raises(ValueError, match="Trusted manifest is invalid"):
+            await service.get_dataset_preview(
+                DummyUser(user_id="user-1"),
+                "alpaca_sip",
+                limit=5,
+                table="alpaca_sip_daily",
+            )
+
+
+def test_handoff_query_uses_explicit_dataset_default() -> None:
+    query = data_explorer_module._handoff_query_for_dataset(
+        "crsp",
+        ["crsp_monthly", "crsp_daily"],
+    )
+
+    assert query == "SELECT * FROM crsp_daily LIMIT 100"

--- a/tests/libs/web_console_services/test_sql_explorer_service.py
+++ b/tests/libs/web_console_services/test_sql_explorer_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -700,14 +701,29 @@ def test_execution_allowed_requires_attestation_in_production(
         module.ensure_sql_explorer_execution_allowed()
 
 
-def test_service_init_requires_attestation_in_production(
+def test_service_init_defers_attestation_probe_in_production(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(module, "_APP_ENV", "production")
     monkeypatch.setenv("SQL_EXPLORER_DEPLOY_ATTESTED", "false")
+    monkeypatch.setattr(
+        module,
+        "_verify_sandbox",
+        lambda: pytest.fail("constructor should not run sandbox probe"),
+    )
 
+    svc = SqlExplorerService(rate_limiter=_DummyRateLimiter())
+
+    assert svc is not None
+
+
+def test_create_scoped_query_connection_requires_attestation_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module, "_APP_ENV", "production")
+    monkeypatch.setenv("SQL_EXPLORER_DEPLOY_ATTESTED", "false")
     with pytest.raises(RuntimeError, match="deploy-attested"):
-        SqlExplorerService(rate_limiter=_DummyRateLimiter())
+        module.create_scoped_query_connection("crsp", available_tables=set())
 
 
 def test_service_init_rate_limiter_guards(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -767,9 +783,32 @@ async def test_execute_query_timeout_interrupts_connection(
             "SELECT * FROM crsp_daily",
             timeout_seconds=0,
             available_tables={"crsp_daily"},
-        )
+    )
 
     assert conn.interrupt_called is True
+    assert conn.closed is True
+
+
+@pytest.mark.asyncio()
+async def test_execute_scoped_query_timeout_waits_for_worker_cleanup() -> None:
+    class SlowConn(_DummyConn):
+        def __init__(self) -> None:
+            super().__init__()
+            self.finished = threading.Event()
+
+        def execute(self, sql: str) -> _DummyConn:
+            del sql
+            time.sleep(0.05)
+            self.finished.set()
+            return self
+
+    conn = SlowConn()
+
+    with pytest.raises(TimeoutError):
+        await module.execute_scoped_query_with_timeout(conn, "SELECT 1", timeout_seconds=0.01)
+
+    assert conn.interrupt_called is True
+    assert conn.finished.is_set()
 
 
 @pytest.mark.asyncio()
@@ -835,23 +874,44 @@ async def test_execute_query_audit_statuses(
     with pytest.raises(RateLimitExceededError):
         await service_rl.execute_query(operator_user, "crsp", "SELECT * FROM crsp_daily")
 
+    original_execute_frame = module.execute_scoped_query_frame_with_timeout
+
     # concurrency_limit
-    async def raise_concurrency(conn: Any, sql: str, timeout_seconds: int) -> pl.DataFrame:
-        del conn, sql, timeout_seconds
+    async def raise_concurrency(
+        dataset: str,
+        sql: str,
+        timeout_seconds: int,
+        *,
+        available_tables: set[str],
+        table_paths: dict[str, module.TablePathSpec] | None = None,
+    ) -> pl.DataFrame:
+        del dataset, sql, timeout_seconds, available_tables, table_paths
         raise ConcurrencyLimitError("busy")
 
-    monkeypatch.setattr(module, "_execute_query_with_timeout", raise_concurrency)
+    monkeypatch.setattr(module, "execute_scoped_query_frame_with_timeout", raise_concurrency)
     with pytest.raises(ConcurrencyLimitError):
         await service.execute_query(operator_user, "crsp", "SELECT * FROM crsp_daily")
 
     # timeout
-    async def raise_timeout(conn: Any, sql: str, timeout_seconds: int) -> pl.DataFrame:
-        del conn, sql, timeout_seconds
+    async def raise_timeout(
+        dataset: str,
+        sql: str,
+        timeout_seconds: int,
+        *,
+        available_tables: set[str],
+        table_paths: dict[str, module.TablePathSpec] | None = None,
+    ) -> pl.DataFrame:
+        del dataset, sql, timeout_seconds, available_tables, table_paths
         raise TimeoutError
 
-    monkeypatch.setattr(module, "_execute_query_with_timeout", raise_timeout)
+    monkeypatch.setattr(module, "execute_scoped_query_frame_with_timeout", raise_timeout)
     with pytest.raises(TimeoutError):
         await service.execute_query(operator_user, "crsp", "SELECT * FROM crsp_daily")
+    monkeypatch.setattr(
+        module,
+        "execute_scoped_query_frame_with_timeout",
+        original_execute_frame,
+    )
 
     # error
     monkeypatch.setattr(

--- a/tests/libs/web_console_services/test_sql_explorer_service.py
+++ b/tests/libs/web_console_services/test_sql_explorer_service.py
@@ -7,6 +7,7 @@ import json
 import logging
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -71,6 +72,11 @@ class _DummyConn:
 
     def close(self) -> None:
         self.closed = True
+
+
+async def _wait_until(predicate: Callable[[], bool], *, interval: float = 0.01) -> None:
+    while not predicate():
+        await asyncio.sleep(interval)
 
 
 @pytest.fixture(autouse=True)
@@ -518,6 +524,14 @@ def test_resolve_table_paths_fail_closed_on_unreadable_alpaca_manifest(
     assert _raw_path_spec(cached_paths["alpaca_sip_daily"]) == ()
     assert "sql_explorer_alpaca_sip_daily_manifest_unreadable" not in caplog.text
 
+    monkeypatch.setattr(module, "_ALPACA_SIP_MANIFEST_FAILURE_CACHE_TTL_SECONDS", 0.0)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        expired_paths = module._resolve_table_paths()
+
+    assert _raw_path_spec(expired_paths["alpaca_sip_daily"]) == ()
+    assert "sql_explorer_alpaca_sip_daily_manifest_unreadable" in caplog.text
+
 
 def test_resolve_table_paths_handles_manifest_stat_race(
     tmp_path: Path,
@@ -785,12 +799,14 @@ async def test_execute_query_timeout_interrupts_connection(
             available_tables={"crsp_daily"},
     )
 
-    assert conn.interrupt_called is True
-    assert conn.closed is True
+    await asyncio.wait_for(_wait_until(lambda: conn.interrupt_called), timeout=1.0)
+    await asyncio.wait_for(_wait_until(lambda: conn.closed), timeout=1.0)
 
 
 @pytest.mark.asyncio()
-async def test_execute_scoped_query_timeout_waits_for_worker_cleanup() -> None:
+async def test_execute_query_timeout_returns_before_worker_cleanup(
+    operator_user: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     class SlowConn(_DummyConn):
         def __init__(self) -> None:
             super().__init__()
@@ -798,17 +814,30 @@ async def test_execute_scoped_query_timeout_waits_for_worker_cleanup() -> None:
 
         def execute(self, sql: str) -> _DummyConn:
             del sql
-            time.sleep(0.05)
+            time.sleep(0.2)
             self.finished.set()
             return self
 
+    service = SqlExplorerService(rate_limiter=_DummyRateLimiter())
     conn = SlowConn()
+    monkeypatch.setattr(module, "_create_query_connection", lambda dataset, available_tables: conn)
 
+    started = time.monotonic()
     with pytest.raises(TimeoutError):
-        await module.execute_scoped_query_with_timeout(conn, "SELECT 1", timeout_seconds=0.01)
+        await service.execute_query(
+            operator_user,
+            "crsp",
+            "SELECT * FROM crsp_daily",
+            timeout_seconds=0.01,
+            available_tables={"crsp_daily"},
+        )
+    elapsed = time.monotonic() - started
 
-    assert conn.interrupt_called is True
-    assert conn.finished.is_set()
+    assert elapsed < 0.15
+    await asyncio.wait_for(_wait_until(lambda: conn.interrupt_called), timeout=1.0)
+    assert conn.finished.is_set() is False
+    assert await asyncio.to_thread(conn.finished.wait, 1.0)
+    assert conn.closed is True
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_sql_explorer_service.py
+++ b/tests/libs/web_console_services/test_sql_explorer_service.py
@@ -27,6 +27,12 @@ from libs.web_console_services.sql_explorer_service import (
 )
 
 
+def _raw_path_spec(path_spec: module.TablePathSpec) -> str | tuple[str, ...]:
+    if isinstance(path_spec, module.ResolvedTablePathSpec):
+        return path_spec.path_spec
+    return path_spec
+
+
 class _DummyRateLimiter:
     def __init__(self, allowed: bool = True, fallback_mode: str = "deny") -> None:
         self.allowed = allowed
@@ -120,6 +126,7 @@ def test_safe_error_message_returns_canonical_codes() -> None:
     assert _safe_error_message("validation_error", "raw") == "Query failed validation"
     assert _safe_error_message("unknown", "raw") == "Internal execution error"
     assert _safe_error_message("success") is None
+    assert _safe_error_message("queued") is None
 
 
 def test_fingerprint_query_replaces_literals_and_handles_unparseable() -> None:
@@ -134,7 +141,7 @@ def test_fingerprint_query_replaces_literals_and_handles_unparseable() -> None:
 def test_create_query_connection_sets_extension_lockdown(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeResult:
         def fetchall(self) -> list[tuple[str]]:
-            return [("core_functions",), ("parquet",)]
+            return [("core_functions",), ("jemalloc",), ("parquet",)]
 
     class FakeConn:
         def __init__(self) -> None:
@@ -155,8 +162,59 @@ def test_create_query_connection_sets_extension_lockdown(monkeypatch: pytest.Mon
 
     module._create_query_connection("crsp", available_tables=set())
 
-    assert "SET enable_extension_autoloading = false" in fake_conn.statements
+    assert "LOAD core_functions" in fake_conn.statements
+    assert "LOAD icu" in fake_conn.statements
+    assert "LOAD jemalloc" not in fake_conn.statements
+    assert "LOAD json" in fake_conn.statements
+    assert "LOAD parquet" in fake_conn.statements
     assert "SET enable_extension_loading = false" in fake_conn.statements
+    assert "SET enable_extension_autoloading = false" in fake_conn.statements
+    assert "SET autoinstall_known_extensions = false" in fake_conn.statements
+    assert "SET autoload_known_extensions = false" in fake_conn.statements
+    assert "SET allow_unsigned_extensions = false" in fake_conn.statements
+    assert "SET allow_community_extensions = false" in fake_conn.statements
+    assert fake_conn.statements.index("SET autoinstall_known_extensions = false") < (
+        fake_conn.statements.index("LOAD parquet")
+    )
+    assert fake_conn.statements.index("LOAD parquet") < (
+        fake_conn.statements.index("SET enable_extension_loading = false")
+    )
+
+
+def test_pinned_duckdb_accepts_required_extension_lockdown_options() -> None:
+    conn = module.duckdb.connect()
+    try:
+        conn.execute("SET autoinstall_known_extensions = false")
+        conn.execute("SET autoload_known_extensions = false")
+        conn.execute("SET allow_unsigned_extensions = false")
+        conn.execute("SET allow_community_extensions = false")
+    finally:
+        conn.close()
+
+
+def test_create_query_connection_allows_removed_legacy_lockdown_options_in_production(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root = tmp_path / "data"
+    partition = data_root / "wrds" / "crsp" / "daily" / "part.parquet"
+    partition.parent.mkdir(parents=True)
+    pl.DataFrame({"a": [1]}).write_parquet(partition)
+    monkeypatch.setattr(module, "_APP_ENV", "production")
+    monkeypatch.setattr(module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    monkeypatch.setattr(
+        module,
+        "_resolve_table_paths",
+        lambda: {"crsp_daily": str(partition)},
+    )
+
+    conn = module._create_query_connection("crsp", available_tables={"crsp_daily"})
+    try:
+        result = conn.execute("SELECT count(*) FROM crsp_daily").fetchone()
+    finally:
+        conn.close()
+
+    assert result == (1,)
 
 
 def test_validate_table_paths_detects_alpaca_sip_snapshot_partition(
@@ -178,6 +236,83 @@ def test_validate_table_paths_detects_alpaca_sip_snapshot_partition(
     assert not any("alpaca_sip_daily" in warning for warning in warnings)
 
 
+def test_resolve_sql_table_availability_marks_alpaca_fallback_untrusted(
+    tmp_path: Path,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "fallback" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+
+    resolutions, warnings = module.resolve_sql_table_availability(
+        {"alpaca_sip_daily": str(partition)}
+    )
+
+    daily = resolutions["alpaca_sip_daily"]
+    assert daily.available is True
+    assert daily.fallback_only is True
+    assert daily.manifest_backed is False
+    assert daily.trusted_for_data_page is False
+    assert any("queryable fallback only" in warning for warning in warnings)
+
+
+def test_resolve_sql_table_availability_marks_manifest_pinned_alpaca_trusted(
+    tmp_path: Path,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+
+    resolutions, warnings = module.resolve_sql_table_availability(
+        {"alpaca_sip_daily": (str(partition),)}
+    )
+
+    daily = resolutions["alpaca_sip_daily"]
+    assert daily.available is True
+    assert daily.fallback_only is False
+    assert daily.manifest_backed is True
+    assert daily.trusted_for_data_page is True
+    assert not any("queryable fallback only" in warning for warning in warnings)
+
+
+def test_resolve_sql_table_availability_marks_invalid_manifest_untrusted(
+    tmp_path: Path,
+) -> None:
+    partition = (
+        tmp_path / "data" / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    )
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+
+    resolutions, warnings = module.resolve_sql_table_availability(
+        {
+            "alpaca_sip_daily": module.ResolvedTablePathSpec(
+                path_spec=(str(partition),),
+                manifest_backed=True,
+                manifest_invalid=True,
+            )
+        }
+    )
+
+    daily = resolutions["alpaca_sip_daily"]
+    assert daily.available is True
+    assert daily.manifest_backed is True
+    assert daily.manifest_invalid is True
+    assert daily.trusted_for_data_page is False
+    assert any("manifest is invalid" in warning for warning in warnings)
+
+
+def test_resolve_sql_table_availability_honors_empty_path_override() -> None:
+    resolutions, warnings = module.resolve_sql_table_availability({})
+
+    assert resolutions
+    assert all(not resolution.available for resolution in resolutions.values())
+    assert any("No Parquet files found" in warning for warning in warnings)
+
+
 def test_resolve_table_paths_uses_alpaca_manifest_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -195,19 +330,21 @@ def test_resolve_table_paths_uses_alpaca_manifest_paths(
     manifest_dir = data_root / "manifests"
     manifest_dir.mkdir(parents=True)
     (manifest_dir / "alpaca_sip_daily.json").write_text(
-        json.dumps({"file_paths": [str(partition)]}),
+        json.dumps({"file_paths": [str(partition)], "validation_status": "passed"}),
         encoding="utf-8",
     )
     (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
-        json.dumps({"file_paths": [str(corp_partition)]}),
+        json.dumps({"file_paths": [str(corp_partition)], "validation_status": "passed"}),
         encoding="utf-8",
     )
     monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
 
     paths = module._resolve_table_paths()
 
-    assert paths["alpaca_sip_daily"] == (str(partition),)
-    assert paths["alpaca_sip_corp_actions"] == (str(corp_partition),)
+    assert _raw_path_spec(paths["alpaca_sip_daily"]) == (str(partition),)
+    assert _raw_path_spec(paths["alpaca_sip_corp_actions"]) == (str(corp_partition),)
+    assert isinstance(paths["alpaca_sip_daily"], module.ResolvedTablePathSpec)
+    assert paths["alpaca_sip_daily"].manifest_backed is True
 
 
 def test_resolve_table_paths_uses_nested_relative_manifest_paths(
@@ -223,17 +360,19 @@ def test_resolve_table_paths_uses_nested_relative_manifest_paths(
     manifest_dir = data_root / "manifests"
     manifest_dir.mkdir(parents=True)
     (manifest_dir / "alpaca_sip_daily.json").write_text(
-        json.dumps({"file_paths": ["snapshots/sync-1/2024.parquet"]}),
+        json.dumps(
+            {"file_paths": ["snapshots/sync-1/2024.parquet"], "validation_status": "passed"}
+        ),
         encoding="utf-8",
     )
     monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
 
     paths = module._resolve_table_paths()
 
-    assert paths["alpaca_sip_daily"] == (str(partition),)
+    assert _raw_path_spec(paths["alpaca_sip_daily"]) == (str(partition),)
 
 
-def test_resolve_table_paths_keeps_valid_alpaca_manifest_paths_with_missing_entries(
+def test_resolve_table_paths_rejects_partially_invalid_alpaca_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -252,7 +391,8 @@ def test_resolve_table_paths_keeps_valid_alpaca_manifest_paths_with_missing_entr
                 "file_paths": [
                     "snapshots/sync-1/2024.parquet",
                     "snapshots/sync-1/missing.parquet",
-                ]
+                ],
+                "validation_status": "passed",
             }
         ),
         encoding="utf-8",
@@ -262,8 +402,84 @@ def test_resolve_table_paths_keeps_valid_alpaca_manifest_paths_with_missing_entr
     with caplog.at_level(logging.WARNING):
         paths = module._resolve_table_paths()
 
-    assert paths["alpaca_sip_daily"] == (str(partition),)
+    daily = paths["alpaca_sip_daily"]
+    assert _raw_path_spec(daily) == ()
+    assert isinstance(daily, module.ResolvedTablePathSpec)
+    assert daily.manifest_invalid is True
+    assert daily.manifest_backed is False
     assert "sql_explorer_alpaca_sip_manifest_invalid_paths" in caplog.text
+
+
+def test_resolve_table_paths_rejects_failed_alpaca_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_root = tmp_path
+    data_root = project_root / "data"
+    storage_root = data_root / "alpaca" / "sip" / "daily"
+    partition = storage_root / "snapshots" / "sync-1" / "2024.parquet"
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    manifest_dir = data_root / "manifests"
+    manifest_dir.mkdir(parents=True)
+    manifest_path = manifest_dir / "alpaca_sip_daily.json"
+    manifest_path.write_text(
+        json.dumps({"file_paths": [str(partition)], "validation_status": "failed"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
+    module._ALPACA_SIP_MANIFEST_PATH_CACHE.clear()
+
+    with caplog.at_level(logging.WARNING):
+        paths = module._resolve_table_paths()
+
+    daily = paths["alpaca_sip_daily"]
+    assert _raw_path_spec(daily) == ()
+    assert isinstance(daily, module.ResolvedTablePathSpec)
+    assert daily.manifest_invalid is True
+    assert daily.manifest_backed is False
+    assert "sql_explorer_alpaca_sip_manifest_untrusted" in caplog.text
+    assert str(manifest_path.resolve()) in module._ALPACA_SIP_MANIFEST_PATH_CACHE
+
+
+def test_resolve_table_paths_marks_missing_alpaca_manifest_status_fallback_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_root = tmp_path
+    data_root = project_root / "data"
+    storage_root = data_root / "alpaca" / "sip" / "daily"
+    partition = storage_root / "snapshots" / "sync-1" / "2024.parquet"
+    partition.parent.mkdir(parents=True)
+    partition.write_bytes(b"PAR1")
+    manifest_dir = data_root / "manifests"
+    manifest_dir.mkdir(parents=True)
+    manifest_path = manifest_dir / "alpaca_sip_daily.json"
+    manifest_path.write_text(
+        json.dumps({"file_paths": [str(partition)]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
+    module._ALPACA_SIP_MANIFEST_PATH_CACHE.clear()
+
+    with caplog.at_level(logging.WARNING):
+        paths = module._resolve_table_paths()
+
+    daily = paths["alpaca_sip_daily"]
+    assert _raw_path_spec(daily) == f"{storage_root.resolve()}/snapshots/*/*.parquet"
+    assert isinstance(daily, module.ResolvedTablePathSpec)
+    assert daily.manifest_invalid is False
+    assert daily.fallback_only is True
+    assert daily.manifest_backed is False
+    assert any(getattr(record, "validation_status", None) == "unknown" for record in caplog.records)
+    assert str(manifest_path.resolve()) in module._ALPACA_SIP_MANIFEST_PATH_CACHE
+
+    resolutions, warnings = module.resolve_sql_table_availability({"alpaca_sip_daily": daily})
+    assert resolutions["alpaca_sip_daily"].available is True
+    assert not any("manifest is invalid" in warning for warning in warnings)
+    assert any("queryable fallback only" in warning for warning in warnings)
 
 
 def test_resolve_table_paths_fail_closed_on_unreadable_alpaca_manifest(
@@ -273,19 +489,74 @@ def test_resolve_table_paths_fail_closed_on_unreadable_alpaca_manifest(
 ) -> None:
     project_root = tmp_path
     data_root = project_root / "data"
-    fallback_partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "old" / "2024.parquet"
+    fallback_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "old" / "2024.parquet"
+    )
     fallback_partition.parent.mkdir(parents=True)
     fallback_partition.write_bytes(b"PAR1")
     manifest_dir = data_root / "manifests"
     manifest_dir.mkdir(parents=True)
-    (manifest_dir / "alpaca_sip_daily.json").write_text("{not-json", encoding="utf-8")
+    manifest_path = manifest_dir / "alpaca_sip_daily.json"
+    manifest_path.write_text("{not-json", encoding="utf-8")
     monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
+    module._ALPACA_SIP_MANIFEST_PATH_CACHE.clear()
 
     with caplog.at_level(logging.WARNING):
         paths = module._resolve_table_paths()
 
-    assert paths["alpaca_sip_daily"] == ()
+    assert _raw_path_spec(paths["alpaca_sip_daily"]) == ()
+    assert isinstance(paths["alpaca_sip_daily"], module.ResolvedTablePathSpec)
+    assert paths["alpaca_sip_daily"].manifest_invalid is True
     assert "sql_explorer_alpaca_sip_daily_manifest_unreadable" in caplog.text
+    assert str(manifest_path.resolve()) in module._ALPACA_SIP_MANIFEST_PATH_CACHE
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        cached_paths = module._resolve_table_paths()
+
+    assert _raw_path_spec(cached_paths["alpaca_sip_daily"]) == ()
+    assert "sql_explorer_alpaca_sip_daily_manifest_unreadable" not in caplog.text
+
+
+def test_resolve_table_paths_handles_manifest_stat_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_root = tmp_path
+    data_root = project_root / "data"
+    manifest_dir = data_root / "manifests"
+    manifest_dir.mkdir(parents=True)
+    manifest_path = manifest_dir / "alpaca_sip_daily.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
+    module._ALPACA_SIP_MANIFEST_PATH_CACHE.clear()
+
+    original_exists = Path.exists
+    original_stat = Path.stat
+
+    def racing_exists(path: Path) -> bool:
+        if path == manifest_path:
+            return True
+        return original_exists(path)
+
+    def disappearing_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if path == manifest_path:
+            raise FileNotFoundError("manifest disappeared")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", racing_exists)
+    monkeypatch.setattr(Path, "stat", disappearing_stat)
+
+    with caplog.at_level(logging.WARNING):
+        paths = module._resolve_table_paths()
+
+    daily = paths["alpaca_sip_daily"]
+    assert _raw_path_spec(daily) == ()
+    assert isinstance(daily, module.ResolvedTablePathSpec)
+    assert daily.manifest_invalid is True
+    assert "sql_explorer_alpaca_sip_daily_manifest_unreadable" in caplog.text
+    assert str(manifest_path.resolve()) not in module._ALPACA_SIP_MANIFEST_PATH_CACHE
 
 
 def test_resolve_table_paths_fail_closed_on_non_object_alpaca_manifest(
@@ -295,7 +566,9 @@ def test_resolve_table_paths_fail_closed_on_non_object_alpaca_manifest(
 ) -> None:
     project_root = tmp_path
     data_root = project_root / "data"
-    fallback_partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "old" / "2024.parquet"
+    fallback_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "old" / "2024.parquet"
+    )
     fallback_partition.parent.mkdir(parents=True)
     fallback_partition.write_bytes(b"PAR1")
     manifest_dir = data_root / "manifests"
@@ -306,7 +579,9 @@ def test_resolve_table_paths_fail_closed_on_non_object_alpaca_manifest(
     with caplog.at_level(logging.WARNING):
         paths = module._resolve_table_paths()
 
-    assert paths["alpaca_sip_daily"] == ()
+    assert _raw_path_spec(paths["alpaca_sip_daily"]) == ()
+    assert isinstance(paths["alpaca_sip_daily"], module.ResolvedTablePathSpec)
+    assert paths["alpaca_sip_daily"].manifest_invalid is True
     assert "sql_explorer_alpaca_sip_daily_manifest_unreadable" in caplog.text
     assert any(
         getattr(record, "error", None) == "Manifest JSON is not an object"
@@ -343,7 +618,7 @@ def test_create_query_connection_handles_manifest_path_list(
 ) -> None:
     class FakeResult:
         def fetchall(self) -> list[tuple[str]]:
-            return [("core_functions",), ("parquet",)]
+            return [("core_functions",), ("jemalloc",), ("parquet",)]
 
     class FakeConn:
         def __init__(self) -> None:
@@ -416,9 +691,21 @@ def test_service_init_unset_app_env_defaults_to_local(
     assert svc is not None
 
 
-def test_service_init_requires_attestation_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_execution_allowed_requires_attestation_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(module, "_APP_ENV", "production")
     monkeypatch.setenv("SQL_EXPLORER_DEPLOY_ATTESTED", "false")
+    with pytest.raises(RuntimeError, match="deploy-attested"):
+        module.ensure_sql_explorer_execution_allowed()
+
+
+def test_service_init_requires_attestation_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module, "_APP_ENV", "production")
+    monkeypatch.setenv("SQL_EXPLORER_DEPLOY_ATTESTED", "false")
+
     with pytest.raises(RuntimeError, match="deploy-attested"):
         SqlExplorerService(rate_limiter=_DummyRateLimiter())
 
@@ -432,12 +719,14 @@ def test_service_init_rate_limiter_guards(monkeypatch: pytest.MonkeyPatch) -> No
         SqlExplorerService(rate_limiter=_DummyRateLimiter(fallback_mode="allow"))
 
 
-def test_service_init_dev_mode_forbidden_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_execution_allowed_dev_mode_forbidden_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(module, "_APP_ENV", "production")
     monkeypatch.setattr(module, "_IS_DEV_MODE", True)
     monkeypatch.setenv("SQL_EXPLORER_DEPLOY_ATTESTED", "true")
     with pytest.raises(RuntimeError, match="forbidden"):
-        SqlExplorerService(rate_limiter=_DummyRateLimiter())
+        module.ensure_sql_explorer_execution_allowed()
 
 
 @pytest.mark.asyncio()
@@ -652,6 +941,29 @@ def test_verify_sandbox_writable_dir_is_failure(
     assert safe is False
     assert len(failures) == 1
     assert "filesystem_write_allowed" in failures[0]
+
+
+def test_ensure_execution_allowed_rechecks_sandbox_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def fake_verify() -> tuple[bool, list[str]]:
+        nonlocal calls
+        calls += 1
+        return True, []
+
+    times = iter([10.0, 10.5, 71.0])
+    monkeypatch.setattr(module, "_sandbox_probe_result", None)
+    monkeypatch.setattr(module, "_SANDBOX_PROBE_CACHE_TTL_SECONDS", 60.0)
+    monkeypatch.setattr(module, "_verify_sandbox", fake_verify)
+    monkeypatch.setattr(module.time, "monotonic", lambda: next(times))
+
+    module.ensure_sql_explorer_execution_allowed()
+    module.ensure_sql_explorer_execution_allowed()
+    module.ensure_sql_explorer_execution_allowed()
+
+    assert calls == 2
 
 
 def test_log_query_no_raw_sql_by_default(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/libs/web_console_services/test_sql_validator.py
+++ b/tests/libs/web_console_services/test_sql_validator.py
@@ -132,6 +132,32 @@ def test_validate_accepts_simple_select(validator: SQLValidator) -> None:
     assert error is None
 
 
+def test_literal_smoke_query_allows_select_literal(validator: SQLValidator) -> None:
+    assert validator.is_literal_smoke_query("SELECT 1") is True
+    assert validator.is_literal_smoke_query("SELECT 'ok' AS status") is True
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT count(*) FROM range(1000000)",
+        "SELECT * FROM generate_series(1, 10)",
+        "SELECT * FROM (SELECT 1) AS t",
+        "SELECT unnest([1, 2, 3])",
+        "SELECT 1 WHERE random() > 0",
+        "SELECT 1 ORDER BY random()",
+        "SELECT 1 LIMIT 1 OFFSET random()",
+        "SELECT 1 HAVING random() > 0",
+        "SELECT 1 QUALIFY random() > 0",
+    ],
+)
+def test_literal_smoke_query_rejects_computed_sources(
+    validator: SQLValidator,
+    query: str,
+) -> None:
+    assert validator.is_literal_smoke_query(query) is False
+
+
 def test_validate_accepts_alpaca_sip_corp_actions_table(validator: SQLValidator) -> None:
     ok, error = validator.validate("SELECT * FROM alpaca_sip_corp_actions", "alpaca_sip")
     assert ok is True


### PR DESCRIPTION
## Summary
- Back `/data` previews, ad hoc queries, and queued exports with the same scoped DuckDB execution path as SQL Explorer.
- Add manifest-aware table availability, trust labels, SQL Explorer handoff URLs, query templates, Alpaca SIP provenance, null-column reason codes, and fallback-only blocking on `/data`.
- Restore SQL Explorer production execution guards, pin DuckDB to 1.4.4, lock down extension loading, and allow required data acquisition scripts into the web-console image.
- Harden SQL validation for literal smoke queries, synthetic sources, table functions, and non-projection tableless clauses.

## Data Trust Behavior
- Trusted Alpaca SIP data requires passed, manifest-backed parquet paths.
- Missing validation status is fallback-only for standalone SQL Explorer inspection.
- Failed, partial, unreadable, or invalid manifests fail closed and do not advertise `/data` as queryable.
- Inline capped results render the displayed row count while preserving `has_more` sentinel metadata in the DTO.

## Validation
- Claude review: no issues.
- Gemini review: no issues.
- Codex review: no issues after fixing two valid findings.
- `source .venv/bin/activate && ruff check ...` focused pass.
- `source .venv/bin/activate && mypy --strict ...` focused pass.
- `source .venv/bin/activate && pytest -q ...` focused pass: 270 passed, 1 warning.
- `source .venv/bin/activate && make ci-local`: passed, 12,923 passed, 24 skipped, 3 xfailed.

## Notes
- Unrelated local change in `docs/AI/AI_GUIDE.md` was intentionally excluded from this commit and PR.
