### PR TITLE
feat(data): add read-time split adjustment engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ zen_precommit.changeset
 .claude/*.lock
 .claude/workflow-audit.log
 .claude/analysis/
+.claude/worktrees/
 
 # ai_workflow
 .ai_workflow/*.lock

--- a/apps/web_console_ng/components/data_context_ribbon.py
+++ b/apps/web_console_ng/components/data_context_ribbon.py
@@ -6,7 +6,10 @@ from typing import Any
 
 from nicegui import ui
 
-from apps.web_console_ng.components.data_management_common import format_datetime
+from apps.web_console_ng.components.data_management_common import (
+    format_datetime,
+    summary_supports_split_adjustment,
+)
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_DAILY_DATASET,
     ALPACA_SIP_MANIFEST_DATASETS,
@@ -70,8 +73,15 @@ def _tone_class(tone: str) -> str:
 
 def _count_backtest_blocked_rows(summary: AlpacaSipManifestSummaryDTO) -> int:
     manifests_by_dataset = {manifest.dataset: manifest for manifest in summary.manifests}
+    split_adjustment_available = summary_supports_split_adjustment(summary)
     return sum(
-        int(_dataset_blocks_backtest(dataset, manifests_by_dataset.get(dataset)))
+        int(
+            _dataset_blocks_backtest(
+                dataset,
+                manifests_by_dataset.get(dataset),
+                split_adjustment_available=split_adjustment_available,
+            )
+        )
         for dataset in ALPACA_SIP_MANIFEST_DATASETS
     )
 
@@ -79,11 +89,13 @@ def _count_backtest_blocked_rows(summary: AlpacaSipManifestSummaryDTO) -> int:
 def _dataset_blocks_backtest(
     dataset: str,
     manifest: ManifestSummaryDTO | None,
+    *,
+    split_adjustment_available: bool = False,
 ) -> bool:
     if manifest is None or manifest.validation_status != "passed":
         return True
     if dataset == ALPACA_SIP_DAILY_DATASET:
-        return manifest.read_time_adjustment_mode != "available"
+        return not split_adjustment_available and manifest.read_time_adjustment_mode != "available"
     return False
 
 

--- a/apps/web_console_ng/components/data_detail_drawer.py
+++ b/apps/web_console_ng/components/data_detail_drawer.py
@@ -9,6 +9,7 @@ from nicegui import ui
 
 from apps.web_console_ng.components.data_management_common import (
     format_datetime,
+    manifest_has_native_returns,
     summary_supports_split_adjustment,
 )
 from libs.data.data_pipeline.read_time_adjustment import (
@@ -95,7 +96,7 @@ def _present_detail_fields(
     ]
     validation_ok = manifest.validation_status == "passed"
     split_adjustment_available = summary_supports_split_adjustment(summary)
-    native_returns_available = _manifest_has_native_returns(manifest)
+    native_returns_available = manifest_has_native_returns(manifest)
     returns_available = split_adjustment_available or native_returns_available
     readiness = (
         f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
@@ -197,7 +198,7 @@ def _readiness_for_present_manifest(
             readiness = f"{readiness}; raw_sip_returns_unavailable"
         return readiness
     if is_daily:
-        if _manifest_has_native_returns(manifest):
+        if manifest_has_native_returns(manifest):
             return "ready: native adjusted returns available"
         return "blocked: raw_sip_returns_unavailable"
     if warnings:
@@ -215,12 +216,6 @@ def _daily_return_column_state(
     if native_returns_available:
         return "available"
     return "not available"
-
-
-def _manifest_has_native_returns(manifest: ManifestSummaryDTO | None) -> bool:
-    if manifest is None or manifest.validation_status != "passed":
-        return False
-    return manifest.read_time_adjustment_mode == "available"
 
 
 __all__ = ["build_manifest_detail_fields", "render_manifest_detail_drawer"]

--- a/apps/web_console_ng/components/data_detail_drawer.py
+++ b/apps/web_console_ng/components/data_detail_drawer.py
@@ -7,7 +7,15 @@ from typing import Any
 
 from nicegui import ui
 
-from apps.web_console_ng.components.data_management_common import format_datetime
+from apps.web_console_ng.components.data_management_common import (
+    format_datetime,
+    summary_supports_split_adjustment,
+)
+from libs.data.data_pipeline.read_time_adjustment import (
+    READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
+    READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+    READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE,
+)
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
@@ -21,7 +29,7 @@ _CANONICAL_STORAGE_MODES = {
 }
 
 _READ_TIME_ADJUSTMENT_MODES = {
-    ALPACA_SIP_DAILY_DATASET: "unavailable",
+    ALPACA_SIP_DAILY_DATASET: READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE,
     ALPACA_SIP_CORP_ACTIONS_DATASET: "not applicable",
 }
 
@@ -86,7 +94,14 @@ def _present_detail_fields(
         if not warning.startswith("alpaca_sip_missing_manifest:")
     ]
     validation_ok = manifest.validation_status == "passed"
-    readiness = _readiness_for_present_manifest(manifest, warnings)
+    split_adjustment_available = summary_supports_split_adjustment(summary)
+    native_returns_available = _manifest_has_native_returns(manifest)
+    returns_available = split_adjustment_available or native_returns_available
+    readiness = (
+        f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
+        if manifest.dataset == ALPACA_SIP_DAILY_DATASET and returns_available
+        else _readiness_for_present_manifest(manifest, warnings)
+    )
     fields = [
         {"field": "Dataset", "value": manifest.dataset},
         {"field": "Local state", "value": "present"},
@@ -111,7 +126,10 @@ def _present_detail_fields(
         {"field": "Canonical storage mode", "value": _canonical_storage_mode(manifest.dataset)},
         {
             "field": "Read-time adjustment mode",
-            "value": _read_time_adjustment_mode(manifest.dataset),
+            "value": _read_time_adjustment_mode_for_manifest(
+                manifest,
+                split_adjustment_available=split_adjustment_available,
+            ),
         },
         {"field": "Symbol set hash", "value": _value(manifest.symbol_set_hash)},
         {"field": "Query/params hash", "value": _value(manifest.query_params_hash)},
@@ -122,11 +140,22 @@ def _present_detail_fields(
         },
     ]
     if manifest.dataset == ALPACA_SIP_DAILY_DATASET:
+        derived_value = _daily_return_column_state(
+            split_adjustment_available=split_adjustment_available,
+            native_returns_available=native_returns_available,
+        )
         fields.extend(
             [
-                {"field": "adj_close", "value": "not available"},
-                {"field": "ret", "value": "not available"},
-                {"field": "Backtest readiness", "value": readiness},
+                {"field": "adj_close", "value": derived_value},
+                {"field": "ret", "value": derived_value},
+                {
+                    "field": "Backtest readiness",
+                    "value": (
+                        f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
+                        if returns_available
+                        else readiness
+                    ),
+                },
             ]
         )
     return fields
@@ -138,6 +167,19 @@ def _canonical_storage_mode(dataset: str) -> str:
 
 def _read_time_adjustment_mode(dataset: str) -> str:
     return _READ_TIME_ADJUSTMENT_MODES.get(dataset, "-")
+
+
+def _read_time_adjustment_mode_for_manifest(
+    manifest: ManifestSummaryDTO,
+    *,
+    split_adjustment_available: bool,
+) -> str:
+    dataset = manifest.dataset
+    if dataset == ALPACA_SIP_DAILY_DATASET and split_adjustment_available:
+        return READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED
+    if dataset == ALPACA_SIP_DAILY_DATASET and manifest.read_time_adjustment_mode:
+        return manifest.read_time_adjustment_mode
+    return _read_time_adjustment_mode(dataset)
 
 
 def _value(value: Any) -> str:
@@ -155,10 +197,30 @@ def _readiness_for_present_manifest(
             readiness = f"{readiness}; raw_sip_returns_unavailable"
         return readiness
     if is_daily:
+        if _manifest_has_native_returns(manifest):
+            return "ready: native adjusted returns available"
         return "blocked: raw_sip_returns_unavailable"
     if warnings:
         return "warn: companion manifest issue"
     return "corporate actions only"
+
+
+def _daily_return_column_state(
+    *,
+    split_adjustment_available: bool,
+    native_returns_available: bool,
+) -> str:
+    if split_adjustment_available:
+        return "derived split-adjusted"
+    if native_returns_available:
+        return "available"
+    return "not available"
+
+
+def _manifest_has_native_returns(manifest: ManifestSummaryDTO | None) -> bool:
+    if manifest is None or manifest.validation_status != "passed":
+        return False
+    return manifest.read_time_adjustment_mode == "available"
 
 
 __all__ = ["build_manifest_detail_fields", "render_manifest_detail_drawer"]

--- a/apps/web_console_ng/components/data_detail_drawer.py
+++ b/apps/web_console_ng/components/data_detail_drawer.py
@@ -97,11 +97,10 @@ def _present_detail_fields(
     validation_ok = manifest.validation_status == "passed"
     split_adjustment_available = summary_supports_split_adjustment(summary)
     native_returns_available = manifest_has_native_returns(manifest)
-    returns_available = split_adjustment_available or native_returns_available
-    readiness = (
-        f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
-        if manifest.dataset == ALPACA_SIP_DAILY_DATASET and returns_available
-        else _readiness_for_present_manifest(manifest, warnings)
+    readiness = _readiness_for_present_manifest(
+        manifest,
+        warnings,
+        split_adjustment_available=split_adjustment_available,
     )
     fields = [
         {"field": "Dataset", "value": manifest.dataset},
@@ -151,11 +150,7 @@ def _present_detail_fields(
                 {"field": "ret", "value": derived_value},
                 {
                     "field": "Backtest readiness",
-                    "value": (
-                        f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
-                        if returns_available
-                        else readiness
-                    ),
+                    "value": readiness,
                 },
             ]
         )
@@ -190,6 +185,8 @@ def _value(value: Any) -> str:
 def _readiness_for_present_manifest(
     manifest: ManifestSummaryDTO,
     warnings: list[str],
+    *,
+    split_adjustment_available: bool,
 ) -> str:
     is_daily = manifest.dataset == ALPACA_SIP_DAILY_DATASET
     if manifest.validation_status != "passed":
@@ -198,6 +195,8 @@ def _readiness_for_present_manifest(
             readiness = f"{readiness}; raw_sip_returns_unavailable"
         return readiness
     if is_daily:
+        if split_adjustment_available:
+            return f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
         if manifest_has_native_returns(manifest):
             return "ready: native adjusted returns available"
         return "blocked: raw_sip_returns_unavailable"

--- a/apps/web_console_ng/components/data_management_common.py
+++ b/apps/web_console_ng/components/data_management_common.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 from typing import Any
 
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    AlpacaSipManifestSummaryDTO,
+)
+
 TREND_DATASETS: tuple[str, ...] = (
     "crsp",
     "compustat",
     "taq",
     "fama_french",
     "alpaca_sip",
+)
+_SPLIT_ADJUSTMENT_BLOCKING_WARNINGS = frozenset(
+    {
+        "alpaca_sip_companion_manifest_stale",
+        "alpaca_sip_companion_symbol_set_mismatch",
+    }
 )
 
 
@@ -29,4 +41,21 @@ def get_user_id_safe(user: Any) -> str | None:
     return str(val) if val is not None else None
 
 
-__all__ = ["TREND_DATASETS", "format_datetime", "get_user_id_safe"]
+def summary_supports_split_adjustment(summary: AlpacaSipManifestSummaryDTO) -> bool:
+    """Return whether Alpaca SIP daily bars can use read-time split adjustment."""
+    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
+    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
+    corp_actions = manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
+    if daily is None or corp_actions is None:
+        return False
+    if daily.validation_status != "passed" or corp_actions.validation_status != "passed":
+        return False
+    return not any(warning in _SPLIT_ADJUSTMENT_BLOCKING_WARNINGS for warning in summary.warnings)
+
+
+__all__ = [
+    "TREND_DATASETS",
+    "format_datetime",
+    "get_user_id_safe",
+    "summary_supports_split_adjustment",
+]

--- a/apps/web_console_ng/components/data_management_common.py
+++ b/apps/web_console_ng/components/data_management_common.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from libs.web_console_services.data_manifest_service import (
-    ALPACA_SIP_CORP_ACTIONS_DATASET,
-    ALPACA_SIP_DAILY_DATASET,
-    AlpacaSipManifestSummaryDTO,
+from libs.web_console_services.alpaca_sip_manifest_helpers import (
+    manifest_has_native_returns,
+    summary_supports_split_adjustment,
 )
 
 TREND_DATASETS: tuple[str, ...] = (
@@ -16,12 +15,6 @@ TREND_DATASETS: tuple[str, ...] = (
     "taq",
     "fama_french",
     "alpaca_sip",
-)
-_SPLIT_ADJUSTMENT_BLOCKING_WARNINGS = frozenset(
-    {
-        "alpaca_sip_companion_manifest_stale",
-        "alpaca_sip_companion_symbol_set_mismatch",
-    }
 )
 
 
@@ -41,21 +34,10 @@ def get_user_id_safe(user: Any) -> str | None:
     return str(val) if val is not None else None
 
 
-def summary_supports_split_adjustment(summary: AlpacaSipManifestSummaryDTO) -> bool:
-    """Return whether Alpaca SIP daily bars can use read-time split adjustment."""
-    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
-    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    corp_actions = manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
-    if daily is None or corp_actions is None:
-        return False
-    if daily.validation_status != "passed" or corp_actions.validation_status != "passed":
-        return False
-    return not any(warning in _SPLIT_ADJUSTMENT_BLOCKING_WARNINGS for warning in summary.warnings)
-
-
 __all__ = [
     "TREND_DATASETS",
     "format_datetime",
     "get_user_id_safe",
+    "manifest_has_native_returns",
     "summary_supports_split_adjustment",
 ]

--- a/apps/web_console_ng/components/data_operations_grid.py
+++ b/apps/web_console_ng/components/data_operations_grid.py
@@ -8,6 +8,7 @@ from nicegui import ui
 
 from apps.web_console_ng.components.data_management_common import (
     format_datetime,
+    manifest_has_native_returns,
     summary_supports_split_adjustment,
 )
 from libs.data.data_pipeline.read_time_adjustment import (
@@ -72,11 +73,11 @@ def _row_from_manifest_or_missing(
     is_daily = dataset == ALPACA_SIP_DAILY_DATASET
     raw_state = "Raw OHLC" if is_daily else "-"
     adjustment_available = summary_supports_split_adjustment(summary)
-    returns_available = adjustment_available or _manifest_has_native_returns(manifest)
+    returns_available = adjustment_available or manifest_has_native_returns(manifest)
     adjustment_state = _adjustment_state(
         is_daily,
         split_adjustment_available=adjustment_available,
-        native_returns_available=_manifest_has_native_returns(manifest),
+        native_returns_available=manifest_has_native_returns(manifest),
     )
     if manifest is None:
         readiness = "blocked: alpaca_sip_untrusted_without_manifest"
@@ -171,7 +172,7 @@ def _warnings_for_dataset(
             (item for item in summary.manifests if item.dataset == ALPACA_SIP_DAILY_DATASET),
             None,
         )
-        if not summary_supports_split_adjustment(summary) and not _manifest_has_native_returns(
+        if not summary_supports_split_adjustment(summary) and not manifest_has_native_returns(
             manifest
         ):
             warnings.append("raw_sip_returns_unavailable")
@@ -191,12 +192,6 @@ def _adjustment_state(
     if native_returns_available:
         return "adj_close/ret: available"
     return "adj_close: not available; ret: not available"
-
-
-def _manifest_has_native_returns(manifest: ManifestSummaryDTO | None) -> bool:
-    if manifest is None or manifest.validation_status != "passed":
-        return False
-    return manifest.read_time_adjustment_mode == "available"
 
 
 __all__ = ["build_manifest_grid_rows", "render_manifest_operations_grid"]

--- a/apps/web_console_ng/components/data_operations_grid.py
+++ b/apps/web_console_ng/components/data_operations_grid.py
@@ -6,7 +6,15 @@ from typing import Any
 
 from nicegui import ui
 
-from apps.web_console_ng.components.data_management_common import format_datetime
+from apps.web_console_ng.components.data_management_common import (
+    format_datetime,
+    summary_supports_split_adjustment,
+)
+from libs.data.data_pipeline.read_time_adjustment import (
+    READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
+    READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+    READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE,
+)
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
@@ -63,8 +71,12 @@ def _row_from_manifest_or_missing(
     warnings = _warnings_for_dataset(dataset, summary)
     is_daily = dataset == ALPACA_SIP_DAILY_DATASET
     raw_state = "Raw OHLC" if is_daily else "-"
-    adjustment_state = (
-        "adj_close: not available; ret: not available" if is_daily else "not price bars"
+    adjustment_available = summary_supports_split_adjustment(summary)
+    returns_available = adjustment_available or _manifest_has_native_returns(manifest)
+    adjustment_state = _adjustment_state(
+        is_daily,
+        split_adjustment_available=adjustment_available,
+        native_returns_available=_manifest_has_native_returns(manifest),
     )
     if manifest is None:
         readiness = "blocked: alpaca_sip_untrusted_without_manifest"
@@ -89,7 +101,9 @@ def _row_from_manifest_or_missing(
             "manifest_checksum": None,
             "adjustment_state": adjustment_state,
             "canonical_storage_mode": "raw" if is_daily else None,
-            "read_time_adjustment_mode": "unavailable" if is_daily else None,
+            "read_time_adjustment_mode": (
+                READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE if is_daily else None
+            ),
             "trusted_manifest_backed": False,
         }
 
@@ -102,6 +116,8 @@ def _row_from_manifest_or_missing(
         readiness = "blocked: untrusted_manifest_validation_failed"
         if is_daily:
             readiness = f"{readiness}; raw_sip_returns_unavailable"
+    elif is_daily and returns_available:
+        readiness = f"ready: {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}"
     elif is_daily:
         readiness = "blocked: raw_sip_returns_unavailable"
     elif warnings:
@@ -128,7 +144,11 @@ def _row_from_manifest_or_missing(
         "manifest_checksum": manifest.manifest_checksum,
         "adjustment_state": adjustment_state,
         "canonical_storage_mode": manifest.canonical_storage_mode,
-        "read_time_adjustment_mode": manifest.read_time_adjustment_mode,
+        "read_time_adjustment_mode": (
+            READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED
+            if is_daily and adjustment_available
+            else manifest.read_time_adjustment_mode
+        ),
         "trusted_manifest_backed": validation_ok,
     }
 
@@ -147,8 +167,36 @@ def _warnings_for_dataset(
         }:
             warnings.append(warning)
     if dataset == ALPACA_SIP_DAILY_DATASET:
-        warnings.append("raw_sip_returns_unavailable")
+        manifest = next(
+            (item for item in summary.manifests if item.dataset == ALPACA_SIP_DAILY_DATASET),
+            None,
+        )
+        if not summary_supports_split_adjustment(summary) and not _manifest_has_native_returns(
+            manifest
+        ):
+            warnings.append("raw_sip_returns_unavailable")
     return sorted(set(warnings))
+
+
+def _adjustment_state(
+    is_daily: bool,
+    *,
+    split_adjustment_available: bool,
+    native_returns_available: bool,
+) -> str:
+    if not is_daily:
+        return "not price bars"
+    if split_adjustment_available:
+        return "adj_close/ret: derived split-adjusted"
+    if native_returns_available:
+        return "adj_close/ret: available"
+    return "adj_close: not available; ret: not available"
+
+
+def _manifest_has_native_returns(manifest: ManifestSummaryDTO | None) -> bool:
+    if manifest is None or manifest.validation_status != "passed":
+        return False
+    return manifest.read_time_adjustment_mode == "available"
 
 
 __all__ = ["build_manifest_grid_rows", "render_manifest_operations_grid"]

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -541,6 +541,7 @@ async def _render_data_explorer_section(
     dataset_map: dict[str, DatasetInfoDTO] = {}
     refresh_query_controls: Callable[[], None] | None = None
     refresh_adjustment_policy: Callable[[], None] | None = None
+    adjusted_preview_container: Any | None = None
 
     with ui.row().classes("w-full gap-4"):
         # Dataset browser sidebar
@@ -655,6 +656,8 @@ async def _render_data_explorer_section(
                 async def on_dataset_change(e: Any) -> None:
                     ds = str(e.value) if e.value else None
                     selected_dataset["value"] = ds
+                    if adjusted_preview_container is not None:
+                        adjusted_preview_container.clear()
                     _show_dataset_info(ds)
                     await _load_schema(ds)
                     if refresh_query_controls is not None:
@@ -675,12 +678,50 @@ async def _render_data_explorer_section(
         # Main content area
         with ui.column().classes("flex-1"):
             adjustment_policy_container = ui.column().classes("w-full mb-4")
+            adjusted_preview_container = ui.column().classes("w-full mb-4")
 
             def _selected_dataset_info() -> DatasetInfoDTO | None:
                 ds = selected_dataset["value"]
                 if ds is None:
                     return None
                 return dataset_map.get(ds)
+
+            async def _load_adjusted_preview() -> None:
+                ds = selected_dataset["value"]
+                if ds != ALPACA_SIP_DATASET_KEY:
+                    ui.notify("Adjusted preview is only available for Alpaca SIP", type="warning")
+                    return
+                if adjusted_preview_container is None:
+                    return
+                adjusted_preview_container.clear()
+                try:
+                    preview = await explorer_service.get_dataset_preview(
+                        user,
+                        ds,
+                        limit=50,
+                        table="alpaca_sip_daily",
+                        read_time_adjustment_mode="split_adjusted",
+                    )
+                    with adjusted_preview_container:
+                        ui.label("Adjusted Preview").classes("font-bold mb-1")
+                        _render_preview_adjustment_metadata(preview)
+                        _render_preview_table(preview)
+                except ValueError as e:
+                    with adjusted_preview_container:
+                        ui.label(str(e)).classes("text-sm text-amber-600")
+                except PermissionError as e:
+                    ui.notify(str(e), type="negative")
+                except Exception:
+                    logger.exception(
+                        "adjusted_preview_failed",
+                        extra={
+                            "method": "get_dataset_preview",
+                            "service": "DataExplorerService",
+                            "dataset": ds,
+                            "user_id": _get_user_id_safe(user),
+                        },
+                    )
+                    ui.notify("Adjusted preview temporarily unavailable", type="warning")
 
             def _refresh_adjustment_policy() -> None:
                 adjustment_policy_container.clear()
@@ -689,7 +730,10 @@ async def _render_data_explorer_section(
                     return
                 with adjustment_policy_container:
                     _render_adjustment_policy_summary(info)
-                    _render_adjusted_preview_controls(info)
+                    _render_adjusted_preview_controls(
+                        info,
+                        on_preview=_load_adjusted_preview if has_query else None,
+                    )
 
             refresh_adjustment_policy = _refresh_adjustment_policy
             _refresh_adjustment_policy()
@@ -896,25 +940,27 @@ def _render_adjustment_policy_summary(payload: DatasetInfoDTO | DataPreviewDTO) 
             ui.label(line).classes("text-xs text-amber-800")
 
 
-def _render_adjusted_preview_controls(dataset_info: DatasetInfoDTO) -> None:
-    """Show the future adjusted preview affordance in a disabled state."""
+def _render_adjusted_preview_controls(
+    dataset_info: DatasetInfoDTO,
+    *,
+    on_preview: Callable[[], Any] | None = None,
+) -> None:
+    """Render adjusted preview controls for datasets with adjustment metadata."""
     if dataset_info.canonical_storage_mode is None and dataset_info.backtest_handoff is None:
         return
     handoff = dataset_info.backtest_handoff
+    preview_available = bool(handoff and handoff.adjusted_preview_available and on_preview)
     unavailable_reason = "read_time_adjustment_layer_not_defined"
     if handoff is not None:
         unavailable_reason = handoff.adjusted_preview_unavailable_reason or unavailable_reason
     with ui.row().classes("w-full gap-2 items-end mt-2"):
-        ui.select(
-            label="Preview Mode",
-            options={
-                "raw": "Raw canonical",
-                "adjusted": "Adjusted derived preview",
-            },
-            value="raw",
-        ).classes("w-56").props("disable")
-        ui.button("Adjusted Preview").props("flat disable")
-        ui.label(unavailable_reason).classes("text-xs text-gray-500")
+        ui.label("Preview mode: split_adjusted").classes("text-xs text-gray-600")
+        button = ui.button("Adjusted Preview", on_click=on_preview if preview_available else None)
+        button.props("flat" if preview_available else "flat disable")
+        if preview_available:
+            ui.label("split_adjusted_read_time_available").classes("text-xs text-green-700")
+        else:
+            ui.label(unavailable_reason).classes("text-xs text-gray-500")
 
 
 def _render_preview_adjustment_metadata(preview: DataPreviewDTO) -> None:
@@ -942,6 +988,12 @@ def _preview_provenance_lines(preview: DataPreviewDTO) -> list[str]:
     for label, value in fields:
         if value is not None and str(value):
             lines.append(f"{label}: {value}")
+    if preview.derived:
+        lines.append(f"derived: {str(preview.derived).lower()}")
+    if preview.derivation_mode:
+        lines.append(f"derivation_mode: {preview.derivation_mode}")
+    if preview.derivation_reason_codes:
+        lines.append("derivation_reasons: " + ", ".join(preview.derivation_reason_codes))
     return lines
 
 
@@ -1006,6 +1058,20 @@ def _build_query_results(
         ui.label(f"Showing: {len(result.rows)} rows").classes("text-sm text-gray-600")
         if result.has_more:
             ui.label("(more results available)").classes("text-sm text-amber-600")
+
+
+def _render_preview_table(preview: DataPreviewDTO) -> None:
+    if not preview.columns:
+        ui.label("No preview rows").classes("text-gray-500")
+        return
+    columns: list[dict[str, Any]] = [
+        {"name": col, "label": col, "field": col, "sortable": True} for col in preview.columns
+    ]
+    ui.table(columns=columns, rows=preview.rows).classes("w-full")
+    with ui.row().classes("gap-4 mt-2"):
+        ui.label(f"Showing: {len(preview.rows)} rows").classes("text-sm text-gray-600")
+        if preview.has_more:
+            ui.label("(more preview rows available)").classes("text-sm text-amber-600")
 
 
 # =============================================================================

--- a/docs/ADRs/ADR-0041-alpaca-sip-historical-provider.md
+++ b/docs/ADRs/ADR-0041-alpaca-sip-historical-provider.md
@@ -97,15 +97,17 @@ path unchanged.
   timing differences.
 - Alpaca SIP cannot provide point-in-time universes in Phase 1.
 - Cost model computation remains CRSP-only in this slice.
-- The Phase 2 sync foundation stores adjusted bars by default. Corporate-action
-  announcements are now synced separately, but raw-bar reconstruction remains
-  future work until the adjustment pipeline consumes those announcements.
+- The Phase 2 sync foundation stores raw bars by default. ADR-0043 adds a
+  read-time split-adjusted derivation path, while dividend-aware total-return
+  adjustment remains future work.
 
 ## Required Follow-Up
 
 - Run the Phase 0 entitlement and reconciliation spike before relying on SIP
   results for strategy decisions.
 - Live-validate corporate-actions ingestion before broad usage.
+- Use ADR-0043 for split-adjusted read-time previews; add a follow-up ADR before
+  claiming dividend-aware total-return semantics.
 - Use ADR-0042 for the research-only hybrid simple-backtest path; add a new ADR
   if a production-grade PIT hybrid is designed.
 - Update ADR-016 or replace it with a broader multi-provider selection ADR if

--- a/docs/ADRs/ADR-0043-read-time-adjustment-engine.md
+++ b/docs/ADRs/ADR-0043-read-time-adjustment-engine.md
@@ -1,0 +1,62 @@
+# ADR-0043: Read-Time Adjustment Engine
+
+## Status
+Accepted
+
+## Date
+2026-05-11
+
+## Context
+
+Alpaca SIP daily bars are stored as immutable raw canonical OHLCV data. PR #218
+and the data-page phases made that raw state visible and blocked workflows that
+would derive returns directly from raw `close`.
+
+The data page now needs an explicit adjustment layer so operators can preview
+derived prices and backtest handoff metadata without rewriting canonical
+storage or implying that raw SIP closes are adjusted.
+
+## Decision
+
+Add a shared read-time adjustment engine that derives `split_adjusted` outputs
+from trusted `alpaca_sip_daily` bars plus trusted `alpaca_sip_corp_actions`
+inputs.
+
+The initial accepted scope is:
+
+- Raw canonical parquet remains unchanged.
+- The engine derives preview/result columns at read time: adjusted OHLCV,
+  `adj_close`, `ret`, adjustment factor, derivation mode, and provenance reason
+  codes.
+- Split ratios come from corporate-action rows whose `ca_type` contains
+  `split`, with `new_rate / old_rate` applied backward before the action date.
+- Missing or invalid split rows are skipped with explicit reason codes.
+- If trusted corporate actions show no split events in scope, the engine still
+  derives an identity adjusted path and computes returns from that derived path.
+- Data Explorer may enable adjusted previews only when both SIP manifests are
+  trusted and companion-manifest checks are clean.
+- The Alpaca SIP data-provider adapter applies the same derivation before
+  simple backtests consume local SIP bars, so readiness and execution agree.
+- Backtest handoff metadata must continue to carry role-keyed manifest IDs,
+  references, checksums, provider signatures, canonical storage modes, and
+  read-time adjustment modes.
+
+Out of scope for this ADR:
+
+- Rewriting canonical raw OHLCV parquet.
+- Treating raw `close` as an adjusted return source.
+- A persisted adjusted dataset.
+- Production-grade dividend total-return adjustment. Cash-dividend handling
+  remains future work and must be explicitly accepted before total-return
+  claims are made.
+
+## Consequences
+
+The data page can now show a dense raw-vs-derived workflow without creating a
+second physical dataset. Backtest readiness can distinguish raw canonical
+storage from a derived read-time price path.
+
+The initial engine is intentionally conservative. It unblocks split-adjusted
+price-return previews, but dividend-aware total-return semantics still require
+a follow-up design and validation pass before production research uses them as
+authoritative total returns.

--- a/docs/ADRs/ADR-0043-read-time-adjustment-engine.md
+++ b/docs/ADRs/ADR-0043-read-time-adjustment-engine.md
@@ -37,6 +37,10 @@ The initial accepted scope is:
   trusted and companion-manifest checks are clean.
 - The Alpaca SIP data-provider adapter applies the same derivation before
   simple backtests consume local SIP bars, so readiness and execution agree.
+- Pinned Alpaca SIP daily snapshots must not read the mutable current
+  `alpaca_sip_corp_actions` manifest. Until backtest metadata can pin and
+  record both inputs together, read-time adjustment is disabled for pinned
+  daily-provider reads and callers fail closed on missing adjusted returns.
 - Backtest handoff metadata must continue to carry role-keyed manifest IDs,
   references, checksums, provider signatures, canonical storage modes, and
   read-time adjustment modes.

--- a/docs/CONCEPTS/read-time-adjustment-service-contract.md
+++ b/docs/CONCEPTS/read-time-adjustment-service-contract.md
@@ -1,6 +1,6 @@
 # Read-Time Adjustment Service Contract Draft
 
-Status: draft for Data Page phase 4. This is not an accepted ADR and does not enable adjusted previews or backtests by itself.
+Status: superseded by ADR-0043 for the initial `split_adjusted` read-time engine.
 
 ## Purpose
 
@@ -22,7 +22,8 @@ Required fields:
 - `roles`: role-keyed inputs for `universe`, `prices`, and `corp_actions`.
 - `start_date` and `end_date`: requested date bounds.
 - `symbols` or `symbol_source`: explicit symbol set or reproducible source.
-- `read_time_adjustment_mode`: requested mode. Phase 4 only supports `unavailable`; future accepted designs may add modes such as `split_adjusted`.
+- `read_time_adjustment_mode`: requested mode. ADR-0043 accepts `split_adjusted`
+  for trusted Alpaca SIP daily bars plus trusted corporate actions.
 
 ## Response Shape
 
@@ -44,6 +45,12 @@ Phase 4 wired codes:
 - `alpaca_sip_manifest_validation_failed`
 - `alpaca_sip_manifest_summary_unavailable`
 
+ADR-0043 wired codes:
+
+- `split_adjusted_read_time_available`
+- `split_adjusted_no_split_actions_in_scope`
+- `split_adjusted_invalid_split_actions_skipped`
+
 Draft/future companion-state codes:
 
 - `alpaca_sip_companion_manifest_stale`
@@ -54,3 +61,14 @@ Draft/future companion-state codes:
 - Data Explorer displays raw canonical storage and unavailable read-time adjustment state.
 - Adjusted preview controls remain disabled with `read_time_adjustment_layer_not_defined`.
 - Backtest handoff metadata may be built for inspection, but backtest submission must remain fail-closed while adjusted returns are unavailable.
+
+## ADR-0043 Behavior
+
+- Data Explorer can request a derived `split_adjusted` preview when both
+  Alpaca SIP manifests are trusted and companion checks are clean.
+- Alpaca SIP simple-backtest fetches use the same split-adjusted read-time
+  derivation before enforcing `adj_close`/`ret` availability.
+- Raw canonical storage remains labeled `raw`.
+- Derived previews carry read-time mode, manifest provenance, provider
+  signatures, and derivation reason codes.
+- Dividend-aware total-return adjustment remains out of scope.

--- a/libs/data/data_pipeline/helpers.py
+++ b/libs/data/data_pipeline/helpers.py
@@ -1,0 +1,30 @@
+"""Shared helpers for dataframe-oriented data pipeline code."""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def normalized_symbols_from_frame(
+    frame: pl.DataFrame,
+    *,
+    column: str = "symbol",
+) -> list[str]:
+    """Return sorted, unique, normalized symbols from a Polars frame."""
+    if frame.is_empty() or column not in frame.columns:
+        return []
+
+    symbols = (
+        frame.get_column(column)
+        .cast(pl.Utf8, strict=False)
+        .str.strip_chars()
+        .str.to_uppercase()
+        .drop_nulls()
+        .unique()
+        .sort()
+        .to_list()
+    )
+    return [symbol for symbol in symbols if isinstance(symbol, str) and symbol]
+
+
+__all__ = ["normalized_symbols_from_frame"]

--- a/libs/data/data_pipeline/read_time_adjustment.py
+++ b/libs/data/data_pipeline/read_time_adjustment.py
@@ -24,12 +24,16 @@ _PRICE_COLUMNS = ("open", "high", "low", "close")
 _CORP_ACTION_REQUIRED_COLUMNS = frozenset({"symbol", "ca_type", "old_rate", "new_rate"})
 _CORP_ACTION_DATE_COLUMNS = ("ex_date", "process_date")
 _SUPPORTED_SPLIT_CA_TYPES = (
+    "forward_split",
+    "forward_splits",
     "reverse_split",
     "reverse_splits",
     "split",
     "splits",
     "stock_split",
     "stock_splits",
+    "unit_split",
+    "unit_splits",
 )
 
 
@@ -118,15 +122,16 @@ def derive_split_adjusted_prices(
 
 
 def _normalize_prices(prices: pl.DataFrame) -> pl.DataFrame:
-    normalized = prices.with_row_index("__input_order").with_columns(
+    return prices.with_row_index("__input_order").with_columns(
         [
-            pl.col("symbol").cast(pl.Utf8).str.to_uppercase(),
+            pl.col("symbol").cast(pl.Utf8).str.strip_chars().str.to_uppercase(),
             pl.col("date").cast(pl.Date, strict=False),
+            *[
+                pl.col(column).cast(pl.Float64, strict=False)
+                for column in (*_PRICE_COLUMNS, "volume")
+            ],
         ]
     )
-    for column in (*_PRICE_COLUMNS, "volume"):
-        normalized = normalized.with_columns(pl.col(column).cast(pl.Float64, strict=False))
-    return normalized
 
 
 def _split_actions(corporate_actions: pl.DataFrame) -> tuple[pl.DataFrame, int]:
@@ -140,8 +145,12 @@ def _split_actions(corporate_actions: pl.DataFrame) -> tuple[pl.DataFrame, int]:
     ]
     normalized = corporate_actions.with_columns(
         [
-            pl.col("symbol").cast(pl.Utf8).str.to_uppercase(),
-            pl.col("ca_type").cast(pl.Utf8).str.to_lowercase(),
+            pl.col("symbol").cast(pl.Utf8).str.strip_chars().str.to_uppercase(),
+            pl.col("ca_type")
+            .cast(pl.Utf8)
+            .str.strip_chars()
+            .str.to_lowercase()
+            .str.replace_all(r"\s+", "_"),
             pl.coalesce(date_exprs).alias("date"),
             pl.col("old_rate").cast(pl.Float64, strict=False),
             pl.col("new_rate").cast(pl.Float64, strict=False),
@@ -152,6 +161,8 @@ def _split_actions(corporate_actions: pl.DataFrame) -> tuple[pl.DataFrame, int]:
         pl.col("date").is_not_null()
         & pl.col("old_rate").is_not_null()
         & pl.col("new_rate").is_not_null()
+        & pl.col("old_rate").is_finite()
+        & pl.col("new_rate").is_finite()
         & (pl.col("old_rate") > 0)
         & (pl.col("new_rate") > 0)
     )

--- a/libs/data/data_pipeline/read_time_adjustment.py
+++ b/libs/data/data_pipeline/read_time_adjustment.py
@@ -1,0 +1,243 @@
+"""Read-time adjustment engine for raw canonical market data.
+
+The engine derives adjusted preview/result columns from immutable raw inputs.
+It does not rewrite canonical parquet storage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import polars as pl
+
+READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE: Literal["unavailable"] = "unavailable"
+READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED: Literal["split_adjusted"] = "split_adjusted"
+READ_TIME_ADJUSTMENT_AVAILABLE_REASON = "split_adjusted_read_time_available"
+READ_TIME_NO_SPLIT_ACTIONS_REASON = "split_adjusted_no_split_actions_in_scope"
+READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON = "split_adjusted_invalid_split_actions_skipped"
+
+ReadTimeAdjustmentMode = Literal["split_adjusted"]
+
+_PRICE_REQUIRED_COLUMNS = frozenset({"symbol", "date", "open", "high", "low", "close", "volume"})
+_PRICE_COLUMNS = ("open", "high", "low", "close")
+_CORP_ACTION_REQUIRED_COLUMNS = frozenset({"symbol", "ca_type", "old_rate", "new_rate"})
+_CORP_ACTION_DATE_COLUMNS = ("ex_date", "process_date")
+
+
+@dataclass(frozen=True)
+class ReadTimeAdjustmentResult:
+    """Derived read-time adjustment output and stable reason metadata."""
+
+    frame: pl.DataFrame
+    mode: ReadTimeAdjustmentMode
+    reason_codes: tuple[str, ...]
+    split_action_count: int
+    skipped_action_count: int
+
+
+def derive_split_adjusted_prices(
+    prices: pl.DataFrame,
+    corporate_actions: pl.DataFrame,
+) -> ReadTimeAdjustmentResult:
+    """Derive split-adjusted OHLCV and return columns from raw SIP inputs.
+
+    The returned frame preserves raw ``open/high/low/close/volume`` columns,
+    adds ``adj_open/adj_high/adj_low/adj_close/adj_volume`` plus ``ret``, and
+    records that the output was derived at read time.
+    """
+    _require_columns(prices, _PRICE_REQUIRED_COLUMNS, label="prices")
+    _require_columns(corporate_actions, _CORP_ACTION_REQUIRED_COLUMNS, label="corporate_actions")
+    if not any(column in corporate_actions.columns for column in _CORP_ACTION_DATE_COLUMNS):
+        raise ValueError(
+            "corporate_actions missing required action date column: "
+            "one of ex_date or process_date"
+        )
+
+    if prices.is_empty():
+        return ReadTimeAdjustmentResult(
+            frame=_empty_adjusted_frame(prices),
+            mode=READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+            reason_codes=(READ_TIME_NO_SPLIT_ACTIONS_REASON,),
+            split_action_count=0,
+            skipped_action_count=0,
+        )
+
+    normalized_prices = _normalize_prices(prices)
+    split_actions, skipped_action_count = _split_actions(corporate_actions)
+    split_factor = _split_factor_frame(normalized_prices, split_actions)
+    adjusted = (
+        normalized_prices.join(split_factor, on=["symbol", "date"], how="left")
+        .with_columns(pl.col("__split_factor").fill_null(1.0))
+        .with_columns(
+            [
+                pl.col("__split_factor").alias("split_adjustment_factor"),
+                (pl.col("open") / pl.col("__split_factor")).alias("adj_open"),
+                (pl.col("high") / pl.col("__split_factor")).alias("adj_high"),
+                (pl.col("low") / pl.col("__split_factor")).alias("adj_low"),
+                (pl.col("close") / pl.col("__split_factor")).alias("adj_close"),
+                (pl.col("volume") * pl.col("__split_factor")).alias("adj_volume"),
+                pl.lit(READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED).alias("read_time_adjustment_mode"),
+                pl.lit("alpaca_sip_daily+alpaca_sip_corp_actions").alias("derived_from"),
+            ]
+        )
+        .sort(["symbol", "date"])
+        .with_columns(pl.col("adj_close").shift(1).over("symbol").alias("__prev_adj_close"))
+        .with_columns(
+            pl.when(pl.col("__prev_adj_close").is_not_null() & (pl.col("__prev_adj_close") != 0))
+            .then((pl.col("adj_close") / pl.col("__prev_adj_close")) - 1.0)
+            .otherwise(None)
+            .alias("ret")
+        )
+        .sort("__input_order")
+        .drop(["__input_order", "__split_factor", "__prev_adj_close"])
+    )
+
+    reason_codes: set[str] = {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}
+    if split_actions.is_empty():
+        reason_codes.add(READ_TIME_NO_SPLIT_ACTIONS_REASON)
+    if skipped_action_count:
+        reason_codes.add(READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON)
+
+    return ReadTimeAdjustmentResult(
+        frame=adjusted,
+        mode=READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+        reason_codes=tuple(sorted(reason_codes)),
+        split_action_count=len(split_actions),
+        skipped_action_count=skipped_action_count,
+    )
+
+
+def _normalize_prices(prices: pl.DataFrame) -> pl.DataFrame:
+    normalized = prices.with_row_index("__input_order").with_columns(
+        [
+            pl.col("symbol").cast(pl.Utf8).str.to_uppercase(),
+            pl.col("date").cast(pl.Date, strict=False),
+        ]
+    )
+    for column in (*_PRICE_COLUMNS, "volume"):
+        normalized = normalized.with_columns(pl.col(column).cast(pl.Float64, strict=False))
+    return normalized
+
+
+def _split_actions(corporate_actions: pl.DataFrame) -> tuple[pl.DataFrame, int]:
+    if corporate_actions.is_empty():
+        return _empty_split_actions(), 0
+
+    date_exprs = [
+        pl.col(column).cast(pl.Date, strict=False)
+        for column in _CORP_ACTION_DATE_COLUMNS
+        if column in corporate_actions.columns
+    ]
+    normalized = corporate_actions.with_columns(
+        [
+            pl.col("symbol").cast(pl.Utf8).str.to_uppercase(),
+            pl.col("ca_type").cast(pl.Utf8).str.to_lowercase(),
+            pl.coalesce(date_exprs).alias("date"),
+            pl.col("old_rate").cast(pl.Float64, strict=False),
+            pl.col("new_rate").cast(pl.Float64, strict=False),
+        ]
+    )
+    splits = normalized.filter(pl.col("ca_type").str.contains("split"))
+    valid_splits = splits.filter(
+        pl.col("date").is_not_null()
+        & pl.col("old_rate").is_not_null()
+        & pl.col("new_rate").is_not_null()
+        & (pl.col("old_rate") > 0)
+        & (pl.col("new_rate") > 0)
+    )
+    skipped_action_count = len(splits) - len(valid_splits)
+    if valid_splits.is_empty():
+        return _empty_split_actions(), skipped_action_count
+
+    split_actions = (
+        valid_splits.select(
+            [
+                "symbol",
+                "date",
+                (pl.col("new_rate") / pl.col("old_rate")).alias("split_ratio"),
+            ]
+        )
+        .group_by(["symbol", "date"])
+        .agg(pl.col("split_ratio").product())
+        .sort(["symbol", "date"])
+    )
+    return split_actions, skipped_action_count
+
+
+def _split_factor_frame(prices: pl.DataFrame, split_actions: pl.DataFrame) -> pl.DataFrame:
+    price_rows = prices.select(["symbol", "date"]).with_columns(
+        [
+            pl.lit(1.0).alias("split_ratio"),
+            pl.lit(True).alias("__is_price_row"),
+        ]
+    )
+    action_rows = split_actions.with_columns(pl.lit(False).alias("__is_price_row"))
+    timeline = (
+        pl.concat([price_rows, action_rows], how="vertical")
+        .group_by(["symbol", "date"])
+        .agg(
+            [
+                pl.col("split_ratio").product(),
+                pl.col("__is_price_row").max(),
+            ]
+        )
+        .sort(["symbol", "date"])
+        .with_columns(
+            pl.col("split_ratio")
+            .reverse()
+            .cum_prod()
+            .shift(1, fill_value=1.0)
+            .reverse()
+            .over("symbol")
+            .alias("__split_factor")
+        )
+    )
+    return timeline.filter(pl.col("__is_price_row")).select(["symbol", "date", "__split_factor"])
+
+
+def _empty_adjusted_frame(prices: pl.DataFrame) -> pl.DataFrame:
+    frame = prices.clone()
+    for column in (
+        "split_adjustment_factor",
+        "adj_open",
+        "adj_high",
+        "adj_low",
+        "adj_close",
+        "adj_volume",
+        "ret",
+    ):
+        if column not in frame.columns:
+            frame = frame.with_columns(pl.lit(None).cast(pl.Float64).alias(column))
+    if "read_time_adjustment_mode" not in frame.columns:
+        frame = frame.with_columns(pl.lit(None).cast(pl.Utf8).alias("read_time_adjustment_mode"))
+    if "derived_from" not in frame.columns:
+        frame = frame.with_columns(pl.lit(None).cast(pl.Utf8).alias("derived_from"))
+    return frame
+
+
+def _empty_split_actions() -> pl.DataFrame:
+    return pl.DataFrame({"symbol": [], "date": [], "split_ratio": []}).with_columns(
+        [
+            pl.col("symbol").cast(pl.Utf8),
+            pl.col("date").cast(pl.Date),
+            pl.col("split_ratio").cast(pl.Float64),
+        ]
+    )
+
+
+def _require_columns(frame: pl.DataFrame, required: frozenset[str], *, label: str) -> None:
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        raise ValueError(f"{label} missing required columns: {', '.join(missing)}")
+
+
+__all__ = [
+    "READ_TIME_ADJUSTMENT_AVAILABLE_REASON",
+    "READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED",
+    "READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE",
+    "READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON",
+    "READ_TIME_NO_SPLIT_ACTIONS_REASON",
+    "ReadTimeAdjustmentResult",
+    "derive_split_adjusted_prices",
+]

--- a/libs/data/data_pipeline/read_time_adjustment.py
+++ b/libs/data/data_pipeline/read_time_adjustment.py
@@ -23,6 +23,14 @@ _PRICE_REQUIRED_COLUMNS = frozenset({"symbol", "date", "open", "high", "low", "c
 _PRICE_COLUMNS = ("open", "high", "low", "close")
 _CORP_ACTION_REQUIRED_COLUMNS = frozenset({"symbol", "ca_type", "old_rate", "new_rate"})
 _CORP_ACTION_DATE_COLUMNS = ("ex_date", "process_date")
+_SUPPORTED_SPLIT_CA_TYPES = (
+    "reverse_split",
+    "reverse_splits",
+    "split",
+    "splits",
+    "stock_split",
+    "stock_splits",
+)
 
 
 @dataclass(frozen=True)
@@ -64,6 +72,7 @@ def derive_split_adjusted_prices(
         )
 
     normalized_prices = _normalize_prices(prices)
+    _ensure_unique_price_keys(normalized_prices)
     split_actions, skipped_action_count = _split_actions(corporate_actions)
     split_factor = _split_factor_frame(normalized_prices, split_actions)
     adjusted = (
@@ -138,7 +147,7 @@ def _split_actions(corporate_actions: pl.DataFrame) -> tuple[pl.DataFrame, int]:
             pl.col("new_rate").cast(pl.Float64, strict=False),
         ]
     )
-    splits = normalized.filter(pl.col("ca_type").str.contains("split"))
+    splits = normalized.filter(pl.col("ca_type").is_in(_SUPPORTED_SPLIT_CA_TYPES))
     valid_splits = splits.filter(
         pl.col("date").is_not_null()
         & pl.col("old_rate").is_not_null()
@@ -223,6 +232,22 @@ def _empty_split_actions() -> pl.DataFrame:
             pl.col("date").cast(pl.Date),
             pl.col("split_ratio").cast(pl.Float64),
         ]
+    )
+
+
+def _ensure_unique_price_keys(prices: pl.DataFrame) -> None:
+    duplicates = (
+        prices.group_by(["symbol", "date"])
+        .agg(pl.len().alias("__duplicate_count"))
+        .filter(pl.col("__duplicate_count") > 1)
+    )
+    if duplicates.is_empty():
+        return
+
+    sample = duplicates.select(["symbol", "date"]).head(1).to_dicts()[0]
+    raise ValueError(
+        "prices contain duplicate symbol/date rows: "
+        f"symbol={sample['symbol']} date={sample['date']}"
     )
 
 

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -260,6 +260,7 @@ class AlpacaSIPLocalProvider:
             partition_paths=partition_paths,
             start_date=start_date,
             end_date=end_date,
+            manifest_end_date=manifest.end_date,
             date_basis=date_basis,
             symbols=symbols,
         )
@@ -378,6 +379,7 @@ class AlpacaSIPLocalProvider:
         partition_paths: list[Path],
         start_date: date,
         end_date: date | None,
+        manifest_end_date: date,
         date_basis: Literal["process_date", "effective_date"],
         symbols: list[str] | None,
     ) -> pl.DataFrame:
@@ -386,24 +388,29 @@ class AlpacaSIPLocalProvider:
             "start_date": start_date,
         }
         if date_basis == "process_date":
+            query_end_date = end_date if end_date is not None else manifest_end_date
+            params["query_end_date"] = query_end_date
             where_clauses = ['"process_date" >= $start_date']
+            where_clauses.append('"process_date" <= $query_end_date')
             order_by = '"symbol", "process_date", "ex_date"'
         else:
+            params["manifest_end_date"] = manifest_end_date
             where_clauses = [
                 '(("ex_date" IS NOT NULL AND "ex_date" >= $start_date) '
                 'OR ("ex_date" IS NULL AND "process_date" >= $start_date))'
             ]
+            where_clauses.append(
+                '(("process_date" IS NOT NULL AND "process_date" <= $manifest_end_date) '
+                'OR ("process_date" IS NULL AND "ex_date" <= $manifest_end_date))'
+            )
             order_by = '"symbol", "ex_date" NULLS LAST, "process_date" NULLS LAST'
 
-        if end_date is not None:
+        if end_date is not None and date_basis == "effective_date":
             params["end_date"] = end_date
-            if date_basis == "process_date":
-                where_clauses.append('"process_date" <= $end_date')
-            else:
-                where_clauses.append(
-                    '(("ex_date" IS NOT NULL AND "ex_date" <= $end_date) '
-                    'OR ("ex_date" IS NULL AND "process_date" <= $end_date))'
-                )
+            where_clauses.append(
+                '(("ex_date" IS NOT NULL AND "ex_date" <= $end_date) '
+                'OR ("ex_date" IS NULL AND "process_date" <= $end_date))'
+            )
 
         if symbols is not None:
             params["symbols"] = sorted(

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -212,6 +212,13 @@ class AlpacaSIPLocalProvider:
         first requested price date so later splits can adjust earlier raw bars.
         A missing corporate-action manifest fails closed via ``DataNotFoundError``.
         """
+        if self._pinned_manifest is not None:
+            raise DataNotFoundError(
+                "Corporate-action reads are disabled for pinned Alpaca SIP daily "
+                "manifests until a companion corporate-actions manifest is pinned "
+                "with the same backtest snapshot."
+            )
+
         manifest = self.manifest_manager.load_manifest(self.CORP_ACTIONS_DATASET_NAME)
         if manifest is None:
             raise DataNotFoundError(

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -15,7 +15,7 @@ import threading
 import weakref
 from datetime import date
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import duckdb
 import polars as pl
@@ -206,15 +206,19 @@ class AlpacaSIPLocalProvider:
         start_date: date,
         end_date: date | None = None,
         coverage_end_date: date | None = None,
+        date_basis: Literal["process_date", "effective_date"] = "process_date",
         symbols: list[str] | None = None,
     ) -> pl.DataFrame:
         """Get paired corporate actions from the trusted manifest.
 
-        ``end_date`` bounds returned corporate-action rows for explicit action
-        reads. ``coverage_end_date`` only validates that the companion manifest
-        is fresh enough for callers, such as read-time adjustment, that need all
-        later trusted split actions from the manifest horizon. A missing
-        corporate-action manifest fails closed via ``DataNotFoundError``.
+        ``end_date`` bounds returned corporate-action rows for explicit action reads.
+        The default ``date_basis`` matches Alpaca's process-date API window, while
+        read-time adjustment can request the effective action date so splits
+        processed before the price window still adjust later raw bars.
+        ``coverage_end_date`` only validates that the companion manifest is fresh
+        enough for callers that need all later trusted split actions from the
+        manifest horizon. A missing corporate-action manifest fails closed via
+        ``DataNotFoundError``.
         """
         required_end_date = coverage_end_date if coverage_end_date is not None else end_date
         if self._pinned_manifest is not None:
@@ -256,6 +260,7 @@ class AlpacaSIPLocalProvider:
             partition_paths=partition_paths,
             start_date=start_date,
             end_date=end_date,
+            date_basis=date_basis,
             symbols=symbols,
         )
 
@@ -373,16 +378,32 @@ class AlpacaSIPLocalProvider:
         partition_paths: list[Path],
         start_date: date,
         end_date: date | None,
+        date_basis: Literal["process_date", "effective_date"],
         symbols: list[str] | None,
     ) -> pl.DataFrame:
         params: dict[str, Any] = {
             "paths": [str(p) for p in partition_paths],
             "start_date": start_date,
         }
-        where_clauses = ['COALESCE("ex_date", "process_date") >= $start_date']
+        if date_basis == "process_date":
+            where_clauses = ['"process_date" >= $start_date']
+            order_by = '"symbol", "process_date", "ex_date"'
+        else:
+            where_clauses = [
+                '(("ex_date" IS NOT NULL AND "ex_date" >= $start_date) '
+                'OR ("ex_date" IS NULL AND "process_date" >= $start_date))'
+            ]
+            order_by = '"symbol", "ex_date" NULLS LAST, "process_date" NULLS LAST'
+
         if end_date is not None:
             params["end_date"] = end_date
-            where_clauses.append('COALESCE("ex_date", "process_date") <= $end_date')
+            if date_basis == "process_date":
+                where_clauses.append('"process_date" <= $end_date')
+            else:
+                where_clauses.append(
+                    '(("ex_date" IS NOT NULL AND "ex_date" <= $end_date) '
+                    'OR ("ex_date" IS NULL AND "process_date" <= $end_date))'
+                )
 
         if symbols is not None:
             params["symbols"] = sorted(
@@ -394,7 +415,7 @@ class AlpacaSIPLocalProvider:
             SELECT *
             FROM read_parquet($paths)
             WHERE {" AND ".join(where_clauses)}
-            ORDER BY "symbol", COALESCE("ex_date", "process_date")
+            ORDER BY {order_by}
         """
 
         with self._connection_lock:

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -205,15 +205,18 @@ class AlpacaSIPLocalProvider:
         *,
         start_date: date,
         end_date: date | None = None,
+        coverage_end_date: date | None = None,
         symbols: list[str] | None = None,
     ) -> pl.DataFrame:
         """Get paired corporate actions from the trusted manifest.
 
-        The read-time split adjustment layer needs actions on or after the
-        first requested price date through the last requested price date so
-        later splits can adjust earlier raw bars without stale companion data.
-        A missing corporate-action manifest fails closed via ``DataNotFoundError``.
+        ``end_date`` bounds returned corporate-action rows for explicit action
+        reads. ``coverage_end_date`` only validates that the companion manifest
+        is fresh enough for callers, such as read-time adjustment, that need all
+        later trusted split actions from the manifest horizon. A missing
+        corporate-action manifest fails closed via ``DataNotFoundError``.
         """
+        required_end_date = coverage_end_date if coverage_end_date is not None else end_date
         if self._pinned_manifest is not None:
             raise DataNotFoundError(
                 "Corporate-action reads are disabled for pinned Alpaca SIP daily "
@@ -238,11 +241,11 @@ class AlpacaSIPLocalProvider:
                 f"{manifest.start_date.isoformat()}, after requested price start "
                 f"{start_date.isoformat()}."
             )
-        if end_date is not None and manifest.end_date < end_date:
+        if required_end_date is not None and manifest.end_date < required_end_date:
             raise DataCoverageError(
                 f"Corporate-action manifest '{self.CORP_ACTIONS_DATASET_NAME}' ends at "
                 f"{manifest.end_date.isoformat()}, before requested price end "
-                f"{end_date.isoformat()}."
+                f"{required_end_date.isoformat()}."
             )
 
         partition_paths = self._get_corp_action_paths_from_manifest(manifest)

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -225,6 +225,17 @@ class AlpacaSIPLocalProvider:
                 f"No manifest found for '{self.CORP_ACTIONS_DATASET_NAME}'. "
                 "Run Alpaca corporate-actions sync first."
             )
+        if manifest.validation_status != "passed":
+            raise DataNotFoundError(
+                f"Corporate-action manifest '{self.CORP_ACTIONS_DATASET_NAME}' "
+                f"is not trusted: validation_status={manifest.validation_status}."
+            )
+        if manifest.start_date > start_date:
+            raise DataNotFoundError(
+                f"Corporate-action manifest '{self.CORP_ACTIONS_DATASET_NAME}' starts at "
+                f"{manifest.start_date.isoformat()}, after requested price start "
+                f"{start_date.isoformat()}."
+            )
 
         partition_paths = self._get_corp_action_paths_from_manifest(manifest)
         if not partition_paths:

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -20,6 +20,9 @@ from typing import Any, cast
 import duckdb
 import polars as pl
 
+from libs.data.data_providers.alpaca_corp_actions_sync import (
+    ALPACA_CORP_ACTIONS_SCHEMA,
+)
 from libs.data.data_providers.alpaca_sip_paths import resolve_alpaca_sip_manifest_path
 from libs.data.data_quality.exceptions import DataNotFoundError
 from libs.data.data_quality.manifest import ManifestManager, SyncManifest
@@ -81,6 +84,7 @@ class AlpacaSIPLocalProvider:
     """
 
     DATASET_NAME = "alpaca_sip_daily"
+    CORP_ACTIONS_DATASET_NAME = "alpaca_sip_corp_actions"
     DATA_ROOT = Path("data")
 
     def __init__(
@@ -89,6 +93,7 @@ class AlpacaSIPLocalProvider:
         manifest_manager: ManifestManager,
         data_root: Path | None = None,
         pinned_manifest: SyncManifest | None = None,
+        corp_actions_storage_path: Path | None = None,
         duckdb_memory_limit: str | None = None,
         duckdb_threads: int | None = None,
     ) -> None:
@@ -99,6 +104,10 @@ class AlpacaSIPLocalProvider:
             manifest_manager: Manager for manifest operations.
             data_root: Root directory for path validation.
             pinned_manifest: Optional immutable manifest to use for all reads.
+            corp_actions_storage_path: Optional path to paired Alpaca SIP
+                corporate-action parquet files. Defaults to
+                ALPACA_CORP_ACTIONS_STORAGE_PATH or
+                ``data_root/alpaca/sip/corp_actions``.
             duckdb_memory_limit: Optional DuckDB memory limit (env fallback:
                 ALPACA_SIP_DUCKDB_MEMORY_LIMIT, default: 2GB).
             duckdb_threads: Optional DuckDB worker threads (env fallback:
@@ -110,6 +119,12 @@ class AlpacaSIPLocalProvider:
         self.storage_path = Path(storage_path).resolve()
         self.manifest_manager = manifest_manager
         self.data_root = (data_root or self.DATA_ROOT).resolve()
+        raw_corp_actions_storage_path = (
+            corp_actions_storage_path
+            or os.getenv("ALPACA_CORP_ACTIONS_STORAGE_PATH")
+            or self.data_root / "alpaca" / "sip" / "corp_actions"
+        )
+        self.corp_actions_storage_path = Path(raw_corp_actions_storage_path).resolve()
         self._pinned_manifest = pinned_manifest
         self._duckdb_memory_limit = self._resolve_duckdb_memory_limit(duckdb_memory_limit)
         self._duckdb_threads = self._resolve_duckdb_threads(duckdb_threads)
@@ -117,6 +132,11 @@ class AlpacaSIPLocalProvider:
         if not self.storage_path.is_relative_to(self.data_root):
             raise ValueError(
                 f"storage_path '{storage_path}' must be within data_root '{self.data_root}'"
+            )
+        if not self.corp_actions_storage_path.is_relative_to(self.data_root):
+            raise ValueError(
+                "corp_actions_storage_path "
+                f"'{self.corp_actions_storage_path}' must be within data_root '{self.data_root}'"
             )
 
         self._thread_local = threading.local()
@@ -180,6 +200,35 @@ class AlpacaSIPLocalProvider:
 
         return result
 
+    def get_corporate_actions(
+        self,
+        *,
+        start_date: date,
+        symbols: list[str] | None = None,
+    ) -> pl.DataFrame:
+        """Get paired corporate actions from the trusted manifest.
+
+        The read-time split adjustment layer needs actions on or after the
+        first requested price date so later splits can adjust earlier raw bars.
+        A missing corporate-action manifest fails closed via ``DataNotFoundError``.
+        """
+        manifest = self.manifest_manager.load_manifest(self.CORP_ACTIONS_DATASET_NAME)
+        if manifest is None:
+            raise DataNotFoundError(
+                f"No manifest found for '{self.CORP_ACTIONS_DATASET_NAME}'. "
+                "Run Alpaca corporate-actions sync first."
+            )
+
+        partition_paths = self._get_corp_action_paths_from_manifest(manifest)
+        if not partition_paths:
+            return pl.DataFrame(schema=ALPACA_CORP_ACTIONS_SCHEMA)
+
+        return self._execute_corp_actions_query(
+            partition_paths=partition_paths,
+            start_date=start_date,
+            symbols=symbols,
+        )
+
     def _get_manifest(self) -> SyncManifest:
         """Load the Alpaca SIP daily manifest."""
         if self._pinned_manifest is not None:
@@ -228,6 +277,28 @@ class AlpacaSIPLocalProvider:
             storage_root=self.storage_path,
         )
 
+    def _resolve_corp_action_manifest_path(self, path: Path) -> Path:
+        return resolve_alpaca_sip_manifest_path(
+            path,
+            data_root=self.data_root,
+            storage_root=self.corp_actions_storage_path,
+        )
+
+    def _get_corp_action_paths_from_manifest(
+        self,
+        manifest: SyncManifest,
+    ) -> list[Path]:
+        paths: list[Path] = []
+        for path_str in manifest.file_paths:
+            resolved = self._resolve_corp_action_manifest_path(Path(path_str))
+            if resolved.is_relative_to(self.corp_actions_storage_path):
+                paths.append(resolved)
+            else:
+                logger.warning(
+                    "Skipping path outside Alpaca SIP corp-actions storage: %s", resolved
+                )
+        return paths
+
     def _execute_query(
         self,
         partition_paths: list[Path],
@@ -237,8 +308,10 @@ class AlpacaSIPLocalProvider:
         columns: list[str] | None,
     ) -> pl.DataFrame:
         """Execute a parameterized DuckDB query over selected partitions."""
-        col_expr = "*" if columns is None else ", ".join(
-            self._quote_identifier(column) for column in columns
+        col_expr = (
+            "*"
+            if columns is None
+            else ", ".join(self._quote_identifier(column) for column in columns)
         )
 
         params: dict[str, Any] = {
@@ -259,6 +332,35 @@ class AlpacaSIPLocalProvider:
             FROM read_parquet($paths)
             WHERE {" AND ".join(where_clauses)}
             ORDER BY "date", "symbol"
+        """
+
+        with self._connection_lock:
+            conn = self._connection_for_current_thread()
+            return conn.execute(query, params).pl()
+
+    def _execute_corp_actions_query(
+        self,
+        partition_paths: list[Path],
+        start_date: date,
+        symbols: list[str] | None,
+    ) -> pl.DataFrame:
+        params: dict[str, Any] = {
+            "paths": [str(p) for p in partition_paths],
+            "start_date": start_date,
+        }
+        where_clauses = ['COALESCE("ex_date", "process_date") >= $start_date']
+
+        if symbols is not None:
+            params["symbols"] = sorted(
+                {symbol.upper().strip() for symbol in symbols if symbol.strip()}
+            )
+            where_clauses.append('"symbol" = ANY($symbols)')
+
+        query = f"""
+            SELECT *
+            FROM read_parquet($paths)
+            WHERE {" AND ".join(where_clauses)}
+            ORDER BY "symbol", COALESCE("ex_date", "process_date")
         """
 
         with self._connection_lock:

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -24,7 +24,7 @@ from libs.data.data_providers.alpaca_corp_actions_sync import (
     ALPACA_CORP_ACTIONS_SCHEMA,
 )
 from libs.data.data_providers.alpaca_sip_paths import resolve_alpaca_sip_manifest_path
-from libs.data.data_quality.exceptions import DataNotFoundError
+from libs.data.data_quality.exceptions import DataCoverageError, DataNotFoundError
 from libs.data.data_quality.manifest import ManifestManager, SyncManifest
 
 logger = logging.getLogger(__name__)
@@ -204,12 +204,14 @@ class AlpacaSIPLocalProvider:
         self,
         *,
         start_date: date,
+        end_date: date | None = None,
         symbols: list[str] | None = None,
     ) -> pl.DataFrame:
         """Get paired corporate actions from the trusted manifest.
 
         The read-time split adjustment layer needs actions on or after the
-        first requested price date so later splits can adjust earlier raw bars.
+        first requested price date through the last requested price date so
+        later splits can adjust earlier raw bars without stale companion data.
         A missing corporate-action manifest fails closed via ``DataNotFoundError``.
         """
         if self._pinned_manifest is not None:
@@ -226,15 +228,21 @@ class AlpacaSIPLocalProvider:
                 "Run Alpaca corporate-actions sync first."
             )
         if manifest.validation_status != "passed":
-            raise DataNotFoundError(
+            raise DataCoverageError(
                 f"Corporate-action manifest '{self.CORP_ACTIONS_DATASET_NAME}' "
                 f"is not trusted: validation_status={manifest.validation_status}."
             )
         if manifest.start_date > start_date:
-            raise DataNotFoundError(
+            raise DataCoverageError(
                 f"Corporate-action manifest '{self.CORP_ACTIONS_DATASET_NAME}' starts at "
                 f"{manifest.start_date.isoformat()}, after requested price start "
                 f"{start_date.isoformat()}."
+            )
+        if end_date is not None and manifest.end_date < end_date:
+            raise DataCoverageError(
+                f"Corporate-action manifest '{self.CORP_ACTIONS_DATASET_NAME}' ends at "
+                f"{manifest.end_date.isoformat()}, before requested price end "
+                f"{end_date.isoformat()}."
             )
 
         partition_paths = self._get_corp_action_paths_from_manifest(manifest)

--- a/libs/data/data_providers/alpaca_sip_local_provider.py
+++ b/libs/data/data_providers/alpaca_sip_local_provider.py
@@ -252,6 +252,7 @@ class AlpacaSIPLocalProvider:
         return self._execute_corp_actions_query(
             partition_paths=partition_paths,
             start_date=start_date,
+            end_date=end_date,
             symbols=symbols,
         )
 
@@ -368,6 +369,7 @@ class AlpacaSIPLocalProvider:
         self,
         partition_paths: list[Path],
         start_date: date,
+        end_date: date | None,
         symbols: list[str] | None,
     ) -> pl.DataFrame:
         params: dict[str, Any] = {
@@ -375,6 +377,9 @@ class AlpacaSIPLocalProvider:
             "start_date": start_date,
         }
         where_clauses = ['COALESCE("ex_date", "process_date") >= $start_date']
+        if end_date is not None:
+            params["end_date"] = end_date
+            where_clauses.append('COALESCE("ex_date", "process_date") <= $end_date')
 
         if symbols is not None:
             params["symbols"] = sorted(

--- a/libs/data/data_providers/protocols.py
+++ b/libs/data/data_providers/protocols.py
@@ -605,7 +605,7 @@ class AlpacaSIPDataProviderAdapter:
         try:
             corporate_actions = self._provider.get_corporate_actions(
                 start_date=start_date,
-                end_date=end_date,
+                coverage_end_date=end_date,
                 symbols=symbols,
             )
         except DataCoverageError as exc:

--- a/libs/data/data_providers/protocols.py
+++ b/libs/data/data_providers/protocols.py
@@ -36,7 +36,7 @@ import polars as pl
 from libs.data.data_pipeline.helpers import normalized_symbols_from_frame
 from libs.data.data_pipeline.read_time_adjustment import derive_split_adjusted_prices
 from libs.data.data_providers.registry import ProviderCapabilities, ProviderType, get_provider_spec
-from libs.data.data_quality.exceptions import DataNotFoundError
+from libs.data.data_quality.exceptions import DataCoverageError, DataNotFoundError
 
 if TYPE_CHECKING:
     from libs.data.data_providers.alpaca_sip_local_provider import AlpacaSIPLocalProvider
@@ -591,19 +591,27 @@ class AlpacaSIPDataProviderAdapter:
         if "adj_close" in df.columns and df["adj_close"].null_count() == 0:
             return df
 
-        get_corporate_actions = getattr(type(self._provider), "get_corporate_actions", None)
-        if get_corporate_actions is None:
-            return df
-
-        start_date = df.select(pl.col("date").min()).item()
-        if not isinstance(start_date, date):
+        date_bounds = df.select(
+            [
+                pl.col("date").min().alias("start_date"),
+                pl.col("date").max().alias("end_date"),
+            ]
+        ).row(0, named=True)
+        start_date = date_bounds["start_date"]
+        end_date = date_bounds["end_date"]
+        if not isinstance(start_date, date) or not isinstance(end_date, date):
             return df
         symbols = normalized_symbols_from_frame(df)
         try:
             corporate_actions = self._provider.get_corporate_actions(
                 start_date=start_date,
+                end_date=end_date,
                 symbols=symbols,
             )
+        except DataCoverageError as exc:
+            raise DataProviderError(
+                f"Alpaca SIP corporate-action manifest incompatible with price range: {exc}"
+            ) from exc
         except DataNotFoundError:
             return df
         except Exception as exc:

--- a/libs/data/data_providers/protocols.py
+++ b/libs/data/data_providers/protocols.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import polars as pl
 
+from libs.data.data_pipeline.helpers import normalized_symbols_from_frame
 from libs.data.data_pipeline.read_time_adjustment import derive_split_adjusted_prices
 from libs.data.data_providers.registry import ProviderCapabilities, ProviderType, get_provider_spec
 from libs.data.data_quality.exceptions import DataNotFoundError
@@ -597,13 +598,7 @@ class AlpacaSIPDataProviderAdapter:
         start_date = df.select(pl.col("date").min()).item()
         if not isinstance(start_date, date):
             return df
-        symbols = sorted(
-            {
-                symbol
-                for raw_symbol in df.get_column("symbol").to_list()
-                if (symbol := str(raw_symbol).strip().upper())
-            }
-        )
+        symbols = normalized_symbols_from_frame(df)
         try:
             corporate_actions = self._provider.get_corporate_actions(
                 start_date=start_date,

--- a/libs/data/data_providers/protocols.py
+++ b/libs/data/data_providers/protocols.py
@@ -606,6 +606,7 @@ class AlpacaSIPDataProviderAdapter:
             corporate_actions = self._provider.get_corporate_actions(
                 start_date=start_date,
                 coverage_end_date=end_date,
+                date_basis="effective_date",
                 symbols=symbols,
             )
         except DataCoverageError as exc:

--- a/libs/data/data_providers/protocols.py
+++ b/libs/data/data_providers/protocols.py
@@ -33,7 +33,9 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import polars as pl
 
+from libs.data.data_pipeline.read_time_adjustment import derive_split_adjusted_prices
 from libs.data.data_providers.registry import ProviderCapabilities, ProviderType, get_provider_spec
+from libs.data.data_quality.exceptions import DataNotFoundError
 
 if TYPE_CHECKING:
     from libs.data.data_providers.alpaca_sip_local_provider import AlpacaSIPLocalProvider
@@ -559,6 +561,8 @@ class AlpacaSIPDataProviderAdapter:
         for column in float_cols:
             df = df.with_columns(pl.col(column).cast(pl.Float64))
 
+        df = self._derive_read_time_adjusted_prices(df)
+
         adjusted_close = pl.col("adj_close")
         previous_adjusted_close = adjusted_close.shift(1).over("symbol")
         df = (
@@ -578,6 +582,42 @@ class AlpacaSIPDataProviderAdapter:
         )
 
         return df.select(UNIFIED_COLUMNS)
+
+    def _derive_read_time_adjusted_prices(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Derive adjusted SIP returns when a paired corp-actions manifest exists."""
+        if df.is_empty() or "date" not in df.columns or "symbol" not in df.columns:
+            return df
+        if "adj_close" in df.columns and df["adj_close"].null_count() == 0:
+            return df
+
+        get_corporate_actions = getattr(type(self._provider), "get_corporate_actions", None)
+        if get_corporate_actions is None:
+            return df
+
+        start_date = df.select(pl.col("date").min()).item()
+        if not isinstance(start_date, date):
+            return df
+        symbols = sorted(
+            {
+                symbol
+                for raw_symbol in df.get_column("symbol").to_list()
+                if (symbol := str(raw_symbol).strip().upper())
+            }
+        )
+        try:
+            corporate_actions = self._provider.get_corporate_actions(
+                start_date=start_date,
+                symbols=symbols,
+            )
+        except DataNotFoundError:
+            return df
+        except Exception as exc:
+            raise DataProviderError(f"Alpaca SIP corporate-action query failed: {exc}") from exc
+
+        try:
+            return derive_split_adjusted_prices(df, corporate_actions).frame
+        except Exception as exc:
+            raise DataProviderError(f"Alpaca SIP read-time adjustment failed: {exc}") from exc
 
     def _empty_result(self) -> pl.DataFrame:
         """Return empty DataFrame with unified schema."""

--- a/libs/data/data_quality/__init__.py
+++ b/libs/data/data_quality/__init__.py
@@ -12,6 +12,7 @@ This module provides:
 
 from libs.data.data_quality.exceptions import (
     ChecksumMismatchError,
+    DataCoverageError,
     DataNotFoundError,
     DatasetNotInSnapshotError,
     DiskSpaceError,
@@ -80,6 +81,7 @@ __all__ = [
     "QuarantineError",
     "LockNotHeldError",
     "DiskSpaceError",
+    "DataCoverageError",
     "DataNotFoundError",
     # Versioning Exceptions
     "SnapshotNotFoundError",

--- a/libs/data/data_quality/exceptions.py
+++ b/libs/data/data_quality/exceptions.py
@@ -99,6 +99,12 @@ class DataNotFoundError(DataQualityError):
     pass
 
 
+class DataCoverageError(DataNotFoundError):
+    """Raised when available data does not cover the requested range."""
+
+    pass
+
+
 # =============================================================================
 # Versioning Exceptions (T1.6)
 # =============================================================================

--- a/libs/web_console_services/alpaca_sip_manifest_helpers.py
+++ b/libs/web_console_services/alpaca_sip_manifest_helpers.py
@@ -1,0 +1,47 @@
+"""Shared Alpaca SIP manifest capability helpers."""
+
+from __future__ import annotations
+
+from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_CORP_ACTIONS_DATASET,
+    ALPACA_SIP_DAILY_DATASET,
+    AlpacaSipManifestSummaryDTO,
+    ManifestSummaryDTO,
+)
+
+SPLIT_ADJUSTMENT_BLOCKING_WARNINGS = frozenset(
+    {
+        "alpaca_sip_companion_manifest_stale",
+        "alpaca_sip_companion_symbol_set_mismatch",
+    }
+)
+
+
+def manifest_has_native_returns(manifest: ManifestSummaryDTO | None) -> bool:
+    """Return whether a trusted daily manifest already carries adjusted returns."""
+    if manifest is None or manifest.validation_status.lower() != "passed":
+        return False
+    return manifest.read_time_adjustment_mode == "available"
+
+
+def summary_supports_split_adjustment(summary: AlpacaSipManifestSummaryDTO) -> bool:
+    """Return whether Alpaca SIP daily bars can use read-time split adjustment."""
+    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
+    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
+    corp_actions = manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
+    if daily is None or corp_actions is None:
+        return False
+    if daily.validation_status.lower() != "passed":
+        return False
+    if corp_actions.validation_status.lower() != "passed":
+        return False
+    return not any(
+        warning in SPLIT_ADJUSTMENT_BLOCKING_WARNINGS for warning in summary.warnings
+    )
+
+
+__all__ = [
+    "SPLIT_ADJUSTMENT_BLOCKING_WARNINGS",
+    "manifest_has_native_returns",
+    "summary_supports_split_adjustment",
+]

--- a/libs/web_console_services/alpaca_sip_manifest_helpers.py
+++ b/libs/web_console_services/alpaca_sip_manifest_helpers.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
+    ALPACA_SIP_COMPANION_MANIFEST_STALE,
+    ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
     AlpacaSipManifestSummaryDTO,
@@ -11,8 +14,9 @@ from libs.web_console_services.data_manifest_service import (
 
 SPLIT_ADJUSTMENT_BLOCKING_WARNINGS = frozenset(
     {
-        "alpaca_sip_companion_manifest_stale",
-        "alpaca_sip_companion_symbol_set_mismatch",
+        ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
+        ALPACA_SIP_COMPANION_MANIFEST_STALE,
+        ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
     }
 )
 
@@ -35,12 +39,15 @@ def summary_supports_split_adjustment(summary: AlpacaSipManifestSummaryDTO) -> b
         return False
     if corp_actions.validation_status.lower() != "passed":
         return False
-    return not any(
-        warning in SPLIT_ADJUSTMENT_BLOCKING_WARNINGS for warning in summary.warnings
-    )
+    if corp_actions.start_date > daily.start_date or corp_actions.end_date < daily.end_date:
+        return False
+    return not any(warning in SPLIT_ADJUSTMENT_BLOCKING_WARNINGS for warning in summary.warnings)
 
 
 __all__ = [
+    "ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH",
+    "ALPACA_SIP_COMPANION_MANIFEST_STALE",
+    "ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH",
     "SPLIT_ADJUSTMENT_BLOCKING_WARNINGS",
     "manifest_has_native_returns",
     "summary_supports_split_adjustment",

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal, TypedDict, cast
 from urllib.parse import urlencode
 from uuid import uuid4
@@ -72,6 +72,7 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_DATASETS = tuple(DATASET_TABLES)
 _PREVIEW_TIMEOUT_SECONDS = 10
 _PREVIEW_RATE_LIMIT = 30
+_ADJUSTED_PREVIEW_LOOKBACK_DAYS = 31
 _INTERACTIVE_ROW_LIMIT = 10_000
 _INTERACTIVE_FETCH_LIMIT = _INTERACTIVE_ROW_LIMIT + 1
 DATA_EXPORT_RATE_LIMIT = 5
@@ -769,23 +770,51 @@ class DataExplorerService:
         )
 
         fetch_limit = limit + 1
-        price_query = "SELECT * FROM alpaca_sip_daily " f"ORDER BY symbol, date LIMIT {fetch_limit}"
+        price_query_parameters: list[Any] | None = None
+        preview_start_date = _split_adjusted_preview_start_date(
+            alpaca_summary,
+            provenance_trusted_tables,
+        )
+        if preview_start_date is None:
+            price_query = (
+                f"SELECT * FROM alpaca_sip_daily ORDER BY symbol, date LIMIT {fetch_limit}"
+            )
+        else:
+            price_query_parameters = [preview_start_date]
+            price_query = (
+                "SELECT * FROM alpaca_sip_daily "
+                "WHERE date >= CAST(? AS DATE) "
+                f"ORDER BY symbol, date LIMIT {fetch_limit}"
+            )
         prices = await self._execute_sql_frame(
             dataset=dataset,
             sql=price_query,
             table_paths={"alpaca_sip_daily": trusted_table_paths["alpaca_sip_daily"]},
             timeout_seconds=_PREVIEW_TIMEOUT_SECONDS,
+            parameters=price_query_parameters,
         )
         fetched_row_count = len(prices)
         has_more = fetched_row_count > limit
+        warmup_prices = await self._load_split_adjusted_warmup_prices(
+            dataset=dataset,
+            prices=prices,
+            preview_start_date=preview_start_date,
+            table_paths=trusted_table_paths,
+        )
+        adjustment_prices = _prepend_split_adjusted_warmup_prices(
+            prices=prices,
+            warmup_prices=warmup_prices,
+        )
 
         corp_actions = await self._load_corporate_actions_for_prices(
             dataset=dataset,
-            prices=prices,
+            prices=adjustment_prices,
             table_paths=trusted_table_paths,
         )
-        adjustment_result = derive_split_adjusted_prices(prices, corp_actions)
+        adjustment_result = derive_split_adjusted_prices(adjustment_prices, corp_actions)
         frame = adjustment_result.frame
+        if preview_start_date is not None and not warmup_prices.is_empty():
+            frame = _drop_split_adjusted_warmup_rows(frame, preview_start_date)
         if has_more:
             frame = frame.head(limit)
 
@@ -845,6 +874,46 @@ class DataExplorerService:
             sql_handoff_url=_sql_handoff_url(dataset, ["alpaca_sip_daily"]),
             **provenance,
         )
+
+    async def _load_split_adjusted_warmup_prices(
+        self,
+        *,
+        dataset: str,
+        prices: pl.DataFrame,
+        preview_start_date: date | None,
+        table_paths: dict[str, TablePathSpec],
+    ) -> pl.DataFrame:
+        if preview_start_date is None or prices.is_empty():
+            return pl.DataFrame()
+
+        symbols = normalized_symbols_from_frame(prices)
+        if not symbols:
+            return pl.DataFrame()
+
+        symbol_placeholders = ", ".join("?" for _symbol in symbols)
+        warmup_query = (
+            "SELECT * FROM ("
+            "SELECT *, row_number() OVER (PARTITION BY symbol ORDER BY date DESC) "
+            "AS __rta_warmup_rank "
+            "FROM alpaca_sip_daily "
+            f"WHERE symbol IN ({symbol_placeholders}) "
+            "AND date < CAST(? AS DATE)"
+            ") WHERE __rta_warmup_rank = 1 "
+            "ORDER BY symbol, date"
+        )
+        warmup = cast(
+            pl.DataFrame,
+            await self._execute_sql_frame(
+                dataset=dataset,
+                sql=warmup_query,
+                table_paths={"alpaca_sip_daily": table_paths["alpaca_sip_daily"]},
+                timeout_seconds=_PREVIEW_TIMEOUT_SECONDS,
+                parameters=[*symbols, preview_start_date],
+            ),
+        )
+        if "__rta_warmup_rank" in warmup.columns:
+            return warmup.drop("__rta_warmup_rank")
+        return warmup
 
     async def _load_corporate_actions_for_prices(
         self,
@@ -1271,6 +1340,40 @@ def _price_date_bounds(prices: pl.DataFrame) -> tuple[date, date] | None:
     if not isinstance(min_date, date) or not isinstance(max_date, date):
         return None
     return min_date, max_date
+
+
+def _split_adjusted_preview_start_date(
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
+    trusted_tables: list[str],
+) -> date | None:
+    daily_manifest = _trusted_manifest_for_table(
+        alpaca_summary,
+        "alpaca_sip_daily",
+        trusted_tables,
+    )
+    if daily_manifest is None:
+        return None
+    lookback_start = daily_manifest.end_date - timedelta(days=_ADJUSTED_PREVIEW_LOOKBACK_DAYS)
+    return max(daily_manifest.start_date, lookback_start)
+
+
+def _prepend_split_adjusted_warmup_prices(
+    *,
+    prices: pl.DataFrame,
+    warmup_prices: pl.DataFrame,
+) -> pl.DataFrame:
+    if prices.is_empty() or warmup_prices.is_empty():
+        return prices
+    return pl.concat([warmup_prices, prices], how="vertical_relaxed")
+
+
+def _drop_split_adjusted_warmup_rows(
+    frame: pl.DataFrame,
+    preview_start_date: date,
+) -> pl.DataFrame:
+    if frame.is_empty() or "date" not in frame.columns:
+        return frame
+    return frame.filter(pl.col("date").cast(pl.Date, strict=False) >= preview_start_date)
 
 
 def _preview_candidate_tables(dataset: str, allowed_tables: list[str]) -> list[str]:

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -8,11 +8,21 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import UTC, datetime
-from typing import Any, Literal, TypedDict
+from datetime import UTC, date, datetime
+from typing import Any, Literal, TypedDict, cast
 from urllib.parse import urlencode
 from uuid import uuid4
 
+import polars as pl
+
+from libs.data.data_pipeline.read_time_adjustment import (
+    READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
+    READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+    READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE,
+    READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON,
+    READ_TIME_NO_SPLIT_ACTIONS_REASON,
+    derive_split_adjusted_prices,
+)
 from libs.platform.web_console_auth.helpers import get_user_id
 from libs.platform.web_console_auth.permissions import (
     Permission,
@@ -83,6 +93,7 @@ class _DatasetAdjustmentMetadata(TypedDict, total=False):
     warnings: list[str]
     backtest_handoff: BacktestHandoffDTO | None
 
+
 _DATASET_DESCRIPTIONS: dict[str, str] = {
     "crsp": "CRSP stock and index history",
     "compustat": "Compustat fundamentals",
@@ -110,6 +121,7 @@ _NULL_COLUMN_REASONS_BY_TABLE: dict[str, dict[str, str]] = {
         "ret": "raw_sip_returns_unavailable",
     }
 }
+_RAW_SIP_RETURNS_UNAVAILABLE = "raw_sip_returns_unavailable"
 _ALPACA_SIP_BACKTEST_ROLE_TABLES: dict[str, str] = {
     "universe": "alpaca_sip_daily",
     "prices": "alpaca_sip_daily",
@@ -117,11 +129,19 @@ _ALPACA_SIP_BACKTEST_ROLE_TABLES: dict[str, str] = {
 }
 _ALPACA_SIP_DAILY_ADJUSTMENT_MODE = "raw"
 _ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE = "raw"
-_ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE = "unavailable"
+_ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE = READ_TIME_ADJUSTMENT_MODE_UNAVAILABLE
 _ALPACA_SIP_CORP_ACTIONS_STORAGE_MODE = "read_only_adjustment_input"
 _ADJUSTED_PREVIEW_UNAVAILABLE_REASON = "read_time_adjustment_layer_not_defined"
 _ALPACA_SIP_MANIFEST_VALIDATION_FAILED_REASON = "alpaca_sip_manifest_validation_failed"
 _ALPACA_SIP_UNTRUSTED_REASON = "alpaca_sip_untrusted_without_manifest"
+_ALPACA_SIP_COMPANION_MANIFEST_STALE_REASON = "alpaca_sip_companion_manifest_stale"
+_ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH_REASON = "alpaca_sip_companion_symbol_set_mismatch"
+_ALPACA_SIP_COMPANION_BLOCKING_REASONS = frozenset(
+    {
+        _ALPACA_SIP_COMPANION_MANIFEST_STALE_REASON,
+        _ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH_REASON,
+    }
+)
 
 
 class RateLimitExceeded(RuntimeError):
@@ -193,7 +213,9 @@ class DataExplorerService:
             fallback_tables = sorted(
                 resolution.table
                 for resolution in dataset_resolutions
-                if resolution.available and resolution.fallback_only and not resolution.manifest_invalid
+                if resolution.available
+                and resolution.fallback_only
+                and not resolution.manifest_invalid
             )
             invalid_manifest_tables = sorted(
                 resolution.table
@@ -282,6 +304,7 @@ class DataExplorerService:
         dataset: str,
         limit: int = 100,
         table: str | None = None,
+        read_time_adjustment_mode: Literal["raw", "split_adjusted"] = "raw",
     ) -> DataPreviewDTO:
         """Get first N rows of dataset.
 
@@ -297,6 +320,18 @@ class DataExplorerService:
                 raise ValueError("Preview limit cannot exceed 1000 rows")
             if limit <= 0:
                 raise ValueError("Preview limit must be positive")
+            if read_time_adjustment_mode == READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED:
+                return await self._get_split_adjusted_preview(
+                    user,
+                    dataset=dataset,
+                    limit=limit,
+                    table=table,
+                    started=started,
+                )
+            if read_time_adjustment_mode != "raw":
+                raise ValueError(
+                    f"Unsupported read-time adjustment mode: {read_time_adjustment_mode}"
+                )
 
             (
                 table_name,
@@ -678,6 +713,167 @@ class DataExplorerService:
             )
             raise
 
+    async def _get_split_adjusted_preview(
+        self,
+        user: Any,
+        *,
+        dataset: str,
+        limit: int,
+        table: str | None,
+        started: float,
+    ) -> DataPreviewDTO:
+        if dataset != ALPACA_SIP_DATASET_KEY:
+            raise ValueError("Split-adjusted preview is only available for alpaca_sip")
+        if table not in {None, "alpaca_sip_daily"}:
+            raise ValueError("Split-adjusted preview is only available for alpaca_sip_daily")
+
+        referenced_tables = ["alpaca_sip_daily", "alpaca_sip_corp_actions"]
+        trusted_table_paths = await self._trusted_available_tables_for_query(
+            dataset,
+            referenced_tables,
+        )
+        table_resolutions, _warnings = await self._resolve_table_availability()
+        daily_resolution = table_resolutions["alpaca_sip_daily"]
+        provenance_trusted_tables = sorted(trusted_table_paths)
+
+        alpaca_summary, alpaca_summary_unavailable = await self._get_alpaca_summary()
+        if not _read_time_adjustment_available(
+            trusted_tables=provenance_trusted_tables,
+            alpaca_summary=alpaca_summary,
+            alpaca_summary_unavailable=alpaca_summary_unavailable,
+        ):
+            handoff = _build_backtest_handoff(
+                dataset,
+                trusted_tables=provenance_trusted_tables,
+                alpaca_summary=alpaca_summary,
+                alpaca_summary_unavailable=alpaca_summary_unavailable,
+                queryable_state=_queryable_state_for_table(daily_resolution),
+            )
+            reasons = (
+                ", ".join(handoff.reason_codes)
+                if handoff is not None and handoff.reason_codes
+                else _ADJUSTED_PREVIEW_UNAVAILABLE_REASON
+            )
+            raise ValueError(f"Split-adjusted preview unavailable: {reasons}")
+
+        await self._enforce_rate_limit(
+            user,
+            action="data_preview",
+            max_requests=_PREVIEW_RATE_LIMIT,
+            window=60,
+        )
+
+        fetch_limit = limit + 1
+        price_query = "SELECT * FROM alpaca_sip_daily " f"ORDER BY symbol, date LIMIT {fetch_limit}"
+        prices = await self._execute_sql_frame(
+            dataset=dataset,
+            sql=price_query,
+            table_paths={"alpaca_sip_daily": trusted_table_paths["alpaca_sip_daily"]},
+            timeout_seconds=_PREVIEW_TIMEOUT_SECONDS,
+        )
+        fetched_row_count = len(prices)
+        has_more = fetched_row_count > limit
+
+        corp_actions = await self._load_corporate_actions_for_prices(
+            dataset=dataset,
+            prices=prices,
+            table_paths=trusted_table_paths,
+        )
+        adjustment_result = derive_split_adjusted_prices(prices, corp_actions)
+        frame = adjustment_result.frame
+        if has_more:
+            frame = frame.head(limit)
+
+        provenance = await self._preview_provenance_for_table(
+            "alpaca_sip_daily",
+            dataset=dataset,
+            trusted_tables=provenance_trusted_tables,
+        )
+        warnings = sorted(
+            {
+                *(
+                    str(item)
+                    for item in provenance.get("warnings", [])
+                    if str(item) != _RAW_SIP_RETURNS_UNAVAILABLE
+                ),
+                *(
+                    code
+                    for code in adjustment_result.reason_codes
+                    if code
+                    in {
+                        READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON,
+                        READ_TIME_NO_SPLIT_ACTIONS_REASON,
+                    }
+                ),
+            }
+        )
+        provenance.update(
+            {
+                "read_time_adjustment_mode": READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+                "null_column_reasons": {},
+                "warnings": warnings,
+                "derived": True,
+                "derivation_mode": READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+                "derivation_reason_codes": list(adjustment_result.reason_codes),
+            }
+        )
+
+        execution_ms = int((time.monotonic() - started) * 1000)
+        log_sql_query_audit(
+            user,
+            dataset,
+            "READ_TIME_ADJUSTMENT_PREVIEW split_adjusted alpaca_sip_daily",
+            price_query,
+            len(frame),
+            execution_ms,
+            "success",
+            None,
+        )
+        return DataPreviewDTO(
+            columns=list(frame.columns),
+            rows=frame.to_dicts(),
+            total_count=fetched_row_count,
+            has_more=has_more,
+            table="alpaca_sip_daily",
+            queryable_state=_queryable_state_for_table(daily_resolution),
+            trusted_manifest_backed=daily_resolution.manifest_backed,
+            sql_handoff_url=_sql_handoff_url(dataset, ["alpaca_sip_daily"]),
+            **provenance,
+        )
+
+    async def _load_corporate_actions_for_prices(
+        self,
+        *,
+        dataset: str,
+        prices: pl.DataFrame,
+        table_paths: dict[str, TablePathSpec],
+    ) -> pl.DataFrame:
+        if prices.is_empty():
+            corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
+        else:
+            date_bounds = _price_date_bounds(prices)
+            symbols = _price_symbols(prices)
+            if date_bounds is None or not symbols:
+                corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
+            else:
+                start_date, _end_date = date_bounds
+                symbol_list = ", ".join(_sql_string_literal(symbol) for symbol in symbols)
+                corp_query = (
+                    "SELECT * FROM alpaca_sip_corp_actions "
+                    f"WHERE symbol IN ({symbol_list}) "
+                    f"AND coalesce(ex_date, process_date) >= DATE '{start_date.isoformat()}' "
+                    "ORDER BY symbol, coalesce(ex_date, process_date)"
+                )
+        return cast(
+            pl.DataFrame,
+            await self._execute_sql_frame(
+                dataset=dataset,
+                sql=corp_query,
+                table_paths={"alpaca_sip_corp_actions": table_paths["alpaca_sip_corp_actions"]},
+                timeout_seconds=_PREVIEW_TIMEOUT_SECONDS,
+            ),
+        )
+
     def _require_permission(self, user: Any, permission: Permission) -> None:
         if not has_permission(user, permission):
             raise PermissionError(f"Permission {permission.value} required")
@@ -729,10 +925,7 @@ class DataExplorerService:
             if self._uses_shared_table_availability_cache
             else self._table_availability_cache
         )
-        if (
-            cache is not None
-            and now - cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
-        ):
+        if cache is not None and now - cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS:
             return cache[1]
 
         lock = (
@@ -747,10 +940,7 @@ class DataExplorerService:
                 if self._uses_shared_table_availability_cache
                 else self._table_availability_cache
             )
-            if (
-                cache is not None
-                and now - cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS
-            ):
+            if cache is not None and now - cache[0] < _TABLE_AVAILABILITY_CACHE_TTL_SECONDS:
                 return cache[1]
 
             result = await asyncio.to_thread(resolve_sql_table_availability, self._table_paths)
@@ -875,6 +1065,10 @@ class DataExplorerService:
                 ),
             }
 
+        if table_name == "alpaca_sip_daily" and manifest.read_time_adjustment_mode == "available":
+            null_column_reasons = {}
+            warnings = []
+
         return {
             "manifest_id": manifest.manifest_id,
             "manifest_reference": manifest.manifest_reference,
@@ -964,9 +1158,7 @@ class DataExplorerService:
                         raise ValueError(
                             f"{table} is queryable fallback only; trusted manifest required for /data"
                         )
-                    raise ValueError(
-                        f"No trusted local data available for table {table}"
-                    )
+                    raise ValueError(f"No trusted local data available for table {table}")
                 continue
             provenance_trusted_tables = (
                 sorted(trusted_table_paths) if dataset == ALPACA_SIP_DATASET_KEY else [table]
@@ -1009,9 +1201,7 @@ class DataExplorerService:
                     raise ValueError(
                         f"{table} is queryable fallback only; trusted manifest required for /data"
                     )
-                raise ValueError(
-                    f"No trusted local data available for table {table}"
-                )
+                raise ValueError(f"No trusted local data available for table {table}")
         missing_trusted = sorted(set(referenced_tables) - set(trusted_table_paths))
         if missing_trusted:
             raise ValueError(
@@ -1060,6 +1250,33 @@ def _trusted_table_paths_for_dataset(
             continue
         trusted_paths[item.table] = item.path_spec
     return trusted_paths
+
+
+def _price_date_bounds(prices: pl.DataFrame) -> tuple[date, date] | None:
+    if "date" not in prices.columns or prices.is_empty():
+        return None
+    dates = prices.select(pl.col("date").cast(pl.Date))
+    min_date = dates.select(pl.col("date").min()).item()
+    max_date = dates.select(pl.col("date").max()).item()
+    if not isinstance(min_date, date) or not isinstance(max_date, date):
+        return None
+    return min_date, max_date
+
+
+def _price_symbols(prices: pl.DataFrame) -> list[str]:
+    if "symbol" not in prices.columns or prices.is_empty():
+        return []
+    return sorted(
+        {
+            symbol
+            for raw_symbol in prices.get_column("symbol").to_list()
+            if (symbol := str(raw_symbol).strip().upper())
+        }
+    )
+
+
+def _sql_string_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
 
 
 def _preview_candidate_tables(dataset: str, allowed_tables: list[str]) -> list[str]:
@@ -1111,6 +1328,35 @@ def _trusted_alpaca_summary_manifests(
     ]
 
 
+def _read_time_adjustment_available(
+    *,
+    trusted_tables: list[str],
+    alpaca_summary: AlpacaSipManifestSummaryDTO | None,
+    alpaca_summary_unavailable: bool,
+) -> bool:
+    if alpaca_summary is None or alpaca_summary_unavailable:
+        return False
+    if any(
+        warning in _ALPACA_SIP_COMPANION_BLOCKING_REASONS for warning in alpaca_summary.warnings
+    ):
+        return False
+    return (
+        _trusted_manifest_for_table(alpaca_summary, "alpaca_sip_daily", trusted_tables) is not None
+        and _trusted_manifest_for_table(
+            alpaca_summary,
+            "alpaca_sip_corp_actions",
+            trusted_tables,
+        )
+        is not None
+    )
+
+
+def _daily_manifest_has_returns(manifest: ManifestSummaryDTO | None) -> bool:
+    if manifest is None or manifest.validation_status.lower() != "passed":
+        return False
+    return manifest.read_time_adjustment_mode == "available"
+
+
 def _dataset_adjustment_metadata(
     dataset: str,
     *,
@@ -1122,12 +1368,21 @@ def _dataset_adjustment_metadata(
     if dataset != ALPACA_SIP_DATASET_KEY:
         return {}
 
+    read_time_available = _read_time_adjustment_available(
+        trusted_tables=trusted_tables,
+        alpaca_summary=alpaca_summary,
+        alpaca_summary_unavailable=alpaca_summary_unavailable,
+    )
     daily_manifest = _trusted_manifest_for_table(
         alpaca_summary,
         "alpaca_sip_daily",
         trusted_tables,
     )
-    warnings = set(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"].values())
+    daily_returns_available = _daily_manifest_has_returns(daily_manifest)
+    returns_available = read_time_available or daily_returns_available
+    warnings: set[str] = set()
+    if not returns_available:
+        warnings.update(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"].values())
     if alpaca_summary_unavailable:
         warnings.add("alpaca_sip_manifest_summary_unavailable")
     if alpaca_summary is not None:
@@ -1142,11 +1397,17 @@ def _dataset_adjustment_metadata(
             daily_manifest.canonical_storage_mode if daily_manifest is not None else None,
             _ALPACA_SIP_DAILY_CANONICAL_STORAGE_MODE,
         ),
-        "read_time_adjustment_mode": _manifest_text(
-            daily_manifest.read_time_adjustment_mode if daily_manifest is not None else None,
-            _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+        "read_time_adjustment_mode": (
+            READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED
+            if read_time_available
+            else _manifest_text(
+                daily_manifest.read_time_adjustment_mode if daily_manifest is not None else None,
+                _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+            )
         ),
-        "null_column_reasons": dict(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"]),
+        "null_column_reasons": (
+            {} if returns_available else dict(_NULL_COLUMN_REASONS_BY_TABLE["alpaca_sip_daily"])
+        ),
         "warnings": sorted(warnings),
         "backtest_handoff": _build_backtest_handoff(
             dataset,
@@ -1169,20 +1430,39 @@ def _build_backtest_handoff(
     if dataset != ALPACA_SIP_DATASET_KEY:
         return None
 
-    reason_codes: set[str] = {_ADJUSTED_PREVIEW_UNAVAILABLE_REASON}
+    read_time_available = _read_time_adjustment_available(
+        trusted_tables=trusted_tables,
+        alpaca_summary=alpaca_summary,
+        alpaca_summary_unavailable=alpaca_summary_unavailable,
+    )
+    reason_codes: set[str] = (
+        {READ_TIME_ADJUSTMENT_AVAILABLE_REASON}
+        if read_time_available
+        else {_ADJUSTED_PREVIEW_UNAVAILABLE_REASON}
+    )
     if queryable_state == "queryable_fallback_only":
         reason_codes.add("alpaca_sip_untrusted_without_manifest")
     if alpaca_summary_unavailable:
         reason_codes.add("alpaca_sip_manifest_summary_unavailable")
+    if alpaca_summary is not None:
+        reason_codes.update(
+            str(warning)
+            for warning in alpaca_summary.warnings
+            if warning in _ALPACA_SIP_COMPANION_BLOCKING_REASONS
+        )
 
     daily_manifest = _trusted_manifest_for_table(
         alpaca_summary,
         "alpaca_sip_daily",
         trusted_tables,
     )
-    selected_read_time_adjustment_mode = _manifest_text(
-        daily_manifest.read_time_adjustment_mode if daily_manifest is not None else None,
-        _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+    selected_read_time_adjustment_mode = (
+        READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED
+        if read_time_available
+        else _manifest_text(
+            daily_manifest.read_time_adjustment_mode if daily_manifest is not None else None,
+            _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
+        )
     )
 
     data_roles: dict[str, BacktestRoleProvenanceDTO] = {}
@@ -1201,21 +1481,33 @@ def _build_backtest_handoff(
                 reason_codes.add("raw_sip_returns_unavailable")
             continue
 
-        data_roles[role] = _role_provenance_from_manifest(role, table, manifest)
+        data_roles[role] = _role_provenance_from_manifest(
+            role,
+            table,
+            manifest,
+            read_time_adjustment_mode_override=(
+                READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED
+                if read_time_available and table == "alpaca_sip_daily"
+                else None
+            ),
+        )
         if table == "alpaca_sip_daily":
             read_mode = _manifest_text(
                 manifest.read_time_adjustment_mode,
                 _ALPACA_SIP_DAILY_READ_TIME_ADJUSTMENT_MODE,
             )
-            if read_mode != "available":
+            if read_mode != "available" and not read_time_available:
                 reason_codes.add("raw_sip_returns_unavailable")
 
     return BacktestHandoffDTO(
         dataset=dataset,
         data_roles=data_roles,
         selected_read_time_adjustment_mode=selected_read_time_adjustment_mode,
-        adjusted_preview_available=False,
-        adjusted_preview_unavailable_reason=_ADJUSTED_PREVIEW_UNAVAILABLE_REASON,
+        derived=read_time_available,
+        adjusted_preview_available=read_time_available,
+        adjusted_preview_unavailable_reason=(
+            None if read_time_available else _ADJUSTED_PREVIEW_UNAVAILABLE_REASON
+        ),
         reason_codes=sorted(reason_codes),
     )
 
@@ -1247,9 +1539,7 @@ def _manifest_candidates_for_table(
         return []
     manifest_dataset = _ALPACA_SIP_TABLE_MANIFEST_DATASETS.get(table, table)
     return [
-        candidate
-        for candidate in alpaca_summary.manifests
-        if candidate.dataset == manifest_dataset
+        candidate for candidate in alpaca_summary.manifests if candidate.dataset == manifest_dataset
     ]
 
 
@@ -1283,6 +1573,8 @@ def _role_provenance_from_manifest(
     role: str,
     table: str,
     manifest: ManifestSummaryDTO,
+    *,
+    read_time_adjustment_mode_override: str | None = None,
 ) -> BacktestRoleProvenanceDTO:
     return BacktestRoleProvenanceDTO(
         role=role,
@@ -1299,7 +1591,9 @@ def _role_provenance_from_manifest(
         source_feed=_optional_text(manifest.source_feed),
         adjustment_mode=_optional_text(manifest.adjustment_mode),
         canonical_storage_mode=_role_canonical_storage_mode(table, manifest),
-        read_time_adjustment_mode=_role_read_time_adjustment_mode(table, manifest),
+        read_time_adjustment_mode=(
+            read_time_adjustment_mode_override or _role_read_time_adjustment_mode(table, manifest)
+        ),
     )
 
 

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -853,6 +853,7 @@ class DataExplorerService:
         prices: pl.DataFrame,
         table_paths: dict[str, TablePathSpec],
     ) -> pl.DataFrame:
+        corp_query_parameters: list[Any] | None = None
         if prices.is_empty():
             corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
         else:
@@ -862,11 +863,12 @@ class DataExplorerService:
                 corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
             else:
                 start_date, _end_date = date_bounds
-                symbol_list = ", ".join(_sql_string_literal(symbol) for symbol in symbols)
+                symbol_placeholders = ", ".join("?" for _symbol in symbols)
+                corp_query_parameters = [*symbols, start_date]
                 corp_query = (
                     "SELECT * FROM alpaca_sip_corp_actions "
-                    f"WHERE symbol IN ({symbol_list}) "
-                    f"AND coalesce(ex_date, process_date) >= DATE '{start_date.isoformat()}' "
+                    f"WHERE symbol IN ({symbol_placeholders}) "
+                    "AND coalesce(ex_date, process_date) >= CAST(? AS DATE) "
                     "ORDER BY symbol, coalesce(ex_date, process_date)"
                 )
         return cast(
@@ -876,6 +878,7 @@ class DataExplorerService:
                 sql=corp_query,
                 table_paths={"alpaca_sip_corp_actions": table_paths["alpaca_sip_corp_actions"]},
                 timeout_seconds=_PREVIEW_TIMEOUT_SECONDS,
+                parameters=corp_query_parameters,
             ),
         )
 
@@ -1234,6 +1237,7 @@ class DataExplorerService:
         sql: str,
         table_paths: dict[str, TablePathSpec],
         timeout_seconds: int,
+        parameters: list[Any] | None = None,
     ) -> Any:
         await asyncio.to_thread(ensure_sql_explorer_execution_allowed)
         return await execute_scoped_query_frame_with_timeout(
@@ -1242,6 +1246,7 @@ class DataExplorerService:
             timeout_seconds,
             available_tables=set(table_paths),
             table_paths=table_paths,
+            parameters=parameters,
         )
 
 
@@ -1266,10 +1271,6 @@ def _price_date_bounds(prices: pl.DataFrame) -> tuple[date, date] | None:
     if not isinstance(min_date, date) or not isinstance(max_date, date):
         return None
     return min_date, max_date
-
-
-def _sql_string_literal(value: str) -> str:
-    return "'" + value.replace("'", "''") + "'"
 
 
 def _preview_candidate_tables(dataset: str, allowed_tables: list[str]) -> list[str]:

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -931,14 +931,30 @@ class DataExplorerService:
             if date_bounds is None or not symbols:
                 corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
             else:
-                start_date, _end_date = date_bounds
+                start_date, _price_end_date = date_bounds
+                query_end_date = _trusted_manifest_end_date(
+                    table_paths.get("alpaca_sip_corp_actions")
+                )
                 symbol_placeholders = ", ".join("?" for _symbol in symbols)
-                corp_query_parameters = [*symbols, start_date]
+                corp_query_parameters = [*symbols, start_date, start_date]
+                upper_bound_clause = ""
+                if query_end_date is not None:
+                    corp_query_parameters.extend([query_end_date, query_end_date])
+                    upper_bound_clause = (
+                        "AND ("
+                        "(process_date IS NOT NULL AND process_date <= CAST(? AS DATE)) "
+                        "OR (process_date IS NULL AND ex_date <= CAST(? AS DATE))"
+                        ") "
+                    )
                 corp_query = (
                     "SELECT * FROM alpaca_sip_corp_actions "
                     f"WHERE symbol IN ({symbol_placeholders}) "
-                    "AND coalesce(ex_date, process_date) >= CAST(? AS DATE) "
-                    "ORDER BY symbol, coalesce(ex_date, process_date)"
+                    "AND ("
+                    "(ex_date IS NOT NULL AND ex_date >= CAST(? AS DATE)) "
+                    "OR (ex_date IS NULL AND process_date >= CAST(? AS DATE))"
+                    ") "
+                    f"{upper_bound_clause}"
+                    "ORDER BY symbol, ex_date NULLS LAST, process_date NULLS LAST"
                 )
         return cast(
             pl.DataFrame,
@@ -1340,6 +1356,13 @@ def _price_date_bounds(prices: pl.DataFrame) -> tuple[date, date] | None:
     if not isinstance(min_date, date) or not isinstance(max_date, date):
         return None
     return min_date, max_date
+
+
+def _trusted_manifest_end_date(path_spec: TablePathSpec | None) -> date | None:
+    value = getattr(path_spec, "manifest_end_date", None)
+    if isinstance(value, date):
+        return value
+    return None
 
 
 def _split_adjusted_preview_start_date(

--- a/libs/web_console_services/data_explorer_service.py
+++ b/libs/web_console_services/data_explorer_service.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import polars as pl
 
+from libs.data.data_pipeline.helpers import normalized_symbols_from_frame
 from libs.data.data_pipeline.read_time_adjustment import (
     READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
     READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
@@ -31,6 +32,10 @@ from libs.platform.web_console_auth.permissions import (
 )
 from libs.platform.web_console_auth.rate_limiter import RateLimiter, get_rate_limiter
 
+from .alpaca_sip_manifest_helpers import (
+    manifest_has_native_returns,
+    summary_supports_split_adjustment,
+)
 from .data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
@@ -852,7 +857,7 @@ class DataExplorerService:
             corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
         else:
             date_bounds = _price_date_bounds(prices)
-            symbols = _price_symbols(prices)
+            symbols = normalized_symbols_from_frame(prices)
             if date_bounds is None or not symbols:
                 corp_query = "SELECT * FROM alpaca_sip_corp_actions LIMIT 0"
             else:
@@ -1263,18 +1268,6 @@ def _price_date_bounds(prices: pl.DataFrame) -> tuple[date, date] | None:
     return min_date, max_date
 
 
-def _price_symbols(prices: pl.DataFrame) -> list[str]:
-    if "symbol" not in prices.columns or prices.is_empty():
-        return []
-    return sorted(
-        {
-            symbol
-            for raw_symbol in prices.get_column("symbol").to_list()
-            if (symbol := str(raw_symbol).strip().upper())
-        }
-    )
-
-
 def _sql_string_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
@@ -1336,9 +1329,7 @@ def _read_time_adjustment_available(
 ) -> bool:
     if alpaca_summary is None or alpaca_summary_unavailable:
         return False
-    if any(
-        warning in _ALPACA_SIP_COMPANION_BLOCKING_REASONS for warning in alpaca_summary.warnings
-    ):
+    if not summary_supports_split_adjustment(alpaca_summary):
         return False
     return (
         _trusted_manifest_for_table(alpaca_summary, "alpaca_sip_daily", trusted_tables) is not None
@@ -1349,12 +1340,6 @@ def _read_time_adjustment_available(
         )
         is not None
     )
-
-
-def _daily_manifest_has_returns(manifest: ManifestSummaryDTO | None) -> bool:
-    if manifest is None or manifest.validation_status.lower() != "passed":
-        return False
-    return manifest.read_time_adjustment_mode == "available"
 
 
 def _dataset_adjustment_metadata(
@@ -1378,7 +1363,7 @@ def _dataset_adjustment_metadata(
         "alpaca_sip_daily",
         trusted_tables,
     )
-    daily_returns_available = _daily_manifest_has_returns(daily_manifest)
+    daily_returns_available = manifest_has_native_returns(daily_manifest)
     returns_available = read_time_available or daily_returns_available
     warnings: set[str] = set()
     if not returns_available:

--- a/libs/web_console_services/data_manifest_service.py
+++ b/libs/web_console_services/data_manifest_service.py
@@ -23,6 +23,9 @@ ALPACA_SIP_MANIFEST_DATASETS: tuple[str, ...] = (
     ALPACA_SIP_DAILY_DATASET,
     ALPACA_SIP_CORP_ACTIONS_DATASET,
 )
+ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH = "alpaca_sip_companion_symbol_set_mismatch"
+ALPACA_SIP_COMPANION_MANIFEST_STALE = "alpaca_sip_companion_manifest_stale"
+ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH = "alpaca_sip_companion_date_range_mismatch"
 
 _ALPACA_SIP_COMPANION_MAX_END_DATE_DRIFT_DAYS = 1
 _DEFAULT_DATA_ROOT = Path(os.getenv("DATA_ROOT", "data")).resolve()
@@ -252,11 +255,13 @@ class DataManifestService:
             and corp_actions.symbol_set_hash
             and daily.symbol_set_hash != corp_actions.symbol_set_hash
         ):
-            warnings.append("alpaca_sip_companion_symbol_set_mismatch")
+            warnings.append(ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH)
 
         end_date_drift = abs((daily.end_date - corp_actions.end_date).days)
         if end_date_drift > _ALPACA_SIP_COMPANION_MAX_END_DATE_DRIFT_DAYS:
-            warnings.append("alpaca_sip_companion_manifest_stale")
+            warnings.append(ALPACA_SIP_COMPANION_MANIFEST_STALE)
+        if corp_actions.start_date > daily.start_date or corp_actions.end_date < daily.end_date:
+            warnings.append(ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH)
 
         return warnings
 

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -15,6 +15,9 @@ from libs.platform.web_console_auth.permissions import (
     has_permission,
 )
 from libs.web_console_services.alpaca_sip_manifest_helpers import (
+    ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
+    ALPACA_SIP_COMPANION_MANIFEST_STALE,
+    ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
     manifest_has_native_returns,
     summary_supports_split_adjustment,
 )
@@ -39,8 +42,6 @@ CRSP_UNIVERSE_MANIFEST_DATASET = "crsp_daily"
 RAW_SIP_RETURNS_UNAVAILABLE = "raw_sip_returns_unavailable"
 ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST = "alpaca_sip_untrusted_without_manifest"
 ALPACA_SIP_MANIFEST_VALIDATION_FAILED = "alpaca_sip_manifest_validation_failed"
-ALPACA_SIP_COMPANION_MANIFEST_STALE = "alpaca_sip_companion_manifest_stale"
-ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH = "alpaca_sip_companion_symbol_set_mismatch"
 CRSP_UNIVERSE_UNAVAILABLE = "crsp_universe_unavailable"
 HYBRID_PRICE_COMPONENT_READY = "hybrid_price_component_ready"
 HYBRID_PRICE_COMPONENT_WARNING = "hybrid_price_component_warning"
@@ -253,6 +254,20 @@ def _alpaca_sip_checks(
                     target_section="acquisition",
                 )
             )
+        elif warning == ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH:
+            checks.append(
+                DataReadinessCheckDTO(
+                    code=ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
+                    status=pairing_status,
+                    message=(
+                        "Corporate actions manifest date coverage does not span the daily "
+                        "bars manifest range."
+                    ),
+                    source="manifest_pairing",
+                    action_label="Refresh corporate-actions coverage",
+                    target_section="acquisition",
+                )
+            )
         elif warning == ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH:
             checks.append(
                 DataReadinessCheckDTO(
@@ -320,9 +335,7 @@ def _hybrid_price_component_check_from_summary(
 ) -> DataReadinessCheckDTO:
     manifests = {manifest.dataset: manifest for manifest in summary.manifests}
     component_states: list[Literal["blocked", "warning"]] = []
-    daily_returns_available = manifest_has_native_returns(
-        manifests.get(ALPACA_SIP_DAILY_DATASET)
-    )
+    daily_returns_available = manifest_has_native_returns(manifests.get(ALPACA_SIP_DAILY_DATASET))
     requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
     for dataset, required in (
         (ALPACA_SIP_DAILY_DATASET, True),
@@ -341,6 +354,7 @@ def _hybrid_price_component_check_from_summary(
     if any(
         warning
         in {
+            ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
             ALPACA_SIP_COMPANION_MANIFEST_STALE,
             ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
         }

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -14,6 +14,10 @@ from libs.platform.web_console_auth.permissions import (
     has_dataset_permission,
     has_permission,
 )
+from libs.web_console_services.alpaca_sip_manifest_helpers import (
+    manifest_has_native_returns,
+    summary_supports_split_adjustment,
+)
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
@@ -188,7 +192,7 @@ def _alpaca_sip_checks(
 ) -> list[DataReadinessCheckDTO]:
     manifests = {manifest.dataset: manifest for manifest in summary.manifests}
     daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    daily_returns_available = _daily_manifest_has_returns(daily)
+    daily_returns_available = manifest_has_native_returns(daily)
     requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
     checks: list[DataReadinessCheckDTO] = [
         _manifest_check(
@@ -204,7 +208,7 @@ def _alpaca_sip_checks(
     ]
 
     if requires_returns:
-        if _read_time_adjustment_available(summary):
+        if summary_supports_split_adjustment(summary):
             checks.append(
                 DataReadinessCheckDTO(
                     code=READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
@@ -299,30 +303,6 @@ def _manifest_check(
     )
 
 
-def _read_time_adjustment_available(summary: AlpacaSipManifestSummaryDTO) -> bool:
-    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
-    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    corp_actions = manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
-    if daily is None or corp_actions is None:
-        return False
-    if daily.validation_status != "passed" or corp_actions.validation_status != "passed":
-        return False
-    return not any(
-        warning
-        in {
-            ALPACA_SIP_COMPANION_MANIFEST_STALE,
-            ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
-        }
-        for warning in summary.warnings
-    )
-
-
-def _daily_manifest_has_returns(manifest: ManifestSummaryDTO | None) -> bool:
-    if manifest is None or manifest.validation_status != "passed":
-        return False
-    return manifest.read_time_adjustment_mode == "available"
-
-
 def _crsp_unavailable_check(message: str) -> DataReadinessCheckDTO:
     return DataReadinessCheckDTO(
         code=CRSP_UNIVERSE_UNAVAILABLE,
@@ -340,7 +320,9 @@ def _hybrid_price_component_check_from_summary(
 ) -> DataReadinessCheckDTO:
     manifests = {manifest.dataset: manifest for manifest in summary.manifests}
     component_states: list[Literal["blocked", "warning"]] = []
-    daily_returns_available = _daily_manifest_has_returns(manifests.get(ALPACA_SIP_DAILY_DATASET))
+    daily_returns_available = manifest_has_native_returns(
+        manifests.get(ALPACA_SIP_DAILY_DATASET)
+    )
     requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
     for dataset, required in (
         (ALPACA_SIP_DAILY_DATASET, True),
@@ -354,7 +336,7 @@ def _hybrid_price_component_check_from_summary(
             component_states.append("blocked" if required else "warning")
 
     needs_split_adjustment = requires_returns and not daily_returns_available
-    if needs_split_adjustment and not _read_time_adjustment_available(summary):
+    if needs_split_adjustment and not summary_supports_split_adjustment(summary):
         component_states.append("blocked")
     if any(
         warning

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -6,6 +6,9 @@ import asyncio
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from libs.data.data_pipeline.read_time_adjustment import (
+    READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
+)
 from libs.platform.web_console_auth.permissions import (
     Permission,
     has_dataset_permission,
@@ -125,9 +128,7 @@ class DataReadinessService:
             checks = list(_alpaca_sip_checks(summary, workflow))
         else:
             checks = [_hybrid_price_component_check_from_summary(summary, workflow)]
-        crsp_manifest = self._manifest_service.get_manifest_summary(
-            CRSP_UNIVERSE_MANIFEST_DATASET
-        )
+        crsp_manifest = self._manifest_service.get_manifest_summary(CRSP_UNIVERSE_MANIFEST_DATASET)
         if crsp_manifest is None:
             checks.append(_crsp_unavailable_check("CRSP universe manifest is missing."))
         elif crsp_manifest.validation_status != "passed":
@@ -186,39 +187,53 @@ def _alpaca_sip_checks(
     workflow: ReadinessWorkflow,
 ) -> list[DataReadinessCheckDTO]:
     manifests = {manifest.dataset: manifest for manifest in summary.manifests}
+    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
+    daily_returns_available = _daily_manifest_has_returns(daily)
+    requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
     checks: list[DataReadinessCheckDTO] = [
         _manifest_check(
             ALPACA_SIP_DAILY_DATASET,
-            manifests.get(ALPACA_SIP_DAILY_DATASET),
+            daily,
             required=True,
         ),
         _manifest_check(
             ALPACA_SIP_CORP_ACTIONS_DATASET,
             manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET),
-            required=workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS,
+            required=requires_returns and not daily_returns_available,
         ),
     ]
 
-    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
-    if requires_returns and _raw_returns_unavailable(daily):
-        checks.append(
-            DataReadinessCheckDTO(
-                code=RAW_SIP_RETURNS_UNAVAILABLE,
-                status="blocked",
-                message=(
-                    "Simple backtests requiring ret or adj_close are blocked while "
-                    "Alpaca SIP canonical OHLC is raw and read-time adjustment is unavailable."
-                ),
-                source="read_time_adjustment_policy",
-                action_label="Use CRSP adjusted returns or wait for adjustment layer",
-                target_section="backtest",
+    if requires_returns:
+        if _read_time_adjustment_available(summary):
+            checks.append(
+                DataReadinessCheckDTO(
+                    code=READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
+                    status="passed",
+                    message=(
+                        "Split-adjusted read-time prices can derive adj_close and ret "
+                        "from trusted raw SIP bars and corporate actions."
+                    ),
+                    source="read_time_adjustment_policy",
+                )
             )
-        )
+        elif daily is not None and not daily_returns_available:
+            checks.append(
+                DataReadinessCheckDTO(
+                    code=RAW_SIP_RETURNS_UNAVAILABLE,
+                    status="blocked",
+                    message=(
+                        "Simple backtests requiring ret or adj_close are blocked while "
+                        "Alpaca SIP canonical OHLC is raw and read-time adjustment is unavailable."
+                    ),
+                    source="read_time_adjustment_policy",
+                    action_label="Use CRSP adjusted returns or wait for adjustment layer",
+                    target_section="backtest",
+                ),
+            )
 
     for warning in summary.warnings:
         pairing_status: Literal["blocked", "warning"] = (
-            "blocked" if requires_returns else "warning"
+            "blocked" if requires_returns and not daily_returns_available else "warning"
         )
         if warning == ALPACA_SIP_COMPANION_MANIFEST_STALE:
             checks.append(
@@ -284,13 +299,28 @@ def _manifest_check(
     )
 
 
-def _raw_returns_unavailable(manifest: ManifestSummaryDTO | None) -> bool:
-    if manifest is None:
+def _read_time_adjustment_available(summary: AlpacaSipManifestSummaryDTO) -> bool:
+    manifests = {manifest.dataset: manifest for manifest in summary.manifests}
+    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
+    corp_actions = manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
+    if daily is None or corp_actions is None:
         return False
-    return (
-        manifest.canonical_storage_mode == "raw"
-        and manifest.read_time_adjustment_mode != "available"
+    if daily.validation_status != "passed" or corp_actions.validation_status != "passed":
+        return False
+    return not any(
+        warning
+        in {
+            ALPACA_SIP_COMPANION_MANIFEST_STALE,
+            ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
+        }
+        for warning in summary.warnings
     )
+
+
+def _daily_manifest_has_returns(manifest: ManifestSummaryDTO | None) -> bool:
+    if manifest is None or manifest.validation_status != "passed":
+        return False
+    return manifest.read_time_adjustment_mode == "available"
 
 
 def _crsp_unavailable_check(message: str) -> DataReadinessCheckDTO:
@@ -310,20 +340,21 @@ def _hybrid_price_component_check_from_summary(
 ) -> DataReadinessCheckDTO:
     manifests = {manifest.dataset: manifest for manifest in summary.manifests}
     component_states: list[Literal["blocked", "warning"]] = []
+    daily_returns_available = _daily_manifest_has_returns(manifests.get(ALPACA_SIP_DAILY_DATASET))
+    requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
     for dataset, required in (
         (ALPACA_SIP_DAILY_DATASET, True),
         (
             ALPACA_SIP_CORP_ACTIONS_DATASET,
-            workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS,
+            requires_returns and not daily_returns_available,
         ),
     ):
         manifest = manifests.get(dataset)
         if manifest is None or manifest.validation_status != "passed":
             component_states.append("blocked" if required else "warning")
 
-    daily = manifests.get(ALPACA_SIP_DAILY_DATASET)
-    requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
-    if requires_returns and _raw_returns_unavailable(daily):
+    needs_split_adjustment = requires_returns and not daily_returns_available
+    if needs_split_adjustment and not _read_time_adjustment_available(summary):
         component_states.append("blocked")
     if any(
         warning
@@ -333,7 +364,7 @@ def _hybrid_price_component_check_from_summary(
         }
         for warning in summary.warnings
     ):
-        component_states.append("blocked" if requires_returns else "warning")
+        component_states.append("blocked" if needs_split_adjustment else "warning")
 
     return _hybrid_price_component_status_check(
         has_blockers="blocked" in component_states,
@@ -412,4 +443,5 @@ __all__ = [
     "HYBRID_PRICE_COMPONENT_READY",
     "HYBRID_PRICE_COMPONENT_WARNING",
     "RAW_SIP_RETURNS_UNAVAILABLE",
+    "READ_TIME_ADJUSTMENT_AVAILABLE_REASON",
 ]

--- a/libs/web_console_services/data_readiness_service.py
+++ b/libs/web_console_services/data_readiness_service.py
@@ -337,21 +337,31 @@ def _hybrid_price_component_check_from_summary(
     component_states: list[Literal["blocked", "warning"]] = []
     daily_returns_available = manifest_has_native_returns(manifests.get(ALPACA_SIP_DAILY_DATASET))
     requires_returns = workflow in _ALPACA_SIP_WORKFLOWS_REQUIRING_RETURNS
-    for dataset, required in (
-        (ALPACA_SIP_DAILY_DATASET, True),
-        (
-            ALPACA_SIP_CORP_ACTIONS_DATASET,
-            requires_returns and not daily_returns_available,
-        ),
-    ):
-        manifest = manifests.get(dataset)
-        if manifest is None or manifest.validation_status != "passed":
-            component_states.append("blocked" if required else "warning")
-
     needs_split_adjustment = requires_returns and not daily_returns_available
-    if needs_split_adjustment and not summary_supports_split_adjustment(summary):
-        component_states.append("blocked")
-    if any(
+
+    if needs_split_adjustment:
+        if not summary_supports_split_adjustment(summary):
+            component_states.append("blocked")
+    else:
+        daily_manifest = manifests.get(ALPACA_SIP_DAILY_DATASET)
+        if daily_manifest is None or daily_manifest.validation_status != "passed":
+            component_states.append("blocked")
+
+        corp_actions_manifest = manifests.get(ALPACA_SIP_CORP_ACTIONS_DATASET)
+        if corp_actions_manifest is None or corp_actions_manifest.validation_status != "passed":
+            component_states.append("warning")
+
+        if _has_companion_quality_warning(summary):
+            component_states.append("warning")
+
+    return _hybrid_price_component_status_check(
+        has_blockers="blocked" in component_states,
+        has_warnings="warning" in component_states,
+    )
+
+
+def _has_companion_quality_warning(summary: AlpacaSipManifestSummaryDTO) -> bool:
+    return any(
         warning
         in {
             ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
@@ -359,12 +369,6 @@ def _hybrid_price_component_check_from_summary(
             ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
         }
         for warning in summary.warnings
-    ):
-        component_states.append("blocked" if needs_split_adjustment else "warning")
-
-    return _hybrid_price_component_status_check(
-        has_blockers="blocked" in component_states,
-        has_warnings="warning" in component_states,
     )
 
 

--- a/libs/web_console_services/schemas/data_management.py
+++ b/libs/web_console_services/schemas/data_management.py
@@ -228,6 +228,7 @@ class BacktestHandoffDTO(BaseModel):
     dataset: str
     data_roles: dict[str, BacktestRoleProvenanceDTO] = Field(default_factory=dict)
     selected_read_time_adjustment_mode: str = "unavailable"
+    derived: bool = False
     adjusted_preview_available: bool = False
     adjusted_preview_unavailable_reason: str | None = None
     reason_codes: list[str] = Field(default_factory=list)
@@ -281,6 +282,9 @@ class DataPreviewDTO(BaseModel):
     canonical_storage_mode: str | None = None
     read_time_adjustment_mode: str | None = None
     provider_signature: ProviderSignatureDTO | None = None
+    derived: bool = False
+    derivation_mode: str | None = None
+    derivation_reason_codes: list[str] = Field(default_factory=list)
     null_column_reasons: dict[str, str] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
     backtest_handoff: BacktestHandoffDTO | None = None

--- a/libs/web_console_services/sql_explorer_service.py
+++ b/libs/web_console_services/sql_explorer_service.py
@@ -12,7 +12,7 @@ import socket
 import threading
 import time
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path as _Path
 from typing import Any
@@ -713,9 +713,7 @@ def resolve_sql_table_availability(
                 fallback_only = bool(manifest_required and isinstance(path_spec, str))
                 manifest_invalid = False
             trusted_for_data_page = bool(
-                available
-                and not manifest_invalid
-                and (not manifest_required or manifest_backed)
+                available and not manifest_invalid and (not manifest_required or manifest_backed)
             )
             if manifest_invalid:
                 warnings.append(
@@ -924,8 +922,9 @@ def can_query_dataset(user: Any, dataset: str) -> bool:
 def _query_frame_from_connection(
     conn: duckdb.DuckDBPyConnection,
     sql: str,
+    parameters: Sequence[Any] | None = None,
 ) -> pl.DataFrame:
-    result = conn.execute(sql)
+    result = conn.execute(sql, parameters) if parameters is not None else conn.execute(sql)
     df = result.pl()
     cell_count = len(df) * len(df.columns)
     if cell_count > _MAX_CELLS:
@@ -988,11 +987,13 @@ async def _execute_query_with_timeout(
     conn: duckdb.DuckDBPyConnection,
     sql: str,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    *,
+    parameters: Sequence[Any] | None = None,
 ) -> pl.DataFrame:
     """Execute query with bounded concurrency and timeout-safe cleanup."""
 
     return await _execute_query_callable_with_timeout(
-        lambda: _query_frame_from_connection(conn, sql),
+        lambda: _query_frame_from_connection(conn, sql, parameters),
         timeout_seconds,
         conn.interrupt,
     )
@@ -1008,11 +1009,13 @@ class _ScopedQueryRunner:
         available_tables: set[str],
         table_paths: dict[str, TablePathSpec] | None,
         sql: str,
+        parameters: Sequence[Any] | None,
     ) -> None:
         self._dataset = dataset
         self._available_tables = available_tables
         self._table_paths = table_paths
         self._sql = sql
+        self._parameters = parameters
         self._conn: duckdb.DuckDBPyConnection | None = None
         self._conn_lock = threading.Lock()
         self._interrupt_requested = threading.Event()
@@ -1028,7 +1031,7 @@ class _ScopedQueryRunner:
         try:
             if self._interrupt_requested.is_set():
                 conn.interrupt()
-            return _query_frame_from_connection(conn, self._sql)
+            return _query_frame_from_connection(conn, self._sql, self._parameters)
         finally:
             try:
                 conn.close()
@@ -1052,6 +1055,7 @@ async def execute_scoped_query_frame_with_timeout(
     *,
     available_tables: set[str],
     table_paths: dict[str, TablePathSpec] | None = None,
+    parameters: Sequence[Any] | None = None,
 ) -> pl.DataFrame:
     """Execute a scoped DuckDB query while owning close in the query worker thread."""
 
@@ -1060,6 +1064,7 @@ async def execute_scoped_query_frame_with_timeout(
         available_tables=available_tables,
         table_paths=table_paths,
         sql=sql,
+        parameters=parameters,
     )
     return await _execute_query_callable_with_timeout(
         runner.run,
@@ -1072,9 +1077,16 @@ async def execute_scoped_query_with_timeout(
     conn: duckdb.DuckDBPyConnection,
     sql: str,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    *,
+    parameters: Sequence[Any] | None = None,
 ) -> pl.DataFrame:
     """Execute a scoped DuckDB query with shared timeout/concurrency limits."""
-    return await _execute_query_with_timeout(conn, sql, timeout_seconds)
+    return await _execute_query_with_timeout(
+        conn,
+        sql,
+        timeout_seconds,
+        parameters=parameters,
+    )
 
 
 def check_sensitive_tables(tables: list[str]) -> None:

--- a/libs/web_console_services/sql_explorer_service.py
+++ b/libs/web_console_services/sql_explorer_service.py
@@ -13,7 +13,7 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path as _Path
 from typing import Any
 from uuid import uuid4
@@ -65,6 +65,8 @@ class ResolvedTablePathSpec(BaseModel, frozen=True):
     manifest_backed: bool = False
     fallback_only: bool = False
     manifest_invalid: bool = False
+    manifest_start_date: date | None = None
+    manifest_end_date: date | None = None
 
 
 _TablePathSpec = _RawTablePathSpec | ResolvedTablePathSpec
@@ -534,6 +536,8 @@ def _resolve_alpaca_sip_snapshot_paths(
                     path_spec=raw_path_spec,
                     manifest_backed=bool(raw_path_spec),
                     manifest_invalid=not raw_path_spec,
+                    manifest_start_date=_parse_manifest_date(manifest.get("start_date")),
+                    manifest_end_date=_parse_manifest_date(manifest.get("end_date")),
                 )
                 return _cache_resolved_alpaca_sip_manifest_path(
                     cache_key,
@@ -556,6 +560,17 @@ def _resolve_alpaca_sip_snapshot_paths(
         path_spec=fallback_path_spec,
         fallback_only=True,
     )
+
+
+def _parse_manifest_date(value: Any) -> date | None:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _resolve_alpaca_sip_daily_paths(data_root: str) -> _TablePathSpec:

--- a/tests/apps/web_console_ng/components/test_data_manifest_components.py
+++ b/tests/apps/web_console_ng/components/test_data_manifest_components.py
@@ -43,9 +43,7 @@ def _manifest(
     adjustment_read_mode = (
         read_time_adjustment_mode
         if read_time_adjustment_mode is not None
-        else "unavailable"
-        if is_daily
-        else None
+        else "unavailable" if is_daily else None
     )
     signature = ProviderSignatureDTO(
         provider_id="alpaca_sip",
@@ -157,15 +155,15 @@ def test_grid_and_detail_expose_present_raw_manifest_provenance() -> None:
 
     assert daily["trusted_manifest_backed"] is True
     assert daily["canonical_storage_mode"] == "raw"
-    assert daily["read_time_adjustment_mode"] == "unavailable"
+    assert daily["read_time_adjustment_mode"] == "split_adjusted"
     assert daily["manifest_id"] == "alpaca_sip_daily@v1:checksum"
     assert corp_actions["readiness"] == "corporate actions only"
     assert detail_map["Manifest checksum"] == "alpaca_sip_daily-checksum"
     assert detail_map["Canonical storage mode"] == "raw"
-    assert detail_map["Read-time adjustment mode"] == "unavailable"
-    assert detail_map["adj_close"] == "not available"
-    assert detail_map["ret"] == "not available"
-    assert "raw_sip_returns_unavailable" in detail_map["Backtest readiness"]
+    assert detail_map["Read-time adjustment mode"] == "split_adjusted"
+    assert detail_map["adj_close"] == "derived split-adjusted"
+    assert detail_map["ret"] == "derived split-adjusted"
+    assert "split_adjusted_read_time_available" in detail_map["Backtest readiness"]
     assert "provider_id" in detail_map["Provider signature"]
 
 

--- a/tests/apps/web_console_ng/pages/test_data_management_wiring.py
+++ b/tests/apps/web_console_ng/pages/test_data_management_wiring.py
@@ -622,9 +622,7 @@ class TestBuildQueryResults:
 
         def _select(*_args: Any, **kwargs: Any) -> _FakeElement:
             element_cls = (
-                _DatasetSelect
-                if kwargs.get("label") == "Select Dataset"
-                else _FakeElement
+                _DatasetSelect if kwargs.get("label") == "Select Dataset" else _FakeElement
             )
             return element_cls(
                 value=kwargs.get("value"),
@@ -712,9 +710,7 @@ class TestBuildQueryResults:
                     )
                 },
                 adjusted_preview_available=False,
-                adjusted_preview_unavailable_reason=(
-                    "read_time_adjustment_layer_not_defined"
-                ),
+                adjusted_preview_unavailable_reason=("read_time_adjustment_layer_not_defined"),
                 reason_codes=[
                     "raw_sip_returns_unavailable",
                     "read_time_adjustment_layer_not_defined",
@@ -791,12 +787,8 @@ class TestBuildQueryResults:
         row.__enter__ = MagicMock(return_value=row)
         row.__exit__ = MagicMock(return_value=False)
         mock_ui.row.return_value = row
-        select = MagicMock()
-        select.classes.return_value = select
-        select.props.return_value = select
         button = MagicMock()
         button.props.return_value = button
-        mock_ui.select.return_value = select
         mock_ui.button.return_value = button
         mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
         dataset = DatasetInfoDTO(
@@ -805,15 +797,13 @@ class TestBuildQueryResults:
             backtest_handoff=BacktestHandoffDTO(
                 dataset="alpaca_sip",
                 adjusted_preview_available=False,
-                adjusted_preview_unavailable_reason=(
-                    "read_time_adjustment_layer_not_defined"
-                ),
+                adjusted_preview_unavailable_reason=("read_time_adjustment_layer_not_defined"),
             ),
         )
 
         dm_module._render_adjusted_preview_controls(dataset)
 
-        select.props.assert_called_once_with("disable")
+        mock_ui.select.assert_not_called()
         button.props.assert_called_once_with("flat disable")
 
     @patch("apps.web_console_ng.pages.data_management.ui")
@@ -825,12 +815,8 @@ class TestBuildQueryResults:
         row.__enter__ = MagicMock(return_value=row)
         row.__exit__ = MagicMock(return_value=False)
         mock_ui.row.return_value = row
-        select = MagicMock()
-        select.classes.return_value = select
-        select.props.return_value = select
         button = MagicMock()
         button.props.return_value = button
-        mock_ui.select.return_value = select
         mock_ui.button.return_value = button
         mock_ui.label.return_value = MagicMock(classes=MagicMock(return_value=MagicMock()))
         dataset = DatasetInfoDTO(
@@ -843,6 +829,7 @@ class TestBuildQueryResults:
 
         labels = [call.args[0] for call in mock_ui.label.call_args_list if call.args]
         assert "read_time_adjustment_layer_not_defined" in labels
+        mock_ui.select.assert_not_called()
 
     @patch("apps.web_console_ng.pages.data_management.ui")
     def test_adjusted_preview_controls_hidden_without_adjustment_metadata(

--- a/tests/libs/data/data_pipeline/test_read_time_adjustment.py
+++ b/tests/libs/data/data_pipeline/test_read_time_adjustment.py
@@ -1,0 +1,125 @@
+"""Tests for read-time adjustment derivation from raw canonical inputs."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from libs.data.data_pipeline.read_time_adjustment import (
+    READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
+    READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+    READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON,
+    READ_TIME_NO_SPLIT_ACTIONS_REASON,
+    derive_split_adjusted_prices,
+)
+
+
+def _prices() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL", "AAPL"],
+            "date": [date(2020, 8, 28), date(2020, 8, 31), date(2020, 9, 1)],
+            "open": [500.0, 125.0, 130.0],
+            "high": [504.0, 126.0, 132.0],
+            "low": [496.0, 124.0, 129.0],
+            "close": [500.0, 125.0, 130.0],
+            "volume": [1_000_000.0, 4_000_000.0, 3_800_000.0],
+        }
+    )
+
+
+def _corp_actions() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "ca_type": ["stock_split"],
+            "ex_date": [date(2020, 8, 31)],
+            "process_date": [date(2020, 8, 30)],
+            "old_rate": [1.0],
+            "new_rate": [4.0],
+        }
+    )
+
+
+def test_split_adjustment_derives_adjusted_close_and_returns() -> None:
+    result = derive_split_adjusted_prices(_prices(), _corp_actions())
+
+    assert result.mode == READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED
+    assert result.reason_codes == (READ_TIME_ADJUSTMENT_AVAILABLE_REASON,)
+    assert result.split_action_count == 1
+    assert result.frame["close"].to_list() == [500.0, 125.0, 130.0]
+    assert result.frame["adj_close"].to_list() == [125.0, 125.0, 130.0]
+    assert result.frame["split_adjustment_factor"].to_list() == [4.0, 1.0, 1.0]
+    assert result.frame["adj_volume"].to_list() == [4_000_000.0, 4_000_000.0, 3_800_000.0]
+    assert result.frame["ret"].to_list()[0] is None
+    assert result.frame["ret"].to_list()[1:] == pytest.approx([0.0, 0.04])
+    assert result.frame["read_time_adjustment_mode"].to_list() == [
+        READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+        READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+        READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
+    ]
+
+
+def test_split_adjustment_applies_non_trading_day_action_to_prior_rows() -> None:
+    corp_actions = _corp_actions().with_columns(pl.lit(date(2020, 8, 30)).alias("ex_date"))
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert result.frame["adj_close"].to_list() == [125.0, 125.0, 130.0]
+    assert result.frame["ret"].to_list()[0] is None
+    assert result.frame["ret"].to_list()[1:] == pytest.approx([0.0, 0.04])
+
+
+def test_no_split_actions_still_derives_trusted_identity_price_path() -> None:
+    corp_actions = _corp_actions().with_columns(pl.lit("cash_dividend").alias("ca_type"))
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert READ_TIME_NO_SPLIT_ACTIONS_REASON in result.reason_codes
+    assert result.frame["adj_close"].to_list() == [500.0, 125.0, 130.0]
+    assert result.frame["ret"].to_list()[0] is None
+    assert result.frame["ret"].to_list()[1:] == pytest.approx([-0.75, 0.04])
+
+
+def test_invalid_split_actions_are_skipped_with_reason_code() -> None:
+    corp_actions = _corp_actions().with_columns(pl.lit(None).cast(pl.Float64).alias("new_rate"))
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert result.skipped_action_count == 1
+    assert READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON in result.reason_codes
+    assert READ_TIME_NO_SPLIT_ACTIONS_REASON in result.reason_codes
+
+
+def test_malformed_split_rates_are_skipped_with_reason_code() -> None:
+    corp_actions = _corp_actions().with_columns(pl.lit("not-a-rate").alias("old_rate"))
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert result.skipped_action_count == 1
+    assert READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON in result.reason_codes
+    assert result.frame["adj_close"].to_list() == [500.0, 125.0, 130.0]
+
+
+def test_malformed_split_dates_are_skipped_with_reason_code() -> None:
+    corp_actions = _corp_actions().with_columns(
+        [
+            pl.lit("not-a-date").alias("ex_date"),
+            pl.lit(None).cast(pl.Date).alias("process_date"),
+        ]
+    )
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert result.skipped_action_count == 1
+    assert READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON in result.reason_codes
+    assert result.frame["adj_close"].to_list() == [500.0, 125.0, 130.0]
+
+
+def test_missing_corporate_action_date_column_fails_closed() -> None:
+    corp_actions = _corp_actions().drop(["ex_date", "process_date"])
+
+    with pytest.raises(ValueError, match="action date column"):
+        derive_split_adjusted_prices(_prices(), corp_actions)

--- a/tests/libs/data/data_pipeline/test_read_time_adjustment.py
+++ b/tests/libs/data/data_pipeline/test_read_time_adjustment.py
@@ -7,6 +7,7 @@ from datetime import date
 import polars as pl
 import pytest
 
+from libs.data.data_pipeline.helpers import normalized_symbols_from_frame
 from libs.data.data_pipeline.read_time_adjustment import (
     READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
     READ_TIME_ADJUSTMENT_MODE_SPLIT_ADJUSTED,
@@ -123,3 +124,9 @@ def test_missing_corporate_action_date_column_fails_closed() -> None:
 
     with pytest.raises(ValueError, match="action date column"):
         derive_split_adjusted_prices(_prices(), corp_actions)
+
+
+def test_normalized_symbols_from_frame_uses_polars_native_normalization() -> None:
+    frame = pl.DataFrame({"symbol": [" aapl", "MSFT", "AAPL ", None, ""]})
+
+    assert normalized_symbols_from_frame(frame) == ["AAPL", "MSFT"]

--- a/tests/libs/data/data_pipeline/test_read_time_adjustment.py
+++ b/tests/libs/data/data_pipeline/test_read_time_adjustment.py
@@ -84,6 +84,32 @@ def test_no_split_actions_still_derives_trusted_identity_price_path() -> None:
     assert result.frame["ret"].to_list()[1:] == pytest.approx([-0.75, 0.04])
 
 
+def test_split_off_action_type_is_not_treated_as_split() -> None:
+    corp_actions = _corp_actions().with_columns(pl.lit("split_off").alias("ca_type"))
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert READ_TIME_NO_SPLIT_ACTIONS_REASON in result.reason_codes
+    assert result.split_action_count == 0
+    assert result.frame["adj_close"].to_list() == [500.0, 125.0, 130.0]
+
+
+def test_reverse_split_action_type_is_supported() -> None:
+    corp_actions = _corp_actions().with_columns(
+        [
+            pl.lit("reverse_split").alias("ca_type"),
+            pl.lit(4.0).alias("old_rate"),
+            pl.lit(1.0).alias("new_rate"),
+        ]
+    )
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert result.split_action_count == 1
+    assert result.frame["split_adjustment_factor"].to_list() == [0.25, 1.0, 1.0]
+    assert result.frame["adj_close"].to_list() == [2000.0, 125.0, 130.0]
+
+
 def test_invalid_split_actions_are_skipped_with_reason_code() -> None:
     corp_actions = _corp_actions().with_columns(pl.lit(None).cast(pl.Float64).alias("new_rate"))
 
@@ -124,6 +150,13 @@ def test_missing_corporate_action_date_column_fails_closed() -> None:
 
     with pytest.raises(ValueError, match="action date column"):
         derive_split_adjusted_prices(_prices(), corp_actions)
+
+
+def test_duplicate_symbol_date_price_rows_fail_closed() -> None:
+    prices = pl.concat([_prices(), _prices().head(1)], how="vertical")
+
+    with pytest.raises(ValueError, match="duplicate symbol/date"):
+        derive_split_adjusted_prices(prices, _corp_actions())
 
 
 def test_normalized_symbols_from_frame_uses_polars_native_normalization() -> None:

--- a/tests/libs/data/data_pipeline/test_read_time_adjustment.py
+++ b/tests/libs/data/data_pipeline/test_read_time_adjustment.py
@@ -94,6 +94,26 @@ def test_split_off_action_type_is_not_treated_as_split() -> None:
     assert result.frame["adj_close"].to_list() == [500.0, 125.0, 130.0]
 
 
+@pytest.mark.parametrize(
+    "ca_type",
+    [" forward split ", "forward_splits", "unit_split", "unit splits"],
+)
+def test_alpaca_split_type_is_supported_with_normalization(ca_type: str) -> None:
+    prices = _prices().with_columns(pl.lit(" aapl ").alias("symbol"))
+    corp_actions = _corp_actions().with_columns(
+        [
+            pl.lit(" aapl ").alias("symbol"),
+            pl.lit(ca_type).alias("ca_type"),
+        ]
+    )
+
+    result = derive_split_adjusted_prices(prices, corp_actions)
+
+    assert result.split_action_count == 1
+    assert result.frame["symbol"].to_list() == ["AAPL", "AAPL", "AAPL"]
+    assert result.frame["adj_close"].to_list() == [125.0, 125.0, 130.0]
+
+
 def test_reverse_split_action_type_is_supported() -> None:
     corp_actions = _corp_actions().with_columns(
         [
@@ -128,6 +148,16 @@ def test_malformed_split_rates_are_skipped_with_reason_code() -> None:
     assert result.skipped_action_count == 1
     assert READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON in result.reason_codes
     assert result.frame["adj_close"].to_list() == [500.0, 125.0, 130.0]
+
+
+def test_non_finite_split_rates_are_skipped_with_reason_code() -> None:
+    corp_actions = _corp_actions().with_columns(pl.lit(float("inf")).alias("new_rate"))
+
+    result = derive_split_adjusted_prices(_prices(), corp_actions)
+
+    assert result.skipped_action_count == 1
+    assert READ_TIME_INVALID_SPLIT_ACTIONS_SKIPPED_REASON in result.reason_codes
+    assert READ_TIME_NO_SPLIT_ACTIONS_REASON in result.reason_codes
 
 
 def test_malformed_split_dates_are_skipped_with_reason_code() -> None:

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -512,12 +512,22 @@ class TestAlpacaSIPLocalProvider:
         corp_path = corp_dir / "actions.parquet"
         pl.DataFrame(
             {
-                "symbol": ["AAPL", "AAPL", "AAPL"],
-                "ca_type": ["stock_split", "stock_split", "stock_split"],
-                "process_date": [date(2020, 8, 30), date(2020, 9, 1), date(2020, 9, 14)],
-                "ex_date": [date(2020, 8, 31), date(2020, 9, 10), date(2020, 9, 15)],
-                "old_rate": [1.0, 1.0, 1.0],
-                "new_rate": [4.0, 2.0, 3.0],
+                "symbol": ["AAPL", "AAPL", "AAPL", "AAPL"],
+                "ca_type": ["stock_split", "stock_split", "stock_split", "stock_split"],
+                "process_date": [
+                    date(2020, 8, 30),
+                    date(2020, 9, 1),
+                    date(2020, 9, 14),
+                    date(2020, 10, 5),
+                ],
+                "ex_date": [
+                    date(2020, 8, 31),
+                    date(2020, 9, 10),
+                    date(2020, 9, 15),
+                    date(2020, 10, 6),
+                ],
+                "old_rate": [1.0, 1.0, 1.0, 1.0],
+                "new_rate": [4.0, 2.0, 3.0, 5.0],
             }
         ).write_parquet(corp_path)
         manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
@@ -570,6 +580,7 @@ class TestAlpacaSIPLocalProvider:
             date(2020, 9, 10),
             date(2020, 9, 15),
         ]
+        assert date(2020, 10, 6) not in unbounded["ex_date"].to_list()
 
     def test_invalid_column_raises(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -514,6 +514,101 @@ class TestAlpacaSIPDataProviderAdapter:
 
         assert df["ret"].to_list() == [None, None]
 
+    def test_adapter_derives_split_adjusted_returns_from_corp_actions_manifest(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        data_root = tmp_path / "data"
+        daily_dir = data_root / "alpaca" / "sip" / "daily"
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        manifest_dir = data_root / "manifests"
+        lock_dir = data_root / "locks"
+        daily_dir.mkdir(parents=True)
+        corp_dir.mkdir(parents=True)
+        manifest_dir.mkdir(parents=True)
+        lock_dir.mkdir(parents=True)
+        daily_path = daily_dir / "2020.parquet"
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "date": [date(2020, 8, 28), date(2020, 8, 31), date(2020, 9, 1)],
+                "symbol": ["AAPL", "AAPL", "AAPL"],
+                "open": [500.0, 125.0, 130.0],
+                "high": [504.0, 126.0, 132.0],
+                "low": [496.0, 124.0, 129.0],
+                "close": [500.0, 125.0, 130.0],
+                "volume": [1_000_000.0, 4_000_000.0, 3_800_000.0],
+                "trade_count": [10_000.0, 11_000.0, 12_000.0],
+                "vwap": [501.0, 125.5, 130.5],
+                "adj_close": [None, None, None],
+                "ret": [None, None, None],
+            },
+            schema={column: ALPACA_SIP_SCHEMA[column] for column in ALPACA_SIP_COLUMNS},
+        ).write_parquet(daily_path)
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 30)],
+                "ex_date": [date(2020, 8, 31)],
+                "old_rate": [1.0],
+                "new_rate": [4.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_base = {
+            "sync_timestamp": datetime.now(UTC).isoformat(),
+            "checksum": "abc123",
+            "checksum_algorithm": "sha256",
+            "schema_version": "v1.0.0",
+            "wrds_query_hash": "alpaca-sip-local-test",
+            "validation_status": "passed",
+            "manifest_version": 1,
+        }
+        (manifest_dir / "alpaca_sip_daily.json").write_text(
+            json.dumps(
+                {
+                    **manifest_base,
+                    "dataset": "alpaca_sip_daily",
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-09-01",
+                    "row_count": 3,
+                    "file_paths": [str(daily_path)],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
+            json.dumps(
+                {
+                    **manifest_base,
+                    "dataset": "alpaca_sip_corp_actions",
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-09-01",
+                    "row_count": 1,
+                    "file_paths": [str(corp_path)],
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest_manager = ManifestManager(
+            storage_path=manifest_dir,
+            lock_dir=lock_dir,
+            data_root=data_root,
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=daily_dir,
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+        adapter = AlpacaSIPDataProviderAdapter(provider)
+
+        df = adapter.get_daily_prices(["AAPL"], date(2020, 8, 28), date(2020, 9, 1))
+
+        assert df["close"].to_list() == [500.0, 125.0, 130.0]
+        assert df["adj_close"].to_list() == [125.0, 125.0, 130.0]
+        assert df["ret"].to_list()[0] is None
+        assert df["ret"].to_list()[1:] == pytest.approx([0.0, 0.04])
+
     def test_adapter_rejects_empty_symbols(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
     ) -> None:

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -311,6 +311,55 @@ class TestAlpacaSIPLocalProvider:
 
         assert df.height == 2
 
+    def test_pinned_manifest_disables_current_corp_actions_manifest(
+        self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
+    ) -> None:
+        data_root, manifest_manager, _ = mock_alpaca_sip_data
+        pinned_manifest = manifest_manager.load_manifest("alpaca_sip_daily")
+        assert pinned_manifest is not None
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        corp_dir.mkdir(parents=True)
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 30)],
+                "ex_date": [date(2020, 8, 31)],
+                "old_rate": [1.0],
+                "new_rate": [4.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "dataset": "alpaca_sip_corp_actions",
+                    "sync_timestamp": datetime.now(UTC).isoformat(),
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-09-01",
+                    "row_count": 1,
+                    "checksum": "abc123",
+                    "checksum_algorithm": "sha256",
+                    "schema_version": "v1.0.0",
+                    "wrds_query_hash": "alpaca-sip-local-test",
+                    "file_paths": [str(corp_path)],
+                    "validation_status": "passed",
+                    "manifest_version": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=data_root / "alpaca" / "sip" / "daily",
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+            pinned_manifest=pinned_manifest,
+        )
+
+        with pytest.raises(DataNotFoundError, match="pinned Alpaca SIP daily"):
+            provider.get_corporate_actions(start_date=date(2020, 8, 28), symbols=["AAPL"])
+
     def test_invalid_column_raises(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
     ) -> None:

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -360,6 +360,98 @@ class TestAlpacaSIPLocalProvider:
         with pytest.raises(DataNotFoundError, match="pinned Alpaca SIP daily"):
             provider.get_corporate_actions(start_date=date(2020, 8, 28), symbols=["AAPL"])
 
+    def test_untrusted_corp_actions_manifest_fails_closed(
+        self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
+    ) -> None:
+        data_root, manifest_manager, _ = mock_alpaca_sip_data
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        corp_dir.mkdir(parents=True)
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 30)],
+                "ex_date": [date(2020, 8, 31)],
+                "old_rate": [1.0],
+                "new_rate": [4.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "dataset": "alpaca_sip_corp_actions",
+                    "sync_timestamp": datetime.now(UTC).isoformat(),
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-09-01",
+                    "row_count": 1,
+                    "checksum": "abc123",
+                    "checksum_algorithm": "sha256",
+                    "schema_version": "v1.0.0",
+                    "wrds_query_hash": "alpaca-sip-local-test",
+                    "file_paths": [str(corp_path)],
+                    "validation_status": "failed",
+                    "manifest_version": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=data_root / "alpaca" / "sip" / "daily",
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+
+        with pytest.raises(DataNotFoundError, match="not trusted"):
+            provider.get_corporate_actions(start_date=date(2020, 8, 28), symbols=["AAPL"])
+
+    def test_corp_actions_manifest_start_after_price_range_fails_closed(
+        self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
+    ) -> None:
+        data_root, manifest_manager, _ = mock_alpaca_sip_data
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        corp_dir.mkdir(parents=True)
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 30)],
+                "ex_date": [date(2020, 8, 31)],
+                "old_rate": [1.0],
+                "new_rate": [4.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "dataset": "alpaca_sip_corp_actions",
+                    "sync_timestamp": datetime.now(UTC).isoformat(),
+                    "start_date": "2020-08-29",
+                    "end_date": "2020-09-01",
+                    "row_count": 1,
+                    "checksum": "abc123",
+                    "checksum_algorithm": "sha256",
+                    "schema_version": "v1.0.0",
+                    "wrds_query_hash": "alpaca-sip-local-test",
+                    "file_paths": [str(corp_path)],
+                    "validation_status": "passed",
+                    "manifest_version": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=data_root / "alpaca" / "sip" / "daily",
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+
+        with pytest.raises(DataNotFoundError, match="after requested price start"):
+            provider.get_corporate_actions(start_date=date(2020, 8, 28), symbols=["AAPL"])
+
     def test_invalid_column_raises(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
     ) -> None:

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -21,6 +21,7 @@ from libs.data.data_providers.protocols import (
     UNIFIED_COLUMNS,
     AlpacaSIPDataProviderAdapter,
     DataProvider,
+    DataProviderError,
     ProviderNotSupportedError,
 )
 from libs.data.data_quality.exceptions import DataNotFoundError
@@ -452,6 +453,56 @@ class TestAlpacaSIPLocalProvider:
         with pytest.raises(DataNotFoundError, match="after requested price start"):
             provider.get_corporate_actions(start_date=date(2020, 8, 28), symbols=["AAPL"])
 
+    def test_corp_actions_manifest_end_before_price_range_fails_closed(
+        self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
+    ) -> None:
+        data_root, manifest_manager, _ = mock_alpaca_sip_data
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        corp_dir.mkdir(parents=True)
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 30)],
+                "ex_date": [date(2020, 8, 31)],
+                "old_rate": [1.0],
+                "new_rate": [4.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "dataset": "alpaca_sip_corp_actions",
+                    "sync_timestamp": datetime.now(UTC).isoformat(),
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-08-31",
+                    "row_count": 1,
+                    "checksum": "abc123",
+                    "checksum_algorithm": "sha256",
+                    "schema_version": "v1.0.0",
+                    "wrds_query_hash": "alpaca-sip-local-test",
+                    "file_paths": [str(corp_path)],
+                    "validation_status": "passed",
+                    "manifest_version": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=data_root / "alpaca" / "sip" / "daily",
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+
+        with pytest.raises(DataNotFoundError, match="before requested price end"):
+            provider.get_corporate_actions(
+                start_date=date(2020, 8, 28),
+                end_date=date(2020, 9, 1),
+                symbols=["AAPL"],
+            )
+
     def test_invalid_column_raises(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
     ) -> None:
@@ -649,6 +700,7 @@ class TestAlpacaSIPDataProviderAdapter:
                 "ret": [None, None],
             }
         )
+        provider.get_corporate_actions.side_effect = DataNotFoundError("no companion manifest")
         adapter = AlpacaSIPDataProviderAdapter(provider)
 
         df = adapter.get_daily_prices(["AAPL"], date(2023, 1, 3), date(2023, 1, 4))
@@ -749,6 +801,97 @@ class TestAlpacaSIPDataProviderAdapter:
         assert df["adj_close"].to_list() == [125.0, 125.0, 130.0]
         assert df["ret"].to_list()[0] is None
         assert df["ret"].to_list()[1:] == pytest.approx([0.0, 0.04])
+
+    def test_adapter_rejects_stale_corp_actions_manifest(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        data_root = tmp_path / "data"
+        daily_dir = data_root / "alpaca" / "sip" / "daily"
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        manifest_dir = data_root / "manifests"
+        lock_dir = data_root / "locks"
+        daily_dir.mkdir(parents=True)
+        corp_dir.mkdir(parents=True)
+        manifest_dir.mkdir(parents=True)
+        lock_dir.mkdir(parents=True)
+        daily_path = daily_dir / "2020.parquet"
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "date": [date(2020, 8, 28), date(2020, 9, 1)],
+                "symbol": ["AAPL", "AAPL"],
+                "open": [500.0, 130.0],
+                "high": [504.0, 132.0],
+                "low": [496.0, 129.0],
+                "close": [500.0, 130.0],
+                "volume": [1_000_000.0, 3_800_000.0],
+                "trade_count": [10_000.0, 12_000.0],
+                "vwap": [501.0, 130.5],
+                "adj_close": [None, None],
+                "ret": [None, None],
+            },
+            schema={column: ALPACA_SIP_SCHEMA[column] for column in ALPACA_SIP_COLUMNS},
+        ).write_parquet(daily_path)
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 30)],
+                "ex_date": [date(2020, 8, 31)],
+                "old_rate": [1.0],
+                "new_rate": [4.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_base = {
+            "sync_timestamp": datetime.now(UTC).isoformat(),
+            "checksum": "abc123",
+            "checksum_algorithm": "sha256",
+            "schema_version": "v1.0.0",
+            "wrds_query_hash": "alpaca-sip-local-test",
+            "validation_status": "passed",
+            "manifest_version": 1,
+        }
+        (manifest_dir / "alpaca_sip_daily.json").write_text(
+            json.dumps(
+                {
+                    **manifest_base,
+                    "dataset": "alpaca_sip_daily",
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-09-01",
+                    "row_count": 2,
+                    "file_paths": [str(daily_path)],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
+            json.dumps(
+                {
+                    **manifest_base,
+                    "dataset": "alpaca_sip_corp_actions",
+                    "start_date": "2020-08-28",
+                    "end_date": "2020-08-31",
+                    "row_count": 1,
+                    "file_paths": [str(corp_path)],
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest_manager = ManifestManager(
+            storage_path=manifest_dir,
+            lock_dir=lock_dir,
+            data_root=data_root,
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=daily_dir,
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+        adapter = AlpacaSIPDataProviderAdapter(provider)
+
+        with pytest.raises(DataProviderError, match="before requested price end"):
+            adapter.get_daily_prices(["AAPL"], date(2020, 8, 28), date(2020, 9, 1))
 
     def test_adapter_rejects_empty_symbols(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -553,6 +553,7 @@ class TestAlpacaSIPLocalProvider:
         )
         unbounded = provider.get_corporate_actions(
             start_date=date(2020, 8, 1),
+            coverage_end_date=date(2020, 9, 1),
             symbols=["AAPL"],
         )
 
@@ -860,6 +861,101 @@ class TestAlpacaSIPDataProviderAdapter:
         assert df["adj_close"].to_list() == [125.0, 125.0, 130.0]
         assert df["ret"].to_list()[0] is None
         assert df["ret"].to_list()[1:] == pytest.approx([0.0, 0.04])
+
+    def test_adapter_includes_later_manifest_splits_for_adjusted_prices(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        data_root = tmp_path / "data"
+        daily_dir = data_root / "alpaca" / "sip" / "daily"
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        manifest_dir = data_root / "manifests"
+        lock_dir = data_root / "locks"
+        daily_dir.mkdir(parents=True)
+        corp_dir.mkdir(parents=True)
+        manifest_dir.mkdir(parents=True)
+        lock_dir.mkdir(parents=True)
+        daily_path = daily_dir / "2020.parquet"
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "date": [date(2020, 8, 1), date(2020, 8, 2)],
+                "symbol": ["AAPL", "AAPL"],
+                "open": [100.0, 104.0],
+                "high": [101.0, 105.0],
+                "low": [99.0, 103.0],
+                "close": [100.0, 104.0],
+                "volume": [1_000_000.0, 1_100_000.0],
+                "trade_count": [10_000.0, 11_000.0],
+                "vwap": [100.5, 104.5],
+                "adj_close": [None, None],
+                "ret": [None, None],
+            },
+            schema={column: ALPACA_SIP_SCHEMA[column] for column in ALPACA_SIP_COLUMNS},
+        ).write_parquet(daily_path)
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "ca_type": ["stock_split"],
+                "process_date": [date(2020, 8, 31)],
+                "ex_date": [date(2020, 9, 1)],
+                "old_rate": [1.0],
+                "new_rate": [2.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_base = {
+            "sync_timestamp": datetime.now(UTC).isoformat(),
+            "checksum": "abc123",
+            "checksum_algorithm": "sha256",
+            "schema_version": "v1.0.0",
+            "wrds_query_hash": "alpaca-sip-local-test",
+            "validation_status": "passed",
+            "manifest_version": 1,
+        }
+        (manifest_dir / "alpaca_sip_daily.json").write_text(
+            json.dumps(
+                {
+                    **manifest_base,
+                    "dataset": "alpaca_sip_daily",
+                    "start_date": "2020-08-01",
+                    "end_date": "2020-08-02",
+                    "row_count": 2,
+                    "file_paths": [str(daily_path)],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
+            json.dumps(
+                {
+                    **manifest_base,
+                    "dataset": "alpaca_sip_corp_actions",
+                    "start_date": "2020-08-01",
+                    "end_date": "2020-09-01",
+                    "row_count": 1,
+                    "file_paths": [str(corp_path)],
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest_manager = ManifestManager(
+            storage_path=manifest_dir,
+            lock_dir=lock_dir,
+            data_root=data_root,
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=daily_dir,
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+        adapter = AlpacaSIPDataProviderAdapter(provider)
+
+        df = adapter.get_daily_prices(["AAPL"], date(2020, 8, 1), date(2020, 8, 2))
+
+        assert df["close"].to_list() == [100.0, 104.0]
+        assert df["adj_close"].to_list() == [50.0, 52.0]
+        assert df["ret"].to_list()[0] is None
+        assert df["ret"].to_list()[1] == pytest.approx(0.04)
 
     def test_adapter_rejects_stale_corp_actions_manifest(
         self,

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -503,6 +503,65 @@ class TestAlpacaSIPLocalProvider:
                 symbols=["AAPL"],
             )
 
+    def test_corp_actions_query_respects_requested_end_date(
+        self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
+    ) -> None:
+        data_root, manifest_manager, _ = mock_alpaca_sip_data
+        corp_dir = data_root / "alpaca" / "sip" / "corp_actions"
+        corp_dir.mkdir(parents=True)
+        corp_path = corp_dir / "actions.parquet"
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL", "AAPL"],
+                "ca_type": ["stock_split", "stock_split"],
+                "process_date": [date(2020, 8, 30), date(2020, 9, 14)],
+                "ex_date": [date(2020, 8, 31), date(2020, 9, 15)],
+                "old_rate": [1.0, 1.0],
+                "new_rate": [4.0, 2.0],
+            }
+        ).write_parquet(corp_path)
+        manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "dataset": "alpaca_sip_corp_actions",
+                    "sync_timestamp": datetime.now(UTC).isoformat(),
+                    "start_date": "2020-08-01",
+                    "end_date": "2020-09-30",
+                    "row_count": 2,
+                    "checksum": "abc123",
+                    "checksum_algorithm": "sha256",
+                    "schema_version": "v1.0.0",
+                    "wrds_query_hash": "alpaca-sip-local-test",
+                    "file_paths": [str(corp_path)],
+                    "validation_status": "passed",
+                    "manifest_version": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        provider = AlpacaSIPLocalProvider(
+            storage_path=data_root / "alpaca" / "sip" / "daily",
+            manifest_manager=manifest_manager,
+            data_root=data_root,
+        )
+
+        bounded = provider.get_corporate_actions(
+            start_date=date(2020, 8, 1),
+            end_date=date(2020, 9, 1),
+            symbols=["AAPL"],
+        )
+        unbounded = provider.get_corporate_actions(
+            start_date=date(2020, 8, 1),
+            symbols=["AAPL"],
+        )
+
+        assert bounded["ex_date"].to_list() == [date(2020, 8, 31)]
+        assert unbounded["ex_date"].to_list() == [
+            date(2020, 8, 31),
+            date(2020, 9, 15),
+        ]
+
     def test_invalid_column_raises(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
     ) -> None:

--- a/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
+++ b/tests/libs/data/data_providers/test_alpaca_sip_local_provider.py
@@ -503,7 +503,7 @@ class TestAlpacaSIPLocalProvider:
                 symbols=["AAPL"],
             )
 
-    def test_corp_actions_query_respects_requested_end_date(
+    def test_corp_actions_query_respects_requested_process_date_window(
         self, mock_alpaca_sip_data: tuple[Path, ManifestManager, list[Path]]
     ) -> None:
         data_root, manifest_manager, _ = mock_alpaca_sip_data
@@ -512,12 +512,12 @@ class TestAlpacaSIPLocalProvider:
         corp_path = corp_dir / "actions.parquet"
         pl.DataFrame(
             {
-                "symbol": ["AAPL", "AAPL"],
-                "ca_type": ["stock_split", "stock_split"],
-                "process_date": [date(2020, 8, 30), date(2020, 9, 14)],
-                "ex_date": [date(2020, 8, 31), date(2020, 9, 15)],
-                "old_rate": [1.0, 1.0],
-                "new_rate": [4.0, 2.0],
+                "symbol": ["AAPL", "AAPL", "AAPL"],
+                "ca_type": ["stock_split", "stock_split", "stock_split"],
+                "process_date": [date(2020, 8, 30), date(2020, 9, 1), date(2020, 9, 14)],
+                "ex_date": [date(2020, 8, 31), date(2020, 9, 10), date(2020, 9, 15)],
+                "old_rate": [1.0, 1.0, 1.0],
+                "new_rate": [4.0, 2.0, 3.0],
             }
         ).write_parquet(corp_path)
         manifest_path = data_root / "manifests" / "alpaca_sip_corp_actions.json"
@@ -528,7 +528,7 @@ class TestAlpacaSIPLocalProvider:
                     "sync_timestamp": datetime.now(UTC).isoformat(),
                     "start_date": "2020-08-01",
                     "end_date": "2020-09-30",
-                    "row_count": 2,
+                    "row_count": 3,
                     "checksum": "abc123",
                     "checksum_algorithm": "sha256",
                     "schema_version": "v1.0.0",
@@ -557,9 +557,17 @@ class TestAlpacaSIPLocalProvider:
             symbols=["AAPL"],
         )
 
-        assert bounded["ex_date"].to_list() == [date(2020, 8, 31)]
+        assert bounded["process_date"].to_list() == [
+            date(2020, 8, 30),
+            date(2020, 9, 1),
+        ]
+        assert bounded["ex_date"].to_list() == [
+            date(2020, 8, 31),
+            date(2020, 9, 10),
+        ]
         assert unbounded["ex_date"].to_list() == [
             date(2020, 8, 31),
+            date(2020, 9, 10),
             date(2020, 9, 15),
         ]
 
@@ -897,7 +905,7 @@ class TestAlpacaSIPDataProviderAdapter:
             {
                 "symbol": ["AAPL"],
                 "ca_type": ["stock_split"],
-                "process_date": [date(2020, 8, 31)],
+                "process_date": [date(2020, 7, 31)],
                 "ex_date": [date(2020, 9, 1)],
                 "old_rate": [1.0],
                 "new_rate": [2.0],
@@ -930,7 +938,7 @@ class TestAlpacaSIPDataProviderAdapter:
                 {
                     **manifest_base,
                     "dataset": "alpaca_sip_corp_actions",
-                    "start_date": "2020-08-01",
+                    "start_date": "2020-07-31",
                     "end_date": "2020-09-01",
                     "row_count": 1,
                     "file_paths": [str(corp_path)],

--- a/tests/libs/data/data_providers/test_protocols.py
+++ b/tests/libs/data/data_providers/test_protocols.py
@@ -29,6 +29,7 @@ from libs.data.data_providers.protocols import (
     ProviderUnavailableError,
     YFinanceDataProviderAdapter,
 )
+from libs.data.data_quality.exceptions import DataNotFoundError
 
 if TYPE_CHECKING:
     pass
@@ -272,6 +273,7 @@ class TestAlpacaSIPSchemaNormalization:
                 "ret": [None, None, None],
             }
         )
+        provider.get_corporate_actions.side_effect = DataNotFoundError("no companion manifest")
         adapter = AlpacaSIPDataProviderAdapter(provider)
 
         df = adapter.get_daily_prices(["AAPL"], date(2024, 1, 2), date(2024, 1, 4))

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -1766,6 +1766,8 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
                     _manifest_summary(
                         dataset="alpaca_sip_daily",
                         validation_status="passed",
+                        start_date=date(2020, 8, 28),
+                        end_date=date(2020, 9, 1),
                         manifest_id="alpaca_sip_daily@v1:abc",
                         manifest_reference="manifests://alpaca_sip_daily.json",
                         manifest_checksum="abc",
@@ -1781,6 +1783,8 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
                     _manifest_summary(
                         dataset="alpaca_sip_corp_actions",
                         validation_status="passed",
+                        start_date=date(2020, 8, 28),
+                        end_date=date(2020, 9, 1),
                         manifest_id="alpaca_sip_corp_actions@v1:def",
                         manifest_reference="manifests://alpaca_sip_corp_actions.json",
                         manifest_checksum="def",
@@ -1881,6 +1885,8 @@ async def test_get_dataset_preview_returns_split_adjusted_alpaca_preview(
             _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="passed",
+                start_date=date(2020, 1, 2),
+                end_date=date(2020, 1, 3),
                 manifest_id="alpaca_sip_daily@v1:abc",
                 manifest_reference="manifests://alpaca_sip_daily.json",
                 manifest_checksum="abc",
@@ -1891,6 +1897,8 @@ async def test_get_dataset_preview_returns_split_adjusted_alpaca_preview(
             _manifest_summary(
                 dataset="alpaca_sip_corp_actions",
                 validation_status="passed",
+                start_date=date(2020, 1, 2),
+                end_date=date(2020, 8, 31),
                 manifest_id="alpaca_sip_corp_actions@v1:def",
                 manifest_reference="manifests://alpaca_sip_corp_actions.json",
                 manifest_checksum="def",
@@ -2028,6 +2036,36 @@ async def test_get_dataset_preview_applies_future_split_to_older_price_chunk(
     assert preview.rows[0]["adj_close"] == 125.0
     assert preview.rows[1]["adj_close"] == 130.0
     assert preview.rows[1]["ret"] == pytest.approx(0.04)
+
+
+@pytest.mark.asyncio()
+async def test_load_corporate_actions_for_prices_uses_bound_parameters(
+    rate_limiter: AsyncMock,
+) -> None:
+    service = DataExplorerService(rate_limiter=rate_limiter)
+    captured: dict[str, Any] = {}
+
+    async def capture_execute_sql_frame(**kwargs: Any) -> pl.DataFrame:
+        captured.update(kwargs)
+        return pl.DataFrame()
+
+    service._execute_sql_frame = capture_execute_sql_frame  # type: ignore[method-assign]
+    prices = pl.DataFrame(
+        {
+            "symbol": ["BRK'B", "AAPL", "AAPL"],
+            "date": [date(2020, 1, 2), date(2020, 1, 3), date(2020, 1, 4)],
+        }
+    )
+
+    await service._load_corporate_actions_for_prices(
+        dataset="alpaca_sip",
+        prices=prices,
+        table_paths={"alpaca_sip_corp_actions": ("actions.parquet",)},
+    )
+
+    assert captured["parameters"] == ["AAPL", "BRK'B", date(2020, 1, 2)]
+    assert "BRK'B" not in captured["sql"]
+    assert captured["sql"].count("?") == 3
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -2162,12 +2162,27 @@ async def test_load_corporate_actions_for_prices_uses_bound_parameters(
     await service._load_corporate_actions_for_prices(
         dataset="alpaca_sip",
         prices=prices,
-        table_paths={"alpaca_sip_corp_actions": ("actions.parquet",)},
+        table_paths={
+            "alpaca_sip_corp_actions": sql_module.ResolvedTablePathSpec(
+                path_spec=("actions.parquet",),
+                manifest_backed=True,
+                manifest_end_date=date(2020, 8, 31),
+            )
+        },
     )
 
-    assert captured["parameters"] == ["AAPL", "BRK'B", date(2020, 1, 2)]
+    assert captured["parameters"] == [
+        "AAPL",
+        "BRK'B",
+        date(2020, 1, 2),
+        date(2020, 1, 2),
+        date(2020, 8, 31),
+        date(2020, 8, 31),
+    ]
     assert "BRK'B" not in captured["sql"]
-    assert captured["sql"].count("?") == 3
+    assert "process_date <= CAST(? AS DATE)" in captured["sql"]
+    assert "coalesce" not in captured["sql"].lower()
+    assert captured["sql"].count("?") == 6
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -1885,8 +1885,8 @@ async def test_get_dataset_preview_returns_split_adjusted_alpaca_preview(
             _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="passed",
-                start_date=date(2020, 1, 2),
-                end_date=date(2020, 1, 3),
+                start_date=date(2020, 8, 28),
+                end_date=date(2020, 9, 1),
                 manifest_id="alpaca_sip_daily@v1:abc",
                 manifest_reference="manifests://alpaca_sip_daily.json",
                 manifest_checksum="abc",
@@ -1897,8 +1897,117 @@ async def test_get_dataset_preview_returns_split_adjusted_alpaca_preview(
             _manifest_summary(
                 dataset="alpaca_sip_corp_actions",
                 validation_status="passed",
-                start_date=date(2020, 1, 2),
-                end_date=date(2020, 8, 31),
+                start_date=date(2020, 8, 28),
+                end_date=date(2020, 9, 1),
+                manifest_id="alpaca_sip_corp_actions@v1:def",
+                manifest_reference="manifests://alpaca_sip_corp_actions.json",
+                manifest_checksum="def",
+            ),
+        ]
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={
+            "alpaca_sip_daily": (str(daily_partition),),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+        patch("libs.web_console_services.data_explorer_service.log_sql_query_audit") as audit,
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=3,
+            table="alpaca_sip_daily",
+            read_time_adjustment_mode="split_adjusted",
+        )
+
+    assert preview.derived is True
+    assert preview.derivation_mode == "split_adjusted"
+    assert preview.read_time_adjustment_mode == "split_adjusted"
+    assert preview.null_column_reasons == {}
+    assert preview.warnings == []
+    assert preview.rows[0]["close"] == 500.0
+    assert preview.rows[0]["adj_close"] == 125.0
+    assert preview.rows[1]["ret"] == 0.0
+    assert "WHERE date >= CAST(? AS DATE)" in audit.call_args.args[3]
+    assert "ORDER BY symbol, date" in audit.call_args.args[3]
+    assert preview.backtest_handoff is not None
+    assert preview.backtest_handoff.adjusted_preview_available is True
+    assert preview.backtest_handoff.derived is True
+    assert preview.backtest_handoff.selected_read_time_adjustment_mode == "split_adjusted"
+    assert "raw_sip_returns_unavailable" not in preview.backtest_handoff.reason_codes
+    assert (
+        preview.backtest_handoff.data_roles["prices"].read_time_adjustment_mode == "split_adjusted"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_uses_warmup_row_for_split_adjusted_returns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2020.parquet"
+    )
+    daily_partition.parent.mkdir(parents=True)
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL", "AAPL"],
+            "date": [date(2020, 7, 31), date(2020, 8, 3), date(2020, 8, 4)],
+            "open": [100.0, 110.0, 121.0],
+            "high": [101.0, 111.0, 122.0],
+            "low": [99.0, 109.0, 120.0],
+            "close": [100.0, 110.0, 121.0],
+            "volume": [1_000_000.0, 1_100_000.0, 1_200_000.0],
+        }
+    ).write_parquet(daily_partition)
+    pl.DataFrame(
+        {
+            "symbol": pl.Series([], dtype=pl.Utf8),
+            "ca_type": pl.Series([], dtype=pl.Utf8),
+            "ex_date": pl.Series([], dtype=pl.Date),
+            "process_date": pl.Series([], dtype=pl.Date),
+            "old_rate": pl.Series([], dtype=pl.Float64),
+            "new_rate": pl.Series([], dtype=pl.Float64),
+        }
+    ).write_parquet(corp_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
+                dataset="alpaca_sip_daily",
+                validation_status="passed",
+                start_date=date(2020, 7, 31),
+                end_date=date(2020, 9, 1),
+                manifest_id="alpaca_sip_daily@v1:abc",
+                manifest_reference="manifests://alpaca_sip_daily.json",
+                manifest_checksum="abc",
+                adjustment_mode="raw",
+                canonical_storage_mode="raw",
+                read_time_adjustment_mode="unavailable",
+            ),
+            _manifest_summary(
+                dataset="alpaca_sip_corp_actions",
+                validation_status="passed",
+                start_date=date(2020, 7, 31),
+                end_date=date(2020, 9, 1),
                 manifest_id="alpaca_sip_corp_actions@v1:def",
                 manifest_reference="manifests://alpaca_sip_corp_actions.json",
                 manifest_checksum="def",
@@ -1925,27 +2034,16 @@ async def test_get_dataset_preview_returns_split_adjusted_alpaca_preview(
         preview = await service.get_dataset_preview(
             DummyUser(user_id="user-1"),
             "alpaca_sip",
-            limit=3,
+            limit=2,
             table="alpaca_sip_daily",
             read_time_adjustment_mode="split_adjusted",
         )
 
-    assert preview.derived is True
-    assert preview.derivation_mode == "split_adjusted"
-    assert preview.read_time_adjustment_mode == "split_adjusted"
-    assert preview.null_column_reasons == {}
-    assert preview.warnings == []
-    assert preview.rows[0]["close"] == 500.0
-    assert preview.rows[0]["adj_close"] == 125.0
-    assert preview.rows[1]["ret"] == 0.0
-    assert preview.backtest_handoff is not None
-    assert preview.backtest_handoff.adjusted_preview_available is True
-    assert preview.backtest_handoff.derived is True
-    assert preview.backtest_handoff.selected_read_time_adjustment_mode == "split_adjusted"
-    assert "raw_sip_returns_unavailable" not in preview.backtest_handoff.reason_codes
-    assert (
-        preview.backtest_handoff.data_roles["prices"].read_time_adjustment_mode == "split_adjusted"
-    )
+    assert [row["date"] for row in preview.rows] == [date(2020, 8, 3), date(2020, 8, 4)]
+    assert preview.rows[0]["ret"] == pytest.approx(0.1)
+    assert preview.rows[1]["ret"] == pytest.approx(0.1)
+    assert preview.total_count == 2
+    assert preview.has_more is False
 
 
 @pytest.mark.asyncio()
@@ -1991,6 +2089,8 @@ async def test_get_dataset_preview_applies_future_split_to_older_price_chunk(
             _manifest_summary(
                 dataset="alpaca_sip_daily",
                 validation_status="passed",
+                start_date=date(2020, 1, 2),
+                end_date=date(2020, 1, 3),
                 manifest_id="alpaca_sip_daily@v1:abc",
                 manifest_reference="manifests://alpaca_sip_daily.json",
                 manifest_checksum="abc",
@@ -2001,6 +2101,8 @@ async def test_get_dataset_preview_applies_future_split_to_older_price_chunk(
             _manifest_summary(
                 dataset="alpaca_sip_corp_actions",
                 validation_status="passed",
+                start_date=date(2020, 1, 2),
+                end_date=date(2020, 8, 31),
                 manifest_id="alpaca_sip_corp_actions@v1:def",
                 manifest_reference="manifests://alpaca_sip_corp_actions.json",
                 manifest_checksum="def",

--- a/tests/libs/web_console_services/test_data_explorer_service.py
+++ b/tests/libs/web_console_services/test_data_explorer_service.py
@@ -100,11 +100,16 @@ def _alpaca_summary(
         manifests=manifests,
         present_datasets=sorted({manifest.dataset for manifest in manifests}),
         missing_datasets=[],
-        latest_sync=latest_sync or max(
+        latest_sync=latest_sync
+        or max(
             (manifest.sync_timestamp for manifest in manifests),
             default=None,
         ),
-        row_count=row_count if row_count is not None else sum(manifest.row_count for manifest in manifests),
+        row_count=(
+            row_count
+            if row_count is not None
+            else sum(manifest.row_count for manifest in manifests)
+        ),
         schema_versions=sorted({manifest.schema_version for manifest in manifests}),
         validation_statuses=sorted({manifest.validation_status for manifest in manifests}),
         sync_validation_status="passed",
@@ -914,10 +919,7 @@ async def test_list_datasets_exposes_trusted_alpaca_manifest_summary(
     assert "raw_sip_returns_unavailable" in alpaca.backtest_handoff.reason_codes
     assert alpaca.backtest_handoff.data_roles["prices"].available is True
     assert alpaca.backtest_handoff.data_roles["prices"].canonical_storage_mode == "raw"
-    assert (
-        alpaca.backtest_handoff.data_roles["prices"].read_time_adjustment_mode
-        == "unavailable"
-    )
+    assert alpaca.backtest_handoff.data_roles["prices"].read_time_adjustment_mode == "unavailable"
 
 
 @pytest.mark.asyncio()
@@ -1023,19 +1025,18 @@ async def test_list_datasets_builds_role_keyed_backtest_handoff_metadata(
     assert alpaca.backtest_handoff is not None
     handoff = alpaca.backtest_handoff
     assert sorted(handoff.data_roles) == ["corp_actions", "prices", "universe"]
-    assert handoff.adjusted_preview_available is False
-    assert handoff.adjusted_preview_unavailable_reason == (
-        "read_time_adjustment_layer_not_defined"
-    )
+    assert handoff.adjusted_preview_available is True
+    assert handoff.adjusted_preview_unavailable_reason is None
+    assert handoff.derived is True
+    assert handoff.selected_read_time_adjustment_mode == "split_adjusted"
     assert handoff.data_roles["universe"].manifest_ids == ["alpaca_sip_daily@v1:abc"]
     assert handoff.data_roles["prices"].provider_signature == daily_signature
+    assert handoff.data_roles["prices"].read_time_adjustment_mode == "split_adjusted"
     assert handoff.data_roles["corp_actions"].manifest_checksums == ["def"]
-    assert (
-        handoff.data_roles["corp_actions"].canonical_storage_mode
-        == "read_only_adjustment_input"
-    )
+    assert handoff.data_roles["corp_actions"].canonical_storage_mode == "read_only_adjustment_input"
     assert handoff.data_roles["corp_actions"].read_time_adjustment_mode == "not_applicable"
-    assert "raw_sip_returns_unavailable" in handoff.reason_codes
+    assert "raw_sip_returns_unavailable" not in handoff.reason_codes
+    assert "split_adjusted_read_time_available" in handoff.reason_codes
 
 
 @pytest.mark.asyncio()
@@ -1166,9 +1167,7 @@ async def test_list_datasets_filters_alpaca_summary_to_trusted_manifests(
     assert alpaca.sql_handoff_url is not None
     assert "alpaca_sip_corp_actions" in alpaca.sql_handoff_url
     assert "alpaca_sip_daily" not in alpaca.sql_handoff_url
-    assert [template.table for template in alpaca.query_templates] == [
-        "alpaca_sip_corp_actions"
-    ]
+    assert [template.table for template in alpaca.query_templates] == ["alpaca_sip_corp_actions"]
     assert alpaca.backtest_handoff is not None
     assert (
         alpaca.backtest_handoff.data_roles["prices"].unavailable_reason
@@ -1340,8 +1339,8 @@ async def test_alpaca_manifest_summary_timeout_failure_cache_uses_fresh_timestam
     rate_limiter: AsyncMock,
 ) -> None:
     manifest_service = MagicMock()
-    manifest_service.get_alpaca_sip_summary.side_effect = (
-        lambda: data_explorer_module.time.sleep(0.12)
+    manifest_service.get_alpaca_sip_summary.side_effect = lambda: data_explorer_module.time.sleep(
+        0.12
     )
     service = DataExplorerService(rate_limiter=rate_limiter, manifest_service=manifest_service)
     monkeypatch.setattr(data_explorer_module, "_MANIFEST_SUMMARY_TIMEOUT_SECONDS", 0.08)
@@ -1734,9 +1733,7 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
             "ret": [None],
         }
     ).write_parquet(partition)
-    pl.DataFrame({"symbol": ["AAPL"], "ex_date": [date(2026, 1, 2)]}).write_parquet(
-        corp_partition
-    )
+    pl.DataFrame({"symbol": ["AAPL"], "ex_date": [date(2026, 1, 2)]}).write_parquet(corp_partition)
     monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
     service = DataExplorerService(
         rate_limiter=rate_limiter,
@@ -1830,14 +1827,251 @@ async def test_get_dataset_preview_returns_alpaca_manifest_provenance(
     }
     assert preview.warnings == ["raw_sip_returns_unavailable"]
     assert preview.backtest_handoff is not None
-    assert preview.backtest_handoff.data_roles["prices"].manifest_ids == [
-        "alpaca_sip_daily@v1:abc"
-    ]
+    assert preview.backtest_handoff.data_roles["prices"].manifest_ids == ["alpaca_sip_daily@v1:abc"]
     assert preview.backtest_handoff.data_roles["corp_actions"].available is True
     assert preview.backtest_handoff.data_roles["corp_actions"].manifest_ids == [
         "alpaca_sip_corp_actions@v1:def"
     ]
-    assert "raw_sip_returns_unavailable" in preview.backtest_handoff.reason_codes
+    assert "raw_sip_returns_unavailable" not in preview.backtest_handoff.reason_codes
+    assert "split_adjusted_read_time_available" in preview.backtest_handoff.reason_codes
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_returns_split_adjusted_alpaca_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2020.parquet"
+    )
+    daily_partition.parent.mkdir(parents=True)
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL", "AAPL"],
+            "date": [date(2020, 8, 28), date(2020, 8, 31), date(2020, 9, 1)],
+            "open": [500.0, 125.0, 130.0],
+            "high": [504.0, 126.0, 132.0],
+            "low": [496.0, 124.0, 129.0],
+            "close": [500.0, 125.0, 130.0],
+            "volume": [1_000_000.0, 4_000_000.0, 3_800_000.0],
+            "adj_close": [None, None, None],
+            "ret": [None, None, None],
+        }
+    ).write_parquet(daily_partition)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "ca_type": ["stock_split"],
+            "ex_date": [date(2020, 8, 31)],
+            "process_date": [date(2020, 8, 30)],
+            "old_rate": [1.0],
+            "new_rate": [4.0],
+        }
+    ).write_parquet(corp_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
+                dataset="alpaca_sip_daily",
+                validation_status="passed",
+                manifest_id="alpaca_sip_daily@v1:abc",
+                manifest_reference="manifests://alpaca_sip_daily.json",
+                manifest_checksum="abc",
+                adjustment_mode="raw",
+                canonical_storage_mode="raw",
+                read_time_adjustment_mode="unavailable",
+            ),
+            _manifest_summary(
+                dataset="alpaca_sip_corp_actions",
+                validation_status="passed",
+                manifest_id="alpaca_sip_corp_actions@v1:def",
+                manifest_reference="manifests://alpaca_sip_corp_actions.json",
+                manifest_checksum="def",
+            ),
+        ]
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={
+            "alpaca_sip_daily": (str(daily_partition),),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=3,
+            table="alpaca_sip_daily",
+            read_time_adjustment_mode="split_adjusted",
+        )
+
+    assert preview.derived is True
+    assert preview.derivation_mode == "split_adjusted"
+    assert preview.read_time_adjustment_mode == "split_adjusted"
+    assert preview.null_column_reasons == {}
+    assert preview.warnings == []
+    assert preview.rows[0]["close"] == 500.0
+    assert preview.rows[0]["adj_close"] == 125.0
+    assert preview.rows[1]["ret"] == 0.0
+    assert preview.backtest_handoff is not None
+    assert preview.backtest_handoff.adjusted_preview_available is True
+    assert preview.backtest_handoff.derived is True
+    assert preview.backtest_handoff.selected_read_time_adjustment_mode == "split_adjusted"
+    assert "raw_sip_returns_unavailable" not in preview.backtest_handoff.reason_codes
+    assert (
+        preview.backtest_handoff.data_roles["prices"].read_time_adjustment_mode == "split_adjusted"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_applies_future_split_to_older_price_chunk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2020.parquet"
+    )
+    daily_partition.parent.mkdir(parents=True)
+    corp_partition = (
+        data_root / "alpaca" / "sip" / "corp_actions" / "snapshots" / "sync-1" / "actions.parquet"
+    )
+    corp_partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL"],
+            "date": [date(2020, 1, 2), date(2020, 1, 3)],
+            "open": [500.0, 520.0],
+            "high": [504.0, 524.0],
+            "low": [496.0, 516.0],
+            "close": [500.0, 520.0],
+            "volume": [1_000_000.0, 1_100_000.0],
+        }
+    ).write_parquet(daily_partition)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "ca_type": ["stock_split"],
+            "ex_date": [date(2020, 8, 31)],
+            "process_date": [date(2020, 8, 30)],
+            "old_rate": [1.0],
+            "new_rate": [4.0],
+        }
+    ).write_parquet(corp_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    manifest_service = MagicMock()
+    manifest_service.get_alpaca_sip_summary.return_value = _alpaca_summary(
+        [
+            _manifest_summary(
+                dataset="alpaca_sip_daily",
+                validation_status="passed",
+                manifest_id="alpaca_sip_daily@v1:abc",
+                manifest_reference="manifests://alpaca_sip_daily.json",
+                manifest_checksum="abc",
+                adjustment_mode="raw",
+                canonical_storage_mode="raw",
+                read_time_adjustment_mode="unavailable",
+            ),
+            _manifest_summary(
+                dataset="alpaca_sip_corp_actions",
+                validation_status="passed",
+                manifest_id="alpaca_sip_corp_actions@v1:def",
+                manifest_reference="manifests://alpaca_sip_corp_actions.json",
+                manifest_checksum="def",
+            ),
+        ]
+    )
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        manifest_service=manifest_service,
+        table_paths={
+            "alpaca_sip_daily": (str(daily_partition),),
+            "alpaca_sip_corp_actions": (str(corp_partition),),
+        },
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_explorer_service.get_user_id", return_value="user-1"),
+    ):
+        preview = await service.get_dataset_preview(
+            DummyUser(user_id="user-1"),
+            "alpaca_sip",
+            limit=2,
+            table="alpaca_sip_daily",
+            read_time_adjustment_mode="split_adjusted",
+        )
+
+    assert preview.rows[0]["date"] == date(2020, 1, 2)
+    assert preview.rows[0]["adj_close"] == 125.0
+    assert preview.rows[1]["adj_close"] == 130.0
+    assert preview.rows[1]["ret"] == pytest.approx(0.04)
+
+
+@pytest.mark.asyncio()
+async def test_get_dataset_preview_blocks_split_adjusted_without_companion_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rate_limiter: AsyncMock,
+) -> None:
+    data_root = tmp_path / "data"
+    daily_partition = (
+        data_root / "alpaca" / "sip" / "daily" / "snapshots" / "sync-1" / "2020.parquet"
+    )
+    daily_partition.parent.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "date": [date(2020, 8, 28)],
+            "open": [500.0],
+            "high": [504.0],
+            "low": [496.0],
+            "close": [500.0],
+            "volume": [1_000_000.0],
+        }
+    ).write_parquet(daily_partition)
+    monkeypatch.setattr(sql_module, "_ALLOWED_DATA_ROOTS", [data_root.resolve()])
+    service = DataExplorerService(
+        rate_limiter=rate_limiter,
+        table_paths={"alpaca_sip_daily": (str(daily_partition),)},
+    )
+
+    with (
+        patch("libs.web_console_services.data_explorer_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_explorer_service.has_dataset_permission",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(ValueError, match="alpaca_sip_corp_actions"):
+            await service.get_dataset_preview(
+                DummyUser(user_id="user-1"),
+                "alpaca_sip",
+                table="alpaca_sip_daily",
+                read_time_adjustment_mode="split_adjusted",
+            )
 
 
 @pytest.mark.asyncio()

--- a/tests/libs/web_console_services/test_data_manifest_service.py
+++ b/tests/libs/web_console_services/test_data_manifest_service.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 from libs.data.data_quality.manifest import SyncManifest
 from libs.web_console_services.data_manifest_service import (
+    ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
+    ALPACA_SIP_COMPANION_MANIFEST_STALE,
+    ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
     ALPACA_SIP_DATASET_KEY,
@@ -24,6 +27,7 @@ def _write_manifest(
     dataset: str,
     row_count: int = 10,
     validation_status: str = "passed",
+    start_date: date = date(2026, 4, 1),
     end_date: date = date(2026, 4, 30),
     symbol_set_hash: str | None = "symbols-v1",
 ) -> None:
@@ -32,7 +36,7 @@ def _write_manifest(
     manifest = SyncManifest(
         dataset=dataset,
         sync_timestamp=SYNC_TS,
-        start_date=date(2026, 4, 1),
+        start_date=start_date,
         end_date=end_date,
         row_count=row_count,
         checksum=f"{dataset}-checksum",
@@ -127,8 +131,32 @@ def test_alpaca_sip_summary_adds_companion_warnings(tmp_path: Path) -> None:
 
     summary = service.get_alpaca_sip_summary()
 
-    assert "alpaca_sip_companion_symbol_set_mismatch" in summary.warnings
-    assert "alpaca_sip_companion_manifest_stale" in summary.warnings
+    assert ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH in summary.warnings
+    assert ALPACA_SIP_COMPANION_MANIFEST_STALE in summary.warnings
+    assert ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH in summary.warnings
+
+
+def test_alpaca_sip_summary_warns_when_companion_starts_after_daily(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    _write_manifest(
+        data_root,
+        dataset=ALPACA_SIP_DAILY_DATASET,
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 30),
+    )
+    _write_manifest(
+        data_root,
+        dataset=ALPACA_SIP_CORP_ACTIONS_DATASET,
+        start_date=date(2026, 4, 5),
+        end_date=date(2026, 4, 30),
+    )
+    service = DataManifestService(data_root=data_root)
+
+    summary = service.get_alpaca_sip_summary()
+
+    assert ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH in summary.warnings
 
 
 def test_provider_signature_sanitizer_drops_unknown_sensitive_fields() -> None:

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -28,6 +28,7 @@ from libs.web_console_services.data_readiness_service import (
     HYBRID_PRICE_COMPONENT_BLOCKED,
     HYBRID_PRICE_COMPONENT_READY,
     RAW_SIP_RETURNS_UNAVAILABLE,
+    READ_TIME_ADJUSTMENT_AVAILABLE_REASON,
     DataReadinessService,
 )
 from libs.web_console_services.provider_signature import ProviderSignatureDTO
@@ -91,9 +92,7 @@ def _manifest(
         read_time_adjustment_mode=(
             read_time_adjustment_mode
             if read_time_adjustment_mode is not None
-            else "unavailable"
-            if is_daily
-            else None
+            else "unavailable" if is_daily else None
         ),
         provider_signature=ProviderSignatureDTO(
             provider_id=provider_id,
@@ -144,6 +143,7 @@ def test_alpaca_sip_simple_backtest_blocks_missing_manifests(
     assert readiness.status == "blocked"
     assert ALPACA_SIP_UNTRUSTED_WITHOUT_MANIFEST in readiness.blockers
     assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+    assert READ_TIME_ADJUSTMENT_AVAILABLE_REASON not in [check.code for check in readiness.checks]
 
 
 def test_alpaca_sip_readiness_uses_distinct_code_for_invalid_manifest(
@@ -172,7 +172,7 @@ def test_alpaca_sip_readiness_exposes_pairing_warnings(
 ) -> None:
     summary = _summary(
         [
-            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
             _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
         ],
         warnings=[
@@ -192,7 +192,7 @@ def test_alpaca_sip_readiness_exposes_pairing_warnings(
     assert ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH in readiness.warnings
 
 
-def test_alpaca_sip_simple_backtest_blocks_pairing_warnings(
+def test_alpaca_sip_simple_backtest_warns_pairing_when_daily_returns_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     summary = _summary(
@@ -209,9 +209,31 @@ def test_alpaca_sip_simple_backtest_blocks_pairing_warnings(
 
     readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
 
+    assert readiness.status == "warning"
+    assert ALPACA_SIP_COMPANION_MANIFEST_STALE in readiness.warnings
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def test_alpaca_sip_simple_backtest_blocks_pairing_for_raw_daily_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+        warnings=[ALPACA_SIP_COMPANION_MANIFEST_STALE],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
     assert readiness.status == "blocked"
     assert ALPACA_SIP_COMPANION_MANIFEST_STALE in readiness.blockers
-    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+    assert RAW_SIP_RETURNS_UNAVAILABLE in readiness.blockers
 
 
 def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(
@@ -219,7 +241,7 @@ def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(
 ) -> None:
     summary = _summary(
         [
-            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_DAILY_DATASET),
             _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
         ],
     )
@@ -232,6 +254,27 @@ def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(
 
     assert readiness.status == "ready"
     assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+
+
+def test_alpaca_sip_simple_backtest_ready_with_raw_manifest_and_split_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(ALPACA_SIP_DAILY_DATASET),
+            _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
+        ],
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+    assert readiness.status == "ready"
+    assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
+    assert "split_adjusted_read_time_available" in [check.code for check in readiness.checks]
 
 
 @pytest.mark.asyncio()
@@ -318,7 +361,7 @@ def test_hybrid_readiness_requires_crsp_universe(monkeypatch: pytest.MonkeyPatch
 
     assert readiness.status == "blocked"
     assert CRSP_UNIVERSE_UNAVAILABLE in readiness.blockers
-    assert HYBRID_PRICE_COMPONENT_BLOCKED in readiness.blockers
+    assert HYBRID_PRICE_COMPONENT_BLOCKED not in readiness.blockers
     assert RAW_SIP_RETURNS_UNAVAILABLE not in readiness.blockers
 
 
@@ -382,7 +425,7 @@ def test_hybrid_readiness_blocks_stale_price_component_for_return_workflow(
 ) -> None:
     summary = _summary(
         [
-            _manifest(ALPACA_SIP_DAILY_DATASET, read_time_adjustment_mode="available"),
+            _manifest(ALPACA_SIP_DAILY_DATASET),
             _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
         ],
         warnings=[ALPACA_SIP_COMPANION_MANIFEST_STALE],
@@ -428,8 +471,8 @@ def test_hybrid_readiness_scrubs_sip_details_without_direct_sip_access(
         "hybrid_research_backtest",
     )
 
-    assert readiness.status == "blocked"
-    assert readiness.blockers == [HYBRID_PRICE_COMPONENT_BLOCKED]
+    assert readiness.status == "ready"
+    assert readiness.blockers == []
     assert all("alpaca_sip" not in check.code for check in readiness.checks)
 
 

--- a/tests/libs/web_console_services/test_data_readiness_service.py
+++ b/tests/libs/web_console_services/test_data_readiness_service.py
@@ -18,6 +18,7 @@ from libs.web_console_services.data_manifest_service import (
     ManifestSummaryDTO,
 )
 from libs.web_console_services.data_readiness_service import (
+    ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
     ALPACA_SIP_COMPANION_MANIFEST_STALE,
     ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
     ALPACA_SIP_MANIFEST_VALIDATION_FAILED,
@@ -67,6 +68,8 @@ def _manifest(
     *,
     validation_status: str = "passed",
     read_time_adjustment_mode: str | None = None,
+    start_date: date = date(2026, 4, 1),
+    end_date: date = date(2026, 4, 30),
 ) -> ManifestSummaryDTO:
     is_daily = dataset == ALPACA_SIP_DAILY_DATASET
     provider_id = "crsp" if dataset == CRSP_UNIVERSE_MANIFEST_DATASET else "alpaca_sip"
@@ -80,8 +83,8 @@ def _manifest(
         schema_version="v1",
         validation_status=validation_status,
         sync_timestamp=NOW,
-        start_date=date(2026, 4, 1),
-        end_date=date(2026, 4, 30),
+        start_date=start_date,
+        end_date=end_date,
         row_count=10,
         file_count=1,
         provider_id=provider_id,
@@ -92,7 +95,9 @@ def _manifest(
         read_time_adjustment_mode=(
             read_time_adjustment_mode
             if read_time_adjustment_mode is not None
-            else "unavailable" if is_daily else None
+            else "unavailable"
+            if is_daily
+            else None
         ),
         provider_signature=ProviderSignatureDTO(
             provider_id=provider_id,
@@ -176,6 +181,7 @@ def test_alpaca_sip_readiness_exposes_pairing_warnings(
             _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
         ],
         warnings=[
+            ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH,
             ALPACA_SIP_COMPANION_MANIFEST_STALE,
             ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH,
         ],
@@ -188,6 +194,7 @@ def test_alpaca_sip_readiness_exposes_pairing_warnings(
     readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "quality_analysis")
 
     assert readiness.status == "warning"
+    assert ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH in readiness.warnings
     assert ALPACA_SIP_COMPANION_MANIFEST_STALE in readiness.warnings
     assert ALPACA_SIP_COMPANION_SYMBOL_SET_MISMATCH in readiness.warnings
 
@@ -222,7 +229,7 @@ def test_alpaca_sip_simple_backtest_blocks_pairing_for_raw_daily_manifest(
             _manifest(ALPACA_SIP_DAILY_DATASET),
             _manifest(ALPACA_SIP_CORP_ACTIONS_DATASET),
         ],
-        warnings=[ALPACA_SIP_COMPANION_MANIFEST_STALE],
+        warnings=[ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH],
     )
     service = DataReadinessService(
         manifest_service=cast(DataManifestService, FakeManifestService(summary))
@@ -232,8 +239,37 @@ def test_alpaca_sip_simple_backtest_blocks_pairing_for_raw_daily_manifest(
     readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
 
     assert readiness.status == "blocked"
-    assert ALPACA_SIP_COMPANION_MANIFEST_STALE in readiness.blockers
+    assert ALPACA_SIP_COMPANION_DATE_RANGE_MISMATCH in readiness.blockers
     assert RAW_SIP_RETURNS_UNAVAILABLE in readiness.blockers
+
+
+def test_alpaca_sip_simple_backtest_blocks_split_engine_when_companion_range_misses_daily(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(
+        [
+            _manifest(
+                ALPACA_SIP_DAILY_DATASET,
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 4, 30),
+            ),
+            _manifest(
+                ALPACA_SIP_CORP_ACTIONS_DATASET,
+                start_date=date(2026, 4, 5),
+                end_date=date(2026, 4, 30),
+            ),
+        ]
+    )
+    service = DataReadinessService(
+        manifest_service=cast(DataManifestService, FakeManifestService(summary))
+    )
+    _allow_readiness(monkeypatch, {"alpaca_sip"})
+
+    readiness = service.get_readiness(DummyUser(), ALPACA_SIP_DATASET_KEY, "simple_backtest")
+
+    assert readiness.status == "blocked"
+    assert RAW_SIP_RETURNS_UNAVAILABLE in readiness.blockers
+    assert READ_TIME_ADJUSTMENT_AVAILABLE_REASON not in [check.code for check in readiness.checks]
 
 
 def test_alpaca_sip_simple_backtest_ready_when_adjustment_available(

--- a/tests/libs/web_console_services/test_sql_explorer_service.py
+++ b/tests/libs/web_console_services/test_sql_explorer_service.py
@@ -8,6 +8,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -337,11 +338,25 @@ def test_resolve_table_paths_uses_alpaca_manifest_paths(
     manifest_dir = data_root / "manifests"
     manifest_dir.mkdir(parents=True)
     (manifest_dir / "alpaca_sip_daily.json").write_text(
-        json.dumps({"file_paths": [str(partition)], "validation_status": "passed"}),
+        json.dumps(
+            {
+                "file_paths": [str(partition)],
+                "validation_status": "passed",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-31",
+            }
+        ),
         encoding="utf-8",
     )
     (manifest_dir / "alpaca_sip_corp_actions.json").write_text(
-        json.dumps({"file_paths": [str(corp_partition)], "validation_status": "passed"}),
+        json.dumps(
+            {
+                "file_paths": [str(corp_partition)],
+                "validation_status": "passed",
+                "start_date": "2026-01-01",
+                "end_date": "2026-02-15",
+            }
+        ),
         encoding="utf-8",
     )
     monkeypatch.setattr(module, "_PROJECT_ROOT", project_root)
@@ -352,6 +367,10 @@ def test_resolve_table_paths_uses_alpaca_manifest_paths(
     assert _raw_path_spec(paths["alpaca_sip_corp_actions"]) == (str(corp_partition),)
     assert isinstance(paths["alpaca_sip_daily"], module.ResolvedTablePathSpec)
     assert paths["alpaca_sip_daily"].manifest_backed is True
+    assert paths["alpaca_sip_daily"].manifest_start_date == date(2026, 1, 1)
+    assert paths["alpaca_sip_daily"].manifest_end_date == date(2026, 1, 31)
+    assert isinstance(paths["alpaca_sip_corp_actions"], module.ResolvedTablePathSpec)
+    assert paths["alpaca_sip_corp_actions"].manifest_end_date == date(2026, 2, 15)
 
 
 def test_resolve_table_paths_uses_nested_relative_manifest_paths(
@@ -797,7 +816,7 @@ async def test_execute_query_timeout_interrupts_connection(
             "SELECT * FROM crsp_daily",
             timeout_seconds=0,
             available_tables={"crsp_daily"},
-    )
+        )
 
     await asyncio.wait_for(_wait_until(lambda: conn.interrupt_called), timeout=1.0)
     await asyncio.wait_for(_wait_until(lambda: conn.closed), timeout=1.0)


### PR DESCRIPTION
## Summary
- add a shared split-adjusted read-time derivation engine for raw Alpaca SIP daily bars plus corporate actions
- wire derived previews, backtest handoff metadata, readiness, and operations/detail UI states around trusted manifests
- apply the same derivation in the Alpaca SIP provider adapter before simple backtests consume raw SIP snapshots
- document the accepted scope in ADR-0043 and update the service contract

## Validation
- Gemini staged-diff review: no actionable issues found
- Codex review against master: no actionable regression found
- `PYTHONUNBUFFERED=1 PYTEST_XDIST_AUTO_NUM_WORKERS=2 make ci-local`
