### PR TITLE
[codex] Surface data readiness quality checks

### DIFF
--- a/apps/web_console_ng/components/data_quality_section.py
+++ b/apps/web_console_ng/components/data_quality_section.py
@@ -1,0 +1,72 @@
+"""Manifest-backed data quality section components."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_management_common import format_datetime
+from libs.web_console_services.schemas.data_management import DataQualitySummaryDTO
+
+
+def build_quality_signal_rows(summary: DataQualitySummaryDTO) -> list[dict[str, Any]]:
+    """Build compact rows for quality-signal display."""
+    return [
+        {
+            "check": signal.check,
+            "status": signal.status,
+            "source": signal.source,
+            "observed_at": format_datetime(signal.observed_at),
+            "message": signal.message,
+            "reason_codes": ", ".join(signal.reason_codes) if signal.reason_codes else "-",
+        }
+        for signal in summary.signals
+    ]
+
+
+def render_quality_summary(summary: DataQualitySummaryDTO) -> None:
+    """Render manifest/report-backed quality state."""
+    with ui.column().classes("w-full p-4 mb-4 border border-gray-200 rounded"):
+        ui.label("Alpaca SIP Quality Inputs").classes("text-lg font-bold")
+        with ui.row().classes("gap-3 flex-wrap"):
+            with ui.card().classes("p-3 min-w-[220px]"):
+                ui.label("Overall").classes("text-xs text-gray-500")
+                ui.label(summary.status).classes(
+                    f"text-lg font-bold {_quality_status_class(summary.status)}"
+                )
+                ui.label(f"Generated: {format_datetime(summary.generated_at)}").classes(
+                    "text-xs text-gray-500"
+                )
+            with ui.card().classes("p-3 min-w-[280px]"):
+                ui.label("Acknowledgments").classes("text-xs text-gray-500")
+                ack_state = "persistent" if summary.acknowledgments_persistent else "unavailable"
+                ui.label(ack_state).classes(
+                    f"text-lg font-bold {_quality_status_class(ack_state)}"
+                )
+                ui.label(summary.acknowledgment_status_source).classes("text-xs text-gray-500")
+
+        rows = build_quality_signal_rows(summary)
+        ui.table(
+            columns=[
+                {"name": "check", "label": "Check", "field": "check"},
+                {"name": "status", "label": "Status", "field": "status"},
+                {"name": "source", "label": "Source", "field": "source"},
+                {"name": "observed_at", "label": "Observed", "field": "observed_at"},
+                {"name": "message", "label": "Message", "field": "message"},
+                {"name": "reason_codes", "label": "Reason Codes", "field": "reason_codes"},
+            ],
+            rows=rows,
+            pagination={"rowsPerPage": 10},
+        ).classes("w-full")
+
+
+def _quality_status_class(status: str) -> str:
+    if status == "failed":
+        return "text-red-700"
+    if status in {"warning", "unavailable"}:
+        return "text-amber-700"
+    return "text-green-700"
+
+
+__all__ = ["build_quality_signal_rows", "render_quality_summary"]

--- a/apps/web_console_ng/components/data_readiness_section.py
+++ b/apps/web_console_ng/components/data_readiness_section.py
@@ -1,0 +1,81 @@
+"""Readiness section for manifest-backed data workflows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nicegui import ui
+
+from apps.web_console_ng.components.data_management_common import format_datetime
+from libs.web_console_services.schemas.data_management import DataReadinessDTO
+
+
+def build_readiness_rows(readiness: DataReadinessDTO) -> list[dict[str, Any]]:
+    """Build rows for compact readiness display."""
+    return [
+        {
+            "status": check.status,
+            "code": check.code,
+            "source": check.source,
+            "message": check.message,
+            "action": check.action_label or "-",
+            "target": check.target_section or "-",
+        }
+        for check in readiness.checks
+    ]
+
+
+def render_readiness_section(readiness_items: list[DataReadinessDTO]) -> None:
+    """Render workflow readiness summaries."""
+    if not readiness_items:
+        return
+    with ui.column().classes("w-full p-4 mb-4 border border-gray-200 rounded"):
+        ui.label("Backtest Readiness").classes("text-lg font-bold")
+        with ui.row().classes("gap-3 flex-wrap"):
+            for readiness in readiness_items:
+                with ui.card().classes("p-3 min-w-[240px]"):
+                    ui.label(readiness.dataset).classes("font-bold")
+                    ui.label(f"Workflow: {readiness.workflow}").classes("text-xs text-gray-500")
+                    ui.label(f"Status: {readiness.status}").classes(
+                        f"text-sm font-bold {_status_class(readiness.status)}"
+                    )
+                    if readiness.blockers:
+                        ui.label("Blockers: " + ", ".join(readiness.blockers)).classes(
+                            "text-xs text-red-700"
+                        )
+                    if readiness.warnings:
+                        ui.label("Warnings: " + ", ".join(readiness.warnings)).classes(
+                            "text-xs text-amber-700"
+                        )
+                    ui.label(f"Checked: {format_datetime(readiness.generated_at)}").classes(
+                        "text-xs text-gray-500"
+                    )
+
+        for readiness in readiness_items:
+            rows = build_readiness_rows(readiness)
+            if not rows:
+                continue
+            ui.label(f"{readiness.dataset} checks").classes("font-bold mt-3")
+            ui.table(
+                columns=[
+                    {"name": "status", "label": "Status", "field": "status"},
+                    {"name": "code", "label": "Reason Code", "field": "code"},
+                    {"name": "source", "label": "Source", "field": "source"},
+                    {"name": "message", "label": "Message", "field": "message"},
+                    {"name": "action", "label": "Action", "field": "action"},
+                    {"name": "target", "label": "Target", "field": "target"},
+                ],
+                rows=rows,
+                pagination={"rowsPerPage": 10},
+            ).classes("w-full")
+
+
+def _status_class(status: str) -> str:
+    if status == "blocked":
+        return "text-red-700"
+    if status == "warning":
+        return "text-amber-700"
+    return "text-green-700"
+
+
+__all__ = ["build_readiness_rows", "render_readiness_section"]

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -321,10 +321,12 @@ async def _render_manifest_transparency(
         return None
 
     alpaca_summary = None
+    alpaca_summary_failed = False
     if has_alpaca_sip:
         try:
             alpaca_summary = await asyncio.to_thread(manifest_service.get_alpaca_sip_summary)
         except Exception:
+            alpaca_summary_failed = True
             logger.exception(
                 "service_call_failed",
                 extra={
@@ -341,9 +343,9 @@ async def _render_manifest_transparency(
     readiness_failures = 0
     readiness_targets: list[tuple[str, ReadinessWorkflow]] = []
     failed_readiness_targets: list[str] = []
-    if has_alpaca_sip:
+    if has_alpaca_sip and not alpaca_summary_failed:
         readiness_targets.append((ALPACA_SIP_DATASET_KEY, "simple_backtest"))
-    if has_hybrid:
+    if has_hybrid and not alpaca_summary_failed:
         readiness_targets.append((HYBRID_CRSP_SIP_DATASET_KEY, "hybrid_research_backtest"))
 
     async def _load_readiness_target(
@@ -352,8 +354,7 @@ async def _render_manifest_transparency(
     ) -> tuple[DataReadinessDTO | None, str | None]:
         try:
             return (
-                await asyncio.to_thread(
-                    readiness_service.get_readiness,
+                await readiness_service.get_readiness_async(
                     user,
                     dataset,
                     workflow,
@@ -387,7 +388,7 @@ async def _render_manifest_transparency(
             logger.exception(
                 "service_call_failed",
                 extra={
-                    "method": "get_readiness",
+                    "method": "get_readiness_async",
                     "service": "DataReadinessService",
                     "dataset": dataset,
                     "workflow": workflow,

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -78,6 +78,7 @@ from libs.web_console_services.data_readiness_service import (
 from libs.web_console_services.data_sync_service import DataSyncService
 from libs.web_console_services.schemas.data_management import (
     DataPreviewDTO,
+    DataReadinessDTO,
     DatasetInfoDTO,
     QueryResultDTO,
     QueryTemplateDTO,
@@ -339,7 +340,7 @@ async def _render_manifest_transparency(
     async def _load_readiness_target(
         dataset: str,
         workflow: ReadinessWorkflow,
-    ) -> tuple[Any | None, str | None]:
+    ) -> tuple[DataReadinessDTO | None, str | None]:
         try:
             return (
                 await asyncio.to_thread(

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -68,6 +68,7 @@ from libs.web_console_services.data_explorer_service import (
 )
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_DATASET_KEY,
+    AlpacaSipManifestSummaryDTO,
     DataManifestService,
 )
 from libs.web_console_services.data_quality_service import DataQualityService
@@ -180,7 +181,11 @@ async def data_management_page() -> None:
         )
         return
 
-    await _render_manifest_transparency(user, manifest_service, readiness_service)
+    alpaca_sip_summary = await _render_manifest_transparency(
+        user,
+        manifest_service,
+        readiness_service,
+    )
 
     # Overlap guard flags (per-client scope — each page load creates a new function scope)
     _sync_refreshing = False
@@ -207,7 +212,11 @@ async def data_management_page() -> None:
                     alerts_container,
                     scores_container,
                     _load_alerts_fn,
-                ) = await _render_data_quality_section(user, quality_service)
+                ) = await _render_data_quality_section(
+                    user,
+                    quality_service,
+                    alpaca_sip_summary=alpaca_sip_summary,
+                )
 
     # === Auto-refresh Timers ===
     async def refresh_sync_status() -> None:
@@ -302,14 +311,14 @@ async def _render_manifest_transparency(
     user: dict[str, Any],
     manifest_service: DataManifestService,
     readiness_service: DataReadinessService,
-) -> None:
+) -> AlpacaSipManifestSummaryDTO | None:
     """Render Phase 1 manifest transparency for authorized Alpaca SIP users."""
     if not has_permission(user, Permission.VIEW_DATA_SYNC):
-        return
+        return None
     has_alpaca_sip = has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)
     has_hybrid = has_dataset_permission(user, HYBRID_CRSP_SIP_DATASET_KEY)
     if not has_alpaca_sip and not has_hybrid:
-        return
+        return None
 
     alpaca_summary = None
     if has_alpaca_sip:
@@ -410,6 +419,7 @@ async def _render_manifest_transparency(
             },
         )
         ui.notify("Some readiness checks are temporarily unavailable", type="warning")
+    return alpaca_summary
 
 
 # =============================================================================
@@ -972,6 +982,8 @@ def _build_query_results(
 async def _render_data_quality_section(
     user: dict[str, Any],
     quality_service: DataQualityService,
+    *,
+    alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
 ) -> tuple[ui.column | None, ui.column | None, Callable[[], Any] | None]:
     """Render Data Quality reports section.
 
@@ -985,7 +997,10 @@ async def _render_data_quality_section(
         user, ALPACA_SIP_DATASET_KEY
     ):
         try:
-            alpaca_quality = await quality_service.get_alpaca_sip_quality_summary(user)
+            alpaca_quality = await quality_service.get_alpaca_sip_quality_summary(
+                user,
+                alpaca_sip_summary=alpaca_sip_summary,
+            )
             _data_quality_section.render_quality_summary(alpaca_quality)
         except PermissionError:
             logger.warning(
@@ -1010,7 +1025,11 @@ async def _render_data_quality_section(
     # Quality score cards at top of section
     scores_container = ui.column().classes("w-full mb-4")
     with scores_container:
-        await _build_quality_score_cards(user, quality_service)
+        await _build_quality_score_cards(
+            user,
+            quality_service,
+            alpaca_sip_summary=alpaca_sip_summary,
+        )
 
     with ui.tabs().classes("w-full") as quality_tabs:
         tab_validation = ui.tab("Validation Results")
@@ -1023,7 +1042,11 @@ async def _render_data_quality_section(
 
     with ui.tab_panels(quality_tabs, value=tab_validation).classes("w-full"):
         with ui.tab_panel(tab_validation):
-            await _render_validation_results(user, quality_service)
+            await _render_validation_results(
+                user,
+                quality_service,
+                alpaca_sip_summary=alpaca_sip_summary,
+            )
 
         with ui.tab_panel(tab_anomalies):
             alerts_container, load_alerts_fn = await _render_anomaly_alerts(user, quality_service)
@@ -1040,10 +1063,16 @@ async def _render_data_quality_section(
 async def _build_quality_score_cards(
     user: dict[str, Any],
     quality_service: DataQualityService,
+    *,
+    alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
 ) -> None:
     """Build quality score cards per dataset using compute_quality_scores()."""
     try:
-        validations = await quality_service.get_validation_results(user, dataset=None)
+        validations = await quality_service.get_validation_results(
+            user,
+            dataset=None,
+            alpaca_sip_summary=alpaca_sip_summary,
+        )
         alerts = await quality_service.get_anomaly_alerts(user, severity=None, acknowledged=None)
         quarantine = await quality_service.get_quarantine_status(user)
     except PermissionError as exc:
@@ -1102,6 +1131,8 @@ async def _build_quality_score_cards(
 async def _render_validation_results(
     user: dict[str, Any],
     quality_service: DataQualityService,
+    *,
+    alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
 ) -> None:
     """Render validation results table with dataset filter."""
     ui.label("Recent Validation Results").classes("font-bold mb-2")
@@ -1117,7 +1148,11 @@ async def _render_validation_results(
     async def load_results() -> None:
         ds = None if dataset_filter.value == "all" else str(dataset_filter.value)
         try:
-            results = await quality_service.get_validation_results(user, dataset=ds)
+            results = await quality_service.get_validation_results(
+                user,
+                dataset=ds,
+                alpaca_sip_summary=alpaca_sip_summary,
+            )
             results_container.clear()
             with results_container:
                 _build_validation_table(results)

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -31,6 +31,8 @@ from nicegui import ui
 
 from apps.web_console_ng.auth.middleware import get_current_user, requires_auth
 from apps.web_console_ng.components import data_manifest_panel as _data_manifest_panel
+from apps.web_console_ng.components import data_quality_section as _data_quality_section
+from apps.web_console_ng.components import data_readiness_section as _data_readiness_section
 from apps.web_console_ng.components import data_sync_section as _data_sync_section
 from apps.web_console_ng.components.data_management_common import (
     TREND_DATASETS as _TREND_DATASETS,
@@ -64,14 +66,22 @@ from libs.web_console_services.data_explorer_service import (
 from libs.web_console_services.data_explorer_service import (
     RateLimitExceeded as ExplorerRateLimitExceeded,
 )
-from libs.web_console_services.data_manifest_service import DataManifestService
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_DATASET_KEY,
+    DataManifestService,
+)
 from libs.web_console_services.data_quality_service import DataQualityService
+from libs.web_console_services.data_readiness_service import (
+    HYBRID_CRSP_SIP_DATASET_KEY,
+    DataReadinessService,
+)
 from libs.web_console_services.data_sync_service import DataSyncService
 from libs.web_console_services.schemas.data_management import (
     DataPreviewDTO,
     DatasetInfoDTO,
     QueryResultDTO,
     QueryTemplateDTO,
+    ReadinessWorkflow,
 )
 
 logger = logging.getLogger(__name__)
@@ -126,8 +136,9 @@ async def data_management_page() -> None:
     # Instantiate services at page-load time (not module level)
     sync_service = DataSyncService()
     explorer_service = DataExplorerService()
-    quality_service = DataQualityService()
     manifest_service = DataManifestService()
+    quality_service = DataQualityService(manifest_service=manifest_service)
+    readiness_service = DataReadinessService(manifest_service=manifest_service)
 
     # Page title
     ui.label("Data Management").classes("text-2xl font-bold mb-4")
@@ -168,7 +179,7 @@ async def data_management_page() -> None:
         )
         return
 
-    await _render_manifest_transparency(user, manifest_service)
+    await _render_manifest_transparency(user, manifest_service, readiness_service)
 
     # Overlap guard flags (per-client scope — each page load creates a new function scope)
     _sync_refreshing = False
@@ -289,28 +300,115 @@ async def data_management_page() -> None:
 async def _render_manifest_transparency(
     user: dict[str, Any],
     manifest_service: DataManifestService,
+    readiness_service: DataReadinessService,
 ) -> None:
     """Render Phase 1 manifest transparency for authorized Alpaca SIP users."""
     if not has_permission(user, Permission.VIEW_DATA_SYNC):
         return
-    if not has_dataset_permission(user, "alpaca_sip"):
+    has_alpaca_sip = has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)
+    has_hybrid = has_dataset_permission(user, HYBRID_CRSP_SIP_DATASET_KEY)
+    if not has_alpaca_sip and not has_hybrid:
         return
 
-    try:
-        summary = await asyncio.to_thread(manifest_service.get_alpaca_sip_summary)
-    except Exception:
-        logger.exception(
-            "service_call_failed",
+    alpaca_summary = None
+    if has_alpaca_sip:
+        try:
+            alpaca_summary = await asyncio.to_thread(manifest_service.get_alpaca_sip_summary)
+        except Exception:
+            logger.exception(
+                "service_call_failed",
+                extra={
+                    "method": "get_alpaca_sip_summary",
+                    "service": "DataManifestService",
+                    "user_id": _get_user_id_safe(user),
+                },
+            )
+            ui.notify("Manifest status temporarily unavailable", type="warning")
+        else:
+            _data_manifest_panel.render_manifest_transparency_panel(alpaca_summary)
+
+    readiness_items = []
+    readiness_failures = 0
+    readiness_targets: list[tuple[str, ReadinessWorkflow]] = []
+    failed_readiness_targets: list[str] = []
+    if has_alpaca_sip:
+        readiness_targets.append((ALPACA_SIP_DATASET_KEY, "simple_backtest"))
+    if has_hybrid:
+        readiness_targets.append((HYBRID_CRSP_SIP_DATASET_KEY, "hybrid_research_backtest"))
+
+    async def _load_readiness_target(
+        dataset: str,
+        workflow: ReadinessWorkflow,
+    ) -> tuple[Any | None, str | None]:
+        try:
+            return (
+                await asyncio.to_thread(
+                    readiness_service.get_readiness,
+                    user,
+                    dataset,
+                    workflow,
+                    alpaca_sip_summary=alpaca_summary,
+                ),
+                None,
+            )
+        except PermissionError:
+            logger.warning(
+                "readiness_permission_divergence",
+                extra={
+                    "dataset": dataset,
+                    "workflow": workflow,
+                    "service": "DataReadinessService",
+                    "user_id": _get_user_id_safe(user),
+                },
+            )
+            return None, None
+        except ValueError:
+            logger.exception(
+                "readiness_target_configuration_invalid",
+                extra={
+                    "dataset": dataset,
+                    "workflow": workflow,
+                    "service": "DataReadinessService",
+                    "user_id": _get_user_id_safe(user),
+                },
+            )
+            return None, f"{dataset}:{workflow}"
+        except Exception:
+            logger.exception(
+                "service_call_failed",
+                extra={
+                    "method": "get_readiness",
+                    "service": "DataReadinessService",
+                    "dataset": dataset,
+                    "workflow": workflow,
+                    "user_id": _get_user_id_safe(user),
+                },
+            )
+            return None, f"{dataset}:{workflow}"
+
+    if readiness_targets:
+        readiness_results = await asyncio.gather(
+            *(_load_readiness_target(dataset, workflow) for dataset, workflow in readiness_targets)
+        )
+        for readiness, failed_target in readiness_results:
+            if readiness is not None:
+                readiness_items.append(readiness)
+            if failed_target is not None:
+                readiness_failures += 1
+                failed_readiness_targets.append(failed_target)
+    if readiness_items:
+        _data_readiness_section.render_readiness_section(readiness_items)
+    if readiness_failures:
+        logger.warning(
+            "readiness_status_partial_failure",
             extra={
-                "method": "get_alpaca_sip_summary",
-                "service": "DataManifestService",
+                "failure_count": readiness_failures,
+                "failed_targets": failed_readiness_targets,
+                "service": "DataReadinessService",
                 "user_id": _get_user_id_safe(user),
             },
         )
-        ui.notify("Manifest status temporarily unavailable", type="warning")
-        return
-
-    _data_manifest_panel.render_manifest_transparency_panel(summary)
+        ui.notify("Some readiness checks are temporarily unavailable", type="warning")
 
 
 # =============================================================================
@@ -882,6 +980,32 @@ async def _render_data_quality_section(
     """
     ui.label("Data Quality Reports").classes("text-xl font-bold mb-2")
 
+    if has_permission(user, Permission.VIEW_DATA_QUALITY) and has_dataset_permission(
+        user, ALPACA_SIP_DATASET_KEY
+    ):
+        try:
+            alpaca_quality = await quality_service.get_alpaca_sip_quality_summary(user)
+            _data_quality_section.render_quality_summary(alpaca_quality)
+        except PermissionError:
+            logger.warning(
+                "alpaca_sip_quality_permission_divergence",
+                extra={
+                    "method": "get_alpaca_sip_quality_summary",
+                    "service": "DataQualityService",
+                    "user_id": _get_user_id_safe(user),
+                },
+            )
+        except Exception:
+            logger.exception(
+                "service_call_failed",
+                extra={
+                    "method": "get_alpaca_sip_quality_summary",
+                    "service": "DataQualityService",
+                    "user_id": _get_user_id_safe(user),
+                },
+            )
+            ui.notify("Alpaca SIP quality inputs temporarily unavailable", type="warning")
+
     # Quality score cards at top of section
     scores_container = ui.column().classes("w-full mb-4")
     with scores_container:
@@ -1140,11 +1264,17 @@ def _build_anomaly_alert_cards(
     severity_lookup: dict[str, str],
 ) -> None:
     """Build alert cards from normalized AnomalyAlertDTO list."""
-    can_ack = has_permission(user, Permission.ACKNOWLEDGE_ALERTS)
+    ack_persistent = quality_service.acknowledgments_persistent
+    user_can_ack = has_permission(user, Permission.ACKNOWLEDGE_ALERTS)
 
     if not alerts:
         ui.label("No alerts matching filters").classes("text-gray-500")
         return
+
+    if user_can_ack and not ack_persistent:
+        ui.label(
+            "Acknowledgment controls are unavailable until server-side persistence is enabled"
+        ).classes("text-xs text-amber-700 mb-2")
 
     for alert in alerts:
         sev = severity_lookup.get(alert.id, alert.severity)
@@ -1164,7 +1294,7 @@ def _build_anomaly_alert_cards(
                     f"(current: {alert.current_value}, expected: {alert.expected_value})"
                 ).classes("text-sm text-gray-600 mt-1")
 
-            if can_ack and not alert.acknowledged:
+            if user_can_ack and ack_persistent and not alert.acknowledged:
                 _alert_id = alert.id
 
                 async def ack_alert(aid: str = _alert_id) -> None:

--- a/libs/data/data_quality/quality_scorer.py
+++ b/libs/data/data_quality/quality_scorer.py
@@ -5,7 +5,7 @@ Service DTOs (ValidationResultDTO, AnomalyAlertDTO, QuarantineEntryDTO)
 already satisfy these protocols without adapters.
 
 Scoring formula per dataset:
-    validation_pass_rate = passed_count / total_validations * 100
+    validation_pass_rate = passed_count / total_scored_validations * 100
     anomaly_penalty = min(unacknowledged_count * 5.0, 30.0)
     quarantine_penalty = min(quarantine_count * 10.0, 20.0)
     overall_score = max(0.0, validation_pass_rate - anomaly_penalty - quarantine_penalty)
@@ -130,7 +130,8 @@ def compute_quality_scores(
     """Compute quality scores per dataset from raw service data.
 
     Groups inputs by dataset and computes:
-    - validation_pass_rate: % of validations with normalized status "passed"
+    - validation_pass_rate: % of scored validations with normalized status "passed"
+      (availability rows are excluded from pass/fail scoring)
     - anomaly_penalty: min(unacked_count * 5.0, 30.0)
     - quarantine_penalty: min(quarantine_count * 10.0, 20.0)
     - overall_score: max(0.0, pass_rate - anomaly_penalty - quarantine_penalty)
@@ -147,7 +148,11 @@ def compute_quality_scores(
     scores: list[QualityScore] = []
     for ds in sorted(datasets):
         # Validations for this dataset
-        ds_validations = [v for v in validations if v.dataset == ds]
+        ds_validations = [
+            v
+            for v in validations
+            if v.dataset == ds and normalize_validation_status(v.status) != "unavailable"
+        ]
         total = len(ds_validations)
 
         if total == 0:

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -54,6 +54,7 @@ _ALPACA_FEED_DELTA_CHECK = "alpaca_feed_delta"
 _ALPACA_SIP_INTEGRITY_LATEST_REPORT = "alpaca_sip_integrity_latest.json"
 _ALPACA_FEED_DELTA_LATEST_REPORT = "alpaca_iex_sip_delta_latest.json"
 _ALPACA_QUALITY_REPORT_ROOTS_ENV = "ALPACA_QUALITY_REPORT_ROOTS"
+_MAX_QUALITY_REPORT_BYTES = 5 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -110,7 +111,7 @@ class AlpacaQualityReportStore:
     ) -> Path | None:
         configured = os.getenv(env_var, "").strip()
         if configured:
-            path = Path(configured).expanduser()
+            path = Path(configured)
             if path.is_absolute():
                 return self._resolve_quality_report_candidate(
                     path,
@@ -202,8 +203,15 @@ class AlpacaQualityReportStore:
             raw_root = raw_root.strip()
             if not raw_root:
                 continue
+            root_path = Path(raw_root)
+            if not root_path.is_absolute():
+                logger.warning(
+                    "alpaca_quality_report_root_not_absolute",
+                    extra={"root": raw_root},
+                )
+                continue
             try:
-                roots.append(Path(raw_root).expanduser().resolve(strict=True))
+                roots.append(root_path.resolve(strict=True))
             except FileNotFoundError:
                 logger.warning(
                     "alpaca_quality_report_root_missing",
@@ -222,6 +230,29 @@ class AlpacaQualityReportStore:
         *,
         expected_report_type: str,
     ) -> QualityReportState | None:
+        try:
+            report_stat = report_path.stat()
+        except OSError as exc:
+            logger.warning(
+                "alpaca_quality_report_unreadable",
+                extra={
+                    "path": str(report_path),
+                    "report_type": expected_report_type,
+                    "error": str(exc),
+                },
+            )
+            return None
+        if report_stat.st_size > _MAX_QUALITY_REPORT_BYTES:
+            logger.warning(
+                "alpaca_quality_report_too_large",
+                extra={
+                    "path": str(report_path),
+                    "report_type": expected_report_type,
+                    "size_bytes": report_stat.st_size,
+                    "max_bytes": _MAX_QUALITY_REPORT_BYTES,
+                },
+            )
+            return None
         try:
             payload = json.loads(report_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -245,14 +276,6 @@ class AlpacaQualityReportStore:
             else ""
         )
         raw_status = str(payload.get("status", "unknown"))
-        try:
-            observed_at = datetime.fromtimestamp(report_path.stat().st_mtime, UTC)
-        except OSError as exc:
-            logger.debug(
-                "alpaca_quality_report_stat_unavailable",
-                extra={"report_path": str(report_path), "error": str(exc)},
-            )
-            observed_at = None
         return QualityReportState(
             report_type=expected_report_type,
             status=_normalize_report_status(raw_status),
@@ -262,7 +285,7 @@ class AlpacaQualityReportStore:
             end=str(payload.get("end", "")),
             timeframe=str(payload.get("timeframe", "")),
             path=report_path,
-            observed_at=observed_at,
+            observed_at=datetime.fromtimestamp(report_stat.st_mtime, UTC),
             tolerance_version=tolerance_version,
         )
 

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -565,14 +565,14 @@ def _build_alpaca_sip_quality_summary(
         _manifest_validation_signal(summary),
         _manifest_pairing_signal(summary),
         _quality_report_signal(
-            "alpaca_sip_integrity",
+            _ALPACA_SIP_INTEGRITY_CHECK,
             "No persisted Alpaca SIP deterministic re-pull integrity report is available.",
             "Alpaca SIP deterministic re-pull integrity report",
             integrity_report,
             generated_at,
         ),
         _quality_report_signal(
-            "alpaca_feed_delta",
+            _ALPACA_FEED_DELTA_CHECK,
             "No persisted Alpaca IEX-vs-SIP feed-delta report is available.",
             "Alpaca IEX-vs-SIP feed-delta report",
             feed_delta_report,

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -119,6 +119,7 @@ class DataQualityService:
             if dataset
             else [item for item in mock if has_dataset_permission(user, item.dataset)]
         )
+        alpaca_results: list[ValidationResultDTO] = []
         if (dataset is None and has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)) or (
             dataset == ALPACA_SIP_DATASET_KEY
         ):
@@ -129,10 +130,13 @@ class DataQualityService:
                     "alpaca_sip_manifest_summary_unavailable",
                     extra={"dataset": ALPACA_SIP_DATASET_KEY},
                 )
-                filtered.append(_alpaca_sip_unavailable_validation_result(now))
+                alpaca_results.append(_alpaca_sip_unavailable_validation_result(now))
             else:
-                filtered.extend(self._alpaca_sip_validation_results(now, summary))
-        return filtered[:limit]
+                alpaca_results.extend(self._alpaca_sip_validation_results(now, summary))
+
+        if dataset is None:
+            return [*alpaca_results, *filtered][:limit]
+        return [*filtered, *alpaca_results][:limit]
 
     async def get_alpaca_sip_quality_summary(self, user: Any) -> DataQualitySummaryDTO:
         """Return manifest-backed Alpaca SIP quality state for the data page."""

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -50,6 +50,8 @@ _MOCK_QUALITY_DATASETS = tuple(
 )
 _ALPACA_SIP_INTEGRITY_CHECK = "alpaca_sip_integrity"
 _ALPACA_FEED_DELTA_CHECK = "alpaca_feed_delta"
+_ALPACA_SIP_INTEGRITY_LATEST_REPORT = "alpaca_sip_integrity_latest.json"
+_ALPACA_FEED_DELTA_LATEST_REPORT = "alpaca_iex_sip_delta_latest.json"
 
 
 @dataclass(frozen=True)
@@ -78,6 +80,7 @@ class AlpacaQualityReportStore:
         report_path = self._resolve_report_path(
             env_var="ALPACA_SIP_INTEGRITY_REPORT",
             pattern="alpaca_sip_integrity*.json",
+            latest_filename=_ALPACA_SIP_INTEGRITY_LATEST_REPORT,
         )
         if report_path is None:
             return None
@@ -88,12 +91,19 @@ class AlpacaQualityReportStore:
         report_path = self._resolve_report_path(
             env_var="ALPACA_FEED_DELTA_REPORT",
             pattern="alpaca_iex_sip_delta*.json",
+            latest_filename=_ALPACA_FEED_DELTA_LATEST_REPORT,
         )
         if report_path is None:
             return None
         return self._load_report(report_path, expected_report_type="alpaca_feed_delta")
 
-    def _resolve_report_path(self, *, env_var: str, pattern: str) -> Path | None:
+    def _resolve_report_path(
+        self,
+        *,
+        env_var: str,
+        pattern: str,
+        latest_filename: str,
+    ) -> Path | None:
         configured = os.getenv(env_var, "").strip()
         if configured:
             path = Path(configured)
@@ -113,7 +123,29 @@ class AlpacaQualityReportStore:
         quality_dir = self._data_root / "quality"
         if not quality_dir.exists():
             return None
+        latest_pointer = self._resolve_quality_report_candidate(quality_dir / latest_filename)
+        if latest_pointer is not None:
+            return latest_pointer
         return self._latest_report_path(quality_dir, pattern)
+
+    def _resolve_quality_report_candidate(self, candidate: Path) -> Path | None:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.debug(
+                "alpaca_quality_report_candidate_unavailable",
+                extra={"report_path": str(candidate), "error": str(exc)},
+            )
+            return None
+        if not resolved.is_relative_to(self._data_root):
+            logger.warning(
+                "alpaca_quality_report_outside_data_root",
+                extra={"path": str(resolved), "data_root": str(self._data_root)},
+            )
+            return None
+        return resolved
 
     def _latest_report_path(self, quality_dir: Path, pattern: str) -> Path | None:
         latest_path: Path | None = None
@@ -268,9 +300,7 @@ class DataQualityService:
                 summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
             alpaca_results.extend(self._alpaca_sip_validation_results(now, summary))
 
-        if dataset is None:
-            return [*alpaca_results, *filtered][:limit]
-        return [*filtered, *alpaca_results][:limit]
+        return [*alpaca_results, *filtered][:limit]
 
     async def get_alpaca_sip_quality_summary(
         self,

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -6,6 +6,7 @@ Enforces dataset-level access on all read paths for licensing compliance.
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import json
 import logging
 import os
@@ -52,6 +53,7 @@ _ALPACA_SIP_INTEGRITY_CHECK = "alpaca_sip_integrity"
 _ALPACA_FEED_DELTA_CHECK = "alpaca_feed_delta"
 _ALPACA_SIP_INTEGRITY_LATEST_REPORT = "alpaca_sip_integrity_latest.json"
 _ALPACA_FEED_DELTA_LATEST_REPORT = "alpaca_iex_sip_delta_latest.json"
+_ALPACA_QUALITY_REPORT_ROOTS_ENV = "ALPACA_QUALITY_REPORT_ROOTS"
 
 
 @dataclass(frozen=True)
@@ -75,6 +77,7 @@ class AlpacaQualityReportStore:
 
     def __init__(self, *, data_root: Path | None = None) -> None:
         self._data_root = data_root.resolve() if data_root is not None else _DEFAULT_DATA_ROOT
+        self._trusted_report_roots = self._load_trusted_report_roots()
 
     def get_integrity_report(self) -> QualityReportState | None:
         """Return the latest deterministic SIP re-pull integrity report, if present."""
@@ -111,7 +114,7 @@ class AlpacaQualityReportStore:
             if path.is_absolute():
                 return self._resolve_quality_report_candidate(
                     path,
-                    allow_outside_data_root=True,
+                    trusted_roots=self._trusted_report_roots,
                 )
             return self._resolve_quality_report_candidate(self._data_root / path)
 
@@ -127,8 +130,9 @@ class AlpacaQualityReportStore:
         self,
         candidate: Path,
         *,
-        allow_outside_data_root: bool = False,
+        trusted_roots: tuple[Path, ...] | None = None,
     ) -> Path | None:
+        roots = trusted_roots if trusted_roots is not None else (self._data_root,)
         try:
             resolved = candidate.resolve(strict=True)
         except FileNotFoundError:
@@ -139,10 +143,13 @@ class AlpacaQualityReportStore:
                 extra={"report_path": str(candidate), "error": str(exc)},
             )
             return None
-        if not allow_outside_data_root and not resolved.is_relative_to(self._data_root):
+        if not any(resolved.is_relative_to(root) for root in roots):
             logger.warning(
-                "alpaca_quality_report_outside_data_root",
-                extra={"path": str(resolved), "data_root": str(self._data_root)},
+                "alpaca_quality_report_outside_trusted_roots",
+                extra={
+                    "path": str(resolved),
+                    "trusted_roots": [str(root) for root in roots],
+                },
             )
             return None
         try:
@@ -160,27 +167,54 @@ class AlpacaQualityReportStore:
         latest_path: Path | None = None
         latest_key: tuple[float, str] | None = None
         try:
-            for candidate in quality_dir.glob(pattern):
-                safe_candidate = self._resolve_quality_report_candidate(candidate)
-                if safe_candidate is None:
-                    continue
-                try:
-                    candidate_key = (safe_candidate.stat().st_mtime, safe_candidate.name)
-                except OSError as exc:
-                    logger.debug(
-                        "alpaca_quality_report_stat_unavailable",
-                        extra={"report_path": str(safe_candidate), "error": str(exc)},
-                    )
-                    continue
-                if latest_key is None or candidate_key > latest_key:
-                    latest_key = candidate_key
-                    latest_path = safe_candidate
+            with os.scandir(quality_dir) as entries:
+                candidates = (
+                    Path(entry.path) for entry in entries if fnmatch.fnmatch(entry.name, pattern)
+                )
+                for candidate in candidates:
+                    safe_candidate = self._resolve_quality_report_candidate(candidate)
+                    if safe_candidate is None:
+                        continue
+                    try:
+                        candidate_key = (safe_candidate.stat().st_mtime, safe_candidate.name)
+                    except OSError as exc:
+                        logger.debug(
+                            "alpaca_quality_report_stat_unavailable",
+                            extra={"report_path": str(safe_candidate), "error": str(exc)},
+                        )
+                        continue
+                    if latest_key is None or candidate_key > latest_key:
+                        latest_key = candidate_key
+                        latest_path = safe_candidate
         except OSError as exc:
             logger.debug(
                 "alpaca_quality_report_scan_unavailable",
                 extra={"quality_dir": str(quality_dir), "pattern": pattern, "error": str(exc)},
             )
         return latest_path
+
+    def _load_trusted_report_roots(self) -> tuple[Path, ...]:
+        roots = [self._data_root]
+        configured = os.getenv(_ALPACA_QUALITY_REPORT_ROOTS_ENV, "").strip()
+        if not configured:
+            return tuple(roots)
+        for raw_root in configured.split(os.pathsep):
+            raw_root = raw_root.strip()
+            if not raw_root:
+                continue
+            try:
+                roots.append(Path(raw_root).expanduser().resolve(strict=True))
+            except FileNotFoundError:
+                logger.warning(
+                    "alpaca_quality_report_root_missing",
+                    extra={"root": raw_root},
+                )
+            except OSError as exc:
+                logger.warning(
+                    "alpaca_quality_report_root_unavailable",
+                    extra={"root": raw_root, "error": str(exc)},
+                )
+        return tuple(roots)
 
     def _load_report(
         self,

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -404,8 +404,9 @@ def _manifest_validation_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQua
         elif summary.missing_datasets:
             message = "Missing Alpaca SIP manifests: " + ", ".join(sorted(summary.missing_datasets))
         elif failed:
+            sorted_failed = sorted(failed, key=lambda manifest: manifest.dataset)
             message = "Alpaca SIP manifest validation failed: " + ", ".join(
-                f"{manifest.dataset}={manifest.validation_status}" for manifest in failed
+                f"{manifest.dataset}={manifest.validation_status}" for manifest in sorted_failed
             )
         else:
             message = "No Alpaca SIP manifests found."

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -463,7 +463,7 @@ def _manifest_pairing_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQualit
         source="manifest",
         observed_at=summary.latest_sync,
         message=message,
-        reason_codes=reason_codes,
+        reason_codes=sorted(reason_codes),
     )
 
 

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -6,8 +6,12 @@ Enforces dataset-level access on all read paths for licensing compliance.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -39,10 +43,123 @@ from .schemas.data_management import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_DATA_ROOT = Path(os.getenv("DATA_ROOT", "data")).resolve()
 _SUPPORTED_DATASETS = ("crsp", "compustat", "taq", "fama_french", "alpaca_sip")
 _MOCK_QUALITY_DATASETS = tuple(
     dataset for dataset in _SUPPORTED_DATASETS if dataset != ALPACA_SIP_DATASET_KEY
 )
+_ALPACA_SIP_INTEGRITY_CHECK = "alpaca_sip_integrity"
+_ALPACA_FEED_DELTA_CHECK = "alpaca_feed_delta"
+
+
+@dataclass(frozen=True)
+class QualityReportState:
+    """Latest persisted quality report metadata for a data-quality signal."""
+
+    report_type: str
+    status: Literal["passed", "warning", "failed"]
+    raw_status: str
+    content_hash: str
+    start: str
+    end: str
+    timeframe: str
+    path: Path | None = None
+    tolerance_version: str = ""
+
+
+class AlpacaQualityReportStore:
+    """Read persisted Alpaca SIP quality reports from the local data root."""
+
+    def __init__(self, *, data_root: Path | None = None) -> None:
+        self._data_root = data_root.resolve() if data_root is not None else _DEFAULT_DATA_ROOT
+
+    def get_integrity_report(self) -> QualityReportState | None:
+        """Return the latest deterministic SIP re-pull integrity report, if present."""
+        report_path = self._resolve_report_path(
+            env_var="ALPACA_SIP_INTEGRITY_REPORT",
+            pattern="alpaca_sip_integrity*.json",
+        )
+        if report_path is None:
+            return None
+        return self._load_report(report_path, expected_report_type="alpaca_sip_integrity")
+
+    def get_feed_delta_report(self) -> QualityReportState | None:
+        """Return the latest IEX-vs-SIP feed-delta report, if present."""
+        report_path = self._resolve_report_path(
+            env_var="ALPACA_FEED_DELTA_REPORT",
+            pattern="alpaca_iex_sip_delta*.json",
+        )
+        if report_path is None:
+            return None
+        return self._load_report(report_path, expected_report_type="alpaca_feed_delta")
+
+    def _resolve_report_path(self, *, env_var: str, pattern: str) -> Path | None:
+        configured = os.getenv(env_var, "").strip()
+        if configured:
+            path = Path(configured)
+            resolved = path.resolve() if path.is_absolute() else (self._data_root / path).resolve()
+            if not resolved.is_relative_to(self._data_root):
+                logger.warning(
+                    "alpaca_quality_report_outside_data_root",
+                    extra={
+                        "path": str(resolved),
+                        "data_root": str(self._data_root),
+                        "env_var": env_var,
+                    },
+                )
+                return None
+            return resolved if resolved.exists() else None
+
+        quality_dir = self._data_root / "quality"
+        if not quality_dir.exists():
+            return None
+        candidates = sorted(
+            quality_dir.glob(pattern),
+            key=lambda path: (path.stat().st_mtime, path.name),
+            reverse=True,
+        )
+        return candidates[0] if candidates else None
+
+    def _load_report(
+        self,
+        report_path: Path,
+        *,
+        expected_report_type: str,
+    ) -> QualityReportState | None:
+        try:
+            payload = json.loads(report_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "alpaca_quality_report_unreadable",
+                extra={
+                    "path": str(report_path),
+                    "report_type": expected_report_type,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+        if not isinstance(payload, dict) or payload.get("report_type") != expected_report_type:
+            return None
+
+        tolerances = payload.get("tolerances")
+        tolerance_version = (
+            str(tolerances.get("version"))
+            if isinstance(tolerances, dict) and tolerances.get("version")
+            else ""
+        )
+        raw_status = str(payload.get("status", "unknown"))
+        return QualityReportState(
+            report_type=expected_report_type,
+            status=_normalize_report_status(raw_status),
+            raw_status=raw_status,
+            content_hash=str(payload.get("content_hash", "")),
+            start=str(payload.get("start", "")),
+            end=str(payload.get("end", "")),
+            timeframe=str(payload.get("timeframe", "")),
+            path=report_path,
+            tolerance_version=tolerance_version,
+        )
 
 
 class DataQualityService:
@@ -65,16 +182,19 @@ class DataQualityService:
         self,
         *,
         manifest_service: DataManifestService | None = None,
-        integrity_reports_available: bool = False,
-        feed_delta_reports_available: bool = False,
+        report_store: AlpacaQualityReportStore | None = None,
+        data_root: Path | None = None,
+        integrity_reports_available: bool | None = None,
+        feed_delta_reports_available: bool | None = None,
     ) -> None:
         # TODO: Replace with PostgreSQL persistence using data_quality_alert_acknowledgments table
         # Current in-memory implementation is for interface validation only.
         # Production requires: INSERT ... ON CONFLICT DO NOTHING RETURNING for idempotency
         self._ack_store: dict[str, AlertAcknowledgmentDTO] = {}
         self._manifest_service = manifest_service or DataManifestService()
-        self._integrity_reports_available = integrity_reports_available
-        self._feed_delta_reports_available = feed_delta_reports_available
+        self._report_store = report_store or AlpacaQualityReportStore(data_root=data_root)
+        self._integrity_reports_available_override = integrity_reports_available
+        self._feed_delta_reports_available_override = feed_delta_reports_available
         # Hard-pinned false until durable DB-backed acknowledgment storage lands.
         self._acknowledgments_persistent = False
 
@@ -148,8 +268,8 @@ class DataQualityService:
             summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
         return _build_alpaca_sip_quality_summary(
             summary,
-            integrity_reports_available=self._integrity_reports_available,
-            feed_delta_reports_available=self._feed_delta_reports_available,
+            integrity_report=self._get_integrity_report_state(),
+            feed_delta_report=self._get_feed_delta_report_state(),
             acknowledgments_persistent=self.acknowledgments_persistent,
         )
 
@@ -315,6 +435,24 @@ class DataQualityService:
         if not has_dataset_permission(user, dataset):
             raise PermissionError(f"Dataset access required for {dataset}")
 
+    def _get_integrity_report_state(self) -> QualityReportState | None:
+        report = self._report_store.get_integrity_report()
+        if report is not None:
+            return report
+        return _quality_report_state_from_override(
+            _ALPACA_SIP_INTEGRITY_CHECK,
+            self._integrity_reports_available_override,
+        )
+
+    def _get_feed_delta_report_state(self) -> QualityReportState | None:
+        report = self._report_store.get_feed_delta_report()
+        if report is not None:
+            return report
+        return _quality_report_state_from_override(
+            _ALPACA_FEED_DELTA_CHECK,
+            self._feed_delta_reports_available_override,
+        )
+
     @staticmethod
     def _resolve_alert_dataset(alert_id: str) -> str:
         # TODO: Query data_anomaly_alerts table to get actual dataset for alert_id
@@ -329,32 +467,42 @@ class DataQualityService:
         raise ValueError(f"Could not resolve dataset for alert_id: {alert_id}")
 
 
-__all__ = ["DataQualityService"]
+__all__ = ["AlpacaQualityReportStore", "DataQualityService", "QualityReportState"]
 
 
 def _build_alpaca_sip_quality_summary(
     summary: AlpacaSipManifestSummaryDTO,
     *,
-    integrity_reports_available: bool,
-    feed_delta_reports_available: bool,
+    integrity_report: QualityReportState | None = None,
+    feed_delta_report: QualityReportState | None = None,
+    integrity_reports_available: bool | None = None,
+    feed_delta_reports_available: bool | None = None,
     acknowledgments_persistent: bool,
 ) -> DataQualitySummaryDTO:
     generated_at = datetime.now(UTC)
+    integrity_report = integrity_report or _quality_report_state_from_override(
+        _ALPACA_SIP_INTEGRITY_CHECK,
+        integrity_reports_available,
+    )
+    feed_delta_report = feed_delta_report or _quality_report_state_from_override(
+        _ALPACA_FEED_DELTA_CHECK,
+        feed_delta_reports_available,
+    )
     signals = [
         _manifest_validation_signal(summary),
         _manifest_pairing_signal(summary),
-        _report_availability_signal(
+        _quality_report_signal(
             "alpaca_sip_integrity",
             "No persisted Alpaca SIP deterministic re-pull integrity report is available.",
-            "Alpaca SIP deterministic re-pull integrity report is available.",
-            integrity_reports_available,
+            "Alpaca SIP deterministic re-pull integrity report",
+            integrity_report,
             generated_at,
         ),
-        _report_availability_signal(
+        _quality_report_signal(
             "alpaca_feed_delta",
             "No persisted Alpaca IEX-vs-SIP feed-delta report is available.",
-            "Alpaca IEX-vs-SIP feed-delta report is available.",
-            feed_delta_reports_available,
+            "Alpaca IEX-vs-SIP feed-delta report",
+            feed_delta_report,
             generated_at,
         ),
         _acknowledgment_persistence_signal(acknowledgments_persistent, generated_at),
@@ -489,22 +637,55 @@ def _manifest_pairing_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQualit
     )
 
 
-def _report_availability_signal(
+def _normalize_report_status(raw_status: str) -> Literal["passed", "warning", "failed"]:
+    normalized = raw_status.lower()
+    if normalized == "passed":
+        return "passed"
+    if normalized == "failed":
+        return "failed"
+    return "warning"
+
+
+def _quality_report_state_from_override(
+    check: str,
+    available: bool | None,
+) -> QualityReportState | None:
+    if available is not True:
+        return None
+    return QualityReportState(
+        report_type=check,
+        status="passed",
+        raw_status="passed",
+        content_hash="",
+        start="",
+        end="",
+        timeframe="",
+    )
+
+
+def _quality_report_signal(
     check: str,
     unavailable_message: str,
-    available_message: str,
-    available: bool,
+    display_name: str,
+    report: QualityReportState | None,
     observed_at: datetime,
 ) -> DataQualitySignalDTO:
-    if available:
+    if report is not None:
+        reason_codes = [f"{check}_report_{report.raw_status}"]
+        if report.content_hash:
+            reason_codes.append(f"{check}_hash:{report.content_hash}")
+        if report.timeframe:
+            reason_codes.append(f"{check}_timeframe:{report.timeframe}")
+        if report.tolerance_version:
+            reason_codes.append(f"{check}_tolerance:{report.tolerance_version}")
         return DataQualitySignalDTO(
             dataset=ALPACA_SIP_DATASET_KEY,
             check=check,
-            status="passed",
+            status=report.status,
             source="report_store",
             observed_at=observed_at,
-            message=available_message,
-            reason_codes=[],
+            message=_quality_report_message(display_name, report),
+            reason_codes=reason_codes,
         )
     return DataQualitySignalDTO(
         dataset=ALPACA_SIP_DATASET_KEY,
@@ -515,6 +696,19 @@ def _report_availability_signal(
         message=unavailable_message,
         reason_codes=[f"{check}_report_unavailable"],
     )
+
+
+def _quality_report_message(display_name: str, report: QualityReportState) -> str:
+    status_text = f"status is {report.raw_status}"
+    details: list[str] = []
+    if report.timeframe:
+        details.append(f"timeframe={report.timeframe}")
+    if report.start or report.end:
+        details.append(f"window={report.start or '-'}..{report.end or '-'}")
+    if report.content_hash:
+        details.append(f"hash={report.content_hash[:16]}")
+    suffix = f" ({', '.join(details)})" if details else ""
+    return f"{display_name} {status_text}{suffix}."
 
 
 def _acknowledgment_persistence_signal(

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -66,6 +66,7 @@ class QualityReportState:
     end: str
     timeframe: str
     path: Path | None = None
+    observed_at: datetime | None = None
     tolerance_version: str = ""
 
 
@@ -106,9 +107,13 @@ class AlpacaQualityReportStore:
     ) -> Path | None:
         configured = os.getenv(env_var, "").strip()
         if configured:
-            path = Path(configured)
-            candidate = path if path.is_absolute() else self._data_root / path
-            return self._resolve_quality_report_candidate(candidate)
+            path = Path(configured).expanduser()
+            if path.is_absolute():
+                return self._resolve_quality_report_candidate(
+                    path,
+                    allow_outside_data_root=True,
+                )
+            return self._resolve_quality_report_candidate(self._data_root / path)
 
         quality_dir = self._data_root / "quality"
         if not quality_dir.exists():
@@ -118,7 +123,12 @@ class AlpacaQualityReportStore:
             return latest_pointer
         return self._latest_report_path(quality_dir, pattern)
 
-    def _resolve_quality_report_candidate(self, candidate: Path) -> Path | None:
+    def _resolve_quality_report_candidate(
+        self,
+        candidate: Path,
+        *,
+        allow_outside_data_root: bool = False,
+    ) -> Path | None:
         try:
             resolved = candidate.resolve(strict=True)
         except FileNotFoundError:
@@ -129,7 +139,7 @@ class AlpacaQualityReportStore:
                 extra={"report_path": str(candidate), "error": str(exc)},
             )
             return None
-        if not resolved.is_relative_to(self._data_root):
+        if not allow_outside_data_root and not resolved.is_relative_to(self._data_root):
             logger.warning(
                 "alpaca_quality_report_outside_data_root",
                 extra={"path": str(resolved), "data_root": str(self._data_root)},
@@ -201,6 +211,14 @@ class AlpacaQualityReportStore:
             else ""
         )
         raw_status = str(payload.get("status", "unknown"))
+        try:
+            observed_at = datetime.fromtimestamp(report_path.stat().st_mtime, UTC)
+        except OSError as exc:
+            logger.debug(
+                "alpaca_quality_report_stat_unavailable",
+                extra={"report_path": str(report_path), "error": str(exc)},
+            )
+            observed_at = None
         return QualityReportState(
             report_type=expected_report_type,
             status=_normalize_report_status(raw_status),
@@ -210,6 +228,7 @@ class AlpacaQualityReportStore:
             end=str(payload.get("end", "")),
             timeframe=str(payload.get("timeframe", "")),
             path=report_path,
+            observed_at=observed_at,
             tolerance_version=tolerance_version,
         )
 
@@ -617,7 +636,7 @@ def _manifest_validation_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQua
         for manifest in failed
     )
     status: Literal["passed", "failed"]
-    if not summary.has_any_manifest or summary.missing_datasets or failed:
+    if not summary.manifests or summary.missing_datasets or failed:
         status = "failed"
     else:
         status = "passed"
@@ -737,7 +756,7 @@ def _quality_report_signal(
             check=check,
             status=report.status,
             source="report_store",
-            observed_at=observed_at,
+            observed_at=report.observed_at or observed_at,
             message=_quality_report_message(display_name, report),
             reason_codes=reason_codes,
         )

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -107,18 +107,8 @@ class AlpacaQualityReportStore:
         configured = os.getenv(env_var, "").strip()
         if configured:
             path = Path(configured)
-            resolved = path.resolve() if path.is_absolute() else (self._data_root / path).resolve()
-            if not resolved.is_relative_to(self._data_root):
-                logger.warning(
-                    "alpaca_quality_report_outside_data_root",
-                    extra={
-                        "path": str(resolved),
-                        "data_root": str(self._data_root),
-                        "env_var": env_var,
-                    },
-                )
-                return None
-            return resolved if resolved.exists() else None
+            candidate = path if path.is_absolute() else self._data_root / path
+            return self._resolve_quality_report_candidate(candidate)
 
         quality_dir = self._data_root / "quality"
         if not quality_dir.exists():
@@ -145,6 +135,15 @@ class AlpacaQualityReportStore:
                 extra={"path": str(resolved), "data_root": str(self._data_root)},
             )
             return None
+        try:
+            if not resolved.is_file():
+                return None
+        except OSError as exc:
+            logger.debug(
+                "alpaca_quality_report_candidate_unavailable",
+                extra={"report_path": str(resolved), "error": str(exc)},
+            )
+            return None
         return resolved
 
     def _latest_report_path(self, quality_dir: Path, pattern: str) -> Path | None:
@@ -152,17 +151,20 @@ class AlpacaQualityReportStore:
         latest_key: tuple[float, str] | None = None
         try:
             for candidate in quality_dir.glob(pattern):
+                safe_candidate = self._resolve_quality_report_candidate(candidate)
+                if safe_candidate is None:
+                    continue
                 try:
-                    candidate_key = (candidate.stat().st_mtime, candidate.name)
+                    candidate_key = (safe_candidate.stat().st_mtime, safe_candidate.name)
                 except OSError as exc:
                     logger.debug(
                         "alpaca_quality_report_stat_unavailable",
-                        extra={"report_path": str(candidate), "error": str(exc)},
+                        extra={"report_path": str(safe_candidate), "error": str(exc)},
                     )
                     continue
                 if latest_key is None or candidate_key > latest_key:
                     latest_key = candidate_key
-                    latest_path = candidate
+                    latest_path = safe_candidate
         except OSError as exc:
             logger.debug(
                 "alpaca_quality_report_scan_unavailable",

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -88,6 +88,8 @@ class DataQualityService:
         user: Any,
         dataset: str | None,
         limit: int = 50,
+        *,
+        alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
     ) -> list[ValidationResultDTO]:
         """Get recent validation run results.
 
@@ -123,26 +125,27 @@ class DataQualityService:
         if (dataset is None and has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)) or (
             dataset == ALPACA_SIP_DATASET_KEY
         ):
-            try:
+            summary = alpaca_sip_summary
+            if summary is None:
                 summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
-            except Exception:
-                logger.exception(
-                    "alpaca_sip_manifest_summary_unavailable",
-                    extra={"dataset": ALPACA_SIP_DATASET_KEY},
-                )
-                alpaca_results.append(_alpaca_sip_unavailable_validation_result(now))
-            else:
-                alpaca_results.extend(self._alpaca_sip_validation_results(now, summary))
+            alpaca_results.extend(self._alpaca_sip_validation_results(now, summary))
 
         if dataset is None:
             return [*alpaca_results, *filtered][:limit]
         return [*filtered, *alpaca_results][:limit]
 
-    async def get_alpaca_sip_quality_summary(self, user: Any) -> DataQualitySummaryDTO:
+    async def get_alpaca_sip_quality_summary(
+        self,
+        user: Any,
+        *,
+        alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
+    ) -> DataQualitySummaryDTO:
         """Return manifest-backed Alpaca SIP quality state for the data page."""
         self._require_permission(user, Permission.VIEW_DATA_QUALITY)
         self._require_dataset_access(user, ALPACA_SIP_DATASET_KEY)
-        summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
+        summary = alpaca_sip_summary
+        if summary is None:
+            summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
         return _build_alpaca_sip_quality_summary(
             summary,
             integrity_reports_available=self._integrity_reports_available,
@@ -272,20 +275,36 @@ class DataQualityService:
     ) -> list[ValidationResultDTO]:
         if summary.latest_sync is not None:
             observed_at = summary.latest_sync
-        signal = _manifest_validation_signal(summary)
-        status: Literal["ok", "error"] = "ok" if signal.status == "passed" else "error"
+        validation_signal = _manifest_validation_signal(summary)
+        pairing_signal = _manifest_pairing_signal(summary)
         return [
             ValidationResultDTO(
                 id="alpaca-sip-manifest-summary",
                 dataset=ALPACA_SIP_DATASET_KEY,
                 sync_run_id=None,
                 validation_type="manifest_summary",
-                status=status,
+                status=_validation_status_from_signal(validation_signal.status),
                 expected_value="trusted daily and corporate-actions manifests",
-                actual_value=_alpaca_sip_validation_actual_value(summary, signal.status),
-                error_message=signal.message if status != "ok" else None,
+                actual_value=_alpaca_sip_validation_actual_value(
+                    summary,
+                    validation_signal.status,
+                ),
+                error_message=(
+                    validation_signal.message if validation_signal.status != "passed" else None
+                ),
                 created_at=observed_at,
-            )
+            ),
+            ValidationResultDTO(
+                id="alpaca-sip-manifest-pairing",
+                dataset=ALPACA_SIP_DATASET_KEY,
+                sync_run_id=None,
+                validation_type="manifest_pairing",
+                status=_validation_status_from_signal(pairing_signal.status),
+                expected_value="paired daily bars and corporate-actions manifests",
+                actual_value=pairing_signal.status,
+                error_message=pairing_signal.message if pairing_signal.status != "passed" else None,
+                created_at=pairing_signal.observed_at or observed_at,
+            ),
         ]
 
     def _require_permission(self, user: Any, permission: Permission) -> None:
@@ -361,20 +380,6 @@ def _build_alpaca_sip_quality_summary(
     )
 
 
-def _alpaca_sip_unavailable_validation_result(observed_at: datetime) -> ValidationResultDTO:
-    return ValidationResultDTO(
-        id="alpaca-sip-manifest-summary-unavailable",
-        dataset=ALPACA_SIP_DATASET_KEY,
-        sync_run_id=None,
-        validation_type="manifest_summary",
-        status="unavailable",
-        expected_value="trusted daily and corporate-actions manifests",
-        actual_value="unavailable",
-        error_message="Alpaca SIP manifest summary unavailable.",
-        created_at=observed_at,
-    )
-
-
 def _alpaca_sip_validation_actual_value(
     summary: AlpacaSipManifestSummaryDTO,
     signal_status: str,
@@ -384,6 +389,18 @@ def _alpaca_sip_validation_actual_value(
     if summary.missing_datasets:
         return summary.sync_validation_status
     return signal_status
+
+
+def _validation_status_from_signal(
+    signal_status: Literal["passed", "warning", "failed", "unavailable"],
+) -> Literal["ok", "warning", "error", "unavailable"]:
+    if signal_status == "passed":
+        return "ok"
+    if signal_status == "warning":
+        return "warning"
+    if signal_status == "unavailable":
+        return "unavailable"
+    return "error"
 
 
 def _manifest_validation_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQualitySignalDTO:

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -5,9 +5,10 @@ Enforces dataset-level access on all read paths for licensing compliance.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from libs.platform.web_console_auth.helpers import get_user_id
@@ -17,9 +18,20 @@ from libs.platform.web_console_auth.permissions import (
     has_permission,
 )
 
+from .data_manifest_service import (
+    ALPACA_SIP_DATASET_KEY,
+    AlpacaSipManifestSummaryDTO,
+    DataManifestService,
+)
+from .data_readiness_service import (
+    ALPACA_SIP_COMPANION_MANIFEST_STALE,
+    ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+)
 from .schemas.data_management import (
     AlertAcknowledgmentDTO,
     AnomalyAlertDTO,
+    DataQualitySignalDTO,
+    DataQualitySummaryDTO,
     QualityTrendDTO,
     QuarantineEntryDTO,
     ValidationResultDTO,
@@ -28,13 +40,16 @@ from .schemas.data_management import (
 logger = logging.getLogger(__name__)
 
 _SUPPORTED_DATASETS = ("crsp", "compustat", "taq", "fama_french", "alpaca_sip")
+_MOCK_QUALITY_DATASETS = tuple(
+    dataset for dataset in _SUPPORTED_DATASETS if dataset != ALPACA_SIP_DATASET_KEY
+)
 
 
 class DataQualityService:
     """Service layer for data quality reporting.
 
     Enforces dataset-level access on all read paths for licensing compliance.
-    Alert acknowledgments stored in PostgreSQL.
+    Alert acknowledgments are currently in-memory placeholders.
 
     IMPORTANT: ALL read paths filter by user's dataset permissions.
     Users only see quality data for datasets they have access to.
@@ -46,11 +61,27 @@ class DataQualityService:
     - DB persistence for alert acknowledgments
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        manifest_service: DataManifestService | None = None,
+        integrity_reports_available: bool = False,
+        feed_delta_reports_available: bool = False,
+    ) -> None:
         # TODO: Replace with PostgreSQL persistence using data_quality_alert_acknowledgments table
         # Current in-memory implementation is for interface validation only.
         # Production requires: INSERT ... ON CONFLICT DO NOTHING RETURNING for idempotency
         self._ack_store: dict[str, AlertAcknowledgmentDTO] = {}
+        self._manifest_service = manifest_service or DataManifestService()
+        self._integrity_reports_available = integrity_reports_available
+        self._feed_delta_reports_available = feed_delta_reports_available
+        # Hard-pinned false until durable DB-backed acknowledgment storage lands.
+        self._acknowledgments_persistent = False
+
+    @property
+    def acknowledgments_persistent(self) -> bool:
+        """Whether alert acknowledgments are backed by durable server-side storage."""
+        return self._acknowledgments_persistent
 
     async def get_validation_results(
         self,
@@ -67,7 +98,7 @@ class DataQualityService:
         if dataset:
             self._require_dataset_access(user, dataset)
 
-        # TODO: Query data_validation_results table instead of mock data
+        # TODO: Query data_validation_results table instead of mock data for non-SIP datasets.
         now = datetime.now(UTC)
         mock = [
             ValidationResultDTO(
@@ -81,14 +112,39 @@ class DataQualityService:
                 error_message=None,
                 created_at=now,
             )
-            for idx, name in enumerate(_SUPPORTED_DATASETS, start=1)
+            for idx, name in enumerate(_MOCK_QUALITY_DATASETS, start=1)
         ]
         filtered = (
             [item for item in mock if item.dataset == dataset]
             if dataset
             else [item for item in mock if has_dataset_permission(user, item.dataset)]
         )
+        if (dataset is None and has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)) or (
+            dataset == ALPACA_SIP_DATASET_KEY
+        ):
+            try:
+                summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
+            except Exception:
+                logger.exception(
+                    "alpaca_sip_manifest_summary_unavailable",
+                    extra={"dataset": ALPACA_SIP_DATASET_KEY},
+                )
+                filtered.append(_alpaca_sip_unavailable_validation_result(now))
+            else:
+                filtered.extend(self._alpaca_sip_validation_results(now, summary))
         return filtered[:limit]
+
+    async def get_alpaca_sip_quality_summary(self, user: Any) -> DataQualitySummaryDTO:
+        """Return manifest-backed Alpaca SIP quality state for the data page."""
+        self._require_permission(user, Permission.VIEW_DATA_QUALITY)
+        self._require_dataset_access(user, ALPACA_SIP_DATASET_KEY)
+        summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
+        return _build_alpaca_sip_quality_summary(
+            summary,
+            integrity_reports_available=self._integrity_reports_available,
+            feed_delta_reports_available=self._feed_delta_reports_available,
+            acknowledgments_persistent=self.acknowledgments_persistent,
+        )
 
     async def get_anomaly_alerts(
         self,
@@ -118,7 +174,7 @@ class DataQualityService:
                 acknowledged_by=None,
                 created_at=now,
             )
-            for idx, name in enumerate(_SUPPORTED_DATASETS, start=1)
+            for idx, name in enumerate(_MOCK_QUALITY_DATASETS, start=1)
         ]
         filtered = [item for item in mock if has_dataset_permission(user, item.dataset)]
         if severity:
@@ -136,7 +192,7 @@ class DataQualityService:
         """Acknowledge an anomaly alert (idempotent).
 
         Permission: ACKNOWLEDGE_ALERTS + dataset-level access for alert's dataset
-        Storage: PostgreSQL alert_acknowledgments table
+        Storage: in-memory placeholder until PostgreSQL persistence is implemented
         Audit: Logged with user, alert_id, reason
         Security: Validate user has access to the dataset referenced by alert_id
 
@@ -201,9 +257,32 @@ class DataQualityService:
                 reason="validation_failure",
                 created_at=now,
             )
-            for name in _SUPPORTED_DATASETS
+            for name in _MOCK_QUALITY_DATASETS
         ]
         return [item for item in mock if has_dataset_permission(user, item.dataset)]
+
+    def _alpaca_sip_validation_results(
+        self,
+        observed_at: datetime,
+        summary: AlpacaSipManifestSummaryDTO,
+    ) -> list[ValidationResultDTO]:
+        if summary.latest_sync is not None:
+            observed_at = summary.latest_sync
+        signal = _manifest_validation_signal(summary)
+        status: Literal["ok", "error"] = "ok" if signal.status == "passed" else "error"
+        return [
+            ValidationResultDTO(
+                id="alpaca-sip-manifest-summary",
+                dataset=ALPACA_SIP_DATASET_KEY,
+                sync_run_id=None,
+                validation_type="manifest_summary",
+                status=status,
+                expected_value="trusted daily and corporate-actions manifests",
+                actual_value=_alpaca_sip_validation_actual_value(summary, signal.status),
+                error_message=signal.message if status != "ok" else None,
+                created_at=observed_at,
+            )
+        ]
 
     def _require_permission(self, user: Any, permission: Permission) -> None:
         if not has_permission(user, permission):
@@ -228,3 +307,217 @@ class DataQualityService:
 
 
 __all__ = ["DataQualityService"]
+
+
+def _build_alpaca_sip_quality_summary(
+    summary: AlpacaSipManifestSummaryDTO,
+    *,
+    integrity_reports_available: bool,
+    feed_delta_reports_available: bool,
+    acknowledgments_persistent: bool,
+) -> DataQualitySummaryDTO:
+    generated_at = datetime.now(UTC)
+    signals = [
+        _manifest_validation_signal(summary),
+        _manifest_pairing_signal(summary),
+        _report_availability_signal(
+            "alpaca_sip_integrity",
+            "No persisted Alpaca SIP deterministic re-pull integrity report is available.",
+            "Alpaca SIP deterministic re-pull integrity report is available.",
+            integrity_reports_available,
+            generated_at,
+        ),
+        _report_availability_signal(
+            "alpaca_feed_delta",
+            "No persisted Alpaca IEX-vs-SIP feed-delta report is available.",
+            "Alpaca IEX-vs-SIP feed-delta report is available.",
+            feed_delta_reports_available,
+            generated_at,
+        ),
+        _acknowledgment_persistence_signal(acknowledgments_persistent, generated_at),
+    ]
+    status: Literal["passed", "warning", "failed", "unavailable"]
+    if any(signal.status == "failed" for signal in signals):
+        status = "failed"
+    elif any(signal.status == "warning" for signal in signals):
+        status = "warning"
+    elif any(signal.status == "unavailable" for signal in signals):
+        status = "unavailable"
+    else:
+        status = "passed"
+    return DataQualitySummaryDTO(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        status=status,
+        generated_at=generated_at,
+        signals=signals,
+        acknowledgments_persistent=acknowledgments_persistent,
+        acknowledgment_status_source=(
+            "persistent_store" if acknowledgments_persistent else "in_memory_store_unavailable"
+        ),
+    )
+
+
+def _alpaca_sip_unavailable_validation_result(observed_at: datetime) -> ValidationResultDTO:
+    return ValidationResultDTO(
+        id="alpaca-sip-manifest-summary-unavailable",
+        dataset=ALPACA_SIP_DATASET_KEY,
+        sync_run_id=None,
+        validation_type="manifest_summary",
+        status="unavailable",
+        expected_value="trusted daily and corporate-actions manifests",
+        actual_value="unavailable",
+        error_message="Alpaca SIP manifest summary unavailable.",
+        created_at=observed_at,
+    )
+
+
+def _alpaca_sip_validation_actual_value(
+    summary: AlpacaSipManifestSummaryDTO,
+    signal_status: str,
+) -> str:
+    if signal_status == "passed":
+        return summary.sync_validation_status
+    if summary.missing_datasets:
+        return summary.sync_validation_status
+    return signal_status
+
+
+def _manifest_validation_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQualitySignalDTO:
+    reason_codes: list[str] = []
+    if summary.missing_datasets:
+        reason_codes.extend(
+            f"alpaca_sip_missing_manifest:{item}" for item in summary.missing_datasets
+        )
+    failed = [manifest for manifest in summary.manifests if manifest.validation_status != "passed"]
+    reason_codes.extend(
+        f"alpaca_sip_manifest_validation_{manifest.validation_status}:{manifest.dataset}"
+        for manifest in failed
+    )
+    status: Literal["passed", "failed"]
+    if not summary.has_any_manifest or summary.missing_datasets or failed:
+        status = "failed"
+    else:
+        status = "passed"
+    if status == "failed":
+        if summary.source_error_message:
+            message = summary.source_error_message
+        elif summary.missing_datasets:
+            message = "Missing Alpaca SIP manifests: " + ", ".join(sorted(summary.missing_datasets))
+        elif failed:
+            message = "Alpaca SIP manifest validation failed: " + ", ".join(
+                f"{manifest.dataset}={manifest.validation_status}" for manifest in failed
+            )
+        else:
+            message = "Alpaca SIP manifest validation failed."
+    else:
+        message = "Alpaca SIP manifests are present and passed validation."
+    return DataQualitySignalDTO(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        check="manifest_validation",
+        status=status,
+        source="manifest",
+        observed_at=summary.latest_sync,
+        message=message,
+        reason_codes=sorted(reason_codes),
+    )
+
+
+def _manifest_pairing_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQualitySignalDTO:
+    # Only pairing warnings are surfaced here; other manifest warnings belong to
+    # producer-specific quality checks as they are added.
+    pairing_warnings = sorted(
+        warning
+        for warning in summary.warnings
+        if warning
+        in {
+            ALPACA_SIP_COMPANION_MANIFEST_STALE,
+            ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+        }
+    )
+    missing_pairing = sorted(
+        f"alpaca_sip_missing_manifest:{dataset}" for dataset in summary.missing_datasets
+    )
+    invalid_pairing = sorted(
+        f"alpaca_sip_manifest_validation_{manifest.validation_status}:{manifest.dataset}"
+        for manifest in summary.manifests
+        if manifest.validation_status != "passed"
+    )
+    reason_codes = [*missing_pairing, *invalid_pairing, *pairing_warnings]
+    status: Literal["passed", "warning", "failed"]
+    if missing_pairing:
+        status = "failed"
+        message = "Companion manifest is missing."
+    elif invalid_pairing:
+        status = "failed"
+        message = "Companion manifest validation failed."
+    elif pairing_warnings:
+        status = "warning"
+        message = "Companion manifests need operator review."
+    else:
+        status = "passed"
+        message = "Daily bars and corporate-actions manifests are paired."
+    return DataQualitySignalDTO(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        check="manifest_pairing",
+        status=status,
+        source="manifest",
+        observed_at=summary.latest_sync,
+        message=message,
+        reason_codes=reason_codes,
+    )
+
+
+def _report_availability_signal(
+    check: str,
+    unavailable_message: str,
+    available_message: str,
+    available: bool,
+    observed_at: datetime,
+) -> DataQualitySignalDTO:
+    if available:
+        return DataQualitySignalDTO(
+            dataset=ALPACA_SIP_DATASET_KEY,
+            check=check,
+            status="passed",
+            source="report_store",
+            observed_at=observed_at,
+            message=available_message,
+            reason_codes=[],
+        )
+    return DataQualitySignalDTO(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        check=check,
+        status="unavailable",
+        source="report_store",
+        observed_at=None,
+        message=unavailable_message,
+        reason_codes=[f"{check}_report_unavailable"],
+    )
+
+
+def _acknowledgment_persistence_signal(
+    acknowledgments_persistent: bool,
+    observed_at: datetime,
+) -> DataQualitySignalDTO:
+    if acknowledgments_persistent:
+        return DataQualitySignalDTO(
+            dataset=ALPACA_SIP_DATASET_KEY,
+            check="quality_acknowledgment_persistence",
+            status="passed",
+            source="persistent_store",
+            observed_at=observed_at,
+            message="Quality acknowledgments are persisted server-side.",
+            reason_codes=[],
+        )
+    return DataQualitySignalDTO(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        check="quality_acknowledgment_persistence",
+        status="unavailable",
+        source="in_memory_store",
+        observed_at=None,
+        message=(
+            "Quality acknowledgment controls are unavailable until server-side "
+            "persistence records actor, time, source, and issue scope."
+        ),
+        reason_codes=["quality_acknowledgment_persistence_unavailable"],
+    )

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -408,7 +408,7 @@ def _manifest_validation_signal(summary: AlpacaSipManifestSummaryDTO) -> DataQua
                 f"{manifest.dataset}={manifest.validation_status}" for manifest in failed
             )
         else:
-            message = "Alpaca SIP manifest validation failed."
+            message = "No Alpaca SIP manifests found."
     else:
         message = "Alpaca SIP manifests are present and passed validation."
     return DataQualitySignalDTO(

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -113,12 +113,11 @@ class AlpacaQualityReportStore:
         quality_dir = self._data_root / "quality"
         if not quality_dir.exists():
             return None
-        candidates = sorted(
+        return max(
             quality_dir.glob(pattern),
             key=lambda path: (path.stat().st_mtime, path.name),
-            reverse=True,
+            default=None,
         )
-        return candidates[0] if candidates else None
 
     def _load_report(
         self,
@@ -127,7 +126,7 @@ class AlpacaQualityReportStore:
         expected_report_type: str,
     ) -> QualityReportState | None:
         try:
-            payload = json.loads(report_path.read_text())
+            payload = json.loads(report_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning(
                 "alpaca_quality_report_unreadable",

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -113,11 +113,30 @@ class AlpacaQualityReportStore:
         quality_dir = self._data_root / "quality"
         if not quality_dir.exists():
             return None
-        return max(
-            quality_dir.glob(pattern),
-            key=lambda path: (path.stat().st_mtime, path.name),
-            default=None,
-        )
+        return self._latest_report_path(quality_dir, pattern)
+
+    def _latest_report_path(self, quality_dir: Path, pattern: str) -> Path | None:
+        latest_path: Path | None = None
+        latest_key: tuple[float, str] | None = None
+        try:
+            for candidate in quality_dir.glob(pattern):
+                try:
+                    candidate_key = (candidate.stat().st_mtime, candidate.name)
+                except OSError as exc:
+                    logger.debug(
+                        "alpaca_quality_report_stat_unavailable",
+                        extra={"report_path": str(candidate), "error": str(exc)},
+                    )
+                    continue
+                if latest_key is None or candidate_key > latest_key:
+                    latest_key = candidate_key
+                    latest_path = candidate
+        except OSError as exc:
+            logger.debug(
+                "alpaca_quality_report_scan_unavailable",
+                extra={"quality_dir": str(quality_dir), "pattern": pattern, "error": str(exc)},
+            )
+        return latest_path
 
     def _load_report(
         self,
@@ -265,10 +284,14 @@ class DataQualityService:
         summary = alpaca_sip_summary
         if summary is None:
             summary = await asyncio.to_thread(self._manifest_service.get_alpaca_sip_summary)
+        integrity_report, feed_delta_report = await asyncio.gather(
+            asyncio.to_thread(self._get_integrity_report_state),
+            asyncio.to_thread(self._get_feed_delta_report_state),
+        )
         return _build_alpaca_sip_quality_summary(
             summary,
-            integrity_report=self._get_integrity_report_state(),
-            feed_delta_report=self._get_feed_delta_report_state(),
+            integrity_report=integrity_report,
+            feed_delta_report=feed_delta_report,
             acknowledgments_persistent=self.acknowledgments_persistent,
         )
 

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -97,12 +97,12 @@ class DataReadinessService:
     ) -> DataReadinessDTO:
         """Return hybrid CRSP-universe plus Alpaca SIP price readiness."""
         self._require_dataset_readiness_access(user, HYBRID_CRSP_SIP_DATASET_KEY)
+        has_direct_sip_access = has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)
         summary = alpaca_sip_summary or self._manifest_service.get_alpaca_sip_summary()
-        alpaca_checks = list(_alpaca_sip_checks(summary, workflow))
-        if has_dataset_permission(user, ALPACA_SIP_DATASET_KEY):
-            checks = alpaca_checks
+        if has_direct_sip_access:
+            checks = list(_alpaca_sip_checks(summary, workflow))
         else:
-            checks = [_hybrid_price_component_check(alpaca_checks)]
+            checks = [_hybrid_price_component_check_from_summary(summary, workflow)]
         crsp_manifest = self._manifest_service.get_manifest_summary(
             CRSP_UNIVERSE_MANIFEST_DATASET
         )
@@ -270,9 +270,54 @@ def _crsp_unavailable_check(message: str) -> DataReadinessCheckDTO:
 def _hybrid_price_component_check(
     checks: list[DataReadinessCheckDTO],
 ) -> DataReadinessCheckDTO:
-    blockers = [check for check in checks if check.status == "blocked"]
-    warnings = [check for check in checks if check.status == "warning"]
-    if blockers:
+    return _hybrid_price_component_status_check(
+        has_blockers=any(check.status == "blocked" for check in checks),
+        has_warnings=any(check.status == "warning" for check in checks),
+    )
+
+
+def _hybrid_price_component_check_from_summary(
+    summary: AlpacaSipManifestSummaryDTO,
+    workflow: ReadinessWorkflow,
+) -> DataReadinessCheckDTO:
+    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
+    component_states: list[Literal["blocked", "warning"]] = []
+    for dataset, required in (
+        (ALPACA_SIP_DAILY_DATASET, True),
+        (
+            ALPACA_SIP_CORP_ACTIONS_DATASET,
+            workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS,
+        ),
+    ):
+        manifest = manifests.get(dataset)
+        if manifest is None or manifest.validation_status != "passed":
+            component_states.append("blocked" if required else "warning")
+
+    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
+    if workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS and _raw_returns_unavailable(daily):
+        component_states.append("blocked")
+    if any(
+        warning
+        in {
+            ALPACA_SIP_COMPANION_MANIFEST_STALE,
+            ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+        }
+        for warning in summary.warnings
+    ):
+        component_states.append("warning")
+
+    return _hybrid_price_component_status_check(
+        has_blockers="blocked" in component_states,
+        has_warnings="warning" in component_states,
+    )
+
+
+def _hybrid_price_component_status_check(
+    *,
+    has_blockers: bool,
+    has_warnings: bool,
+) -> DataReadinessCheckDTO:
+    if has_blockers:
         return DataReadinessCheckDTO(
             code=HYBRID_PRICE_COMPONENT_BLOCKED,
             status="blocked",
@@ -281,7 +326,7 @@ def _hybrid_price_component_check(
             action_label="Review hybrid price component acquisition",
             target_section="acquisition",
         )
-    if warnings:
+    if has_warnings:
         return DataReadinessCheckDTO(
             code=HYBRID_PRICE_COMPONENT_WARNING,
             status="warning",

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -167,7 +167,8 @@ def _alpaca_sip_checks(
     ]
 
     daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    if workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS and _raw_returns_unavailable(daily):
+    requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
+    if requires_returns and _raw_returns_unavailable(daily):
         checks.append(
             DataReadinessCheckDTO(
                 code=RAW_SIP_RETURNS_UNAVAILABLE,
@@ -183,11 +184,14 @@ def _alpaca_sip_checks(
         )
 
     for warning in summary.warnings:
+        pairing_status: Literal["blocked", "warning"] = (
+            "blocked" if requires_returns else "warning"
+        )
         if warning == ALPACA_SIP_COMPANION_MANIFEST_STALE:
             checks.append(
                 DataReadinessCheckDTO(
                     code=ALPACA_SIP_COMPANION_MANIFEST_STALE,
-                    status="warning",
+                    status=pairing_status,
                     message=(
                         "Daily bars and corporate actions manifests are materially out of date "
                         "relative to each other."
@@ -201,7 +205,7 @@ def _alpaca_sip_checks(
             checks.append(
                 DataReadinessCheckDTO(
                     code=ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
-                    status="warning",
+                    status=pairing_status,
                     message=(
                         "Daily bars and corporate actions manifests carry different symbol-set "
                         "hashes."
@@ -267,15 +271,6 @@ def _crsp_unavailable_check(message: str) -> DataReadinessCheckDTO:
     )
 
 
-def _hybrid_price_component_check(
-    checks: list[DataReadinessCheckDTO],
-) -> DataReadinessCheckDTO:
-    return _hybrid_price_component_status_check(
-        has_blockers=any(check.status == "blocked" for check in checks),
-        has_warnings=any(check.status == "warning" for check in checks),
-    )
-
-
 def _hybrid_price_component_check_from_summary(
     summary: AlpacaSipManifestSummaryDTO,
     workflow: ReadinessWorkflow,
@@ -294,7 +289,8 @@ def _hybrid_price_component_check_from_summary(
             component_states.append("blocked" if required else "warning")
 
     daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    if workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS and _raw_returns_unavailable(daily):
+    requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
+    if requires_returns and _raw_returns_unavailable(daily):
         component_states.append("blocked")
     if any(
         warning
@@ -304,7 +300,7 @@ def _hybrid_price_component_check_from_summary(
         }
         for warning in summary.warnings
     ):
-        component_states.append("warning")
+        component_states.append("blocked" if requires_returns else "warning")
 
     return _hybrid_price_component_status_check(
         has_blockers="blocked" in component_states,

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 
 from libs.platform.web_console_auth.permissions import (
     Permission,
@@ -29,7 +29,6 @@ CRSP_DATASET_KEY = "crsp"
 CRSP_UNIVERSE_MANIFEST_DATASET = "crsp_daily"
 
 RAW_SIP_RETURNS_UNAVAILABLE = "raw_sip_returns_unavailable"
-ALPACA_SIP_ACCESS_UNAVAILABLE = "alpaca_sip_access_unavailable"
 ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST = "alpaca_sip_untrusted_without_manifest"
 ALPACA_SIP_MANIFEST_VALIDATION_FAILED = "alpaca_sip_manifest_validation_failed"
 ALPACA_SIP_COMPANION_MANIFEST_STALE = "alpaca_sip_companion_manifest_stale"
@@ -53,7 +52,7 @@ class DataReadinessService:
 
     def get_readiness(
         self,
-        user: object,
+        user: Any,
         dataset: str,
         workflow: ReadinessWorkflow,
         *,
@@ -79,7 +78,7 @@ class DataReadinessService:
 
     def get_alpaca_sip_readiness(
         self,
-        user: object,
+        user: Any,
         workflow: ReadinessWorkflow = "simple_backtest",
         *,
         alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
@@ -91,7 +90,7 @@ class DataReadinessService:
 
     def get_hybrid_crsp_sip_readiness(
         self,
-        user: object,
+        user: Any,
         workflow: ReadinessWorkflow = "hybrid_research_backtest",
         *,
         alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
@@ -131,7 +130,7 @@ class DataReadinessService:
         )
 
     @staticmethod
-    def _require_dataset_readiness_access(user: object, dataset: str) -> None:
+    def _require_dataset_readiness_access(user: Any, dataset: str) -> None:
         if not has_permission(user, Permission.VIEW_DATA_SYNC):
             raise PermissionError(f"Permission {Permission.VIEW_DATA_SYNC.value} required")
         if not has_dataset_permission(user, dataset):
@@ -326,7 +325,6 @@ def _readiness_from_checks(
 
 
 __all__ = [
-    "ALPACA_SIP_ACCESS_UNAVAILABLE",
     "ALPACA_SIP_COMPANION_MANIFEST_STALE",
     "ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH",
     "ALPACA_SIP_MANIFEST_VALIDATION_FAILED",

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -1,0 +1,341 @@
+"""Workflow readiness checks for data-management surfaces."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from libs.platform.web_console_auth.permissions import (
+    Permission,
+    has_dataset_permission,
+    has_permission,
+)
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_DATASET_KEY,
+    AlpacaSipManifestSummaryDTO,
+    DataManifestService,
+    ManifestSummaryDTO,
+)
+from libs.web_console_services.schemas.data_management import (
+    DataReadinessCheckDTO,
+    DataReadinessDTO,
+    ReadinessWorkflow,
+)
+
+HYBRID_CRSP_SIP_DATASET_KEY = "hybrid_crsp_universe_sip_prices"
+CRSP_DATASET_KEY = "crsp"
+CRSP_UNIVERSE_MANIFEST_DATASET = "crsp_daily"
+
+RAW_SIP_RETURNS_UNAVAILABLE = "raw_sip_returns_unavailable"
+ALPACA_SIP_ACCESS_UNAVAILABLE = "alpaca_sip_access_unavailable"
+ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST = "alpaca_sip_untrusted_without_manifest"
+ALPACA_SIP_COMPANION_MANIFEST_STALE = "alpaca_sip_companion_manifest_stale"
+ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH = "alpaca_sip_companion_symbol_set_mismatch"
+CRSP_UNIVERSE_UNAVAILABLE = "crsp_universe_unavailable"
+HYBRID_PRICE_COMPONENT_READY = "hybrid_price_component_ready"
+HYBRID_PRICE_COMPONENT_WARNING = "hybrid_price_component_warning"
+HYBRID_PRICE_COMPONENT_BLOCKED = "hybrid_price_component_blocked"
+
+_ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS = {
+    "simple_backtest",
+    "hybrid_research_backtest",
+}
+
+
+class DataReadinessService:
+    """Evaluate workflow-specific data readiness from trusted manifest state."""
+
+    def __init__(self, *, manifest_service: DataManifestService | None = None) -> None:
+        self._manifest_service = manifest_service or DataManifestService()
+
+    def get_readiness(
+        self,
+        user: object,
+        dataset: str,
+        workflow: ReadinessWorkflow,
+        *,
+        alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
+    ) -> DataReadinessDTO:
+        """Return readiness for a supported dataset/workflow pair.
+
+        This method performs synchronous manifest I/O; async callers should offload it.
+        """
+        if dataset == ALPACA_SIP_DATASET_KEY:
+            return self.get_alpaca_sip_readiness(
+                user,
+                workflow,
+                alpaca_sip_summary=alpaca_sip_summary,
+            )
+        if dataset == HYBRID_CRSP_SIP_DATASET_KEY:
+            return self.get_hybrid_crsp_sip_readiness(
+                user,
+                workflow,
+                alpaca_sip_summary=alpaca_sip_summary,
+            )
+        raise ValueError(f"Unsupported readiness dataset: {dataset}")
+
+    def get_alpaca_sip_readiness(
+        self,
+        user: object,
+        workflow: ReadinessWorkflow = "simple_backtest",
+        *,
+        alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
+    ) -> DataReadinessDTO:
+        """Return Alpaca SIP readiness with fail-closed raw-return blockers."""
+        self._require_dataset_readiness_access(user, ALPACA_SIP_DATASET_KEY)
+        summary = alpaca_sip_summary or self._manifest_service.get_alpaca_sip_summary()
+        return _build_alpaca_sip_readiness(summary, workflow)
+
+    def get_hybrid_crsp_sip_readiness(
+        self,
+        user: object,
+        workflow: ReadinessWorkflow = "hybrid_research_backtest",
+        *,
+        alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
+    ) -> DataReadinessDTO:
+        """Return hybrid CRSP-universe plus Alpaca SIP price readiness."""
+        self._require_dataset_readiness_access(user, HYBRID_CRSP_SIP_DATASET_KEY)
+        summary = alpaca_sip_summary or self._manifest_service.get_alpaca_sip_summary()
+        alpaca_checks = list(_alpaca_sip_checks(summary, workflow))
+        if has_dataset_permission(user, ALPACA_SIP_DATASET_KEY):
+            checks = alpaca_checks
+        else:
+            checks = [_hybrid_price_component_check(alpaca_checks)]
+        crsp_manifest = self._manifest_service.get_manifest_summary(
+            CRSP_UNIVERSE_MANIFEST_DATASET
+        )
+        if crsp_manifest is None:
+            checks.append(_crsp_unavailable_check("CRSP universe manifest is missing."))
+        elif crsp_manifest.validation_status != "passed":
+            checks.append(
+                _crsp_unavailable_check(
+                    f"CRSP universe manifest status is {crsp_manifest.validation_status}.",
+                )
+            )
+        else:
+            checks.append(
+                DataReadinessCheckDTO(
+                    code="crsp_universe_available",
+                    status="passed",
+                    message="CRSP universe manifest is trusted.",
+                    source="manifest",
+                )
+            )
+        return _readiness_from_checks(
+            dataset=HYBRID_CRSP_SIP_DATASET_KEY,
+            workflow=workflow,
+            checks=checks,
+        )
+
+    @staticmethod
+    def _require_dataset_readiness_access(user: object, dataset: str) -> None:
+        if not has_permission(user, Permission.VIEW_DATA_SYNC):
+            raise PermissionError(f"Permission {Permission.VIEW_DATA_SYNC.value} required")
+        if not has_dataset_permission(user, dataset):
+            raise PermissionError(f"Dataset access required for {dataset}")
+
+
+def _build_alpaca_sip_readiness(
+    summary: AlpacaSipManifestSummaryDTO,
+    workflow: ReadinessWorkflow,
+) -> DataReadinessDTO:
+    return _readiness_from_checks(
+        dataset=ALPACA_SIP_DATASET_KEY,
+        workflow=workflow,
+        checks=list(_alpaca_sip_checks(summary, workflow)),
+    )
+
+
+def _alpaca_sip_checks(
+    summary: AlpacaSipManifestSummaryDTO,
+    workflow: ReadinessWorkflow,
+) -> list[DataReadinessCheckDTO]:
+    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
+    checks: list[DataReadinessCheckDTO] = [
+        _manifest_check(
+            ALPACA_SIP_DAILY_DATASET,
+            manifests.get(ALPACA_SIP_DAILY_DATASET),
+            required=True,
+        ),
+        _manifest_check(
+            ALPACA_SIP_CORP_ACTIONS_DATASET,
+            manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            required=workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS,
+        ),
+    ]
+
+    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
+    if workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS and _raw_returns_unavailable(daily):
+        checks.append(
+            DataReadinessCheckDTO(
+                code=RAW_SIP_RETURNS_UNAVAILABLE,
+                status="blocked",
+                message=(
+                    "Simple backtests requiring ret or adj_close are blocked while "
+                    "Alpaca SIP canonical OHLC is raw and read-time adjustment is unavailable."
+                ),
+                source="read_time_adjustment_policy",
+                action_label="Use CRSP adjusted returns or wait for adjustment layer",
+                target_section="backtest",
+            )
+        )
+
+    for warning in summary.warnings:
+        if warning == ALPACA_SIP_COMPANION_MANIFEST_STALE:
+            checks.append(
+                DataReadinessCheckDTO(
+                    code=ALPACA_SIP_COMPANION_MANIFEST_STALE,
+                    status="warning",
+                    message=(
+                        "Daily bars and corporate actions manifests are materially out of date "
+                        "relative to each other."
+                    ),
+                    source="manifest_pairing",
+                    action_label="Refresh the stale companion dataset",
+                    target_section="acquisition",
+                )
+            )
+        elif warning == ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH:
+            checks.append(
+                DataReadinessCheckDTO(
+                    code=ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+                    status="warning",
+                    message=(
+                        "Daily bars and corporate actions manifests carry different symbol-set "
+                        "hashes."
+                    ),
+                    source="manifest_pairing",
+                    action_label="Review manifest cohesion",
+                    target_section="quality",
+                )
+            )
+    return checks
+
+
+def _manifest_check(
+    dataset: str,
+    manifest: ManifestSummaryDTO | None,
+    *,
+    required: bool,
+) -> DataReadinessCheckDTO:
+    if manifest is None:
+        status: Literal["warning", "blocked"] = "blocked" if required else "warning"
+        return DataReadinessCheckDTO(
+            code=ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST,
+            status=status,
+            message=f"{dataset} has no trusted manifest.",
+            source="manifest",
+            action_label="Run acquisition preflight",
+            target_section="acquisition",
+        )
+    if manifest.validation_status != "passed":
+        return DataReadinessCheckDTO(
+            code=ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST,
+            status="blocked" if required else "warning",
+            message=f"{dataset} manifest validation status is {manifest.validation_status}.",
+            source="manifest",
+            action_label="Inspect manifest validation",
+            target_section="quality",
+        )
+    return DataReadinessCheckDTO(
+        code=f"{dataset}_manifest_trusted",
+        status="passed",
+        message=f"{dataset} manifest is trusted.",
+        source="manifest",
+    )
+
+
+def _raw_returns_unavailable(manifest: ManifestSummaryDTO | None) -> bool:
+    if manifest is None:
+        return False
+    return (
+        manifest.canonical_storage_mode == "raw"
+        and manifest.read_time_adjustment_mode != "available"
+    )
+
+
+def _crsp_unavailable_check(message: str) -> DataReadinessCheckDTO:
+    return DataReadinessCheckDTO(
+        code=CRSP_UNIVERSE_UNAVAILABLE,
+        status="blocked",
+        message=message,
+        source="manifest",
+        action_label="Acquire or grant CRSP universe data",
+        target_section="acquisition",
+    )
+
+
+def _hybrid_price_component_check(
+    checks: list[DataReadinessCheckDTO],
+) -> DataReadinessCheckDTO:
+    blockers = [check for check in checks if check.status == "blocked"]
+    warnings = [check for check in checks if check.status == "warning"]
+    if blockers:
+        return DataReadinessCheckDTO(
+            code=HYBRID_PRICE_COMPONENT_BLOCKED,
+            status="blocked",
+            message="Hybrid price component is not ready.",
+            source="manifest",
+            action_label="Review hybrid price component acquisition",
+            target_section="acquisition",
+        )
+    if warnings:
+        return DataReadinessCheckDTO(
+            code=HYBRID_PRICE_COMPONENT_WARNING,
+            status="warning",
+            message="Hybrid price component needs operator review.",
+            source="manifest",
+            action_label="Review hybrid price component quality",
+            target_section="quality",
+        )
+    return DataReadinessCheckDTO(
+        code=HYBRID_PRICE_COMPONENT_READY,
+        status="passed",
+        message="Hybrid price component is trusted.",
+        source="manifest",
+    )
+
+
+def _readiness_from_checks(
+    *,
+    dataset: str,
+    workflow: ReadinessWorkflow,
+    checks: list[DataReadinessCheckDTO],
+) -> DataReadinessDTO:
+    blockers = sorted({check.code for check in checks if check.status == "blocked"})
+    warnings = sorted({check.code for check in checks if check.status == "warning"})
+    status: Literal["ready", "warning", "blocked"]
+    if blockers:
+        status = "blocked"
+    elif warnings:
+        status = "warning"
+    else:
+        status = "ready"
+    return DataReadinessDTO(
+        dataset=dataset,
+        workflow=workflow,
+        status=status,
+        generated_at=datetime.now(UTC),
+        blockers=blockers,
+        warnings=warnings,
+        checks=checks,
+    )
+
+
+__all__ = [
+    "ALPACA_SIP_ACCESS_UNAVAILABLE",
+    "ALPACA_SIP_COMPANION_MANIFEST_STALE",
+    "ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH",
+    "ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST",
+    "CRSP_DATASET_KEY",
+    "CRSP_UNIVERSE_MANIFEST_DATASET",
+    "CRSP_UNIVERSE_UNAVAILABLE",
+    "DataReadinessService",
+    "HYBRID_CRSP_SIP_DATASET_KEY",
+    "HYBRID_PRICE_COMPONENT_BLOCKED",
+    "HYBRID_PRICE_COMPONENT_READY",
+    "HYBRID_PRICE_COMPONENT_WARNING",
+    "RAW_SIP_RETURNS_UNAVAILABLE",
+]

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -61,7 +61,8 @@ class DataReadinessService:
     ) -> DataReadinessDTO:
         """Return readiness for a supported dataset/workflow pair.
 
-        This method performs synchronous manifest I/O; async callers should offload it.
+        This method performs synchronous manifest I/O. Async callers must use
+        get_readiness_async to avoid blocking the event loop.
         """
         if dataset == ALPACA_SIP_DATASET_KEY:
             return self.get_alpaca_sip_readiness(

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -64,6 +64,7 @@ class DataReadinessService:
         This method performs synchronous manifest I/O. Async callers must use
         get_readiness_async to avoid blocking the event loop.
         """
+        _raise_if_running_event_loop()
         if dataset == ALPACA_SIP_DATASET_KEY:
             return self.get_alpaca_sip_readiness(
                 user,
@@ -103,6 +104,7 @@ class DataReadinessService:
         alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
     ) -> DataReadinessDTO:
         """Return Alpaca SIP readiness with fail-closed raw-return blockers."""
+        _raise_if_running_event_loop()
         self._require_dataset_readiness_access(user, ALPACA_SIP_DATASET_KEY)
         summary = alpaca_sip_summary or self._manifest_service.get_alpaca_sip_summary()
         return _build_alpaca_sip_readiness(summary, workflow)
@@ -115,6 +117,7 @@ class DataReadinessService:
         alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
     ) -> DataReadinessDTO:
         """Return hybrid CRSP-universe plus Alpaca SIP price readiness."""
+        _raise_if_running_event_loop()
         self._require_dataset_readiness_access(user, HYBRID_CRSP_SIP_DATASET_KEY)
         has_direct_sip_access = has_dataset_permission(user, ALPACA_SIP_DATASET_KEY)
         summary = alpaca_sip_summary or self._manifest_service.get_alpaca_sip_summary()
@@ -154,6 +157,17 @@ class DataReadinessService:
             raise PermissionError(f"Permission {Permission.VIEW_DATA_SYNC.value} required")
         if not has_dataset_permission(user, dataset):
             raise PermissionError(f"Dataset access required for {dataset}")
+
+
+def _raise_if_running_event_loop() -> None:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    raise RuntimeError(
+        "DataReadinessService synchronous methods block manifest I/O; "
+        "use get_readiness_async from async code."
+    )
 
 
 def _build_alpaca_sip_readiness(

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any, Literal
 
@@ -75,6 +76,23 @@ class DataReadinessService:
                 alpaca_sip_summary=alpaca_sip_summary,
             )
         raise ValueError(f"Unsupported readiness dataset: {dataset}")
+
+    async def get_readiness_async(
+        self,
+        user: Any,
+        dataset: str,
+        workflow: ReadinessWorkflow,
+        *,
+        alpaca_sip_summary: AlpacaSipManifestSummaryDTO | None = None,
+    ) -> DataReadinessDTO:
+        """Return readiness without blocking the event loop on manifest I/O."""
+        return await asyncio.to_thread(
+            self.get_readiness,
+            user,
+            dataset,
+            workflow,
+            alpaca_sip_summary=alpaca_sip_summary,
+        )
 
     def get_alpaca_sip_readiness(
         self,

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -31,6 +31,7 @@ CRSP_UNIVERSE_MANIFEST_DATASET = "crsp_daily"
 RAW_SIP_RETURNS_UNAVAILABLE = "raw_sip_returns_unavailable"
 ALPACA_SIP_ACCESS_UNAVAILABLE = "alpaca_sip_access_unavailable"
 ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST = "alpaca_sip_untrusted_without_manifest"
+ALPACA_SIP_MANIFEST_VALIDATION_FAILED = "alpaca_sip_manifest_validation_failed"
 ALPACA_SIP_COMPANION_MANIFEST_STALE = "alpaca_sip_companion_manifest_stale"
 ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH = "alpaca_sip_companion_symbol_set_mismatch"
 CRSP_UNIVERSE_UNAVAILABLE = "crsp_universe_unavailable"
@@ -232,7 +233,7 @@ def _manifest_check(
         )
     if manifest.validation_status != "passed":
         return DataReadinessCheckDTO(
-            code=ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST,
+            code=ALPACA_SIP_MANIFEST_VALIDATION_FAILED,
             status="blocked" if required else "warning",
             message=f"{dataset} manifest validation status is {manifest.validation_status}.",
             source="manifest",
@@ -328,6 +329,7 @@ __all__ = [
     "ALPACA_SIP_ACCESS_UNAVAILABLE",
     "ALPACA_SIP_COMPANION_MANIFEST_STALE",
     "ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH",
+    "ALPACA_SIP_MANIFEST_VALIDATION_FAILED",
     "ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST",
     "CRSP_DATASET_KEY",
     "CRSP_UNIVERSE_MANIFEST_DATASET",

--- a/libs/web_console_services/schemas/data_management.py
+++ b/libs/web_console_services/schemas/data_management.py
@@ -286,6 +286,61 @@ class DataPreviewDTO(BaseModel):
     backtest_handoff: BacktestHandoffDTO | None = None
 
 
+ReadinessWorkflow = Literal[
+    "data_preview",
+    "simple_backtest",
+    "hybrid_research_backtest",
+    "quality_analysis",
+    "sql_exploration",
+]
+
+
+class DataReadinessCheckDTO(BaseModel):
+    """One workflow-readiness condition with a stable reason code."""
+
+    code: str
+    status: Literal["passed", "warning", "blocked"]
+    message: str
+    source: str
+    action_label: str | None = None
+    target_section: Literal["acquisition", "quality", "backtest"] | None = None
+
+
+class DataReadinessDTO(BaseModel):
+    """Workflow readiness result for a dataset or provider composition."""
+
+    dataset: str
+    workflow: ReadinessWorkflow
+    status: Literal["ready", "warning", "blocked"]
+    generated_at: AwareDatetime
+    blockers: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    checks: list[DataReadinessCheckDTO] = Field(default_factory=list)
+
+
+class DataQualitySignalDTO(BaseModel):
+    """Concrete quality signal surfaced on the data page."""
+
+    dataset: str
+    check: str
+    status: Literal["passed", "warning", "failed", "unavailable"]
+    source: str
+    observed_at: AwareDatetime | None = None
+    message: str
+    reason_codes: list[str] = Field(default_factory=list)
+
+
+class DataQualitySummaryDTO(BaseModel):
+    """Manifest/report-backed quality summary for one dataset family."""
+
+    dataset: str
+    status: Literal["passed", "warning", "failed", "unavailable"]
+    generated_at: AwareDatetime
+    signals: list[DataQualitySignalDTO] = Field(default_factory=list)
+    acknowledgments_persistent: bool
+    acknowledgment_status_source: str
+
+
 class QueryResultDTO(BaseModel):
     """Paginated query results for dataset explorer queries."""
 

--- a/tests/apps/web_console/services/test_data_quality_service.py
+++ b/tests/apps/web_console/services/test_data_quality_service.py
@@ -42,7 +42,7 @@ async def test_get_anomaly_alerts_filters_datasets(
     alerts = await service.get_anomaly_alerts(operator_user, severity=None, acknowledged=None)
 
     datasets = {alert.dataset for alert in alerts}
-    assert datasets == {"crsp", "compustat", "fama_french", "taq", "alpaca_sip"}
+    assert datasets == {"crsp", "compustat", "fama_french", "taq"}
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/components/test_data_manifest_components.py
+++ b/tests/apps/web_console_ng/components/test_data_manifest_components.py
@@ -11,6 +11,8 @@ from apps.web_console_ng.components.data_detail_drawer import (
     build_manifest_detail_fields,
 )
 from apps.web_console_ng.components.data_operations_grid import build_manifest_grid_rows
+from apps.web_console_ng.components.data_quality_section import build_quality_signal_rows
+from apps.web_console_ng.components.data_readiness_section import build_readiness_rows
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
@@ -18,6 +20,12 @@ from libs.web_console_services.data_manifest_service import (
     ManifestSummaryDTO,
 )
 from libs.web_console_services.provider_signature import ProviderSignatureDTO
+from libs.web_console_services.schemas.data_management import (
+    DataQualitySignalDTO,
+    DataQualitySummaryDTO,
+    DataReadinessCheckDTO,
+    DataReadinessDTO,
+)
 
 NOW = datetime(2026, 5, 1, 12, tzinfo=UTC)
 
@@ -251,3 +259,63 @@ def test_missing_companion_warning_stays_on_missing_row() -> None:
     assert metrics["Backtest Blocked"] == 2
     assert "alpaca_sip_untrusted_without_manifest" not in daily["issue_codes"]
     assert "alpaca_sip_untrusted_without_manifest" in corp_actions["issue_codes"]
+
+
+def test_readiness_rows_expose_action_targets() -> None:
+    readiness = DataReadinessDTO(
+        dataset="alpaca_sip",
+        workflow="simple_backtest",
+        status="blocked",
+        generated_at=NOW,
+        blockers=["raw_sip_returns_unavailable"],
+        checks=[
+            DataReadinessCheckDTO(
+                code="raw_sip_returns_unavailable",
+                status="blocked",
+                message="Raw SIP returns are unavailable.",
+                source="read_time_adjustment_policy",
+                action_label="Use adjusted returns",
+                target_section="backtest",
+            )
+        ],
+    )
+
+    rows = build_readiness_rows(readiness)
+
+    assert rows == [
+        {
+            "status": "blocked",
+            "code": "raw_sip_returns_unavailable",
+            "source": "read_time_adjustment_policy",
+            "message": "Raw SIP returns are unavailable.",
+            "action": "Use adjusted returns",
+            "target": "backtest",
+        }
+    ]
+
+
+def test_quality_signal_rows_expose_source_and_reason_codes() -> None:
+    summary = DataQualitySummaryDTO(
+        dataset="alpaca_sip",
+        status="warning",
+        generated_at=NOW,
+        acknowledgments_persistent=False,
+        acknowledgment_status_source="in_memory_store_unavailable",
+        signals=[
+            DataQualitySignalDTO(
+                dataset="alpaca_sip",
+                check="alpaca_feed_delta",
+                status="unavailable",
+                source="report_store",
+                observed_at=None,
+                message="No report persisted.",
+                reason_codes=["alpaca_feed_delta_report_unavailable"],
+            )
+        ],
+    )
+
+    rows = build_quality_signal_rows(summary)
+
+    assert rows[0]["source"] == "report_store"
+    assert rows[0]["observed_at"] == "-"
+    assert rows[0]["reason_codes"] == "alpaca_feed_delta_report_unavailable"

--- a/tests/apps/web_console_ng/pages/test_data_management.py
+++ b/tests/apps/web_console_ng/pages/test_data_management.py
@@ -6,113 +6,17 @@ after the P6T13 service wiring refactor.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from apps.web_console_ng.pages import data_management as dm_module
+from libs.platform.web_console_auth.permissions import Permission
+from libs.web_console_services.data_readiness_service import HYBRID_CRSP_SIP_DATASET_KEY
 
 
-@pytest.mark.asyncio()
-@patch("apps.web_console_ng.pages.data_management.ui")
-async def test_data_sync_no_view_shows_placeholder(
-    mock_ui: MagicMock,
-) -> None:
-    """Sync status placeholder when VIEW_DATA_SYNC is missing."""
-    mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
-
-    sync_service = MagicMock()
-    sync_service.get_sync_status = AsyncMock(return_value=[])
-
-    await dm_module._render_sync_status(
-        {"role": "viewer"}, sync_service, has_view=False, has_trigger=False
-    )
-    sync_service.get_sync_status.assert_not_awaited()
-
-
-@pytest.mark.asyncio()
-@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=False)
-@patch("apps.web_console_ng.pages.data_management.has_dataset_permission")
-async def test_manifest_transparency_requires_sync_view_permission(
-    mock_dataset_permission: MagicMock,
-    mock_permission: MagicMock,
-) -> None:
-    manifest_service = MagicMock()
-
-    await dm_module._render_manifest_transparency({"role": "viewer"}, manifest_service)
-
-    manifest_service.get_alpaca_sip_summary.assert_not_called()
-    mock_dataset_permission.assert_not_called()
-    mock_permission.assert_called_once()
-
-
-@pytest.mark.asyncio()
-@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
-@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=False)
-async def test_manifest_transparency_requires_alpaca_sip_dataset_permission(
-    mock_dataset_permission: MagicMock,
-    mock_permission: MagicMock,
-) -> None:
-    manifest_service = MagicMock()
-
-    await dm_module._render_manifest_transparency({"role": "viewer"}, manifest_service)
-
-    manifest_service.get_alpaca_sip_summary.assert_not_called()
-    mock_permission.assert_called_once()
-    mock_dataset_permission.assert_called_once()
-
-
-@pytest.mark.asyncio()
-@patch("apps.web_console_ng.pages.data_management.ui")
-@patch("apps.web_console_ng.pages.data_management._data_manifest_panel")
-@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
-@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
-async def test_manifest_transparency_renders_authorized_summary(
-    mock_dataset_permission: MagicMock,
-    mock_permission: MagicMock,
-    mock_panel: MagicMock,
-    mock_ui: MagicMock,
-) -> None:
-    summary = MagicMock()
-    manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.return_value = summary
-
-    await dm_module._render_manifest_transparency({"role": "operator"}, manifest_service)
-
-    manifest_service.get_alpaca_sip_summary.assert_called_once_with()
-    mock_panel.render_manifest_transparency_panel.assert_called_once_with(summary)
-    mock_permission.assert_called_once()
-    mock_dataset_permission.assert_called_once()
-    mock_ui.notify.assert_not_called()
-
-
-@pytest.mark.asyncio()
-@patch("apps.web_console_ng.pages.data_management.ui")
-@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
-@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
-async def test_manifest_transparency_warns_when_service_unavailable(
-    mock_dataset_permission: MagicMock,
-    mock_permission: MagicMock,
-    mock_ui: MagicMock,
-) -> None:
-    manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.side_effect = RuntimeError("boom")
-
-    await dm_module._render_manifest_transparency({"role": "operator"}, manifest_service)
-
-    mock_ui.notify.assert_called_once_with(
-        "Manifest status temporarily unavailable", type="warning"
-    )
-    mock_permission.assert_called_once()
-    mock_dataset_permission.assert_called_once()
-
-
-@pytest.mark.asyncio()
-@patch("apps.web_console_ng.pages.data_management.ui")
-async def test_data_quality_section_creates_tabs(
-    mock_ui: MagicMock,
-) -> None:
-    """Quality section creates all four sub-tabs including Quarantine Inspector."""
+def _setup_data_quality_ui(mock_ui: MagicMock) -> None:
     mock_ui.tabs.return_value = MagicMock()
     mock_ui.tabs.return_value.__enter__ = MagicMock()
     mock_ui.tabs.return_value.__exit__ = MagicMock(return_value=False)
@@ -148,6 +52,8 @@ async def test_data_quality_section_creates_tabs(
     mock_ui.expansion.return_value.__enter__ = MagicMock()
     mock_ui.expansion.return_value.__exit__ = MagicMock(return_value=False)
 
+
+def _quality_service_for_section() -> MagicMock:
     quality_service = MagicMock()
     quality_service.get_validation_results = AsyncMock(return_value=[])
     quality_service.get_anomaly_alerts = AsyncMock(return_value=[])
@@ -155,10 +61,241 @@ async def test_data_quality_section_creates_tabs(
         return_value=MagicMock(data_points=[], dataset="crsp", period_days=30)
     )
     quality_service.get_quarantine_status = AsyncMock(return_value=[])
+    quality_service.get_alpaca_sip_quality_summary = AsyncMock(return_value=MagicMock())
+    quality_service.acknowledgments_persistent = False
+    return quality_service
 
-    result = await dm_module._render_data_quality_section(
-        {"role": "admin"}, quality_service
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+async def test_data_sync_no_view_shows_placeholder(
+    mock_ui: MagicMock,
+) -> None:
+    """Sync status placeholder when VIEW_DATA_SYNC is missing."""
+    mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
+
+    sync_service = MagicMock()
+    sync_service.get_sync_status = AsyncMock(return_value=[])
+
+    await dm_module._render_sync_status(
+        {"role": "viewer"}, sync_service, has_view=False, has_trigger=False
     )
+    sync_service.get_sync_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=False)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission")
+async def test_manifest_transparency_requires_sync_view_permission(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+) -> None:
+    manifest_service = MagicMock()
+    readiness_service = MagicMock()
+
+    await dm_module._render_manifest_transparency(
+        {"role": "viewer"}, manifest_service, readiness_service
+    )
+
+    manifest_service.get_alpaca_sip_summary.assert_not_called()
+    readiness_service.get_readiness.assert_not_called()
+    mock_dataset_permission.assert_not_called()
+    mock_permission.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=False)
+async def test_manifest_transparency_requires_alpaca_sip_dataset_permission(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+) -> None:
+    manifest_service = MagicMock()
+    readiness_service = MagicMock()
+
+    await dm_module._render_manifest_transparency(
+        {"role": "viewer"}, manifest_service, readiness_service
+    )
+
+    manifest_service.get_alpaca_sip_summary.assert_not_called()
+    readiness_service.get_readiness.assert_not_called()
+    mock_permission.assert_called_once()
+    assert mock_dataset_permission.call_count == 2
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management._data_readiness_section")
+@patch("apps.web_console_ng.pages.data_management._data_manifest_panel")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission")
+async def test_manifest_transparency_renders_hybrid_readiness_without_direct_sip_access(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_panel: MagicMock,
+    mock_readiness_section: MagicMock,
+) -> None:
+    def dataset_access(_user: dict[str, str], dataset: str) -> bool:
+        return dataset == HYBRID_CRSP_SIP_DATASET_KEY
+
+    mock_dataset_permission.side_effect = dataset_access
+    readiness = MagicMock()
+    manifest_service = MagicMock()
+    readiness_service = MagicMock()
+    readiness_service.get_readiness.return_value = readiness
+
+    await dm_module._render_manifest_transparency(
+        {"role": "viewer"}, manifest_service, readiness_service
+    )
+
+    manifest_service.get_alpaca_sip_summary.assert_not_called()
+    readiness_service.get_readiness.assert_called_once_with(
+        {"role": "viewer"},
+        HYBRID_CRSP_SIP_DATASET_KEY,
+        "hybrid_research_backtest",
+        alpaca_sip_summary=None,
+    )
+    mock_panel.render_manifest_transparency_panel.assert_not_called()
+    mock_readiness_section.render_readiness_section.assert_called_once_with([readiness])
+    mock_permission.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_readiness_section")
+@patch("apps.web_console_ng.pages.data_management._data_manifest_panel")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_manifest_transparency_renders_authorized_summary(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_panel: MagicMock,
+    mock_readiness_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    summary = MagicMock()
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = summary
+    readiness_service = MagicMock()
+
+    await dm_module._render_manifest_transparency(
+        {"role": "operator"}, manifest_service, readiness_service
+    )
+
+    manifest_service.get_alpaca_sip_summary.assert_called_once_with()
+    assert readiness_service.get_readiness.call_count == 2
+    mock_panel.render_manifest_transparency_panel.assert_called_once_with(summary)
+    mock_readiness_section.render_readiness_section.assert_called_once()
+    mock_permission.assert_called_once()
+    assert mock_dataset_permission.call_count == 2
+    mock_ui.notify.assert_not_called()
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_readiness_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_manifest_transparency_warns_when_service_unavailable(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_readiness_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.side_effect = RuntimeError("boom")
+    readiness_service = MagicMock()
+    readiness_service.get_readiness.side_effect = RuntimeError("boom")
+
+    await dm_module._render_manifest_transparency(
+        {"role": "operator"}, manifest_service, readiness_service
+    )
+
+    assert readiness_service.get_readiness.call_count == 2
+    mock_ui.notify.assert_any_call("Manifest status temporarily unavailable", type="warning")
+    mock_ui.notify.assert_any_call(
+        "Some readiness checks are temporarily unavailable", type="warning"
+    )
+    assert mock_ui.notify.call_count == 2
+    mock_readiness_section.render_readiness_section.assert_not_called()
+    mock_permission.assert_called_once()
+    assert mock_dataset_permission.call_count == 2
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_readiness_section")
+@patch("apps.web_console_ng.pages.data_management._data_manifest_panel")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_manifest_transparency_preserves_partial_readiness(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_panel: MagicMock,
+    mock_readiness_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    summary = MagicMock()
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = summary
+    readiness = MagicMock()
+    readiness_service = MagicMock()
+    readiness_service.get_readiness.side_effect = [readiness, RuntimeError("boom")]
+
+    await dm_module._render_manifest_transparency(
+        {"role": "operator"}, manifest_service, readiness_service
+    )
+
+    mock_panel.render_manifest_transparency_panel.assert_called_once_with(summary)
+    mock_readiness_section.render_readiness_section.assert_called_once_with([readiness])
+    mock_ui.notify.assert_called_once_with(
+        "Some readiness checks are temporarily unavailable", type="warning"
+    )
+    mock_permission.assert_called_once()
+    assert mock_dataset_permission.call_count == 2
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_readiness_section")
+@patch("apps.web_console_ng.pages.data_management._data_manifest_panel")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_manifest_transparency_warns_for_invalid_readiness_target(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_panel: MagicMock,
+    mock_readiness_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    summary = MagicMock()
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = summary
+    readiness_service = MagicMock()
+    readiness_service.get_readiness.side_effect = ValueError("unsupported")
+
+    await dm_module._render_manifest_transparency(
+        {"role": "operator"}, manifest_service, readiness_service
+    )
+
+    mock_panel.render_manifest_transparency_panel.assert_called_once_with(summary)
+    mock_readiness_section.render_readiness_section.assert_not_called()
+    mock_ui.notify.assert_called_once_with(
+        "Some readiness checks are temporarily unavailable", type="warning"
+    )
+    mock_permission.assert_called_once()
+    assert mock_dataset_permission.call_count == 2
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+async def test_data_quality_section_creates_tabs(
+    mock_ui: MagicMock,
+) -> None:
+    """Quality section creates all four sub-tabs including Quarantine Inspector."""
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+
+    result = await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
 
     # Returns tuple of (alerts_container, scores_container, load_alerts_fn)
     assert isinstance(result, tuple)
@@ -168,6 +305,246 @@ async def test_data_quality_section_creates_tabs(
     # Should create tabs
     tab_calls = [str(c) for c in mock_ui.tab.call_args_list]
     assert len(tab_calls) >= 4
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_quality_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_data_quality_section_renders_alpaca_sip_quality_summary(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_quality_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+    summary = MagicMock()
+    quality_service.get_alpaca_sip_quality_summary = AsyncMock(return_value=summary)
+
+    await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
+
+    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with({"role": "admin"})
+    mock_quality_section.render_quality_summary.assert_called_once_with(summary)
+    mock_ui.notify.assert_not_called()
+    mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
+    mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_quality_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_data_quality_section_skips_for_quality_permission_error(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_quality_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+    quality_service.get_alpaca_sip_quality_summary = AsyncMock(
+        side_effect=PermissionError("denied")
+    )
+
+    await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
+
+    mock_quality_section.render_quality_summary.assert_not_called()
+    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with({"role": "admin"})
+    mock_ui.notify.assert_not_called()
+    mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
+    mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_quality_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_data_quality_section_warns_when_quality_summary_unavailable(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_quality_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+    quality_service.get_alpaca_sip_quality_summary = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
+
+    mock_quality_section.render_quality_summary.assert_not_called()
+    mock_ui.notify.assert_called_once_with(
+        "Alpaca SIP quality inputs temporarily unavailable", type="warning"
+    )
+    mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
+    mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_quality_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=False)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_data_quality_section_skips_quality_summary_without_view_permission(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_quality_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+
+    await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
+
+    quality_service.get_alpaca_sip_quality_summary.assert_not_awaited()
+    mock_quality_section.render_quality_summary.assert_not_called()
+    assert mock_dataset_permission.call_count >= 1
+    mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_quality_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=False)
+async def test_data_quality_section_skips_quality_summary_without_sip_access(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_quality_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+
+    await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
+
+    quality_service.get_alpaca_sip_quality_summary.assert_not_awaited()
+    mock_quality_section.render_quality_summary.assert_not_called()
+    mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
+    mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
+
+
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+def test_anomaly_alert_cards_disable_acknowledge_without_persistence(
+    mock_permission: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    """Acknowledgment controls remain unavailable until persistence is durable."""
+    label = MagicMock()
+    label.classes.return_value = label
+    mock_ui.label.return_value = label
+    card_context = MagicMock()
+    card_context.__enter__.return_value = card_context
+    card_context.__exit__.return_value = False
+    mock_ui.card.return_value.classes.return_value = card_context
+    row_context = MagicMock()
+    row_context.__enter__.return_value = row_context
+    row_context.__exit__.return_value = False
+    mock_ui.row.return_value.classes.return_value = row_context
+    button = MagicMock()
+    button.props.return_value = button
+    button.classes.return_value = button
+    mock_ui.button.return_value = button
+
+    alerts = [
+        MagicMock(
+            id="alert-1",
+            severity="warning",
+            metric="row_drop",
+            created_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+            acknowledged=False,
+            message="Placeholder alert",
+            deviation_pct=None,
+            current_value=1.0,
+            expected_value=1.0,
+        ),
+        MagicMock(
+            id="alert-2",
+            severity="warning",
+            metric="null_spike",
+            created_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+            acknowledged=False,
+            message="Placeholder alert",
+            deviation_pct=None,
+            current_value=1.0,
+            expected_value=1.0,
+        ),
+    ]
+    quality_service = MagicMock()
+    quality_service.acknowledgments_persistent = False
+
+    dm_module._build_anomaly_alert_cards(
+        alerts,
+        {"role": "operator"},
+        quality_service,
+        {"alert-1": "medium", "alert-2": "medium"},
+    )
+
+    mock_ui.button.assert_not_called()
+    label_texts = [call.args[0] for call in mock_ui.label.call_args_list if call.args]
+    assert (
+        label_texts.count(
+            "Acknowledgment controls are unavailable until server-side persistence is enabled"
+        )
+        == 1
+    )
+    mock_permission.assert_called_once_with({"role": "operator"}, Permission.ACKNOWLEDGE_ALERTS)
+
+
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+def test_anomaly_alert_cards_render_acknowledge_action_with_persistence(
+    mock_permission: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    label = MagicMock()
+    label.classes.return_value = label
+    mock_ui.label.return_value = label
+    card_context = MagicMock()
+    card_context.__enter__.return_value = card_context
+    card_context.__exit__.return_value = False
+    mock_ui.card.return_value.classes.return_value = card_context
+    row_context = MagicMock()
+    row_context.__enter__.return_value = row_context
+    row_context.__exit__.return_value = False
+    mock_ui.row.return_value.classes.return_value = row_context
+    button = MagicMock()
+    button.props.return_value = button
+    button.classes.return_value = button
+    mock_ui.button.return_value = button
+
+    alert = MagicMock(
+        id="alert-1",
+        severity="warning",
+        metric="row_drop",
+        created_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        acknowledged=False,
+        message="Placeholder alert",
+        deviation_pct=None,
+        current_value=1.0,
+        expected_value=1.0,
+    )
+    quality_service = MagicMock()
+    quality_service.acknowledgments_persistent = True
+
+    dm_module._build_anomaly_alert_cards(
+        [alert],
+        {"role": "operator"},
+        quality_service,
+        {"alert-1": "medium"},
+    )
+
+    mock_ui.button.assert_called_once()
+    label_texts = [call.args[0] for call in mock_ui.label.call_args_list if call.args]
+    assert (
+        "Acknowledgment controls are unavailable until server-side persistence is enabled"
+        not in label_texts
+    )
+    mock_permission.assert_called_once_with({"role": "operator"}, Permission.ACKNOWLEDGE_ALERTS)
 
 
 @pytest.mark.asyncio()

--- a/tests/apps/web_console_ng/pages/test_data_management.py
+++ b/tests/apps/web_console_ng/pages/test_data_management.py
@@ -325,7 +325,10 @@ async def test_data_quality_section_renders_alpaca_sip_quality_summary(
 
     await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
 
-    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with({"role": "admin"})
+    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with(
+        {"role": "admin"},
+        alpaca_sip_summary=None,
+    )
     mock_quality_section.render_quality_summary.assert_called_once_with(summary)
     mock_ui.notify.assert_not_called()
     mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
@@ -352,8 +355,48 @@ async def test_data_quality_section_skips_for_quality_permission_error(
     await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
 
     mock_quality_section.render_quality_summary.assert_not_called()
-    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with({"role": "admin"})
+    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with(
+        {"role": "admin"},
+        alpaca_sip_summary=None,
+    )
     mock_ui.notify.assert_not_called()
+    mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
+    mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
+
+
+@pytest.mark.asyncio()
+@patch("apps.web_console_ng.pages.data_management.ui")
+@patch("apps.web_console_ng.pages.data_management._data_quality_section")
+@patch("apps.web_console_ng.pages.data_management.has_permission", return_value=True)
+@patch("apps.web_console_ng.pages.data_management.has_dataset_permission", return_value=True)
+async def test_data_quality_section_reuses_page_alpaca_sip_summary(
+    mock_dataset_permission: MagicMock,
+    mock_permission: MagicMock,
+    mock_quality_section: MagicMock,
+    mock_ui: MagicMock,
+) -> None:
+    _setup_data_quality_ui(mock_ui)
+    quality_service = _quality_service_for_section()
+    quality_summary = MagicMock()
+    manifest_summary = MagicMock()
+    quality_service.get_alpaca_sip_quality_summary = AsyncMock(return_value=quality_summary)
+
+    await dm_module._render_data_quality_section(
+        {"role": "admin"},
+        quality_service,
+        alpaca_sip_summary=manifest_summary,
+    )
+
+    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with(
+        {"role": "admin"},
+        alpaca_sip_summary=manifest_summary,
+    )
+    quality_service.get_validation_results.assert_any_await(
+        {"role": "admin"},
+        dataset=None,
+        alpaca_sip_summary=manifest_summary,
+    )
+    mock_quality_section.render_quality_summary.assert_called_once_with(quality_summary)
     mock_dataset_permission.assert_any_call({"role": "admin"}, "alpaca_sip")
     mock_permission.assert_any_call({"role": "admin"}, Permission.VIEW_DATA_QUALITY)
 
@@ -376,6 +419,10 @@ async def test_data_quality_section_warns_when_quality_summary_unavailable(
     await dm_module._render_data_quality_section({"role": "admin"}, quality_service)
 
     mock_quality_section.render_quality_summary.assert_not_called()
+    quality_service.get_alpaca_sip_quality_summary.assert_awaited_once_with(
+        {"role": "admin"},
+        alpaca_sip_summary=None,
+    )
     mock_ui.notify.assert_called_once_with(
         "Alpaca SIP quality inputs temporarily unavailable", type="warning"
     )

--- a/tests/apps/web_console_ng/pages/test_data_management.py
+++ b/tests/apps/web_console_ng/pages/test_data_management.py
@@ -98,7 +98,7 @@ async def test_manifest_transparency_requires_sync_view_permission(
     )
 
     manifest_service.get_alpaca_sip_summary.assert_not_called()
-    readiness_service.get_readiness.assert_not_called()
+    readiness_service.get_readiness_async.assert_not_called()
     mock_dataset_permission.assert_not_called()
     mock_permission.assert_called_once()
 
@@ -118,7 +118,7 @@ async def test_manifest_transparency_requires_alpaca_sip_dataset_permission(
     )
 
     manifest_service.get_alpaca_sip_summary.assert_not_called()
-    readiness_service.get_readiness.assert_not_called()
+    readiness_service.get_readiness_async.assert_not_called()
     mock_permission.assert_called_once()
     assert mock_dataset_permission.call_count == 2
 
@@ -141,14 +141,14 @@ async def test_manifest_transparency_renders_hybrid_readiness_without_direct_sip
     readiness = MagicMock()
     manifest_service = MagicMock()
     readiness_service = MagicMock()
-    readiness_service.get_readiness.return_value = readiness
+    readiness_service.get_readiness_async = AsyncMock(return_value=readiness)
 
     await dm_module._render_manifest_transparency(
         {"role": "viewer"}, manifest_service, readiness_service
     )
 
     manifest_service.get_alpaca_sip_summary.assert_not_called()
-    readiness_service.get_readiness.assert_called_once_with(
+    readiness_service.get_readiness_async.assert_awaited_once_with(
         {"role": "viewer"},
         HYBRID_CRSP_SIP_DATASET_KEY,
         "hybrid_research_backtest",
@@ -176,13 +176,14 @@ async def test_manifest_transparency_renders_authorized_summary(
     manifest_service = MagicMock()
     manifest_service.get_alpaca_sip_summary.return_value = summary
     readiness_service = MagicMock()
+    readiness_service.get_readiness_async = AsyncMock(return_value=MagicMock())
 
     await dm_module._render_manifest_transparency(
         {"role": "operator"}, manifest_service, readiness_service
     )
 
     manifest_service.get_alpaca_sip_summary.assert_called_once_with()
-    assert readiness_service.get_readiness.call_count == 2
+    assert readiness_service.get_readiness_async.await_count == 2
     mock_panel.render_manifest_transparency_panel.assert_called_once_with(summary)
     mock_readiness_section.render_readiness_section.assert_called_once()
     mock_permission.assert_called_once()
@@ -204,18 +205,15 @@ async def test_manifest_transparency_warns_when_service_unavailable(
     manifest_service = MagicMock()
     manifest_service.get_alpaca_sip_summary.side_effect = RuntimeError("boom")
     readiness_service = MagicMock()
-    readiness_service.get_readiness.side_effect = RuntimeError("boom")
+    readiness_service.get_readiness_async = AsyncMock(side_effect=RuntimeError("boom"))
 
     await dm_module._render_manifest_transparency(
         {"role": "operator"}, manifest_service, readiness_service
     )
 
-    assert readiness_service.get_readiness.call_count == 2
+    readiness_service.get_readiness_async.assert_not_awaited()
     mock_ui.notify.assert_any_call("Manifest status temporarily unavailable", type="warning")
-    mock_ui.notify.assert_any_call(
-        "Some readiness checks are temporarily unavailable", type="warning"
-    )
-    assert mock_ui.notify.call_count == 2
+    assert mock_ui.notify.call_count == 1
     mock_readiness_section.render_readiness_section.assert_not_called()
     mock_permission.assert_called_once()
     assert mock_dataset_permission.call_count == 2
@@ -239,7 +237,9 @@ async def test_manifest_transparency_preserves_partial_readiness(
     manifest_service.get_alpaca_sip_summary.return_value = summary
     readiness = MagicMock()
     readiness_service = MagicMock()
-    readiness_service.get_readiness.side_effect = [readiness, RuntimeError("boom")]
+    readiness_service.get_readiness_async = AsyncMock(
+        side_effect=[readiness, RuntimeError("boom")]
+    )
 
     await dm_module._render_manifest_transparency(
         {"role": "operator"}, manifest_service, readiness_service
@@ -271,7 +271,7 @@ async def test_manifest_transparency_warns_for_invalid_readiness_target(
     manifest_service = MagicMock()
     manifest_service.get_alpaca_sip_summary.return_value = summary
     readiness_service = MagicMock()
-    readiness_service.get_readiness.side_effect = ValueError("unsupported")
+    readiness_service.get_readiness_async = AsyncMock(side_effect=ValueError("unsupported"))
 
     await dm_module._render_manifest_transparency(
         {"role": "operator"}, manifest_service, readiness_service

--- a/tests/libs/data/data_quality/test_quality_scorer.py
+++ b/tests/libs/data/data_quality/test_quality_scorer.py
@@ -126,6 +126,12 @@ class TestComputeQualityScores:
         assert scores[0].overall_score is None
         assert scores[0].validation_pass_rate is None
 
+    def test_unavailable_validations_are_not_scored_as_failures(self) -> None:
+        validations = [FakeValidation("ds1", "unavailable")]
+        scores = compute_quality_scores(validations, [], [])
+        assert scores[0].overall_score is None
+        assert scores[0].validation_pass_rate is None
+
     def test_anomaly_penalty(self) -> None:
         validations = [FakeValidation("ds1", "ok")] * 10
         alerts = [

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -664,6 +664,25 @@ def test_alpaca_report_store_uses_latest_pointer_before_directory_scan(
     assert report.content_hash == "latest-hash"
 
 
+def test_alpaca_report_store_ignores_scan_symlink_outside_data_root(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    quality_dir = data_root / "quality"
+    quality_dir.mkdir(parents=True)
+    outside_dir = tmp_path / "outside"
+    outside_report = _write_quality_report(
+        outside_dir,
+        "alpaca_sip_integrity_evil.json",
+        report_type="alpaca_sip_integrity",
+        status="passed",
+        content_hash="outside-hash",
+    )
+    (quality_dir / "alpaca_sip_integrity_evil.json").symlink_to(outside_report)
+
+    report = AlpacaQualityReportStore(data_root=data_root).get_integrity_report()
+
+    assert report is None
+
+
 @pytest.mark.asyncio()
 async def test_alpaca_sip_quality_summary_loads_report_store_off_event_loop() -> None:
     main_thread_id = get_ident()

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -283,6 +283,31 @@ async def test_get_validation_results_explains_failed_alpaca_manifest_without_so
 
 
 @pytest.mark.asyncio()
+async def test_get_validation_results_explains_missing_alpaca_manifest_without_source_error() -> (
+    None
+):
+    manifest_summary = _summary([]).model_copy(update={"source_error_message": None})
+    manifest_service = FakeManifestService(manifest_summary)
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset="alpaca_sip",
+        )
+
+    assert results[0].status == "error"
+    assert results[0].error_message == "No Alpaca SIP manifests found."
+    assert results[0].actual_value == "failed"
+
+
+@pytest.mark.asyncio()
 async def test_get_validation_results_appends_alpaca_manifest_for_all_datasets() -> None:
     manifest_service = FakeManifestService(
         _summary(

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -283,6 +283,35 @@ async def test_get_validation_results_explains_failed_alpaca_manifest_without_so
 
 
 @pytest.mark.asyncio()
+async def test_get_validation_results_sorts_failed_alpaca_manifest_message() -> None:
+    manifest_summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, validation_status="failed"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET, validation_status="failed"),
+        ]
+    ).model_copy(update={"source_error_message": None})
+    manifest_service = FakeManifestService(manifest_summary)
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset="alpaca_sip",
+        )
+
+    assert results[0].error_message == (
+        "Alpaca SIP manifest validation failed: "
+        f"{ALPACA_SIP_CORP_ACTIONS_DATASET}=failed, {ALPACA_SIP_DAILY_DATASET}=failed"
+    )
+
+
+@pytest.mark.asyncio()
 async def test_get_validation_results_explains_missing_alpaca_manifest_without_source_error() -> (
     None
 ):

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -138,7 +138,7 @@ def _write_quality_report(
     status: str,
     content_hash: str,
     timeframe: str = "1Day",
-) -> None:
+) -> Path:
     quality_dir.mkdir(parents=True, exist_ok=True)
     payload: dict[str, object] = {
         "report_type": report_type,
@@ -150,7 +150,9 @@ def _write_quality_report(
     }
     if report_type == "alpaca_feed_delta":
         payload["tolerances"] = {"version": "alpaca-iex-sip-delta-v1"}
-    (quality_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
+    path = quality_dir / filename
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
 
 
 @pytest.mark.asyncio()
@@ -627,6 +629,39 @@ async def test_alpaca_sip_quality_summary_loads_persisted_report_statuses(
     ].reason_codes
     assert "alpaca_feed_delta_timeframe:1Day" in signals["alpaca_feed_delta"].reason_codes
     assert "hash=feed-delta-hash" in signals["alpaca_feed_delta"].message
+
+
+def test_alpaca_report_store_uses_latest_pointer_before_directory_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    quality_dir = tmp_path / "quality"
+    _write_quality_report(
+        quality_dir,
+        "alpaca_sip_integrity_old.json",
+        report_type="alpaca_sip_integrity",
+        status="failed",
+        content_hash="old-hash",
+    )
+    _write_quality_report(
+        quality_dir,
+        "alpaca_sip_integrity_latest.json",
+        report_type="alpaca_sip_integrity",
+        status="passed",
+        content_hash="latest-hash",
+    )
+    store = AlpacaQualityReportStore(data_root=tmp_path)
+
+    def fail_scan(_quality_dir: Path, _pattern: str) -> Path | None:
+        raise AssertionError("directory scan should not run when latest pointer exists")
+
+    monkeypatch.setattr(store, "_latest_report_path", fail_scan)
+
+    report = store.get_integrity_report()
+
+    assert report is not None
+    assert report.status == "passed"
+    assert report.content_hash == "latest-hash"
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -368,6 +368,38 @@ async def test_get_validation_results_appends_alpaca_manifest_for_all_datasets()
 
 
 @pytest.mark.asyncio()
+async def test_get_validation_results_prioritizes_alpaca_manifest_when_limited() -> None:
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ]
+        )
+    )
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    def dataset_access(_user: DummyUser, dataset: str) -> bool:
+        return dataset in {"crsp", "alpaca_sip"}
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            side_effect=dataset_access,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset=None,
+            limit=1,
+        )
+
+    assert [result.dataset for result in results] == ["alpaca_sip"]
+    assert results[0].validation_type == "manifest_summary"
+
+
+@pytest.mark.asyncio()
 async def test_get_validation_results_degrades_when_alpaca_manifest_unavailable() -> None:
     main_thread_id = get_ident()
     manifest_service = RaisingManifestService()

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -20,6 +20,7 @@ from libs.web_console_services.data_manifest_service import (
     ManifestSummaryDTO,
 )
 from libs.web_console_services.data_quality_service import (
+    _MAX_QUALITY_REPORT_BYTES,
     AlpacaQualityReportStore,
     DataQualityService,
     QualityReportState,
@@ -687,6 +688,17 @@ def test_alpaca_report_store_ignores_scan_symlink_outside_data_root(tmp_path: Pa
     (quality_dir / "alpaca_sip_integrity_evil.json").symlink_to(outside_report)
 
     report = AlpacaQualityReportStore(data_root=data_root).get_integrity_report()
+
+    assert report is None
+
+
+def test_alpaca_report_store_rejects_oversized_report(tmp_path: Path) -> None:
+    quality_dir = tmp_path / "quality"
+    quality_dir.mkdir(parents=True)
+    report_path = quality_dir / "alpaca_sip_integrity_large.json"
+    report_path.write_text("x" * (_MAX_QUALITY_REPORT_BYTES + 1), encoding="utf-8")
+
+    report = AlpacaQualityReportStore(data_root=tmp_path).get_integrity_report()
 
     assert report is None
 

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -20,6 +20,7 @@ from libs.web_console_services.data_manifest_service import (
     ManifestSummaryDTO,
 )
 from libs.web_console_services.data_quality_service import (
+    AlpacaQualityReportStore,
     DataQualityService,
     QualityReportState,
     _build_alpaca_sip_quality_summary,
@@ -49,6 +50,26 @@ class RaisingManifestService:
     def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
         self.thread_ids.append(get_ident())
         raise RuntimeError("manifest store unavailable")
+
+
+class ThreadTrackingReportStore:
+    def __init__(
+        self,
+        *,
+        integrity_report: QualityReportState | None = None,
+        feed_delta_report: QualityReportState | None = None,
+    ) -> None:
+        self.integrity_report = integrity_report
+        self.feed_delta_report = feed_delta_report
+        self.thread_ids: list[int] = []
+
+    def get_integrity_report(self) -> QualityReportState | None:
+        self.thread_ids.append(get_ident())
+        return self.integrity_report
+
+    def get_feed_delta_report(self) -> QualityReportState | None:
+        self.thread_ids.append(get_ident())
+        return self.feed_delta_report
 
 
 @pytest.fixture()
@@ -606,6 +627,58 @@ async def test_alpaca_sip_quality_summary_loads_persisted_report_statuses(
     ].reason_codes
     assert "alpaca_feed_delta_timeframe:1Day" in signals["alpaca_feed_delta"].reason_codes
     assert "hash=feed-delta-hash" in signals["alpaca_feed_delta"].message
+
+
+@pytest.mark.asyncio()
+async def test_alpaca_sip_quality_summary_loads_report_store_off_event_loop() -> None:
+    main_thread_id = get_ident()
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        )
+    )
+    report_store = ThreadTrackingReportStore(
+        integrity_report=QualityReportState(
+            report_type="alpaca_sip_integrity",
+            status="passed",
+            raw_status="passed",
+            content_hash="integrity-hash",
+            start="2024-04-22T00:00:00+00:00",
+            end="2024-04-26T00:00:00+00:00",
+            timeframe="1Day",
+        ),
+        feed_delta_report=QualityReportState(
+            report_type="alpaca_feed_delta",
+            status="passed",
+            raw_status="passed",
+            content_hash="feed-delta-hash",
+            start="2024-04-22T00:00:00+00:00",
+            end="2024-04-26T00:00:00+00:00",
+            timeframe="1Day",
+        ),
+    )
+    svc = DataQualityService(
+        manifest_service=cast(DataManifestService, manifest_service),
+        report_store=cast(AlpacaQualityReportStore, report_store),
+    )
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        summary = await svc.get_alpaca_sip_quality_summary(DummyUser(user_id="user-1"))
+
+    statuses = {signal.check: signal.status for signal in summary.signals}
+    assert statuses["alpaca_sip_integrity"] == "passed"
+    assert statuses["alpaca_feed_delta"] == "passed"
+    assert report_store.thread_ids
+    assert all(thread_id != main_thread_id for thread_id in report_store.thread_ids)
 
 
 def test_alpaca_sip_quality_summary_builder_passes_when_persisted_inputs_available() -> None:

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -584,14 +584,14 @@ async def test_alpaca_sip_quality_summary_loads_persisted_report_statuses(
     tmp_path: Path,
 ) -> None:
     quality_dir = tmp_path / "quality"
-    _write_quality_report(
+    integrity_path = _write_quality_report(
         quality_dir,
         "alpaca_sip_integrity_test.json",
         report_type="alpaca_sip_integrity",
         status="passed",
         content_hash="integrity-hash",
     )
-    _write_quality_report(
+    feed_delta_path = _write_quality_report(
         quality_dir,
         "alpaca_iex_sip_delta_test.json",
         report_type="alpaca_feed_delta",
@@ -628,6 +628,14 @@ async def test_alpaca_sip_quality_summary_loads_persisted_report_statuses(
         "alpaca_sip_integrity"
     ].reason_codes
     assert "alpaca_feed_delta_timeframe:1Day" in signals["alpaca_feed_delta"].reason_codes
+    assert signals["alpaca_sip_integrity"].observed_at == datetime.fromtimestamp(
+        integrity_path.stat().st_mtime,
+        UTC,
+    )
+    assert signals["alpaca_feed_delta"].observed_at == datetime.fromtimestamp(
+        feed_delta_path.stat().st_mtime,
+        UTC,
+    )
     assert "hash=feed-delta-hash" in signals["alpaca_feed_delta"].message
 
 
@@ -681,6 +689,28 @@ def test_alpaca_report_store_ignores_scan_symlink_outside_data_root(tmp_path: Pa
     report = AlpacaQualityReportStore(data_root=data_root).get_integrity_report()
 
     assert report is None
+
+
+def test_alpaca_report_store_allows_configured_absolute_path_outside_data_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root = tmp_path / "data"
+    outside_report = _write_quality_report(
+        tmp_path / "external_quality",
+        "alpaca_sip_integrity_external.json",
+        report_type="alpaca_sip_integrity",
+        status="passed",
+        content_hash="external-hash",
+    )
+    monkeypatch.setenv("ALPACA_SIP_INTEGRITY_REPORT", str(outside_report))
+
+    report = AlpacaQualityReportStore(data_root=data_root).get_integrity_report()
+
+    assert report is not None
+    assert report.path == outside_report
+    assert report.content_hash == "external-hash"
+    assert report.observed_at == datetime.fromtimestamp(outside_report.stat().st_mtime, UTC)
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -696,14 +696,16 @@ def test_alpaca_report_store_allows_configured_absolute_path_outside_data_root(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     data_root = tmp_path / "data"
+    external_root = tmp_path / "external_quality"
     outside_report = _write_quality_report(
-        tmp_path / "external_quality",
+        external_root,
         "alpaca_sip_integrity_external.json",
         report_type="alpaca_sip_integrity",
         status="passed",
         content_hash="external-hash",
     )
     monkeypatch.setenv("ALPACA_SIP_INTEGRITY_REPORT", str(outside_report))
+    monkeypatch.setenv("ALPACA_QUALITY_REPORT_ROOTS", str(external_root))
 
     report = AlpacaQualityReportStore(data_root=data_root).get_integrity_report()
 
@@ -711,6 +713,26 @@ def test_alpaca_report_store_allows_configured_absolute_path_outside_data_root(
     assert report.path == outside_report
     assert report.content_hash == "external-hash"
     assert report.observed_at == datetime.fromtimestamp(outside_report.stat().st_mtime, UTC)
+
+
+def test_alpaca_report_store_rejects_untrusted_configured_absolute_path_outside_data_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root = tmp_path / "data"
+    outside_report = _write_quality_report(
+        tmp_path / "untrusted_quality",
+        "alpaca_sip_integrity_external.json",
+        report_type="alpaca_sip_integrity",
+        status="passed",
+        content_hash="external-hash",
+    )
+    monkeypatch.setenv("ALPACA_SIP_INTEGRITY_REPORT", str(outside_report))
+    monkeypatch.delenv("ALPACA_QUALITY_REPORT_ROOTS", raising=False)
+
+    report = AlpacaQualityReportStore(data_root=data_root).get_integrity_report()
+
+    assert report is None
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from threading import get_ident
+from typing import cast
 from unittest.mock import patch
 
 import pytest
 
-from libs.web_console_services.data_quality_service import DataQualityService
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    AlpacaSipManifestSummaryDTO,
+    DataManifestService,
+    ManifestSummaryDTO,
+)
+from libs.web_console_services.data_quality_service import (
+    DataQualityService,
+    _build_alpaca_sip_quality_summary,
+)
+from libs.web_console_services.provider_signature import ProviderSignatureDTO
 
 
 @dataclass(frozen=True)
@@ -15,9 +29,81 @@ class DummyUser:
     user_id: str
 
 
+class FakeManifestService:
+    def __init__(self, summary: AlpacaSipManifestSummaryDTO) -> None:
+        self._summary = summary
+        self.thread_ids: list[int] = []
+
+    def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
+        self.thread_ids.append(get_ident())
+        return self._summary
+
+
+class RaisingManifestService:
+    def __init__(self) -> None:
+        self.thread_ids: list[int] = []
+
+    def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
+        self.thread_ids.append(get_ident())
+        raise RuntimeError("manifest store unavailable")
+
+
 @pytest.fixture()
 def service() -> DataQualityService:
     return DataQualityService()
+
+
+def _manifest(dataset: str, *, validation_status: str = "passed") -> ManifestSummaryDTO:
+    return ManifestSummaryDTO(
+        dataset=dataset,
+        manifest_reference=f"manifests://{dataset}.json",
+        manifest_id=f"{dataset}@v1:checksum",
+        manifest_checksum=f"{dataset}-checksum",
+        manifest_version=1,
+        schema_version="v1",
+        validation_status=validation_status,
+        sync_timestamp=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 30),
+        row_count=10,
+        file_count=1,
+        provider_id="alpaca_sip",
+        provider_version="2026.04",
+        source_feed="sip",
+        adjustment_mode="raw" if dataset == ALPACA_SIP_DAILY_DATASET else None,
+        canonical_storage_mode="raw" if dataset == ALPACA_SIP_DAILY_DATASET else None,
+        read_time_adjustment_mode=("unavailable" if dataset == ALPACA_SIP_DAILY_DATASET else None),
+        provider_signature=ProviderSignatureDTO(
+            provider_id="alpaca_sip",
+            manifest_id=f"{dataset}@v1:checksum",
+            manifest_reference=f"manifests://{dataset}.json",
+            manifest_checksum=f"{dataset}-checksum",
+            dataset_keys=[dataset],
+        ),
+    )
+
+
+def _summary(
+    manifests: list[ManifestSummaryDTO],
+    *,
+    missing: list[str] | None = None,
+    warnings: list[str] | None = None,
+) -> AlpacaSipManifestSummaryDTO:
+    statuses = sorted({manifest.validation_status for manifest in manifests})
+    return AlpacaSipManifestSummaryDTO(
+        manifests=manifests,
+        present_datasets=sorted(manifest.dataset for manifest in manifests),
+        missing_datasets=missing or [],
+        latest_sync=max((manifest.sync_timestamp for manifest in manifests), default=None),
+        row_count=sum(manifest.row_count for manifest in manifests),
+        schema_versions=sorted({manifest.schema_version for manifest in manifests}),
+        validation_statuses=statuses,
+        sync_validation_status="ok" if statuses == ["passed"] and not missing else "missing",
+        source_status="ok" if statuses == ["passed"] and not missing else "error",
+        source_error_message=None if statuses == ["passed"] and not missing else "missing",
+        source_error_rate_pct=0.0 if statuses == ["passed"] and not missing else 100.0,
+        warnings=warnings or [],
+    )
 
 
 @pytest.mark.asyncio()
@@ -77,6 +163,40 @@ async def test_get_anomaly_alerts_filters_severity_and_acknowledged(
 
 
 @pytest.mark.asyncio()
+async def test_get_anomaly_alerts_excludes_manifest_backed_alpaca_sip_placeholder(
+    service: DataQualityService,
+) -> None:
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        alerts = await service.get_anomaly_alerts(
+            DummyUser(user_id="user-1"), severity=None, acknowledged=None
+        )
+
+    assert "alpaca_sip" not in {alert.dataset for alert in alerts}
+
+
+@pytest.mark.asyncio()
+async def test_get_quarantine_status_excludes_manifest_backed_alpaca_sip_placeholder(
+    service: DataQualityService,
+) -> None:
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        entries = await service.get_quarantine_status(DummyUser(user_id="user-1"))
+
+    assert "alpaca_sip" not in {entry.dataset for entry in entries}
+
+
+@pytest.mark.asyncio()
 async def test_acknowledge_alert_idempotent(service: DataQualityService) -> None:
     with (
         patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
@@ -101,3 +221,270 @@ async def test_acknowledge_alert_idempotent(service: DataQualityService) -> None
 def test_resolve_alert_dataset_invalid_id() -> None:
     with pytest.raises(ValueError, match="Could not resolve dataset"):
         DataQualityService._resolve_alert_dataset("bad-id")
+
+
+@pytest.mark.asyncio()
+async def test_get_validation_results_uses_manifest_for_alpaca_sip() -> None:
+    main_thread_id = get_ident()
+    manifest_service = FakeManifestService(
+        _summary([], missing=[ALPACA_SIP_DAILY_DATASET, ALPACA_SIP_CORP_ACTIONS_DATASET])
+    )
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset="alpaca_sip",
+        )
+
+    assert [result.validation_type for result in results] == ["manifest_summary"]
+    assert results[0].status == "error"
+    assert results[0].actual_value == "missing"
+    assert manifest_service.thread_ids
+    assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
+
+
+@pytest.mark.asyncio()
+async def test_get_validation_results_explains_failed_alpaca_manifest_without_source_error() -> (
+    None
+):
+    manifest_summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, validation_status="failed"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    ).model_copy(update={"source_error_message": None})
+    manifest_service = FakeManifestService(manifest_summary)
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset="alpaca_sip",
+        )
+
+    assert results[0].status == "error"
+    assert (
+        results[0].error_message == "Alpaca SIP manifest validation failed: alpaca_sip_daily=failed"
+    )
+    assert results[0].actual_value == "failed"
+
+
+@pytest.mark.asyncio()
+async def test_get_validation_results_appends_alpaca_manifest_for_all_datasets() -> None:
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ]
+        )
+    )
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    def dataset_access(_user: DummyUser, dataset: str) -> bool:
+        return dataset in {"crsp", "alpaca_sip"}
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            side_effect=dataset_access,
+        ),
+    ):
+        results = await svc.get_validation_results(DummyUser(user_id="user-1"), dataset=None)
+
+    by_dataset = {result.dataset: result for result in results}
+    assert set(by_dataset) == {"crsp", "alpaca_sip"}
+    assert by_dataset["crsp"].status == "ok"
+    assert by_dataset["alpaca_sip"].validation_type == "manifest_summary"
+    assert by_dataset["alpaca_sip"].status == "ok"
+
+
+@pytest.mark.asyncio()
+async def test_get_validation_results_degrades_when_alpaca_manifest_unavailable() -> None:
+    main_thread_id = get_ident()
+    manifest_service = RaisingManifestService()
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    def dataset_access(_user: DummyUser, dataset: str) -> bool:
+        return dataset in {"crsp", "alpaca_sip"}
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            side_effect=dataset_access,
+        ),
+    ):
+        results = await svc.get_validation_results(DummyUser(user_id="user-1"), dataset=None)
+
+    by_dataset = {result.dataset: result for result in results}
+    assert set(by_dataset) == {"crsp", "alpaca_sip"}
+    assert by_dataset["crsp"].status == "ok"
+    assert by_dataset["alpaca_sip"].status == "unavailable"
+    assert by_dataset["alpaca_sip"].actual_value == "unavailable"
+    assert by_dataset["alpaca_sip"].error_message == "Alpaca SIP manifest summary unavailable."
+    assert manifest_service.thread_ids
+    assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
+
+
+@pytest.mark.asyncio()
+async def test_alpaca_sip_quality_summary_marks_unavailable_report_inputs() -> None:
+    main_thread_id = get_ident()
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        )
+    )
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        summary = await svc.get_alpaca_sip_quality_summary(DummyUser(user_id="user-1"))
+
+    statuses = {signal.check: signal.status for signal in summary.signals}
+    assert summary.status == "unavailable"
+    assert statuses["manifest_validation"] == "passed"
+    assert statuses["alpaca_sip_integrity"] == "unavailable"
+    assert statuses["alpaca_feed_delta"] == "unavailable"
+    assert statuses["quality_acknowledgment_persistence"] == "unavailable"
+    assert summary.acknowledgments_persistent is False
+    assert manifest_service.thread_ids
+    assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
+
+
+def test_alpaca_sip_quality_summary_builder_passes_when_persisted_inputs_available() -> None:
+    summary = _build_alpaca_sip_quality_summary(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        ),
+        integrity_reports_available=True,
+        feed_delta_reports_available=True,
+        acknowledgments_persistent=True,
+    )
+
+    statuses = {signal.check: signal.status for signal in summary.signals}
+    assert summary.status == "passed"
+    assert set(statuses.values()) == {"passed"}
+    assert summary.acknowledgments_persistent is True
+    assert summary.acknowledgment_status_source == "persistent_store"
+
+
+@pytest.mark.asyncio()
+async def test_alpaca_sip_quality_summary_warns_on_pairing_warning() -> None:
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+            warnings=["alpaca_sip_companion_manifest_stale"],
+        )
+    )
+    svc = DataQualityService(
+        manifest_service=cast(DataManifestService, manifest_service),
+        integrity_reports_available=True,
+        feed_delta_reports_available=True,
+    )
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        summary = await svc.get_alpaca_sip_quality_summary(DummyUser(user_id="user-1"))
+
+    pairing = next(signal for signal in summary.signals if signal.check == "manifest_pairing")
+    assert summary.status == "warning"
+    assert pairing.status == "warning"
+    assert pairing.reason_codes == ["alpaca_sip_companion_manifest_stale"]
+
+
+@pytest.mark.asyncio()
+async def test_alpaca_sip_quality_summary_fails_missing_companion_manifest() -> None:
+    manifest_service = FakeManifestService(
+        _summary(
+            [_manifest(ALPACA_SIP_DAILY_DATASET)],
+            missing=[ALPACA_SIP_CORP_ACTIONS_DATASET],
+        )
+    )
+    svc = DataQualityService(
+        manifest_service=cast(DataManifestService, manifest_service),
+        integrity_reports_available=True,
+        feed_delta_reports_available=True,
+    )
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        summary = await svc.get_alpaca_sip_quality_summary(DummyUser(user_id="user-1"))
+
+    pairing = next(signal for signal in summary.signals if signal.check == "manifest_pairing")
+    assert summary.status == "failed"
+    assert pairing.status == "failed"
+    assert pairing.reason_codes == [
+        f"alpaca_sip_missing_manifest:{ALPACA_SIP_CORP_ACTIONS_DATASET}"
+    ]
+
+
+@pytest.mark.asyncio()
+async def test_alpaca_sip_quality_summary_fails_invalid_companion_manifest() -> None:
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET, validation_status="failed"),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        )
+    )
+    svc = DataQualityService(
+        manifest_service=cast(DataManifestService, manifest_service),
+        integrity_reports_available=True,
+        feed_delta_reports_available=True,
+    )
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        summary = await svc.get_alpaca_sip_quality_summary(DummyUser(user_id="user-1"))
+
+    pairing = next(signal for signal in summary.signals if signal.check == "manifest_pairing")
+    assert summary.status == "failed"
+    assert pairing.status == "failed"
+    assert pairing.reason_codes == [
+        f"alpaca_sip_manifest_validation_failed:{ALPACA_SIP_DAILY_DATASET}"
+    ]

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -243,9 +243,13 @@ async def test_get_validation_results_uses_manifest_for_alpaca_sip() -> None:
             dataset="alpaca_sip",
         )
 
-    assert [result.validation_type for result in results] == ["manifest_summary"]
+    assert [result.validation_type for result in results] == [
+        "manifest_summary",
+        "manifest_pairing",
+    ]
     assert results[0].status == "error"
     assert results[0].actual_value == "missing"
+    assert results[1].status == "error"
     assert manifest_service.thread_ids
     assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
 
@@ -360,11 +364,15 @@ async def test_get_validation_results_appends_alpaca_manifest_for_all_datasets()
     ):
         results = await svc.get_validation_results(DummyUser(user_id="user-1"), dataset=None)
 
-    by_dataset = {result.dataset: result for result in results}
-    assert set(by_dataset) == {"crsp", "alpaca_sip"}
-    assert by_dataset["crsp"].status == "ok"
-    assert by_dataset["alpaca_sip"].validation_type == "manifest_summary"
-    assert by_dataset["alpaca_sip"].status == "ok"
+    alpaca_results = [result for result in results if result.dataset == "alpaca_sip"]
+    crsp_results = [result for result in results if result.dataset == "crsp"]
+    assert [result.validation_type for result in alpaca_results] == [
+        "manifest_summary",
+        "manifest_pairing",
+    ]
+    assert [result.status for result in alpaca_results] == ["ok", "ok"]
+    assert len(crsp_results) == 1
+    assert crsp_results[0].status == "ok"
 
 
 @pytest.mark.asyncio()
@@ -400,7 +408,38 @@ async def test_get_validation_results_prioritizes_alpaca_manifest_when_limited()
 
 
 @pytest.mark.asyncio()
-async def test_get_validation_results_degrades_when_alpaca_manifest_unavailable() -> None:
+async def test_get_validation_results_includes_alpaca_pairing_signal() -> None:
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+            warnings=["alpaca_sip_companion_manifest_stale"],
+        )
+    )
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset="alpaca_sip",
+        )
+
+    pairing = next(result for result in results if result.validation_type == "manifest_pairing")
+    assert pairing.status == "warning"
+    assert pairing.actual_value == "warning"
+    assert pairing.error_message == "Companion manifests need operator review."
+
+
+@pytest.mark.asyncio()
+async def test_get_validation_results_raises_when_alpaca_manifest_unavailable() -> None:
     main_thread_id = get_ident()
     manifest_service = RaisingManifestService()
     svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
@@ -415,16 +454,42 @@ async def test_get_validation_results_degrades_when_alpaca_manifest_unavailable(
             side_effect=dataset_access,
         ),
     ):
-        results = await svc.get_validation_results(DummyUser(user_id="user-1"), dataset=None)
+        with pytest.raises(RuntimeError, match="manifest store unavailable"):
+            await svc.get_validation_results(DummyUser(user_id="user-1"), dataset=None)
 
-    by_dataset = {result.dataset: result for result in results}
-    assert set(by_dataset) == {"crsp", "alpaca_sip"}
-    assert by_dataset["crsp"].status == "ok"
-    assert by_dataset["alpaca_sip"].status == "unavailable"
-    assert by_dataset["alpaca_sip"].actual_value == "unavailable"
-    assert by_dataset["alpaca_sip"].error_message == "Alpaca SIP manifest summary unavailable."
     assert manifest_service.thread_ids
     assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
+
+
+@pytest.mark.asyncio()
+async def test_get_validation_results_reuses_provided_alpaca_summary() -> None:
+    manifest_service = RaisingManifestService()
+    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        results = await svc.get_validation_results(
+            DummyUser(user_id="user-1"),
+            dataset="alpaca_sip",
+            alpaca_sip_summary=summary,
+        )
+
+    assert [result.validation_type for result in results] == [
+        "manifest_summary",
+        "manifest_pairing",
+    ]
+    assert manifest_service.thread_ids == []
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
+from pathlib import Path
 from threading import get_ident
 from typing import cast
 from unittest.mock import patch
@@ -19,6 +21,7 @@ from libs.web_console_services.data_manifest_service import (
 )
 from libs.web_console_services.data_quality_service import (
     DataQualityService,
+    QualityReportState,
     _build_alpaca_sip_quality_summary,
 )
 from libs.web_console_services.provider_signature import ProviderSignatureDTO
@@ -104,6 +107,29 @@ def _summary(
         source_error_rate_pct=0.0 if statuses == ["passed"] and not missing else 100.0,
         warnings=warnings or [],
     )
+
+
+def _write_quality_report(
+    quality_dir: Path,
+    filename: str,
+    *,
+    report_type: str,
+    status: str,
+    content_hash: str,
+    timeframe: str = "1Day",
+) -> None:
+    quality_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {
+        "report_type": report_type,
+        "status": status,
+        "content_hash": content_hash,
+        "start": "2024-04-22T00:00:00+00:00",
+        "end": "2024-04-26T00:00:00+00:00",
+        "timeframe": timeframe,
+    }
+    if report_type == "alpaca_feed_delta":
+        payload["tolerances"] = {"version": "alpaca-iex-sip-delta-v1"}
+    (quality_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
 
 
 @pytest.mark.asyncio()
@@ -493,7 +519,9 @@ async def test_get_validation_results_reuses_provided_alpaca_summary() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_alpaca_sip_quality_summary_marks_unavailable_report_inputs() -> None:
+async def test_alpaca_sip_quality_summary_marks_unavailable_report_inputs(
+    tmp_path: Path,
+) -> None:
     main_thread_id = get_ident()
     manifest_service = FakeManifestService(
         _summary(
@@ -503,7 +531,10 @@ async def test_alpaca_sip_quality_summary_marks_unavailable_report_inputs() -> N
             ],
         )
     )
-    svc = DataQualityService(manifest_service=cast(DataManifestService, manifest_service))
+    svc = DataQualityService(
+        manifest_service=cast(DataManifestService, manifest_service),
+        data_root=tmp_path,
+    )
 
     with (
         patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
@@ -525,6 +556,58 @@ async def test_alpaca_sip_quality_summary_marks_unavailable_report_inputs() -> N
     assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
 
 
+@pytest.mark.asyncio()
+async def test_alpaca_sip_quality_summary_loads_persisted_report_statuses(
+    tmp_path: Path,
+) -> None:
+    quality_dir = tmp_path / "quality"
+    _write_quality_report(
+        quality_dir,
+        "alpaca_sip_integrity_test.json",
+        report_type="alpaca_sip_integrity",
+        status="passed",
+        content_hash="integrity-hash",
+    )
+    _write_quality_report(
+        quality_dir,
+        "alpaca_iex_sip_delta_test.json",
+        report_type="alpaca_feed_delta",
+        status="warning",
+        content_hash="feed-delta-hash",
+    )
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        )
+    )
+    svc = DataQualityService(
+        manifest_service=cast(DataManifestService, manifest_service),
+        data_root=tmp_path,
+    )
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        summary = await svc.get_alpaca_sip_quality_summary(DummyUser(user_id="user-1"))
+
+    signals = {signal.check: signal for signal in summary.signals}
+    assert summary.status == "warning"
+    assert signals["alpaca_sip_integrity"].status == "passed"
+    assert signals["alpaca_feed_delta"].status == "warning"
+    assert "alpaca_sip_integrity_hash:integrity-hash" in signals[
+        "alpaca_sip_integrity"
+    ].reason_codes
+    assert "alpaca_feed_delta_timeframe:1Day" in signals["alpaca_feed_delta"].reason_codes
+    assert "hash=feed-delta-hash" in signals["alpaca_feed_delta"].message
+
+
 def test_alpaca_sip_quality_summary_builder_passes_when_persisted_inputs_available() -> None:
     summary = _build_alpaca_sip_quality_summary(
         _summary(
@@ -543,6 +626,35 @@ def test_alpaca_sip_quality_summary_builder_passes_when_persisted_inputs_availab
     assert set(statuses.values()) == {"passed"}
     assert summary.acknowledgments_persistent is True
     assert summary.acknowledgment_status_source == "persistent_store"
+
+
+def test_alpaca_sip_quality_summary_builder_preserves_failed_report_status() -> None:
+    summary = _build_alpaca_sip_quality_summary(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        ),
+        integrity_report=QualityReportState(
+            report_type="alpaca_sip_integrity",
+            status="failed",
+            raw_status="failed",
+            content_hash="deadbeefcafebabe",
+            start="2024-04-22T00:00:00+00:00",
+            end="2024-04-26T00:00:00+00:00",
+            timeframe="1Day",
+        ),
+        feed_delta_reports_available=True,
+        acknowledgments_persistent=True,
+    )
+
+    integrity = next(signal for signal in summary.signals if signal.check == "alpaca_sip_integrity")
+    assert summary.status == "failed"
+    assert integrity.status == "failed"
+    assert "alpaca_sip_integrity_report_failed" in integrity.reason_codes
+    assert "alpaca_sip_integrity_hash:deadbeefcafebabe" in integrity.reason_codes
+    assert "timeframe=1Day" in integrity.message
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -1,0 +1,359 @@
+"""Tests for manifest-backed data readiness service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import cast
+
+import pytest
+
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    ALPACA_SIP_DATASET_KEY,
+    AlpacaSipManifestSummaryDTO,
+    DataManifestService,
+    ManifestSummaryDTO,
+)
+from libs.web_console_services.data_readiness_service import (
+    ALPACA_SIP_COMPANION_MANIFEST_STALE,
+    ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+    ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST,
+    CRSP_UNIVERSE_MANIFEST_DATASET,
+    CRSP_UNIVERSE_UNAVAILABLE,
+    HYBRID_CRSP_SIP_DATASET_KEY,
+    HYBRID_PRICE_COMPONENT_BLOCKED,
+    HYBRID_PRICE_COMPONENT_READY,
+    RAW_SIP_RETURNS_UNAVAILABLE,
+    DataReadinessService,
+)
+from libs.web_console_services.provider_signature import ProviderSignatureDTO
+
+NOW = datetime(2026, 5, 1, 12, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class DummyUser:
+    user_id: str = "user-1"
+
+
+class FakeManifestService:
+    def __init__(
+        self,
+        summary: AlpacaSipManifestSummaryDTO,
+        crsp_manifest: ManifestSummaryDTO | None = None,
+    ) -> None:
+        self._summary = summary
+        self._crsp_manifest = crsp_manifest
+
+    def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
+        return self._summary
+
+    def get_manifest_summary(self, dataset: str) -> ManifestSummaryDTO | None:
+        if dataset == CRSP_UNIVERSE_MANIFEST_DATASET:
+            return self._crsp_manifest
+        return None
+
+
+def _manifest(
+    dataset: str,
+    *,
+    validation_status: str = "passed",
+    read_time_adjustment_mode: str | None = None,
+) -> ManifestSummaryDTO:
+    is_daily = dataset == ALPACA_SIP_DAILY_DATASET
+    provider_id = "crsp" if dataset == CRSP_UNIVERSE_MANIFEST_DATASET else "alpaca_sip"
+    source_feed = None if dataset == CRSP_UNIVERSE_MANIFEST_DATASET else "sip"
+    return ManifestSummaryDTO(
+        dataset=dataset,
+        manifest_reference=f"manifests://{dataset}.json",
+        manifest_id=f"{dataset}@v1:checksum",
+        manifest_checksum=f"{dataset}-checksum",
+        manifest_version=1,
+        schema_version="v1",
+        validation_status=validation_status,
+        sync_timestamp=NOW,
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 30),
+        row_count=10,
+        file_count=1,
+        provider_id=provider_id,
+        provider_version="2026.04",
+        source_feed=source_feed,
+        adjustment_mode="raw" if is_daily else None,
+        canonical_storage_mode="raw" if is_daily else None,
+        read_time_adjustment_mode=(
+            read_time_adjustment_mode
+            if read_time_adjustment_mode is not None
+            else "unavailable"
+            if is_daily
+            else None
+        ),
+        provider_signature=ProviderSignatureDTO(
+            provider_id=provider_id,
+            manifest_id=f"{dataset}@v1:checksum",
+            manifest_reference=f"manifests://{dataset}.json",
+            manifest_checksum=f"{dataset}-checksum",
+            dataset_keys=[dataset],
+        ),
+    )
+
+
+def _summary(
+    manifests: list[ManifestSummaryDTO],
+    *,
+    missing: list[str] | None = None,
+    warnings: list[str] | None = None,
+) -> AlpacaSipManifestSummaryDTO:
+    statuses = sorted({manifest.validation_status for manifest in manifests})
+    return AlpacaSipManifestSummaryDTO(
+        manifests=manifests,
+        present_datasets=sorted(manifest.dataset for manifest in manifests),
+        missing_datasets=missing or [],
+        latest_sync=max((manifest.sync_timestamp for manifest in manifests), default=None),
+        row_count=sum(manifest.row_count for manifest in manifests),
+        schema_versions=sorted({manifest.schema_version for manifest in manifests}),
+        validation_statuses=statuses,
+        sync_validation_status="ok" if statuses == ["passed"] and not missing else "missing",
+        source_status="ok" if statuses == ["passed"] and not missing else "error",
+        source_error_rate_pct=0.0 if statuses == ["passed"] and not missing else 100.0,
+        warnings=warnings or [],
+    )
+
+
+def test_alpaca_sip_simple_backtest_blocks_missing_manifests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [],
+        missing=[ALPACA_SIP_DAILY_DATASET, ALPACA_SIP_CORP_ACTIONS_DATASET],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+    assert readiness.status == "blocked"
+    assert ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST in readiness.blockers
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def test_alpaca_sip_readiness_exposes_pairing_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+        warnings=[
+            ALPACA_SIP_COMPANION_MANIFEST_STALE,
+            ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+        ],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "quality_analysis")
+
+    assert readiness.status == "warning"
+    assert ALPACA_SIP_COMPANION_MANIFEST_STALE in readiness.warnings
+    assert ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH in readiness.warnings
+
+
+def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+    assert readiness.status == "ready"
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def test_readiness_rejects_unsupported_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(_summary([])))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    with pytest.raises(ValueError, match="Unsupported readiness dataset"):
+        service.get_readiness(DummyUser(), "unsupported", "simple_backtest")
+
+
+def test_alpaca_sip_readiness_requires_sync_view_permission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(_summary([])))
+    )
+    monkeypatch.setattr(
+        "libs.web_console_services.data_readiness_service.has_permission",
+        lambda _user, _permission: False,
+    )
+    monkeypatch.setattr(
+        "libs.web_console_services.data_readiness_service.has_dataset_permission",
+        lambda _user, _dataset: True,
+    )
+
+    with pytest.raises(PermissionError, match="view_data_sync"):
+        service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+
+def test_hybrid_readiness_requires_crsp_universe(monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {HYBRID_CRSP_SIP_DATASET_KEY})
+
+    readiness = service.get_readiness(
+        DummyUser(),
+        HYBRID_CRSP_SIP_DATASET_KEY,
+        "hybrid_research_backtest",
+    )
+
+    assert readiness.status == "blocked"
+    assert CRSP_UNIVERSE_UNAVAILABLE in readiness.blockers
+    assert HYBRID_PRICE_COMPONENT_BLOCKED in readiness.blockers
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def test_hybrid_readiness_requires_hybrid_dataset_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip", "crsp"})
+
+    with pytest.raises(PermissionError, match=HYBRID_CRSP_SIP_DATASET_KEY):
+        service.get_readiness(
+            DummyUser(),
+            HYBRID_CRSP_SIP_DATASET_KEY,
+            "hybrid_research_backtest",
+        )
+
+
+def test_hybrid_readiness_treats_composite_permission_as_sufficient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+    service = DataReadinessService(
+        manifest_service=cast(
+            DataManifestService,
+            FakeManifestService(summary, _manifest(CRSP_UNIVERSE_MANIFEST_DATASET)),
+        )
+    )
+    _allow_readiness(monkeypatch, {HYBRID_CRSP_SIP_DATASET_KEY})
+
+    readiness = service.get_readiness(
+        DummyUser(),
+        HYBRID_CRSP_SIP_DATASET_KEY,
+        "hybrid_research_backtest",
+    )
+
+    assert readiness.status == "ready"
+    assert HYBRID_PRICE_COMPONENT_READY not in readiness.blockers
+    assert CRSP_UNIVERSE_UNAVAILABLE not in readiness.blockers
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+    assert [check.code for check in readiness.checks if check.source == "manifest"] == [
+        HYBRID_PRICE_COMPONENT_READY,
+        "crsp_universe_available",
+    ]
+
+
+def test_hybrid_readiness_scrubs_sip_details_without_direct_sip_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+    service = DataReadinessService(
+        manifest_service=cast(
+            DataManifestService,
+            FakeManifestService(summary, _manifest(CRSP_UNIVERSE_MANIFEST_DATASET)),
+        )
+    )
+    _allow_readiness(monkeypatch, {HYBRID_CRSP_SIP_DATASET_KEY})
+
+    readiness = service.get_readiness(
+        DummyUser(),
+        HYBRID_CRSP_SIP_DATASET_KEY,
+        "hybrid_research_backtest",
+    )
+
+    assert readiness.status == "blocked"
+    assert readiness.blockers == [HYBRID_PRICE_COMPONENT_BLOCKED]
+    assert all("alpaca_sip" not in check.code for check in readiness.checks)
+
+
+def test_hybrid_readiness_uses_crsp_daily_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ]
+    )
+    service = DataReadinessService(
+        manifest_service=cast(
+            DataManifestService,
+            FakeManifestService(summary, _manifest(CRSP_UNIVERSE_MANIFEST_DATASET)),
+        )
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip", "crsp", HYBRID_CRSP_SIP_DATASET_KEY})
+
+    readiness = service.get_readiness(
+        DummyUser(),
+        HYBRID_CRSP_SIP_DATASET_KEY,
+        "hybrid_research_backtest",
+    )
+
+    assert readiness.status == "ready"
+    assert CRSP_UNIVERSE_UNAVAILABLE not in readiness.blockers
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def _allow_readiness(monkeypatch: pytest.MonkeyPatch, datasets: set[str]) -> None:
+    monkeypatch.setattr(
+        "libs.web_console_services.data_readiness_service.has_permission",
+        lambda _user, _permission: True,
+    )
+    monkeypatch.setattr(
+        "libs.web_console_services.data_readiness_service.has_dataset_permission",
+        lambda _user, dataset: dataset in datasets,
+    )

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
+from threading import get_ident
 from typing import cast
 
 import pytest
@@ -47,11 +48,14 @@ class FakeManifestService:
     ) -> None:
         self._summary = summary
         self._crsp_manifest = crsp_manifest
+        self.thread_ids: list[int] = []
 
     def get_alpaca_sip_summary(self) -> AlpacaSipManifestSummaryDTO:
+        self.thread_ids.append(get_ident())
         return self._summary
 
     def get_manifest_summary(self, dataset: str) -> ManifestSummaryDTO | None:
+        self.thread_ids.append(get_ident())
         if dataset == CRSP_UNIVERSE_MANIFEST_DATASET:
             return self._crsp_manifest
         return None
@@ -228,6 +232,31 @@ def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(
 
     assert readiness.status == "ready"
     assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+@pytest.mark.asyncio()
+async def test_readiness_async_offloads_manifest_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_thread_id = get_ident()
+    manifest_service = FakeManifestService(
+        _summary(
+            [
+                _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+                _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+            ],
+        )
+    )
+    service = DataReadinessService(manifest_service=cast(DataManifestService, manifest_service))
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = await service.get_readiness_async(
+        DummyUser(),
+        ALPACA_SIP_DATASET_KEY,
+        "simple_backtest",
+    )
+
+    assert readiness.status == "ready"
+    assert manifest_service.thread_ids
+    assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
 
 
 def test_readiness_rejects_unsupported_dataset(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -19,6 +19,7 @@ from libs.web_console_services.data_manifest_service import (
 from libs.web_console_services.data_readiness_service import (
     ALPACA_SIP_COMPANION_MANIFEST_STALE,
     ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+    ALPACA_SIP_MANIFEST_VALIDATION_FAILED,
     ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST,
     CRSP_UNIVERSE_MANIFEST_DATASET,
     CRSP_UNIVERSE_UNAVAILABLE,
@@ -139,6 +140,27 @@ def test_alpaca_sip_simple_backtest_blocks_missing_manifests(
     assert readiness.status == "blocked"
     assert ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST in readiness.blockers
     assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def test_alpaca_sip_readiness_uses_distinct_code_for_invalid_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, validation_status="failed"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "quality_analysis")
+
+    assert readiness.status == "blocked"
+    assert ALPACA_SIP_MANIFEST_VALIDATION_FAILED in readiness.blockers
+    assert ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST not in readiness.blockers
 
 
 def test_alpaca_sip_readiness_exposes_pairing_warnings(

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -188,6 +188,28 @@ def test_alpaca_sip_readiness_exposes_pairing_warnings(
     assert ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH in readiness.warnings
 
 
+def test_alpaca_sip_simple_backtest_blocks_pairing_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+        warnings=[ALPACA_SIP_COMPANION_MANIFEST_STALE],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+    assert readiness.status == "blocked"
+    assert ALPACA_SIP_COMPANION_MANIFEST_STALE in readiness.blockers
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
 def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -314,6 +336,34 @@ def test_hybrid_readiness_treats_composite_permission_as_sufficient(
         HYBRID_PRICE_COMPONENT_READY,
         "crsp_universe_available",
     ]
+
+
+def test_hybrid_readiness_blocks_stale_price_component_for_return_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+        warnings=[ALPACA_SIP_COMPANION_MANIFEST_STALE],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(
+            DataManifestService,
+            FakeManifestService(summary, _manifest(CRSP_UNIVERSE_MANIFEST_DATASET)),
+        )
+    )
+    _allow_readiness(monkeypatch, {HYBRID_CRSP_SIP_DATASET_KEY})
+
+    readiness = service.get_readiness(
+        DummyUser(),
+        HYBRID_CRSP_SIP_DATASET_KEY,
+        "hybrid_research_backtest",
+    )
+
+    assert readiness.status == "blocked"
+    assert readiness.blockers == [HYBRID_PRICE_COMPONENT_BLOCKED]
 
 
 def test_hybrid_readiness_scrubs_sip_details_without_direct_sip_access(

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -259,6 +259,16 @@ async def test_readiness_async_offloads_manifest_io(monkeypatch: pytest.MonkeyPa
     assert all(thread_id != main_thread_id for thread_id in manifest_service.thread_ids)
 
 
+@pytest.mark.asyncio()
+async def test_readiness_sync_api_rejects_async_context() -> None:
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(_summary([])))
+    )
+
+    with pytest.raises(RuntimeError, match="use get_readiness_async"):
+        service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+
 def test_readiness_rejects_unsupported_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
     service = DataReadinessService(
         manifest_service=cast(DataManifestService, FakeManifestService(_summary([])))


### PR DESCRIPTION
## Summary
- Add manifest-backed Backtest Readiness and Data Quality sections to the data management page.
- Fail closed for Alpaca SIP/simple backtest readiness when companion manifests are missing, stale, untrusted, mismatched, or read-time adjustment support is unavailable.
- Add hybrid CRSP universe + SIP price readiness with permission-scrubbed SIP component reason codes when users lack direct SIP access.
- Keep quality scoring stable by treating unavailable validation rows as non-scoring, and hide acknowledgment controls until durable server-side persistence exists.

## Review
- Codex: no issues found after final review pass.
- Gemini: no issues found after final review pass.
- Claude: no issues found after final review pass.

## Validation
- `ruff check apps/web_console_ng/components/data_quality_section.py apps/web_console_ng/components/data_readiness_section.py apps/web_console_ng/pages/data_management.py libs/data/data_quality/quality_scorer.py libs/web_console_services/data_quality_service.py libs/web_console_services/data_readiness_service.py libs/web_console_services/schemas/data_management.py tests/apps/web_console/services/test_data_quality_service.py tests/apps/web_console_ng/components/test_data_manifest_components.py tests/apps/web_console_ng/pages/test_data_management.py tests/libs/data/data_quality/test_quality_scorer.py tests/libs/web_console_services/test_data_quality_service.py tests/libs/web_console_services/test_data_readiness_service.py`
- `mypy --strict apps/web_console_ng/components/data_quality_section.py apps/web_console_ng/components/data_readiness_section.py apps/web_console_ng/pages/data_management.py libs/data/data_quality/quality_scorer.py libs/web_console_services/data_quality_service.py libs/web_console_services/data_readiness_service.py libs/web_console_services/schemas/data_management.py tests/apps/web_console/services/test_data_quality_service.py tests/apps/web_console_ng/components/test_data_manifest_components.py tests/apps/web_console_ng/pages/test_data_management.py tests/libs/data/data_quality/test_quality_scorer.py tests/libs/web_console_services/test_data_quality_service.py tests/libs/web_console_services/test_data_readiness_service.py`
- `pytest -q tests/libs/data/data_quality/test_quality_scorer.py tests/libs/web_console_services/test_data_readiness_service.py tests/libs/web_console_services/test_data_quality_service.py tests/apps/web_console_ng/components/test_data_manifest_components.py tests/apps/web_console_ng/pages/test_data_management.py tests/apps/web_console_ng/pages/test_data_management_wiring.py tests/apps/web_console/services/test_data_quality_service.py tests/apps/web_console/services/test_alert_acknowledgment.py` (157 passed)
- `PYTEST_XDIST_AUTO_NUM_WORKERS=4 make ci-local` (12975 passed, 24 skipped, 3 xfailed)
