### PR TITLE
feat(web-console): expose raw adjustment provenance

### DIFF
--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -391,6 +391,7 @@ async def _render_data_explorer_section(
     selected_dataset: dict[str, str | None] = {"value": None}
     dataset_map: dict[str, Any] = {}
     refresh_query_controls: Callable[[], None] | None = None
+    refresh_adjustment_policy: Callable[[], None] | None = None
 
     with ui.row().classes("w-full gap-4"):
         # Dataset browser sidebar
@@ -465,6 +466,7 @@ async def _render_data_explorer_section(
                         availability_reason = getattr(info, "availability_reason", None)
                         if availability_reason:
                             ui.label(availability_reason).classes("text-xs text-amber-600")
+                        _render_adjustment_policy_summary(info)
 
                 async def _load_schema(ds_name: str | None) -> None:
                     """Load schema preview for dataset (requires QUERY_DATA)."""
@@ -482,6 +484,7 @@ async def _render_data_explorer_section(
                             ui.label("Schema Preview").classes("font-bold mb-1")
                             for col in preview.columns:
                                 ui.label(f"  {col}").classes("text-sm text-gray-600 font-mono")
+                            _render_preview_adjustment_metadata(preview)
                     except ValueError as e:
                         with schema_container:
                             ui.label(str(e)).classes("text-sm text-amber-600")
@@ -508,6 +511,8 @@ async def _render_data_explorer_section(
                     await _load_schema(ds)
                     if refresh_query_controls is not None:
                         refresh_query_controls()
+                    if refresh_adjustment_policy is not None:
+                        refresh_adjustment_policy()
 
                 dataset_select.on_value_change(on_dataset_change)
 
@@ -521,6 +526,26 @@ async def _render_data_explorer_section(
 
         # Main content area
         with ui.column().classes("flex-1"):
+            adjustment_policy_container = ui.column().classes("w-full mb-4")
+
+            def _selected_dataset_info() -> Any | None:
+                ds = selected_dataset["value"]
+                if ds is None:
+                    return None
+                return dataset_map.get(ds)
+
+            def _refresh_adjustment_policy() -> None:
+                adjustment_policy_container.clear()
+                info = _selected_dataset_info()
+                if info is None:
+                    return
+                with adjustment_policy_container:
+                    _render_adjustment_policy_summary(info)
+                    _render_adjusted_preview_controls(info)
+
+            refresh_adjustment_policy = _refresh_adjustment_policy
+            _refresh_adjustment_policy()
+
             # Query editor
             with ui.card().classes("w-full p-4 mb-4"):
                 ui.label("Query Editor").classes("font-bold mb-2")
@@ -533,12 +558,6 @@ async def _render_data_explorer_section(
                     ).classes("w-full font-mono")
 
                     results_container = ui.column().classes("w-full mt-4")
-
-                    def _selected_dataset_info() -> Any | None:
-                        ds = selected_dataset["value"]
-                        if ds is None:
-                            return None
-                        return dataset_map.get(ds)
 
                     template_items: dict[str, Any] = {}
                     template_select = ui.select(
@@ -661,7 +680,10 @@ async def _render_data_explorer_section(
                                 )
                                 results_container.clear()
                                 with results_container:
-                                    _build_query_results(result)
+                                    _build_query_results(
+                                        result,
+                                        dataset_info=_selected_dataset_info(),
+                                    )
                             except ValueError as e:
                                 ui.notify(f"Query error: {e}", type="negative")
                             except ExplorerRateLimitExceeded:
@@ -714,8 +736,113 @@ def _set_select_options(select: Any, options: dict[str, str], value: str | None)
     select.update()
 
 
-def _build_query_results(result: Any) -> None:
+def _render_adjustment_policy_summary(payload: Any) -> None:
+    """Render raw/adjusted policy details carried by dataset or preview DTOs."""
+    lines = _adjustment_policy_lines(payload)
+    if not lines:
+        return
+    with ui.column().classes("w-full p-3 mt-2 border border-amber-200 bg-amber-50"):
+        ui.label("Raw/Adjusted Policy").classes("font-bold text-sm text-amber-900")
+        for line in lines:
+            ui.label(line).classes("text-xs text-amber-800")
+
+
+def _render_adjusted_preview_controls(dataset_info: Any) -> None:
+    """Show the future adjusted preview affordance in a disabled state."""
+    if getattr(dataset_info, "canonical_storage_mode", None) is None and getattr(
+        dataset_info, "backtest_handoff", None
+    ) is None:
+        return
+    handoff = getattr(dataset_info, "backtest_handoff", None)
+    unavailable_reason = (
+        getattr(handoff, "adjusted_preview_unavailable_reason", None)
+        or "read_time_adjustment_layer_not_defined"
+    )
+    with ui.row().classes("w-full gap-2 items-end mt-2"):
+        ui.select(
+            label="Preview Mode",
+            options={
+                "raw": "Raw canonical",
+                "adjusted": "Adjusted derived preview",
+            },
+            value="raw",
+        ).classes("w-56").props("disable")
+        ui.button("Adjusted Preview").props("flat disable")
+        ui.label(unavailable_reason).classes("text-xs text-gray-500")
+
+
+def _render_preview_adjustment_metadata(preview: Any) -> None:
+    """Render preview-level provenance and null-column reason codes."""
+    _render_adjustment_policy_summary(preview)
+    lines = _preview_provenance_lines(preview)
+    if not lines:
+        return
+    with ui.column().classes("w-full p-3 mt-2 border border-gray-200 bg-gray-50"):
+        ui.label("Preview Provenance").classes("font-bold text-sm text-gray-800")
+        for line in lines:
+            ui.label(line).classes("text-xs text-gray-600")
+
+
+def _preview_provenance_lines(preview: Any) -> list[str]:
+    fields = (
+        ("manifest_id", "manifest_id"),
+        ("manifest_reference", "manifest_reference"),
+        ("manifest_checksum", "manifest_checksum"),
+        ("provider_id", "provider_id"),
+        ("provider_version", "provider_version"),
+        ("source_feed", "source_feed"),
+    )
+    lines: list[str] = []
+    for attribute, label in fields:
+        value = getattr(preview, attribute, None)
+        if value is not None and str(value):
+            lines.append(f"{label}: {value}")
+    return lines
+
+
+def _adjustment_policy_lines(payload: Any) -> list[str]:
+    lines: list[str] = []
+    canonical_mode = getattr(payload, "canonical_storage_mode", None)
+    read_time_mode = getattr(payload, "read_time_adjustment_mode", None)
+    adjustment_mode = getattr(payload, "adjustment_mode", None)
+    if canonical_mode is not None:
+        lines.append(f"canonical_storage_mode: {canonical_mode}")
+    if read_time_mode is not None:
+        lines.append(f"read_time_adjustment_mode: {read_time_mode}")
+    if adjustment_mode is not None:
+        lines.append(f"adjustment_mode: {adjustment_mode}")
+
+    null_reasons = getattr(payload, "null_column_reasons", {}) or {}
+    for column, reason in sorted(null_reasons.items()):
+        lines.append(f"{column}: {reason}")
+
+    warnings = sorted(str(warning) for warning in (getattr(payload, "warnings", []) or []))
+    for warning in warnings:
+        if warning not in lines:
+            lines.append(warning)
+
+    handoff = getattr(payload, "backtest_handoff", None)
+    if handoff is not None:
+        roles = getattr(handoff, "data_roles", {}) or {}
+        for role, provenance in sorted(roles.items()):
+            dataset = getattr(provenance, "dataset", None) or "-"
+            storage_mode = getattr(provenance, "canonical_storage_mode", None) or "-"
+            read_mode = getattr(provenance, "read_time_adjustment_mode", None) or "-"
+            lines.append(
+                f"backtest role {role}: {dataset}; "
+                f"storage={storage_mode}; read_time_adjustment={read_mode}"
+            )
+        reason_codes = getattr(handoff, "reason_codes", []) or []
+        if reason_codes:
+            lines.append("backtest_handoff_reasons: " + ", ".join(sorted(reason_codes)))
+    return lines
+
+
+def _build_query_results(result: Any, *, dataset_info: Any | None = None) -> None:
     """Build query results table from QueryResultDTO."""
+    if dataset_info is not None:
+        _render_adjustment_policy_summary(dataset_info)
+
     if not result.columns:
         ui.label("No results").classes("text-gray-500")
         return

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -819,9 +819,10 @@ def _adjustment_policy_lines(payload: Any) -> list[str]:
     for column, reason in sorted(null_reasons.items()):
         lines.append(f"{column}: {reason}")
 
-    warnings = sorted(str(warning) for warning in (getattr(payload, "warnings", []) or []))
+    displayed_reasons = {str(reason) for reason in null_reasons.values()}
+    warnings = sorted({str(warning) for warning in (getattr(payload, "warnings", []) or [])})
     for warning in warnings:
-        if warning not in lines:
+        if warning not in displayed_reasons and warning not in lines:
             lines.append(warning)
 
     handoff = getattr(payload, "backtest_handoff", None)

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -452,12 +452,11 @@ async def _render_data_explorer_section(
                         ui.label("Dataset Info").classes("font-bold mb-1")
                         if info.description:
                             ui.label(info.description).classes("text-sm text-gray-600")
-                        queryable_state = getattr(info, "queryable_state", None)
+                        queryable_state = info.queryable_state
                         if queryable_state:
                             ui.label(f"State: {queryable_state}").classes("text-sm text-gray-600")
-                        tables = getattr(info, "tables", None)
-                        if tables:
-                            ui.label(f"Tables: {', '.join(tables)}").classes(
+                        if info.tables:
+                            ui.label(f"Tables: {', '.join(info.tables)}").classes(
                                 "text-sm text-gray-600"
                             )
                         if info.row_count is not None:
@@ -470,9 +469,8 @@ async def _render_data_explorer_section(
                             start = info.date_range.get("start", "?")
                             end = info.date_range.get("end", "?")
                             ui.label(f"Range: {start} to {end}").classes("text-sm text-gray-600")
-                        availability_reason = getattr(info, "availability_reason", None)
-                        if availability_reason:
-                            ui.label(availability_reason).classes("text-xs text-amber-600")
+                        if info.availability_reason:
+                            ui.label(info.availability_reason).classes("text-xs text-amber-600")
                         _render_adjustment_policy_summary(info)
 
                 async def _load_schema(ds_name: str | None) -> None:
@@ -582,7 +580,7 @@ async def _render_data_explorer_section(
 
                     def refresh_query_templates() -> None:
                         info = _selected_dataset_info()
-                        templates = list(getattr(info, "query_templates", []) or [])
+                        templates = info.query_templates if info is not None else []
                         template_items.clear()
                         options: dict[str, str] = {}
                         for idx, template in enumerate(templates):
@@ -614,7 +612,7 @@ async def _render_data_explorer_section(
 
                         def open_sql_explorer() -> None:
                             info = _selected_dataset_info()
-                            handoff_url = getattr(info, "sql_handoff_url", None) if info else None
+                            handoff_url = info.sql_handoff_url if info is not None else None
                             if not handoff_url:
                                 ui.notify(
                                     "SQL Explorer handoff requires trusted local data",
@@ -757,17 +755,12 @@ def _render_adjustment_policy_summary(payload: DatasetInfoDTO | DataPreviewDTO) 
 
 def _render_adjusted_preview_controls(dataset_info: DatasetInfoDTO) -> None:
     """Show the future adjusted preview affordance in a disabled state."""
-    if getattr(dataset_info, "canonical_storage_mode", None) is None and getattr(
-        dataset_info, "backtest_handoff", None
-    ) is None:
+    if dataset_info.canonical_storage_mode is None and dataset_info.backtest_handoff is None:
         return
-    handoff = getattr(dataset_info, "backtest_handoff", None)
+    handoff = dataset_info.backtest_handoff
     unavailable_reason = "read_time_adjustment_layer_not_defined"
     if handoff is not None:
-        unavailable_reason = (
-            getattr(handoff, "adjusted_preview_unavailable_reason", None)
-            or unavailable_reason
-        )
+        unavailable_reason = handoff.adjusted_preview_unavailable_reason or unavailable_reason
     with ui.row().classes("w-full gap-2 items-end mt-2"):
         ui.select(
             label="Preview Mode",
@@ -794,17 +787,16 @@ def _render_preview_adjustment_metadata(preview: DataPreviewDTO) -> None:
 
 
 def _preview_provenance_lines(preview: DataPreviewDTO) -> list[str]:
-    fields = (
-        ("manifest_id", "manifest_id"),
-        ("manifest_reference", "manifest_reference"),
-        ("manifest_checksum", "manifest_checksum"),
-        ("provider_id", "provider_id"),
-        ("provider_version", "provider_version"),
-        ("source_feed", "source_feed"),
+    fields: tuple[tuple[str, str | None], ...] = (
+        ("manifest_id", preview.manifest_id),
+        ("manifest_reference", preview.manifest_reference),
+        ("manifest_checksum", preview.manifest_checksum),
+        ("provider_id", preview.provider_id),
+        ("provider_version", preview.provider_version),
+        ("source_feed", preview.source_feed),
     )
     lines: list[str] = []
-    for attribute, label in fields:
-        value = getattr(preview, attribute, None)
+    for label, value in fields:
         if value is not None and str(value):
             lines.append(f"{label}: {value}")
     return lines
@@ -812,9 +804,9 @@ def _preview_provenance_lines(preview: DataPreviewDTO) -> list[str]:
 
 def _adjustment_policy_lines(payload: DatasetInfoDTO | DataPreviewDTO) -> list[str]:
     lines: list[str] = []
-    canonical_mode = getattr(payload, "canonical_storage_mode", None)
-    read_time_mode = getattr(payload, "read_time_adjustment_mode", None)
-    adjustment_mode = getattr(payload, "adjustment_mode", None)
+    canonical_mode = payload.canonical_storage_mode
+    read_time_mode = payload.read_time_adjustment_mode
+    adjustment_mode = payload.adjustment_mode
     if canonical_mode is not None:
         lines.append(f"canonical_storage_mode: {canonical_mode}")
     if read_time_mode is not None:
@@ -822,28 +814,28 @@ def _adjustment_policy_lines(payload: DatasetInfoDTO | DataPreviewDTO) -> list[s
     if adjustment_mode is not None:
         lines.append(f"adjustment_mode: {adjustment_mode}")
 
-    null_reasons = getattr(payload, "null_column_reasons", {}) or {}
+    null_reasons = payload.null_column_reasons
     for column, reason in sorted(null_reasons.items()):
         lines.append(f"{column}: {reason}")
 
     displayed_reasons = {str(reason) for reason in null_reasons.values()}
-    warnings = sorted({str(warning) for warning in (getattr(payload, "warnings", []) or [])})
+    warnings = sorted({str(warning) for warning in payload.warnings})
     for warning in warnings:
         if warning not in displayed_reasons and warning not in lines:
             lines.append(warning)
 
-    handoff = getattr(payload, "backtest_handoff", None)
+    handoff = payload.backtest_handoff
     if handoff is not None:
-        roles = getattr(handoff, "data_roles", {}) or {}
+        roles = handoff.data_roles
         for role, provenance in sorted(roles.items()):
-            dataset = getattr(provenance, "dataset", None) or "-"
-            storage_mode = getattr(provenance, "canonical_storage_mode", None) or "-"
-            read_mode = getattr(provenance, "read_time_adjustment_mode", None) or "-"
+            dataset = provenance.dataset or "-"
+            storage_mode = provenance.canonical_storage_mode or "-"
+            read_mode = provenance.read_time_adjustment_mode or "-"
             lines.append(
                 f"backtest role {role}: {dataset}; "
                 f"storage={storage_mode}; read_time_adjustment={read_mode}"
             )
-        reason_codes = getattr(handoff, "reason_codes", []) or []
+        reason_codes = handoff.reason_codes
         if reason_codes:
             lines.append("backtest_handoff_reasons: " + ", ".join(sorted(reason_codes)))
     return lines

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -67,6 +67,12 @@ from libs.web_console_services.data_explorer_service import (
 from libs.web_console_services.data_manifest_service import DataManifestService
 from libs.web_console_services.data_quality_service import DataQualityService
 from libs.web_console_services.data_sync_service import DataSyncService
+from libs.web_console_services.schemas.data_management import (
+    DataPreviewDTO,
+    DatasetInfoDTO,
+    QueryResultDTO,
+    QueryTemplateDTO,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -389,7 +395,7 @@ async def _render_data_explorer_section(
 
     # Track selected dataset
     selected_dataset: dict[str, str | None] = {"value": None}
-    dataset_map: dict[str, Any] = {}
+    dataset_map: dict[str, DatasetInfoDTO] = {}
     refresh_query_controls: Callable[[], None] | None = None
     refresh_adjustment_policy: Callable[[], None] | None = None
 
@@ -399,6 +405,7 @@ async def _render_data_explorer_section(
             ui.label("Datasets").classes("font-bold mb-2")
 
             if has_view_datasets or has_query:
+                datasets: list[DatasetInfoDTO]
                 try:
                     datasets = await explorer_service.list_datasets(user)
                 except PermissionError as e:
@@ -528,7 +535,7 @@ async def _render_data_explorer_section(
         with ui.column().classes("flex-1"):
             adjustment_policy_container = ui.column().classes("w-full mb-4")
 
-            def _selected_dataset_info() -> Any | None:
+            def _selected_dataset_info() -> DatasetInfoDTO | None:
                 ds = selected_dataset["value"]
                 if ds is None:
                     return None
@@ -559,7 +566,7 @@ async def _render_data_explorer_section(
 
                     results_container = ui.column().classes("w-full mt-4")
 
-                    template_items: dict[str, Any] = {}
+                    template_items: dict[str, QueryTemplateDTO] = {}
                     template_select = ui.select(
                         label="Query Template",
                         options={},
@@ -737,7 +744,7 @@ def _set_select_options(select: Any, options: dict[str, str], value: str | None)
     select.update()
 
 
-def _render_adjustment_policy_summary(payload: Any) -> None:
+def _render_adjustment_policy_summary(payload: DatasetInfoDTO | DataPreviewDTO) -> None:
     """Render raw/adjusted policy details carried by dataset or preview DTOs."""
     lines = _adjustment_policy_lines(payload)
     if not lines:
@@ -748,7 +755,7 @@ def _render_adjustment_policy_summary(payload: Any) -> None:
             ui.label(line).classes("text-xs text-amber-800")
 
 
-def _render_adjusted_preview_controls(dataset_info: Any) -> None:
+def _render_adjusted_preview_controls(dataset_info: DatasetInfoDTO) -> None:
     """Show the future adjusted preview affordance in a disabled state."""
     if getattr(dataset_info, "canonical_storage_mode", None) is None and getattr(
         dataset_info, "backtest_handoff", None
@@ -774,7 +781,7 @@ def _render_adjusted_preview_controls(dataset_info: Any) -> None:
         ui.label(unavailable_reason).classes("text-xs text-gray-500")
 
 
-def _render_preview_adjustment_metadata(preview: Any) -> None:
+def _render_preview_adjustment_metadata(preview: DataPreviewDTO) -> None:
     """Render preview-level provenance and null-column reason codes."""
     _render_adjustment_policy_summary(preview)
     lines = _preview_provenance_lines(preview)
@@ -786,7 +793,7 @@ def _render_preview_adjustment_metadata(preview: Any) -> None:
             ui.label(line).classes("text-xs text-gray-600")
 
 
-def _preview_provenance_lines(preview: Any) -> list[str]:
+def _preview_provenance_lines(preview: DataPreviewDTO) -> list[str]:
     fields = (
         ("manifest_id", "manifest_id"),
         ("manifest_reference", "manifest_reference"),
@@ -803,7 +810,7 @@ def _preview_provenance_lines(preview: Any) -> list[str]:
     return lines
 
 
-def _adjustment_policy_lines(payload: Any) -> list[str]:
+def _adjustment_policy_lines(payload: DatasetInfoDTO | DataPreviewDTO) -> list[str]:
     lines: list[str] = []
     canonical_mode = getattr(payload, "canonical_storage_mode", None)
     read_time_mode = getattr(payload, "read_time_adjustment_mode", None)
@@ -842,7 +849,11 @@ def _adjustment_policy_lines(payload: Any) -> list[str]:
     return lines
 
 
-def _build_query_results(result: Any, *, dataset_info: Any | None = None) -> None:
+def _build_query_results(
+    result: QueryResultDTO,
+    *,
+    dataset_info: DatasetInfoDTO | None = None,
+) -> None:
     """Build query results table from QueryResultDTO."""
     if dataset_info is not None:
         _render_adjustment_policy_summary(dataset_info)

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -667,6 +667,7 @@ async def _render_data_explorer_section(
                             if not ds:
                                 ui.notify("Please select a dataset", type="warning")
                                 return
+                            queried_dataset_info = dataset_map.get(ds)
                             query_val = str(query_textarea.value).strip()
                             if not query_val:
                                 ui.notify("Please enter a query", type="warning")
@@ -682,7 +683,7 @@ async def _render_data_explorer_section(
                                 with results_container:
                                     _build_query_results(
                                         result,
-                                        dataset_info=_selected_dataset_info(),
+                                        dataset_info=queried_dataset_info,
                                     )
                             except ValueError as e:
                                 ui.notify(f"Query error: {e}", type="negative")
@@ -754,10 +755,12 @@ def _render_adjusted_preview_controls(dataset_info: Any) -> None:
     ) is None:
         return
     handoff = getattr(dataset_info, "backtest_handoff", None)
-    unavailable_reason = (
-        getattr(handoff, "adjusted_preview_unavailable_reason", None)
-        or "read_time_adjustment_layer_not_defined"
-    )
+    unavailable_reason = "read_time_adjustment_layer_not_defined"
+    if handoff is not None:
+        unavailable_reason = (
+            getattr(handoff, "adjusted_preview_unavailable_reason", None)
+            or unavailable_reason
+        )
     with ui.row().classes("w-full gap-2 items-end mt-2"):
         ui.select(
             label="Preview Mode",

--- a/docs/CONCEPTS/read-time-adjustment-service-contract.md
+++ b/docs/CONCEPTS/read-time-adjustment-service-contract.md
@@ -1,0 +1,56 @@
+# Read-Time Adjustment Service Contract Draft
+
+Status: draft for Data Page phase 4. This is not an accepted ADR and does not enable adjusted previews or backtests by itself.
+
+## Purpose
+
+Define the future contract for deriving adjusted preview/result views from raw Alpaca SIP canonical data without mutating canonical storage or implying that raw closes are adjusted.
+
+## Invariants
+
+- Raw input remains immutable. `alpaca_sip_daily` canonical OHLC is stored and labeled as `canonical_storage_mode=raw`.
+- Corporate actions are read-only adjustment inputs. `alpaca_sip_corp_actions` may be used to derive adjusted output, but it is not rewritten into canonical OHLC.
+- Adjusted output is derived preview/result metadata, not stored canonical OHLC.
+- Return derivation is never allowed from raw `close`. `ret` remains unavailable until the service can derive it from an accepted adjusted price path or a trusted provider-supplied return column.
+- Any adjusted preview/result path must be explicitly marked as derived and must carry the raw input and corporate-action provenance used to derive it.
+
+## Request Shape
+
+Required fields:
+
+- `dataset`: logical dataset family, initially `alpaca_sip`.
+- `roles`: role-keyed inputs for `universe`, `prices`, and `corp_actions`.
+- `start_date` and `end_date`: requested date bounds.
+- `symbols` or `symbol_source`: explicit symbol set or reproducible source.
+- `read_time_adjustment_mode`: requested mode. Phase 4 only supports `unavailable`; future accepted designs may add modes such as `split_adjusted`.
+
+## Response Shape
+
+Required fields:
+
+- `derived`: boolean, always true for adjusted outputs.
+- `canonical_storage_mode_by_role`: role-keyed canonical storage modes.
+- `read_time_adjustment_mode_by_role`: role-keyed read-time modes.
+- `manifest_ids`, `manifest_references`, and `manifest_checksums` by role.
+- `provider_ids`, `provider_versions`, `source_feeds`, and sanitized provider signatures by role.
+- `columns`: output columns and per-column derivation state.
+- `reason_codes`: fail-closed or warning reasons.
+
+Phase 4 wired codes:
+
+- `raw_sip_returns_unavailable`
+- `read_time_adjustment_layer_not_defined`
+- `alpaca_sip_untrusted_without_manifest`
+- `alpaca_sip_manifest_validation_failed`
+- `alpaca_sip_manifest_summary_unavailable`
+
+Draft/future companion-state codes:
+
+- `alpaca_sip_companion_manifest_stale`
+- `alpaca_sip_companion_symbol_set_mismatch`
+
+## Phase 4 Behavior
+
+- Data Explorer displays raw canonical storage and unavailable read-time adjustment state.
+- Adjusted preview controls remain disabled with `read_time_adjustment_layer_not_defined`.
+- Backtest handoff metadata may be built for inspection, but backtest submission must remain fail-closed while adjusted returns are unavailable.

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import time
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 from urllib.parse import urlencode
 from uuid import uuid4
 
@@ -25,7 +25,9 @@ from .data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
     ALPACA_SIP_DATASET_KEY,
+    AlpacaSipManifestSummaryDTO,
     DataManifestService,
+    ManifestSummaryDTO,
 )
 from .schemas.data_management import (
     BacktestHandoffDTO,
@@ -66,11 +68,20 @@ _MANIFEST_SUMMARY_CACHE_TTL_SECONDS = 30
 _MANIFEST_SUMMARY_FAILURE_CACHE_TTL_SECONDS = 5
 _MANIFEST_SUMMARY_TIMEOUT_SECONDS = 5.0
 _TableAvailabilityCache = tuple[float, tuple[dict[str, SqlTableResolution], list[str]]]
-_AlpacaSummaryCache = tuple[float, Any | None, bool]
+_AlpacaSummaryCache = tuple[float, AlpacaSipManifestSummaryDTO | None, bool]
 _SHARED_TABLE_AVAILABILITY_CACHE: _TableAvailabilityCache | None = None
 _SHARED_TABLE_AVAILABILITY_LOCK = asyncio.Lock()
 _SHARED_ALPACA_SUMMARY_CACHE: _AlpacaSummaryCache | None = None
 _SHARED_ALPACA_SUMMARY_LOCK = asyncio.Lock()
+
+
+class _DatasetAdjustmentMetadata(TypedDict, total=False):
+    adjustment_mode: str | None
+    canonical_storage_mode: str | None
+    read_time_adjustment_mode: str | None
+    null_column_reasons: dict[str, str]
+    warnings: list[str]
+    backtest_handoff: BacktestHandoffDTO | None
 
 _DATASET_DESCRIPTIONS: dict[str, str] = {
     "crsp": "CRSP stock and index history",
@@ -753,7 +764,7 @@ class DataExplorerService:
                 self._table_availability_cache = (now, result)
             return result
 
-    async def _get_alpaca_summary(self) -> tuple[Any | None, bool]:
+    async def _get_alpaca_summary(self) -> tuple[AlpacaSipManifestSummaryDTO | None, bool]:
         global _SHARED_ALPACA_SUMMARY_CACHE
 
         now = time.monotonic()
@@ -1094,7 +1105,10 @@ def _queryable_state_for_table(resolution: SqlTableResolution) -> str:
     return "missing"
 
 
-def _trusted_alpaca_summary_manifests(alpaca_summary: Any, trusted_tables: list[str]) -> list[Any]:
+def _trusted_alpaca_summary_manifests(
+    alpaca_summary: AlpacaSipManifestSummaryDTO,
+    trusted_tables: list[str],
+) -> list[ManifestSummaryDTO]:
     trusted_manifest_datasets = {
         _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table) for table in trusted_tables
     }
@@ -1111,9 +1125,9 @@ def _dataset_adjustment_metadata(
     *,
     trusted_tables: list[str],
     queryable_state: str,
-    alpaca_summary: Any | None,
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
     alpaca_summary_unavailable: bool,
-) -> dict[str, Any]:
+) -> _DatasetAdjustmentMetadata:
     if dataset != ALPACA_SIP_DATASET_KEY:
         return {}
 
@@ -1160,7 +1174,7 @@ def _build_backtest_handoff(
     dataset: str,
     *,
     trusted_tables: list[str],
-    alpaca_summary: Any | None,
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
     alpaca_summary_unavailable: bool,
     queryable_state: str,
 ) -> BacktestHandoffDTO | None:
@@ -1221,10 +1235,10 @@ def _build_backtest_handoff(
 
 
 def _trusted_manifest_for_table(
-    alpaca_summary: Any | None,
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
     table: str,
     trusted_tables: list[str],
-) -> Any | None:
+) -> ManifestSummaryDTO | None:
     if alpaca_summary is None or table not in trusted_tables:
         return None
     manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
@@ -1239,7 +1253,10 @@ def _trusted_manifest_for_table(
     )
 
 
-def _manifest_candidates_for_table(alpaca_summary: Any | None, table: str) -> list[Any]:
+def _manifest_candidates_for_table(
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
+    table: str,
+) -> list[ManifestSummaryDTO]:
     if alpaca_summary is None:
         return []
     manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
@@ -1251,20 +1268,24 @@ def _manifest_candidates_for_table(alpaca_summary: Any | None, table: str) -> li
 
 
 def _preview_manifest_warning_code(
-    alpaca_summary: Any | None,
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
     table: str,
     trusted_tables: list[str],
 ) -> str:
     manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
+    candidates = _manifest_candidates_for_table(alpaca_summary, table)
+    if any(
+        str(getattr(candidate, "validation_status", "")).lower() != "passed"
+        for candidate in candidates
+    ):
+        return _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON
     if table not in trusted_tables:
         return _ALPACA_SIP_UNTRUSTED_REASON
-    if _manifest_candidates_for_table(alpaca_summary, table):
-        return _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON
     return f"alpaca_sip_missing_manifest:{manifest_dataset}"
 
 
 def _backtest_manifest_unavailable_reason(
-    alpaca_summary: Any | None,
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
     table: str,
     trusted_tables: list[str],
     *,
@@ -1278,7 +1299,7 @@ def _backtest_manifest_unavailable_reason(
 def _role_provenance_from_manifest(
     role: str,
     table: str,
-    manifest: Any,
+    manifest: ManifestSummaryDTO,
 ) -> BacktestRoleProvenanceDTO:
     return BacktestRoleProvenanceDTO(
         role=role,

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -28,6 +28,8 @@ from .data_manifest_service import (
     DataManifestService,
 )
 from .schemas.data_management import (
+    BacktestHandoffDTO,
+    BacktestRoleProvenanceDTO,
     DataPreviewDTO,
     DatasetInfoDTO,
     ExportJobDTO,
@@ -97,6 +99,18 @@ _NULL_COLUMN_REASONS_BY_TABLE: dict[str, dict[str, str]] = {
         "ret": "raw_sip_returns_unavailable",
     }
 }
+_ALPACA_SIP_BACKTEST_ROLE_TABLES: dict[str, str] = {
+    "universe": "alpaca_sip_daily",
+    "prices": "alpaca_sip_daily",
+    "corp_actions": "alpaca_sip_corp_actions",
+}
+_ALPACA_SIP_DAILY_ADJUSTMENT_MODE = "raw"
+_ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE = "raw"
+_ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE = "unavailable"
+_ALPACA_SIP_CORP_ACTIONS_STORAGE_MODE = "read_only_adjustment_input"
+_ADJUSTED_PREVIEW_UNAVAILABLE_REASON = "read_time_adjustment_layer_not_defined"
+_ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON = "alpaca_sip_manifest_validation_failed"
+_ALPACA_SIP_UNTRUSTED_REASON = "alpaca_sip_untrusted_without_manifest"
 
 
 class RateLimitExceeded(RuntimeError):
@@ -243,6 +257,13 @@ class DataExplorerService:
                     ),
                     sql_handoff_url=_sql_handoff_url(dataset, trusted_tables),
                     query_templates=_query_templates_for_dataset(dataset, trusted_tables),
+                    **_dataset_adjustment_metadata(
+                        dataset,
+                        trusted_tables=trusted_tables,
+                        queryable_state=queryable_state,
+                        alpaca_summary=alpaca_summary,
+                        alpaca_summary_unavailable=alpaca_summary_error,
+                    ),
                 )
             )
 
@@ -270,10 +291,12 @@ class DataExplorerService:
             if limit <= 0:
                 raise ValueError("Preview limit must be positive")
 
-            table_name, trusted_table_paths, resolution = await self._select_preview_table(
-                dataset,
-                requested_table=table,
-            )
+            (
+                table_name,
+                trusted_table_paths,
+                resolution,
+                provenance_trusted_tables,
+            ) = await self._select_preview_table(dataset, requested_table=table)
             await self._enforce_rate_limit(
                 user,
                 action="data_preview",
@@ -292,7 +315,11 @@ class DataExplorerService:
             has_more = fetched_row_count > limit
             if has_more:
                 frame = frame.head(limit)
-            preview_provenance = await self._preview_provenance_for_table(table_name)
+            preview_provenance = await self._preview_provenance_for_table(
+                table_name,
+                dataset=dataset,
+                trusted_tables=provenance_trusted_tables,
+            )
             execution_ms = int((time.monotonic() - started) * 1000)
             log_sql_query_audit(
                 user,
@@ -787,7 +814,13 @@ class DataExplorerService:
                     self._alpaca_summary_cache = next_cache
                 return None, True
 
-    async def _preview_provenance_for_table(self, table_name: str) -> dict[str, Any]:
+    async def _preview_provenance_for_table(
+        self,
+        table_name: str,
+        *,
+        dataset: str | None = None,
+        trusted_tables: list[str] | None = None,
+    ) -> dict[str, Any]:
         null_column_reasons = dict(_NULL_COLUMN_REASONS_BY_TABLE.get(table_name, {}))
         warnings = sorted(set(null_column_reasons.values()))
         manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table_name)
@@ -802,20 +835,37 @@ class DataExplorerService:
             return {
                 "null_column_reasons": null_column_reasons,
                 "warnings": [*warnings, "alpaca_sip_manifest_summary_unavailable"],
+                "backtest_handoff": _build_backtest_handoff(
+                    dataset or "",
+                    trusted_tables=trusted_tables or [],
+                    alpaca_summary=None,
+                    alpaca_summary_unavailable=True,
+                    queryable_state="missing",
+                ),
             }
 
-        manifest = next(
-            (
-                candidate
-                for candidate in getattr(alpaca_summary, "manifests", [])
-                if getattr(candidate, "dataset", None) == manifest_dataset
-            ),
-            None,
+        trusted_table_names = trusted_tables if trusted_tables is not None else [table_name]
+        manifest = _trusted_manifest_for_table(
+            alpaca_summary,
+            table_name,
+            trusted_table_names,
         )
         if manifest is None:
+            warning_code = _preview_manifest_warning_code(
+                alpaca_summary,
+                table_name,
+                trusted_table_names,
+            )
             return {
                 "null_column_reasons": null_column_reasons,
-                "warnings": [*warnings, f"alpaca_sip_missing_manifest:{manifest_dataset}"],
+                "warnings": [*warnings, warning_code],
+                "backtest_handoff": _build_backtest_handoff(
+                    dataset or "",
+                    trusted_tables=trusted_table_names,
+                    alpaca_summary=alpaca_summary,
+                    alpaca_summary_unavailable=False,
+                    queryable_state="missing",
+                ),
             }
 
         manifest_version = getattr(manifest, "manifest_version", None)
@@ -837,6 +887,13 @@ class DataExplorerService:
             "provider_signature": getattr(manifest, "provider_signature", None),
             "null_column_reasons": null_column_reasons,
             "warnings": warnings,
+            "backtest_handoff": _build_backtest_handoff(
+                dataset or "",
+                trusted_tables=trusted_table_names,
+                alpaca_summary=alpaca_summary,
+                alpaca_summary_unavailable=False,
+                queryable_state="trusted_manifest_backed",
+            ),
         }
 
     def _audit_query_failure(
@@ -866,7 +923,7 @@ class DataExplorerService:
         dataset: str,
         *,
         requested_table: str | None,
-    ) -> tuple[str, dict[str, TablePathSpec], SqlTableResolution]:
+    ) -> tuple[str, dict[str, TablePathSpec], SqlTableResolution, list[str]]:
         table_resolutions, _warnings = await self._resolve_table_availability()
         allowed_tables = DATASET_TABLES.get(dataset)
         if not allowed_tables:
@@ -909,7 +966,10 @@ class DataExplorerService:
                         f"No trusted local data available for table {table}"
                     )
                 continue
-            return table, {table: trusted_table_paths[table]}, resolution
+            provenance_trusted_tables = (
+                sorted(trusted_table_paths) if dataset == ALPACA_SIP_DATASET_KEY else [table]
+            )
+            return table, {table: trusted_table_paths[table]}, resolution, provenance_trusted_tables
 
         if saw_manifest_invalid:
             raise ValueError(f"Trusted manifest is invalid for {dataset}; re-run validation")
@@ -1044,6 +1104,265 @@ def _trusted_alpaca_summary_manifests(alpaca_summary: Any, trusted_tables: list[
         if getattr(manifest, "dataset", None) in trusted_manifest_datasets
         and str(getattr(manifest, "validation_status", "")).lower() == "passed"
     ]
+
+
+def _dataset_adjustment_metadata(
+    dataset: str,
+    *,
+    trusted_tables: list[str],
+    queryable_state: str,
+    alpaca_summary: Any | None,
+    alpaca_summary_unavailable: bool,
+) -> dict[str, Any]:
+    if dataset != ALPACA_SIP_DATASET_KEY:
+        return {}
+
+    daily_manifest = _trusted_manifest_for_table(
+        alpaca_summary,
+        "alpaca_sip_daily",
+        trusted_tables,
+    )
+    warnings = set(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"].values())
+    if alpaca_summary_unavailable:
+        warnings.add("alpaca_sip_manifest_summary_unavailable")
+    if alpaca_summary is not None:
+        warnings.update(str(warning) for warning in getattr(alpaca_summary, "warnings", []))
+
+    return {
+        "adjustment_mode": _manifest_text(
+            daily_manifest,
+            "adjustment_mode",
+            _ALPACA_SIP_DAILY_ADJUSTMENT_MODE,
+        ),
+        "canonical_storage_mode": _manifest_text(
+            daily_manifest,
+            "canonical_storage_mode",
+            _ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE,
+        ),
+        "read_time_adjustment_mode": _manifest_text(
+            daily_manifest,
+            "read_time_adjustment_mode",
+            _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+        ),
+        "null_column_reasons": dict(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"]),
+        "warnings": sorted(warnings),
+        "backtest_handoff": _build_backtest_handoff(
+            dataset,
+            trusted_tables=trusted_tables,
+            alpaca_summary=alpaca_summary,
+            alpaca_summary_unavailable=alpaca_summary_unavailable,
+            queryable_state=queryable_state,
+        ),
+    }
+
+
+def _build_backtest_handoff(
+    dataset: str,
+    *,
+    trusted_tables: list[str],
+    alpaca_summary: Any | None,
+    alpaca_summary_unavailable: bool,
+    queryable_state: str,
+) -> BacktestHandoffDTO | None:
+    if dataset != ALPACA_SIP_DATASET_KEY:
+        return None
+
+    reason_codes: set[str] = {_ADJUSTED_PREVIEW_UNAVAILABLE_REASON}
+    if queryable_state == "queryable_fallback_only":
+        reason_codes.add("alpaca_sip_untrusted_without_manifest")
+    if alpaca_summary_unavailable:
+        reason_codes.add("alpaca_sip_manifest_summary_unavailable")
+
+    daily_manifest = _trusted_manifest_for_table(
+        alpaca_summary,
+        "alpaca_sip_daily",
+        trusted_tables,
+    )
+    selected_read_time_adjustment_mode = _manifest_text(
+        daily_manifest,
+        "read_time_adjustment_mode",
+        _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+    )
+
+    data_roles: dict[str, BacktestRoleProvenanceDTO] = {}
+    for role, table in _ALPACA_SIP_BACKTEST_ROLE_TABLES.items():
+        manifest = _trusted_manifest_for_table(alpaca_summary, table, trusted_tables)
+        if manifest is None:
+            reason = _backtest_manifest_unavailable_reason(
+                alpaca_summary,
+                table,
+                trusted_tables,
+                alpaca_summary_unavailable=alpaca_summary_unavailable,
+            )
+            reason_codes.add(reason)
+            data_roles[role] = _missing_role_provenance(role, table, reason)
+            if table == "alpaca_sip_daily":
+                reason_codes.add("raw_sip_returns_unavailable")
+            continue
+
+        data_roles[role] = _role_provenance_from_manifest(role, table, manifest)
+        if table == "alpaca_sip_daily":
+            read_mode = _manifest_text(
+                manifest,
+                "read_time_adjustment_mode",
+                _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+            )
+            if read_mode != "available":
+                reason_codes.add("raw_sip_returns_unavailable")
+
+    return BacktestHandoffDTO(
+        dataset=dataset,
+        data_roles=data_roles,
+        selected_read_time_adjustment_mode=selected_read_time_adjustment_mode,
+        adjusted_preview_available=False,
+        adjusted_preview_unavailable_reason=_ADJUSTED_PREVIEW_UNAVAILABLE_REASON,
+        reason_codes=sorted(reason_codes),
+    )
+
+
+def _trusted_manifest_for_table(
+    alpaca_summary: Any | None,
+    table: str,
+    trusted_tables: list[str],
+) -> Any | None:
+    if alpaca_summary is None or table not in trusted_tables:
+        return None
+    manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
+    return next(
+        (
+            candidate
+            for candidate in getattr(alpaca_summary, "manifests", [])
+            if getattr(candidate, "dataset", None) == manifest_dataset
+            and str(getattr(candidate, "validation_status", "")).lower() == "passed"
+        ),
+        None,
+    )
+
+
+def _manifest_candidates_for_table(alpaca_summary: Any | None, table: str) -> list[Any]:
+    if alpaca_summary is None:
+        return []
+    manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
+    return [
+        candidate
+        for candidate in getattr(alpaca_summary, "manifests", [])
+        if getattr(candidate, "dataset", None) == manifest_dataset
+    ]
+
+
+def _preview_manifest_warning_code(
+    alpaca_summary: Any | None,
+    table: str,
+    trusted_tables: list[str],
+) -> str:
+    manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
+    if table not in trusted_tables:
+        return _ALPACA_SIP_UNTRUSTED_REASON
+    if _manifest_candidates_for_table(alpaca_summary, table):
+        return _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON
+    return f"alpaca_sip_missing_manifest:{manifest_dataset}"
+
+
+def _backtest_manifest_unavailable_reason(
+    alpaca_summary: Any | None,
+    table: str,
+    trusted_tables: list[str],
+    *,
+    alpaca_summary_unavailable: bool,
+) -> str:
+    if alpaca_summary_unavailable:
+        return "alpaca_sip_manifest_summary_unavailable"
+    if table not in trusted_tables:
+        return _ALPACA_SIP_UNTRUSTED_REASON
+    if _manifest_candidates_for_table(alpaca_summary, table):
+        return _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON
+    return _ALPACA_SIP_UNTRUSTED_REASON
+
+
+def _role_provenance_from_manifest(
+    role: str,
+    table: str,
+    manifest: Any,
+) -> BacktestRoleProvenanceDTO:
+    return BacktestRoleProvenanceDTO(
+        role=role,
+        dataset=_optional_text(getattr(manifest, "dataset", None)),
+        table=table,
+        available=True,
+        manifest_ids=_optional_text_list(getattr(manifest, "manifest_id", None)),
+        manifest_references=_optional_text_list(getattr(manifest, "manifest_reference", None)),
+        manifest_checksums=_optional_text_list(getattr(manifest, "manifest_checksum", None)),
+        provider_id=_optional_text(getattr(manifest, "provider_id", None)),
+        provider_version=_optional_text(getattr(manifest, "provider_version", None)),
+        # Manifest summaries sanitize provider signatures before this handoff layer.
+        provider_signature=getattr(manifest, "provider_signature", None),
+        source_feed=_optional_text(getattr(manifest, "source_feed", None)),
+        adjustment_mode=_optional_text(getattr(manifest, "adjustment_mode", None)),
+        canonical_storage_mode=_role_canonical_storage_mode(table, manifest),
+        read_time_adjustment_mode=_role_read_time_adjustment_mode(table, manifest),
+    )
+
+
+def _missing_role_provenance(
+    role: str,
+    table: str,
+    reason: str,
+) -> BacktestRoleProvenanceDTO:
+    return BacktestRoleProvenanceDTO(
+        role=role,
+        dataset=_ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table),
+        table=table,
+        available=False,
+        unavailable_reason=reason,
+        canonical_storage_mode=_role_canonical_storage_mode(table, None),
+        read_time_adjustment_mode=_role_read_time_adjustment_mode(table, None),
+    )
+
+
+def _role_canonical_storage_mode(table: str, manifest: Any | None) -> str:
+    if table == "alpaca_sip_daily":
+        return _manifest_text(
+            manifest,
+            "canonical_storage_mode",
+            _ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE,
+        )
+    if table == "alpaca_sip_corp_actions":
+        return _manifest_text(
+            manifest,
+            "canonical_storage_mode",
+            _ALPACA_SIP_CORP_ACTIONS_STORAGE_MODE,
+        )
+    return _manifest_text(manifest, "canonical_storage_mode", "unknown")
+
+
+def _role_read_time_adjustment_mode(table: str, manifest: Any | None) -> str:
+    if table == "alpaca_sip_daily":
+        return _manifest_text(
+            manifest,
+            "read_time_adjustment_mode",
+            _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+        )
+    if table == "alpaca_sip_corp_actions":
+        return _manifest_text(manifest, "read_time_adjustment_mode", "not_applicable")
+    return _manifest_text(manifest, "read_time_adjustment_mode", "unknown")
+
+
+def _manifest_text(manifest: Any | None, attribute: str, default: str) -> str:
+    if manifest is None:
+        return default
+    value = getattr(manifest, attribute, None)
+    return str(value) if value is not None and str(value) else default
+
+
+def _optional_text(value: Any) -> str | None:
+    return str(value) if value is not None and str(value) else None
+
+
+def _optional_text_list(value: Any) -> list[str]:
+    if isinstance(value, list | tuple):
+        return [text for item in value if (text := _optional_text(item)) is not None]
+    text = _optional_text(value)
+    return [text] if text is not None else []
 
 
 def _dataset_description(dataset: str, queryable_state: str) -> str:

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -1272,11 +1272,7 @@ def _backtest_manifest_unavailable_reason(
 ) -> str:
     if alpaca_summary_unavailable:
         return "alpaca_sip_manifest_summary_unavailable"
-    if table not in trusted_tables:
-        return _ALPACA_SIP_UNTRUSTED_REASON
-    if _manifest_candidates_for_table(alpaca_summary, table):
-        return _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON
-    return _ALPACA_SIP_UNTRUSTED_REASON
+    return _preview_manifest_warning_code(alpaca_summary, table, trusted_tables)
 
 
 def _role_provenance_from_manifest(

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -222,15 +222,11 @@ class DataExplorerService:
                     trusted_tables,
                 )
                 if trusted_manifests:
-                    row_count = sum(
-                        int(getattr(manifest, "row_count", 0) or 0)
-                        for manifest in trusted_manifests
-                    )
+                    row_count = sum(manifest.row_count for manifest in trusted_manifests)
                     sync_timestamps = [
-                        sync_timestamp
+                        manifest.sync_timestamp
                         for manifest in trusted_manifests
-                        if (sync_timestamp := getattr(manifest, "sync_timestamp", None))
-                        is not None
+                        if manifest.sync_timestamp is not None
                     ]
                     last_sync = max(sync_timestamps, default=None)
                     starts = [manifest.start_date for manifest in trusted_manifests]
@@ -879,23 +875,18 @@ class DataExplorerService:
                 ),
             }
 
-        manifest_version = getattr(manifest, "manifest_version", None)
         return {
-            "manifest_id": getattr(manifest, "manifest_id", None),
-            "manifest_reference": getattr(manifest, "manifest_reference", None),
-            "manifest_checksum": getattr(manifest, "manifest_checksum", None),
-            "manifest_version": str(manifest_version) if manifest_version is not None else None,
-            "provider_id": getattr(manifest, "provider_id", None),
-            "provider_version": getattr(manifest, "provider_version", None),
-            "source_feed": getattr(manifest, "source_feed", None),
-            "adjustment_mode": getattr(manifest, "adjustment_mode", None),
-            "canonical_storage_mode": getattr(manifest, "canonical_storage_mode", None),
-            "read_time_adjustment_mode": getattr(
-                manifest,
-                "read_time_adjustment_mode",
-                None,
-            ),
-            "provider_signature": getattr(manifest, "provider_signature", None),
+            "manifest_id": manifest.manifest_id,
+            "manifest_reference": manifest.manifest_reference,
+            "manifest_checksum": manifest.manifest_checksum,
+            "manifest_version": str(manifest.manifest_version),
+            "provider_id": manifest.provider_id,
+            "provider_version": manifest.provider_version,
+            "source_feed": manifest.source_feed,
+            "adjustment_mode": manifest.adjustment_mode,
+            "canonical_storage_mode": manifest.canonical_storage_mode,
+            "read_time_adjustment_mode": manifest.read_time_adjustment_mode,
+            "provider_signature": manifest.provider_signature,
             "null_column_reasons": null_column_reasons,
             "warnings": warnings,
             "backtest_handoff": _build_backtest_handoff(
@@ -1114,9 +1105,9 @@ def _trusted_alpaca_summary_manifests(
     }
     return [
         manifest
-        for manifest in getattr(alpaca_summary, "manifests", [])
-        if getattr(manifest, "dataset", None) in trusted_manifest_datasets
-        and str(getattr(manifest, "validation_status", "")).lower() == "passed"
+        for manifest in alpaca_summary.manifests
+        if manifest.dataset in trusted_manifest_datasets
+        and manifest.validation_status.lower() == "passed"
     ]
 
 
@@ -1140,22 +1131,19 @@ def _dataset_adjustment_metadata(
     if alpaca_summary_unavailable:
         warnings.add("alpaca_sip_manifest_summary_unavailable")
     if alpaca_summary is not None:
-        warnings.update(str(warning) for warning in getattr(alpaca_summary, "warnings", []))
+        warnings.update(str(warning) for warning in alpaca_summary.warnings)
 
     return {
         "adjustment_mode": _manifest_text(
-            daily_manifest,
-            "adjustment_mode",
+            daily_manifest.adjustment_mode if daily_manifest is not None else None,
             _ALPACA_SIP_DAILY_ADJUSTMENT_MODE,
         ),
         "canonical_storage_mode": _manifest_text(
-            daily_manifest,
-            "canonical_storage_mode",
+            daily_manifest.canonical_storage_mode if daily_manifest is not None else None,
             _ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE,
         ),
         "read_time_adjustment_mode": _manifest_text(
-            daily_manifest,
-            "read_time_adjustment_mode",
+            daily_manifest.read_time_adjustment_mode if daily_manifest is not None else None,
             _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
         ),
         "null_column_reasons": dict(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"]),
@@ -1193,8 +1181,7 @@ def _build_backtest_handoff(
         trusted_tables,
     )
     selected_read_time_adjustment_mode = _manifest_text(
-        daily_manifest,
-        "read_time_adjustment_mode",
+        daily_manifest.read_time_adjustment_mode if daily_manifest is not None else None,
         _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
     )
 
@@ -1217,8 +1204,7 @@ def _build_backtest_handoff(
         data_roles[role] = _role_provenance_from_manifest(role, table, manifest)
         if table == "alpaca_sip_daily":
             read_mode = _manifest_text(
-                manifest,
-                "read_time_adjustment_mode",
+                manifest.read_time_adjustment_mode,
                 _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
             )
             if read_mode != "available":
@@ -1245,9 +1231,9 @@ def _trusted_manifest_for_table(
     return next(
         (
             candidate
-            for candidate in getattr(alpaca_summary, "manifests", [])
-            if getattr(candidate, "dataset", None) == manifest_dataset
-            and str(getattr(candidate, "validation_status", "")).lower() == "passed"
+            for candidate in alpaca_summary.manifests
+            if candidate.dataset == manifest_dataset
+            and candidate.validation_status.lower() == "passed"
         ),
         None,
     )
@@ -1262,8 +1248,8 @@ def _manifest_candidates_for_table(
     manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
     return [
         candidate
-        for candidate in getattr(alpaca_summary, "manifests", [])
-        if getattr(candidate, "dataset", None) == manifest_dataset
+        for candidate in alpaca_summary.manifests
+        if candidate.dataset == manifest_dataset
     ]
 
 
@@ -1274,10 +1260,7 @@ def _preview_manifest_warning_code(
 ) -> str:
     manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
     candidates = _manifest_candidates_for_table(alpaca_summary, table)
-    if any(
-        str(getattr(candidate, "validation_status", "")).lower() != "passed"
-        for candidate in candidates
-    ):
+    if any(candidate.validation_status.lower() != "passed" for candidate in candidates):
         return _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON
     if table not in trusted_tables:
         return _ALPACA_SIP_UNTRUSTED_REASON
@@ -1303,18 +1286,18 @@ def _role_provenance_from_manifest(
 ) -> BacktestRoleProvenanceDTO:
     return BacktestRoleProvenanceDTO(
         role=role,
-        dataset=_optional_text(getattr(manifest, "dataset", None)),
+        dataset=_optional_text(manifest.dataset),
         table=table,
         available=True,
-        manifest_ids=_optional_text_list(getattr(manifest, "manifest_id", None)),
-        manifest_references=_optional_text_list(getattr(manifest, "manifest_reference", None)),
-        manifest_checksums=_optional_text_list(getattr(manifest, "manifest_checksum", None)),
-        provider_id=_optional_text(getattr(manifest, "provider_id", None)),
-        provider_version=_optional_text(getattr(manifest, "provider_version", None)),
+        manifest_ids=_optional_text_list(manifest.manifest_id),
+        manifest_references=_optional_text_list(manifest.manifest_reference),
+        manifest_checksums=_optional_text_list(manifest.manifest_checksum),
+        provider_id=_optional_text(manifest.provider_id),
+        provider_version=_optional_text(manifest.provider_version),
         # Manifest summaries sanitize provider signatures before this handoff layer.
-        provider_signature=getattr(manifest, "provider_signature", None),
-        source_feed=_optional_text(getattr(manifest, "source_feed", None)),
-        adjustment_mode=_optional_text(getattr(manifest, "adjustment_mode", None)),
+        provider_signature=manifest.provider_signature,
+        source_feed=_optional_text(manifest.source_feed),
+        adjustment_mode=_optional_text(manifest.adjustment_mode),
         canonical_storage_mode=_role_canonical_storage_mode(table, manifest),
         read_time_adjustment_mode=_role_read_time_adjustment_mode(table, manifest),
     )
@@ -1336,38 +1319,34 @@ def _missing_role_provenance(
     )
 
 
-def _role_canonical_storage_mode(table: str, manifest: Any | None) -> str:
+def _role_canonical_storage_mode(table: str, manifest: ManifestSummaryDTO | None) -> str:
+    storage_mode = manifest.canonical_storage_mode if manifest is not None else None
     if table == "alpaca_sip_daily":
         return _manifest_text(
-            manifest,
-            "canonical_storage_mode",
+            storage_mode,
             _ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE,
         )
     if table == "alpaca_sip_corp_actions":
         return _manifest_text(
-            manifest,
-            "canonical_storage_mode",
+            storage_mode,
             _ALPACA_SIP_CORP_ACTIONS_STORAGE_MODE,
         )
-    return _manifest_text(manifest, "canonical_storage_mode", "unknown")
+    return _manifest_text(storage_mode, "unknown")
 
 
-def _role_read_time_adjustment_mode(table: str, manifest: Any | None) -> str:
+def _role_read_time_adjustment_mode(table: str, manifest: ManifestSummaryDTO | None) -> str:
+    adjustment_mode = manifest.read_time_adjustment_mode if manifest is not None else None
     if table == "alpaca_sip_daily":
         return _manifest_text(
-            manifest,
-            "read_time_adjustment_mode",
+            adjustment_mode,
             _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
         )
     if table == "alpaca_sip_corp_actions":
-        return _manifest_text(manifest, "read_time_adjustment_mode", "not_applicable")
-    return _manifest_text(manifest, "read_time_adjustment_mode", "unknown")
+        return _manifest_text(adjustment_mode, "not_applicable")
+    return _manifest_text(adjustment_mode, "unknown")
 
 
-def _manifest_text(manifest: Any | None, attribute: str, default: str) -> str:
-    if manifest is None:
-        return default
-    value = getattr(manifest, attribute, None)
+def _manifest_text(value: object | None, default: str) -> str:
     return str(value) if value is not None and str(value) else default
 
 

--- a/libs/web_console_services/data_manifest_service.py
+++ b/libs/web_console_services/data_manifest_service.py
@@ -295,7 +295,7 @@ class DataManifestService:
 
 def _data_roles_for_dataset(dataset: str) -> dict[str, str] | None:
     role_map = {
-        ALPACA_SIP_DAILY_DATASET: {"prices": dataset},
+        ALPACA_SIP_DAILY_DATASET: {"universe": dataset, "prices": dataset},
         ALPACA_SIP_CORP_ACTIONS_DATASET: {"corp_actions": dataset},
     }
     return role_map.get(dataset)

--- a/libs/web_console_services/schemas/data_management.py
+++ b/libs/web_console_services/schemas/data_management.py
@@ -202,6 +202,37 @@ class QueryTemplateDTO(BaseModel):
     sql: str
 
 
+class BacktestRoleProvenanceDTO(BaseModel):
+    """Replay-safe provenance for one role in a future backtest handoff."""
+
+    role: str
+    dataset: str | None = None
+    table: str | None = None
+    available: bool = False
+    unavailable_reason: str | None = None
+    manifest_ids: list[str] = Field(default_factory=list)
+    manifest_references: list[str] = Field(default_factory=list)
+    manifest_checksums: list[str] = Field(default_factory=list)
+    provider_id: str | None = None
+    provider_version: str | None = None
+    provider_signature: ProviderSignatureDTO | None = None
+    source_feed: str | None = None
+    adjustment_mode: str | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+
+
+class BacktestHandoffDTO(BaseModel):
+    """Role-keyed provenance contract for backtest handoff payloads."""
+
+    dataset: str
+    data_roles: dict[str, BacktestRoleProvenanceDTO] = Field(default_factory=dict)
+    selected_read_time_adjustment_mode: str = "unavailable"
+    adjusted_preview_available: bool = False
+    adjusted_preview_unavailable_reason: str | None = None
+    reason_codes: list[str] = Field(default_factory=list)
+
+
 class DatasetInfoDTO(BaseModel):
     """High-level metadata for a dataset in the explorer."""
 
@@ -218,6 +249,12 @@ class DatasetInfoDTO(BaseModel):
     availability_reason: str | None = None
     sql_handoff_url: str | None = None
     query_templates: list[QueryTemplateDTO] = Field(default_factory=list)
+    adjustment_mode: str | None = None
+    canonical_storage_mode: str | None = None
+    read_time_adjustment_mode: str | None = None
+    null_column_reasons: dict[str, str] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+    backtest_handoff: BacktestHandoffDTO | None = None
 
 
 class DataPreviewDTO(BaseModel):
@@ -246,6 +283,7 @@ class DataPreviewDTO(BaseModel):
     provider_signature: ProviderSignatureDTO | None = None
     null_column_reasons: dict[str, str] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
+    backtest_handoff: BacktestHandoffDTO | None = None
 
 
 class QueryResultDTO(BaseModel):

--- a/tests/apps/web_console_ng/pages/test_data_management_wiring.py
+++ b/tests/apps/web_console_ng/pages/test_data_management_wiring.py
@@ -584,6 +584,85 @@ class TestBuildQueryResults:
         dm_module._build_query_results(result)
         mock_ui.table.assert_not_called()
 
+    @pytest.mark.asyncio()
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    async def test_query_results_use_dataset_captured_before_await(
+        self,
+        mock_ui: MagicMock,
+        explorer_service: MagicMock,
+    ) -> None:
+        buttons: dict[str, Any] = {}
+        textareas_by_label: dict[str, _FakeElement] = {}
+        dataset_change_handlers: list[Any] = []
+        query_started = asyncio.Event()
+        finish_query = asyncio.Event()
+        queried_dataset = DatasetInfoDTO(
+            name="crsp",
+            canonical_storage_mode="raw",
+        )
+        later_selected_dataset = DatasetInfoDTO(
+            name="compustat",
+            canonical_storage_mode="adjusted",
+        )
+
+        class _DatasetSelect(_FakeElement):
+            def on_value_change(self, handler: Any) -> None:
+                dataset_change_handlers.append(handler)
+
+        async def _execute_query(*_args: Any, **_kwargs: Any) -> QueryResultDTO:
+            query_started.set()
+            await finish_query.wait()
+            return _make_query_result()
+
+        mock_ui.row.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.card.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.column.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.label.side_effect = lambda *_args, **_kwargs: _FakeElement()
+        mock_ui.separator.side_effect = lambda *_args, **_kwargs: _FakeElement()
+
+        def _select(*_args: Any, **kwargs: Any) -> _FakeElement:
+            element_cls = (
+                _DatasetSelect
+                if kwargs.get("label") == "Select Dataset"
+                else _FakeElement
+            )
+            return element_cls(
+                value=kwargs.get("value"),
+                options=kwargs.get("options"),
+            )
+
+        def _textarea(*_args: Any, **kwargs: Any) -> _FakeElement:
+            element = _FakeElement(value=kwargs.get("value", ""))
+            label = str(kwargs.get("label", ""))
+            textareas_by_label[label] = element
+            return element
+
+        def _button(label: str, *_args: Any, **kwargs: Any) -> _FakeElement:
+            buttons[label] = kwargs.get("on_click")
+            return _FakeElement()
+
+        mock_ui.select.side_effect = _select
+        mock_ui.textarea.side_effect = _textarea
+        mock_ui.button.side_effect = _button
+        explorer_service.list_datasets = AsyncMock(
+            return_value=[queried_dataset, later_selected_dataset]
+        )
+        explorer_service.execute_query = AsyncMock(side_effect=_execute_query)
+
+        with (
+            patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True),
+            patch("apps.web_console_ng.pages.data_management._build_query_results") as build,
+        ):
+            await dm_module._render_data_explorer_section(ADMIN_USER, explorer_service)
+            textareas_by_label["SQL Query"].value = "SELECT * FROM crsp_daily LIMIT 10"
+            query_task = asyncio.create_task(buttons["Run Query"]())
+            await query_started.wait()
+            await dataset_change_handlers[0](MagicMock(value="compustat"))
+            finish_query.set()
+            await query_task
+
+        assert build.call_args.kwargs["dataset_info"] == queried_dataset
+
     def test_set_select_options_uses_native_helper_when_available(self) -> None:
         select = MagicMock()
         options = {"0": "Latest daily bars"}

--- a/tests/apps/web_console_ng/pages/test_data_management_wiring.py
+++ b/tests/apps/web_console_ng/pages/test_data_management_wiring.py
@@ -27,6 +27,9 @@ from libs.web_console_services.data_sync_service import (
 )
 from libs.web_console_services.schemas.data_management import (
     AnomalyAlertDTO,
+    BacktestHandoffDTO,
+    BacktestRoleProvenanceDTO,
+    DataPreviewDTO,
     DatasetInfoDTO,
     ExportJobDTO,
     QualityTrendDTO,
@@ -598,6 +601,179 @@ class TestBuildQueryResults:
 
         assert select.options == options
         assert select.value == "0"
+
+    def test_adjustment_policy_lines_expose_raw_null_reasons_and_handoff_roles(
+        self,
+    ) -> None:
+        dataset = DatasetInfoDTO(
+            name="alpaca_sip",
+            canonical_storage_mode="raw",
+            read_time_adjustment_mode="unavailable",
+            adjustment_mode="raw",
+            null_column_reasons={
+                "adj_close": "raw_sip_returns_unavailable",
+                "ret": "raw_sip_returns_unavailable",
+            },
+            warnings=["raw_sip_returns_unavailable"],
+            backtest_handoff=BacktestHandoffDTO(
+                dataset="alpaca_sip",
+                data_roles={
+                    "prices": BacktestRoleProvenanceDTO(
+                        role="prices",
+                        dataset="alpaca_sip_daily",
+                        table="alpaca_sip_daily",
+                        available=True,
+                        manifest_ids=["alpaca_sip_daily@v1:abc"],
+                        manifest_references=["manifests://alpaca_sip_daily.json"],
+                        manifest_checksums=["abc"],
+                        provider_id="alpaca_sip",
+                        source_feed="sip",
+                        canonical_storage_mode="raw",
+                        read_time_adjustment_mode="unavailable",
+                    )
+                },
+                adjusted_preview_available=False,
+                adjusted_preview_unavailable_reason=(
+                    "read_time_adjustment_layer_not_defined"
+                ),
+                reason_codes=[
+                    "raw_sip_returns_unavailable",
+                    "read_time_adjustment_layer_not_defined",
+                ],
+            ),
+        )
+
+        lines = dm_module._adjustment_policy_lines(dataset)
+
+        assert "canonical_storage_mode: raw" in lines
+        assert "read_time_adjustment_mode: unavailable" in lines
+        assert "adj_close: raw_sip_returns_unavailable" in lines
+        assert any("backtest role prices: alpaca_sip_daily" in line for line in lines)
+        assert any("raw_sip_returns_unavailable" in line for line in lines)
+
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    def test_render_adjustment_policy_summary_outputs_policy_labels(
+        self,
+        mock_ui: MagicMock,
+    ) -> None:
+        mock_ui.column.return_value = _FakeElement()
+        mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+        dataset = DatasetInfoDTO(
+            name="alpaca_sip",
+            canonical_storage_mode="raw",
+            read_time_adjustment_mode="unavailable",
+            null_column_reasons={"adj_close": "raw_sip_returns_unavailable"},
+            warnings=["read_time_adjustment_layer_not_defined"],
+        )
+
+        dm_module._render_adjustment_policy_summary(dataset)
+
+        labels = [call.args[0] for call in mock_ui.label.call_args_list if call.args]
+        assert "Raw/Adjusted Policy" in labels
+        assert "canonical_storage_mode: raw" in labels
+        assert "read_time_adjustment_mode: unavailable" in labels
+        assert "adj_close: raw_sip_returns_unavailable" in labels
+        assert "read_time_adjustment_layer_not_defined" in labels
+
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    def test_render_preview_adjustment_metadata_outputs_manifest_provenance(
+        self,
+        mock_ui: MagicMock,
+    ) -> None:
+        mock_ui.column.return_value = _FakeElement()
+        mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+        preview = DataPreviewDTO(
+            columns=["symbol"],
+            rows=[{"symbol": "AAPL"}],
+            total_count=1,
+            table="alpaca_sip_daily",
+            canonical_storage_mode="raw",
+            read_time_adjustment_mode="unavailable",
+            manifest_id="alpaca_sip_daily@v1:abc",
+            manifest_reference="manifests://alpaca_sip_daily.json",
+            manifest_checksum="abc",
+            provider_id="alpaca_sip",
+            provider_version="1.0",
+            source_feed="sip",
+        )
+
+        dm_module._render_preview_adjustment_metadata(preview)
+
+        labels = [call.args[0] for call in mock_ui.label.call_args_list if call.args]
+        assert "Raw/Adjusted Policy" in labels
+        assert "Preview Provenance" in labels
+        assert "manifest_id: alpaca_sip_daily@v1:abc" in labels
+        assert "provider_id: alpaca_sip" in labels
+
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    def test_adjusted_preview_controls_are_disabled(self, mock_ui: MagicMock) -> None:
+        row = MagicMock()
+        row.__enter__ = MagicMock(return_value=row)
+        row.__exit__ = MagicMock(return_value=False)
+        mock_ui.row.return_value = row
+        select = MagicMock()
+        select.classes.return_value = select
+        select.props.return_value = select
+        button = MagicMock()
+        button.props.return_value = button
+        mock_ui.select.return_value = select
+        mock_ui.button.return_value = button
+        mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+        dataset = DatasetInfoDTO(
+            name="alpaca_sip",
+            canonical_storage_mode="raw",
+            backtest_handoff=BacktestHandoffDTO(
+                dataset="alpaca_sip",
+                adjusted_preview_available=False,
+                adjusted_preview_unavailable_reason=(
+                    "read_time_adjustment_layer_not_defined"
+                ),
+            ),
+        )
+
+        dm_module._render_adjusted_preview_controls(dataset)
+
+        select.props.assert_called_once_with("disable")
+        button.props.assert_called_once_with("flat disable")
+
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    def test_adjusted_preview_controls_tolerate_missing_handoff(
+        self,
+        mock_ui: MagicMock,
+    ) -> None:
+        row = MagicMock()
+        row.__enter__ = MagicMock(return_value=row)
+        row.__exit__ = MagicMock(return_value=False)
+        mock_ui.row.return_value = row
+        select = MagicMock()
+        select.classes.return_value = select
+        select.props.return_value = select
+        button = MagicMock()
+        button.props.return_value = button
+        mock_ui.select.return_value = select
+        mock_ui.button.return_value = button
+        mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+        dataset = DatasetInfoDTO(
+            name="alpaca_sip",
+            canonical_storage_mode="raw",
+            backtest_handoff=None,
+        )
+
+        dm_module._render_adjusted_preview_controls(dataset)
+
+        labels = [call.args[0] for call in mock_ui.label.call_args_list if call.args]
+        assert "read_time_adjustment_layer_not_defined" in labels
+
+    @patch("apps.web_console_ng.pages.data_management.ui")
+    def test_adjusted_preview_controls_hidden_without_adjustment_metadata(
+        self,
+        mock_ui: MagicMock,
+    ) -> None:
+        dataset = DatasetInfoDTO(name="crsp")
+
+        dm_module._render_adjusted_preview_controls(dataset)
+
+        mock_ui.row.assert_not_called()
 
 
 class TestBuildQualityTrendChart:

--- a/tests/apps/web_console_ng/pages/test_data_management_wiring.py
+++ b/tests/apps/web_console_ng/pages/test_data_management_wiring.py
@@ -729,6 +729,7 @@ class TestBuildQueryResults:
         assert "adj_close: raw_sip_returns_unavailable" in lines
         assert any("backtest role prices: alpaca_sip_daily" in line for line in lines)
         assert any("raw_sip_returns_unavailable" in line for line in lines)
+        assert "raw_sip_returns_unavailable" not in lines
 
     @patch("apps.web_console_ng.pages.data_management.ui")
     def test_render_adjustment_policy_summary_outputs_policy_labels(

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -1125,6 +1125,21 @@ def test_trusted_alpaca_summary_manifests_handles_missing_manifests() -> None:
     assert manifests == []
 
 
+def test_backtest_handoff_uses_preview_missing_manifest_reason() -> None:
+    handoff = data_explorer_module._build_backtest_handoff(
+        "alpaca_sip",
+        trusted_tables=["alpaca_sip_daily"],
+        alpaca_summary=SimpleNamespace(manifests=[]),
+        alpaca_summary_unavailable=False,
+        queryable_state="missing",
+    )
+
+    assert handoff is not None
+    prices = handoff.data_roles["prices"]
+    assert prices.unavailable_reason == "alpaca_sip_missing_manifest:alpaca_sip_daily"
+    assert "alpaca_sip_missing_manifest:alpaca_sip_daily" in handoff.reason_codes
+
+
 def test_optional_text_list_preserves_sequence_values() -> None:
     assert data_explorer_module._optional_text_list(["id-1", None, "", 2]) == [
         "id-1",

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -17,6 +17,10 @@ import pytest
 from libs.web_console_services import data_explorer_service as data_explorer_module
 from libs.web_console_services import sql_explorer_service as sql_module
 from libs.web_console_services.data_explorer_service import DataExplorerService, RateLimitExceeded
+from libs.web_console_services.data_manifest_service import (
+    AlpacaSipManifestSummaryDTO,
+    ManifestSummaryDTO,
+)
 from libs.web_console_services.provider_signature import ProviderSignatureDTO
 from libs.web_console_services.sql_validator import SQLValidator
 
@@ -24,6 +28,90 @@ from libs.web_console_services.sql_validator import SQLValidator
 @dataclass(frozen=True)
 class DummyUser:
     user_id: str
+
+
+def _manifest_summary(
+    *,
+    dataset: str = "alpaca_sip_daily",
+    validation_status: str = "passed",
+    sync_timestamp: datetime | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    row_count: int = 1,
+    manifest_id: str | None = None,
+    manifest_reference: str | None = None,
+    manifest_checksum: str | None = None,
+    manifest_version: int = 1,
+    schema_version: str = "1",
+    provider_id: str | None = "alpaca_sip",
+    provider_version: str | None = "1.0",
+    source_feed: str | None = "sip",
+    adjustment_mode: str | None = None,
+    canonical_storage_mode: str | None = None,
+    read_time_adjustment_mode: str | None = None,
+    provider_signature: ProviderSignatureDTO | None = None,
+) -> ManifestSummaryDTO:
+    timestamp = sync_timestamp or datetime(2026, 1, 3, tzinfo=UTC)
+    reference = manifest_reference or f"manifests://{dataset}.json"
+    checksum = manifest_checksum or f"{dataset}-checksum"
+    signature = provider_signature or ProviderSignatureDTO(
+        provider_id=provider_id or "alpaca_sip",
+        provider_version=provider_version,
+        source_feed=source_feed,
+        adjustment_mode=adjustment_mode,
+        canonical_storage_mode=canonical_storage_mode,
+        read_time_adjustment_mode=read_time_adjustment_mode,
+        manifest_id=manifest_id,
+        manifest_reference=reference,
+        manifest_checksum=checksum,
+        dataset_keys=[dataset],
+    )
+    return ManifestSummaryDTO(
+        dataset=dataset,
+        manifest_reference=reference,
+        manifest_id=manifest_id,
+        manifest_checksum=checksum,
+        manifest_version=manifest_version,
+        schema_version=schema_version,
+        validation_status=validation_status,
+        sync_timestamp=timestamp,
+        start_date=start_date or date(2026, 1, 2),
+        end_date=end_date or date(2026, 1, 2),
+        row_count=row_count,
+        file_count=1,
+        provider_id=provider_id,
+        provider_version=provider_version,
+        source_feed=source_feed,
+        adjustment_mode=adjustment_mode,
+        canonical_storage_mode=canonical_storage_mode,
+        read_time_adjustment_mode=read_time_adjustment_mode,
+        provider_signature=signature,
+    )
+
+
+def _alpaca_summary(
+    manifests: list[ManifestSummaryDTO],
+    *,
+    latest_sync: datetime | None = None,
+    row_count: int | None = None,
+    warnings: list[str] | None = None,
+) -> AlpacaSipManifestSummaryDTO:
+    return AlpacaSipManifestSummaryDTO(
+        manifests=manifests,
+        present_datasets=sorted({manifest.dataset for manifest in manifests}),
+        missing_datasets=[],
+        latest_sync=latest_sync or max(
+            (manifest.sync_timestamp for manifest in manifests),
+            default=None,
+        ),
+        row_count=row_count if row_count is not None else sum(manifest.row_count for manifest in manifests),
+        schema_versions=sorted({manifest.schema_version for manifest in manifests}),
+        validation_statuses=sorted({manifest.validation_status for manifest in manifests}),
+        sync_validation_status="passed",
+        source_status="ready",
+        source_error_rate_pct=0.0,
+        warnings=warnings or [],
+    )
 
 
 @pytest.fixture()
@@ -729,16 +817,16 @@ async def test_list_datasets_hides_untrusted_alpaca_manifest_summary(
     partition.parent.mkdir(parents=True)
     partition.write_bytes(b"PAR1")
     manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
-        has_any_manifest=True,
-        row_count=123,
-        latest_sync=datetime(2026, 1, 3, tzinfo=UTC),
-        manifests=[
-            SimpleNamespace(
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
+                dataset="alpaca_sip_daily_untrusted",
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 2),
+                row_count=123,
             )
         ],
+        row_count=123,
     )
     service = DataExplorerService(
         rate_limiter=rate_limiter,
@@ -775,20 +863,22 @@ async def test_list_datasets_exposes_trusted_alpaca_manifest_summary(
     monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
     latest_sync = datetime(2026, 1, 3, tzinfo=UTC)
     manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
-        has_any_manifest=True,
-        row_count=1,
-        latest_sync=latest_sync,
-        manifests=[
-            SimpleNamespace(
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="passed",
                 sync_timestamp=latest_sync,
                 start_date=date(2026, 1, 2),
                 end_date=date(2026, 1, 2),
                 row_count=1,
+                adjustment_mode="raw",
+                canonical_storage_mode="raw",
+                read_time_adjustment_mode="unavailable",
             )
         ],
+        latest_sync=latest_sync,
+        row_count=1,
     )
     service = DataExplorerService(
         rate_limiter=rate_limiter,
@@ -873,10 +963,9 @@ async def test_list_datasets_builds_role_keyed_backtest_handoff_metadata(
         dataset_keys=["alpaca_sip_corp_actions"],
     )
     manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
-        has_any_manifest=True,
-        manifests=[
-            SimpleNamespace(
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="passed",
                 sync_timestamp=sync_time,
@@ -894,7 +983,7 @@ async def test_list_datasets_builds_role_keyed_backtest_handoff_metadata(
                 read_time_adjustment_mode="unavailable",
                 provider_signature=daily_signature,
             ),
-            SimpleNamespace(
+            _manifest_summary(
                 dataset="alpaca_sip_corp_actions",
                 validation_status="passed",
                 sync_timestamp=sync_time,
@@ -962,12 +1051,9 @@ async def test_list_datasets_does_not_mark_invalid_manifest_path_queryable(
     monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
     failed_sync = datetime(2026, 1, 10, tzinfo=UTC)
     manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
-        has_any_manifest=True,
-        row_count=100,
-        latest_sync=failed_sync,
-        manifests=[
-            SimpleNamespace(
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="failed",
                 sync_timestamp=failed_sync,
@@ -976,6 +1062,8 @@ async def test_list_datasets_does_not_mark_invalid_manifest_path_queryable(
                 row_count=100,
             )
         ],
+        latest_sync=failed_sync,
+        row_count=100,
     )
     service = DataExplorerService(
         rate_limiter=rate_limiter,
@@ -1024,12 +1112,9 @@ async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
     trusted_sync = datetime(2026, 1, 3, tzinfo=UTC)
     failed_sync = datetime(2026, 1, 10, tzinfo=UTC)
     manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
-        has_any_manifest=True,
-        row_count=105,
-        latest_sync=failed_sync,
-        manifests=[
-            SimpleNamespace(
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="failed",
                 sync_timestamp=failed_sync,
@@ -1037,7 +1122,7 @@ async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
                 end_date=date(2026, 1, 10),
                 row_count=100,
             ),
-            SimpleNamespace(
+            _manifest_summary(
                 dataset="alpaca_sip_corp_actions",
                 validation_status="passed",
                 sync_timestamp=trusted_sync,
@@ -1046,6 +1131,8 @@ async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
                 row_count=5,
             ),
         ],
+        latest_sync=failed_sync,
+        row_count=105,
     )
     service = DataExplorerService(
         rate_limiter=rate_limiter,
@@ -1098,21 +1185,19 @@ def test_trusted_alpaca_summary_manifests_maps_tables_to_manifest_datasets(
         "alpaca_sip_daily",
         "alpaca_sip_daily_v1",
     )
-    trusted_manifest = SimpleNamespace(
+    trusted_manifest = _manifest_summary(
         dataset="alpaca_sip_daily_v1",
         validation_status="passed",
     )
-    stale_manifest = SimpleNamespace(
+    stale_manifest = _manifest_summary(
         dataset="alpaca_sip_daily",
         validation_status="passed",
     )
-    failed_manifest = SimpleNamespace(
+    failed_manifest = _manifest_summary(
         dataset="alpaca_sip_daily_v1",
         validation_status="failed",
     )
-    summary = SimpleNamespace(
-        manifests=[trusted_manifest, stale_manifest, failed_manifest],
-    )
+    summary = _alpaca_summary([trusted_manifest, stale_manifest, failed_manifest])
 
     manifests = data_explorer_module._trusted_alpaca_summary_manifests(
         summary,
@@ -1124,7 +1209,7 @@ def test_trusted_alpaca_summary_manifests_maps_tables_to_manifest_datasets(
 
 def test_trusted_alpaca_summary_manifests_handles_missing_manifests() -> None:
     manifests = data_explorer_module._trusted_alpaca_summary_manifests(
-        SimpleNamespace(),
+        _alpaca_summary([]),
         ["alpaca_sip_daily"],
     )
 
@@ -1135,7 +1220,7 @@ def test_backtest_handoff_uses_preview_missing_manifest_reason() -> None:
     handoff = data_explorer_module._build_backtest_handoff(
         "alpaca_sip",
         trusted_tables=["alpaca_sip_daily"],
-        alpaca_summary=SimpleNamespace(manifests=[]),
+        alpaca_summary=_alpaca_summary([]),
         alpaca_summary_unavailable=False,
         queryable_state="missing",
     )
@@ -1679,9 +1764,9 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
     )
     service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
         return_value=(
-            SimpleNamespace(
-                manifests=[
-                    SimpleNamespace(
+            _alpaca_summary(
+                [
+                    _manifest_summary(
                         dataset="alpaca_sip_daily",
                         validation_status="passed",
                         manifest_id="alpaca_sip_daily@v1:abc",
@@ -1696,7 +1781,7 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
                         read_time_adjustment_mode="unavailable",
                         provider_signature=provider_signature,
                     ),
-                    SimpleNamespace(
+                    _manifest_summary(
                         dataset="alpaca_sip_corp_actions",
                         validation_status="passed",
                         manifest_id="alpaca_sip_corp_actions@v1:def",
@@ -1707,7 +1792,7 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
                         provider_version="1.0",
                         source_feed="sip",
                         provider_signature=corp_provider_signature,
-                    )
+                    ),
                 ]
             ),
             False,
@@ -1782,14 +1867,14 @@ async def test_get_dataset_preview_does_not_register_companion_tables_for_sql(
     )
     service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
         return_value=(
-            SimpleNamespace(
-                manifests=[
-                    SimpleNamespace(
+            _alpaca_summary(
+                [
+                    _manifest_summary(
                         dataset="alpaca_sip_daily",
                         validation_status="passed",
                         manifest_id="alpaca_sip_daily@v1:abc",
                     ),
-                    SimpleNamespace(
+                    _manifest_summary(
                         dataset="alpaca_sip_corp_actions",
                         validation_status="passed",
                         manifest_id="alpaca_sip_corp_actions@v1:def",
@@ -1829,9 +1914,9 @@ async def test_preview_provenance_ignores_failed_manifest(
     service = DataExplorerService(rate_limiter=rate_limiter)
     service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
         return_value=(
-            SimpleNamespace(
-                manifests=[
-                    SimpleNamespace(
+            _alpaca_summary(
+                [
+                    _manifest_summary(
                         dataset="alpaca_sip_daily",
                         validation_status="failed",
                         manifest_id="failed-daily",

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -1082,6 +1082,12 @@ async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
     assert [template.table for template in alpaca.query_templates] == [
         "alpaca_sip_corp_actions"
     ]
+    assert alpaca.backtest_handoff is not None
+    assert (
+        alpaca.backtest_handoff.data_roles["prices"].unavailable_reason
+        == "alpaca_sip_manifest_validation_failed"
+    )
+    assert "alpaca_sip_manifest_validation_failed" in alpaca.backtest_handoff.reason_codes
 
 
 def test_trusted_alpaca_summary_manifests_maps_tables_to_manifest_datasets(

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -813,6 +813,140 @@ async def test_list_datasets_exposes_trusted_alpaca_manifest_summary(
     assert alpaca.last_sync == latest_sync
     assert alpaca.sql_handoff_url is not None
     assert alpaca.query_templates
+    assert alpaca.canonical_storage_mode == "raw"
+    assert alpaca.read_time_adjustment_mode == "unavailable"
+    assert alpaca.null_column_reasons == {
+        "adj_close": "raw_sip_returns_unavailable",
+        "ret": "raw_sip_returns_unavailable",
+    }
+    assert alpaca.backtest_handoff is not None
+    assert alpaca.backtest_handoff.adjusted_preview_available is False
+    assert "raw_sip_returns_unavailable" in alpaca.backtest_handoff.reason_codes
+    assert alpaca.backtest_handoff.data_roles["prices"].available is True
+    assert alpaca.backtest_handoff.data_roles["prices"].canonical_storage_mode == "raw"
+    assert (
+        alpaca.backtest_handoff.data_roles["prices"].read_time_adjustment_mode
+        == "unavailable"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_list_datasets_builds_role_keyed_backtest_handoff_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    )
+    daily_partition.parent.mkdir(parents=True)
+    pl.DataFrame({"symbol": ["AAPL"]}).write_parquet(daily_partition)
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame({"symbol": ["AAPL"]}).write_parquet(corp_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    sync_time = datetime(2026, 1, 3, tzinfo=UTC)
+    daily_signature = ProviderSignatureDTO(
+        provider_id="alpaca_sip",
+        provider_version="1.0",
+        source_feed="sip",
+        adjustment_mode="raw",
+        canonical_storage_mode="raw",
+        read_time_adjustment_mode="unavailable",
+        manifest_id="alpaca_sip_daily@v1:abc",
+        manifest_reference="manifests://alpaca_sip_daily.json",
+        manifest_checksum="abc",
+        data_roles={"universe": "alpaca_sip_daily", "prices": "alpaca_sip_daily"},
+        dataset_keys=["alpaca_sip_daily"],
+    )
+    corp_signature = ProviderSignatureDTO(
+        provider_id="alpaca_sip",
+        provider_version="1.0",
+        source_feed="sip",
+        manifest_id="alpaca_sip_corp_actions@v1:def",
+        manifest_reference="manifests://alpaca_sip_corp_actions.json",
+        manifest_checksum="def",
+        data_roles={"corp_actions": "alpaca_sip_corp_actions"},
+        dataset_keys=["alpaca_sip_corp_actions"],
+    )
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = SimpleNamespace(
+        has_any_manifest=True,
+        manifests=[
+            SimpleNamespace(
+                dataset="alpaca_sip_daily",
+                validation_status="passed",
+                sync_timestamp=sync_time,
+                start_date=date(2026, 1, 2),
+                end_date=date(2026, 1, 2),
+                row_count=1,
+                manifest_id="alpaca_sip_daily@v1:abc",
+                manifest_reference="manifests://alpaca_sip_daily.json",
+                manifest_checksum="abc",
+                provider_id="alpaca_sip",
+                provider_version="1.0",
+                source_feed="sip",
+                adjustment_mode="raw",
+                canonical_storage_mode="raw",
+                read_time_adjustment_mode="unavailable",
+                provider_signature=daily_signature,
+            ),
+            SimpleNamespace(
+                dataset="alpaca_sip_corp_actions",
+                validation_status="passed",
+                sync_timestamp=sync_time,
+                start_date=date(2026, 1, 2),
+                end_date=date(2026, 1, 2),
+                row_count=1,
+                manifest_id="alpaca_sip_corp_actions@v1:def",
+                manifest_reference="manifests://alpaca_sip_corp_actions.json",
+                manifest_checksum="def",
+                provider_id="alpaca_sip",
+                provider_version="1.0",
+                source_feed="sip",
+                provider_signature=corp_signature,
+            ),
+        ],
+        warnings=[],
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={
+            "alpaca_sip_daily": (str(daily_partition),),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        datasets = await service.list_datasets(DummyUser(user_id="user-1"))
+
+    alpaca = next(item for item in datasets if item.name == "alpaca_sip")
+    assert alpaca.backtest_handoff is not None
+    handoff = alpaca.backtest_handoff
+    assert sorted(handoff.data_roles) == ["corp_actions", "prices", "universe"]
+    assert handoff.adjusted_preview_available is False
+    assert handoff.adjusted_preview_unavailable_reason == (
+        "read_time_adjustment_layer_not_defined"
+    )
+    assert handoff.data_roles["universe"].manifest_ids == ["alpaca_sip_daily@v1:abc"]
+    assert handoff.data_roles["prices"].provider_signature == daily_signature
+    assert handoff.data_roles["corp_actions"].manifest_checksums == ["def"]
+    assert (
+        handoff.data_roles["corp_actions"].canonical_storage_mode
+        == "read_only_adjustment_input"
+    )
+    assert handoff.data_roles["corp_actions"].read_time_adjustment_mode == "not_applicable"
+    assert "raw_sip_returns_unavailable" in handoff.reason_codes
 
 
 @pytest.mark.asyncio()
@@ -989,6 +1123,13 @@ def test_trusted_alpaca_summary_manifests_handles_missing_manifests() -> None:
     )
 
     assert manifests == []
+
+
+def test_optional_text_list_preserves_sequence_values() -> None:
+    assert data_explorer_module._optional_text_list(["id-1", None, "", 2]) == [
+        "id-1",
+        "2",
+    ]
 
 
 @pytest.mark.asyncio()
@@ -1474,6 +1615,10 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
     data_root = tmp_path / "data"
     partition = data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
     partition.parent.mkdir(parents=True)
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
     pl.DataFrame(
         {
             "symbol": ["AAPL"],
@@ -1483,10 +1628,16 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
             "ret": [None],
         }
     ).write_parquet(partition)
+    pl.DataFrame({"symbol": ["AAPL"], "ex_date": [date(2026, 1, 2)]}).write_parquet(
+        corp_partition
+    )
     monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
     service = DataExplorerService(
         rate_limiter=rate_limiter,
-        table_paths={"alpaca_sip_daily": (str(partition),)},
+        table_paths={
+            "alpaca_sip_daily": (str(partition),),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
     )
     provider_signature = ProviderSignatureDTO(
         provider_id="alpaca_sip",
@@ -1498,12 +1649,20 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
         manifest_reference="manifests://alpaca_sip_daily.json",
         manifest_checksum="abc",
     )
+    corp_provider_signature = ProviderSignatureDTO(
+        provider_id="alpaca_sip",
+        source_feed="sip",
+        manifest_id="alpaca_sip_corp_actions@v1:def",
+        manifest_reference="manifests://alpaca_sip_corp_actions.json",
+        manifest_checksum="def",
+    )
     service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
         return_value=(
             SimpleNamespace(
                 manifests=[
                     SimpleNamespace(
                         dataset="alpaca_sip_daily",
+                        validation_status="passed",
                         manifest_id="alpaca_sip_daily@v1:abc",
                         manifest_reference="manifests://alpaca_sip_daily.json",
                         manifest_checksum="abc",
@@ -1515,6 +1674,18 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
                         canonical_storage_mode="raw",
                         read_time_adjustment_mode="unavailable",
                         provider_signature=provider_signature,
+                    ),
+                    SimpleNamespace(
+                        dataset="alpaca_sip_corp_actions",
+                        validation_status="passed",
+                        manifest_id="alpaca_sip_corp_actions@v1:def",
+                        manifest_reference="manifests://alpaca_sip_corp_actions.json",
+                        manifest_checksum="def",
+                        manifest_version=1,
+                        provider_id="alpaca_sip",
+                        provider_version="1.0",
+                        source_feed="sip",
+                        provider_signature=corp_provider_signature,
                     )
                 ]
             ),
@@ -1552,6 +1723,120 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
         "ret": "raw_sip_returns_unavailable",
     }
     assert preview.warnings == ["raw_sip_returns_unavailable"]
+    assert preview.backtest_handoff is not None
+    assert preview.backtest_handoff.data_roles["prices"].manifest_ids == [
+        "alpaca_sip_daily@v1:abc"
+    ]
+    assert preview.backtest_handoff.data_roles["corp_actions"].available is True
+    assert preview.backtest_handoff.data_roles["corp_actions"].manifest_ids == [
+        "alpaca_sip_corp_actions@v1:def"
+    ]
+    assert "raw_sip_returns_unavailable" in preview.backtest_handoff.reason_codes
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_does_not_register_companion_tables_for_sql(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2026.parquet"
+    )
+    daily_partition.parent.mkdir(parents=True)
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame({"symbol": ["AAPL"]}).write_parquet(daily_partition)
+    corp_partition.write_text("not parquet", encoding="utf-8")
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={
+            "alpaca_sip_daily": (str(daily_partition),),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
+    )
+    service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
+        return_value=(
+            SimpleNamespace(
+                manifests=[
+                    SimpleNamespace(
+                        dataset="alpaca_sip_daily",
+                        validation_status="passed",
+                        manifest_id="alpaca_sip_daily@v1:abc",
+                    ),
+                    SimpleNamespace(
+                        dataset="alpaca_sip_corp_actions",
+                        validation_status="passed",
+                        manifest_id="alpaca_sip_corp_actions@v1:def",
+                    ),
+                ]
+            ),
+            False,
+        )
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=5,
+            table="alpaca_sip_daily",
+        )
+
+    assert preview.rows == [{"symbol": "AAPL"}]
+    assert preview.backtest_handoff is not None
+    assert preview.backtest_handoff.data_roles["corp_actions"].manifest_ids == [
+        "alpaca_sip_corp_actions@v1:def"
+    ]
+
+
+@pytest.mark.asyncio()
+async def test_preview_provenance_ignores_failed_manifest(
+    rate_limiter: AsyncMock,
+) -> None:
+    service = DataExplorerService(rate_limiter=rate_limiter)
+    service._get_alpaca_summary = AsyncMock(  # type: ignore[method-assign]
+        return_value=(
+            SimpleNamespace(
+                manifests=[
+                    SimpleNamespace(
+                        dataset="alpaca_sip_daily",
+                        validation_status="failed",
+                        manifest_id="failed-daily",
+                        manifest_reference="manifests://alpaca_sip_daily.json",
+                        manifest_checksum="bad",
+                        manifest_version=1,
+                    )
+                ]
+            ),
+            False,
+        )
+    )
+
+    provenance = await service._preview_provenance_for_table(
+        "alpaca_sip_daily",
+        dataset="alpaca_sip",
+        trusted_tables=["alpaca_sip_daily"],
+    )
+
+    assert "manifest_id" not in provenance
+    assert "alpaca_sip_manifest_validation_failed" in provenance["warnings"]
+    handoff = provenance["backtest_handoff"]
+    assert handoff is not None
+    assert handoff.data_roles["prices"].available is False
+    assert handoff.data_roles["prices"].manifest_ids == []
+    assert "alpaca_sip_manifest_validation_failed" in handoff.reason_codes
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_manifest_service.py
+++ b/tests/libs/web_console_services/test_data_manifest_service.py
@@ -98,6 +98,10 @@ def test_alpaca_sip_summary_exposes_raw_daily_provenance(tmp_path: Path) -> None
     assert daily.read_time_adjustment_mode == "unavailable"
     assert daily.provider_signature.canonical_storage_mode == "raw"
     assert daily.provider_signature.read_time_adjustment_mode == "unavailable"
+    assert daily.provider_signature.data_roles == {
+        "universe": ALPACA_SIP_DAILY_DATASET,
+        "prices": ALPACA_SIP_DAILY_DATASET,
+    }
     assert daily.manifest_reference == "manifests://alpaca_sip_daily.json"
     assert daily.provider_signature.manifest_reference == daily.manifest_reference
     assert daily.provider_signature.manifest_checksum == daily.manifest_checksum


### PR DESCRIPTION
## Summary
- Surface Alpaca SIP raw/adjusted policy state in Data Explorer dataset, preview, schema, and query-result surfaces.
- Add disabled adjusted-preview controls with `read_time_adjustment_layer_not_defined` until the read-time adjustment layer exists.
- Add role-keyed backtest handoff provenance for `universe`, `prices`, and `corp_actions`, plus a service-contract concept doc.

## Validation
- Gemini review: no findings.
- Claude review: no findings.
- Codex review: no discrete correctness/security/regression findings.
- `ruff check` on touched phase 4 files.
- `mypy --strict` on touched service/UI files.
- `pytest -q tests/libs/web_console_services/test_data_explorer_service.py tests/libs/web_console_services/test_data_manifest_service.py tests/apps/web_console_ng/pages/test_data_management_wiring.py tests/apps/web_console_ng/components/test_data_manifest_components.py`.
- `PYTEST_XDIST_AUTO_NUM_WORKERS=4 make ci-local`.