### PR TITLE
feat(data-page): persist quality acknowledgments server-side (Phase 5 AC)

### DIFF
--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -1371,11 +1371,16 @@ def _build_anomaly_alert_cards(
                 _alert_severity = alert.severity
 
                 async def ack_alert(
+                    _e: Any = None,
                     aid: str = _alert_id,
                     ds: str = _alert_dataset,
                     metric: str = _alert_metric,
                     severity: str = _alert_severity,
                 ) -> None:
+                    # NiceGUI passes ClickEventArguments as the first positional
+                    # arg when the handler can accept one. The ``_e`` slot
+                    # absorbs that event so the loop-closure defaults
+                    # (``aid``, ``ds``, …) are not overwritten by it.
                     try:
                         ack = await quality_service.acknowledge_alert(
                             user,

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -59,6 +59,11 @@ from libs.platform.web_console_auth.permissions import (
     has_dataset_permission,
     has_permission,
 )
+from libs.web_console_services.alert_acknowledgment_store import (
+    AlertAcknowledgmentStore,
+    InMemoryAlertAcknowledgmentStore,
+    PostgresAlertAcknowledgmentStore,
+)
 from libs.web_console_services.data_explorer_service import (
     DATA_EXPORT_RATE_LIMIT,
     DataExplorerService,
@@ -128,6 +133,30 @@ CRITICAL_QUALITY_THRESHOLD = 70.0
 _CLEANUP_OWNER_KEY = "data_management_timers"
 
 
+def _resolve_alert_acknowledgment_store() -> AlertAcknowledgmentStore:
+    """Return a durable acknowledgment store when Postgres is configured.
+
+    Falls back to the in-memory store when the sync DB pool is unavailable, so
+    the page can still render the quality drawer with acknowledgment controls
+    marked unavailable (per the Phase 5 plan AC).
+    """
+    try:
+        from apps.web_console_ng.core.dependencies import get_sync_db_pool
+
+        pool = get_sync_db_pool()
+    except (RuntimeError, ImportError) as exc:
+        # Misconfiguration in production: acknowledgments will not persist.
+        # The page still renders, and the Acknowledge button is gated on
+        # quality_service.acknowledgments_persistent, but operators need to
+        # see this in logs so they can wire up DATABASE_URL.
+        logger.warning(
+            "alert_acknowledgment_store_in_memory",
+            extra={"reason": "sync_db_pool_unavailable", "error": str(exc)},
+        )
+        return InMemoryAlertAcknowledgmentStore()
+    return PostgresAlertAcknowledgmentStore(db_pool=pool)
+
+
 @ui.page("/data")
 @requires_auth
 @main_layout
@@ -139,7 +168,11 @@ async def data_management_page() -> None:
     sync_service = DataSyncService()
     explorer_service = DataExplorerService()
     manifest_service = DataManifestService()
-    quality_service = DataQualityService(manifest_service=manifest_service)
+    ack_store = _resolve_alert_acknowledgment_store()
+    quality_service = DataQualityService(
+        manifest_service=manifest_service,
+        acknowledgment_store=ack_store,
+    )
     readiness_service = DataReadinessService(manifest_service=manifest_service)
 
     # Page title

--- a/apps/web_console_ng/pages/data_management.py
+++ b/apps/web_console_ng/pages/data_management.py
@@ -1366,11 +1366,24 @@ def _build_anomaly_alert_cards(
 
             if user_can_ack and ack_persistent and not alert.acknowledged:
                 _alert_id = alert.id
+                _alert_dataset = alert.dataset
+                _alert_metric = alert.metric
+                _alert_severity = alert.severity
 
-                async def ack_alert(aid: str = _alert_id) -> None:
+                async def ack_alert(
+                    aid: str = _alert_id,
+                    ds: str = _alert_dataset,
+                    metric: str = _alert_metric,
+                    severity: str = _alert_severity,
+                ) -> None:
                     try:
                         ack = await quality_service.acknowledge_alert(
-                            user, aid, "Acknowledged via dashboard"
+                            user,
+                            aid,
+                            "Acknowledged via dashboard",
+                            dataset=ds,
+                            metric=metric,
+                            severity=severity,
                         )
                         ui.notify(
                             f"Alert acknowledged by {ack.acknowledged_by}",

--- a/db/migrations/0034_quality_ack_scope_columns.sql
+++ b/db/migrations/0034_quality_ack_scope_columns.sql
@@ -1,0 +1,30 @@
+-- Migration 0034: Persist source and issue scope on quality alert acknowledgments
+-- Purpose: Phase 5 acceptance criterion — "Quality acknowledgments are persisted
+--          server-side with actor, time, source, and issue scope" (docs/TASKS/2026-05-03-data-page-ui-optimization-plan.md)
+-- Date: 2026-05-12
+--
+-- Changes:
+--   * Relax alert_id to TEXT (and drop the FK to data_anomaly_alerts) so
+--     manifest-derived signal ids ("alpaca-sip-manifest-pairing", etc.) and
+--     mock string ids can be acknowledged today, before alert rows are
+--     materialised in a dedicated table.
+--   * Add explicit source and issue_scope columns so the persisted record
+--     carries the full set required by the plan AC.
+--   * Make original_alert default to an empty object so callers that do not
+--     have a full alert payload (e.g. manifest-derived signals) can still
+--     persist acknowledgments.
+
+ALTER TABLE data_quality_alert_acknowledgments
+    DROP CONSTRAINT IF EXISTS data_quality_alert_acknowledgments_alert_id_fkey;
+
+ALTER TABLE data_quality_alert_acknowledgments
+    ALTER COLUMN alert_id TYPE TEXT USING alert_id::text;
+
+ALTER TABLE data_quality_alert_acknowledgments
+    ADD COLUMN IF NOT EXISTS source VARCHAR(64) NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE data_quality_alert_acknowledgments
+    ADD COLUMN IF NOT EXISTS issue_scope JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE data_quality_alert_acknowledgments
+    ALTER COLUMN original_alert SET DEFAULT '{}'::jsonb;

--- a/libs/web_console_services/alert_acknowledgment_store.py
+++ b/libs/web_console_services/alert_acknowledgment_store.py
@@ -1,0 +1,250 @@
+"""Acknowledgment store for data quality alerts.
+
+The Data Page plan (Phase 5 AC) requires acknowledgments to be persisted
+server-side with actor, time, source, and issue scope before they can affect
+operational state; if persistence is unavailable, acknowledgment controls
+render unavailable.
+
+This module defines the storage contract and ships two implementations:
+
+* :class:`InMemoryAlertAcknowledgmentStore` — used when no durable backend is
+  configured. ``is_persistent`` is False so callers can render the UI as
+  unavailable.
+* :class:`PostgresAlertAcknowledgmentStore` — backed by the
+  ``data_quality_alert_acknowledgments`` table (see migrations 0017 + 0034).
+  Uses ``INSERT ... ON CONFLICT (alert_id) DO NOTHING RETURNING`` to keep
+  acknowledgments idempotent on first-write-wins semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Protocol
+from uuid import uuid4
+
+from .schemas.data_management import AlertAcknowledgmentDTO
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+class AlertAcknowledgmentStore(Protocol):
+    """Read/write contract for alert acknowledgments."""
+
+    @property
+    def is_persistent(self) -> bool:
+        """True iff acknowledgments survive process restarts."""
+
+    def get(self, alert_id: str) -> AlertAcknowledgmentDTO | None:
+        """Return an existing acknowledgment for ``alert_id`` or None."""
+
+    def acknowledge(
+        self,
+        *,
+        alert_id: str,
+        dataset: str,
+        metric: str,
+        severity: str,
+        acknowledged_by: str,
+        reason: str,
+        source: str,
+        issue_scope: dict[str, Any],
+        original_alert: dict[str, Any] | None = None,
+    ) -> AlertAcknowledgmentDTO:
+        """Record an acknowledgment idempotently and return the durable record."""
+
+
+class InMemoryAlertAcknowledgmentStore:
+    """In-memory fallback used when no durable backend is available.
+
+    ``DataQualityService`` runs ``acknowledge`` inside ``asyncio.to_thread``,
+    so two concurrent callers can race on the same ``alert_id``. The
+    read-check-write block is guarded by a ``threading.Lock`` to preserve
+    first-write-wins idempotency. ``Postgres`` does not need this guard
+    because ``INSERT ... ON CONFLICT DO NOTHING RETURNING`` is the atomic
+    idempotency primitive.
+    """
+
+    is_persistent = False
+
+    def __init__(self) -> None:
+        self._records: dict[str, AlertAcknowledgmentDTO] = {}
+        self._lock = threading.Lock()
+
+    def get(self, alert_id: str) -> AlertAcknowledgmentDTO | None:
+        return self._records.get(alert_id)
+
+    def acknowledge(
+        self,
+        *,
+        alert_id: str,
+        dataset: str,
+        metric: str,
+        severity: str,
+        acknowledged_by: str,
+        reason: str,
+        source: str,
+        issue_scope: dict[str, Any],
+        original_alert: dict[str, Any] | None = None,
+    ) -> AlertAcknowledgmentDTO:
+        with self._lock:
+            existing = self._records.get(alert_id)
+            if existing is not None:
+                return existing
+            record = AlertAcknowledgmentDTO(
+                id=str(uuid4()),
+                alert_id=alert_id,
+                dataset=dataset,
+                metric=metric,
+                severity=severity,
+                acknowledged_by=acknowledged_by,
+                acknowledged_at=datetime.now(UTC),
+                reason=reason,
+                source=source,
+                issue_scope=dict(issue_scope),
+            )
+            self._records[alert_id] = record
+            return record
+
+
+class PostgresAlertAcknowledgmentStore:
+    """Durable acknowledgment store backed by Postgres.
+
+    The store keeps the synchronous shape of the rest of ``web_console_services``
+    (services run blocking work in ``asyncio.to_thread``), so all DB access
+    here is sync and uses ``psycopg_pool.ConnectionPool``.
+    """
+
+    is_persistent = True
+
+    _TABLE = "data_quality_alert_acknowledgments"
+
+    def __init__(self, db_pool: ConnectionPool) -> None:
+        self._db_pool = db_pool
+
+    def get(self, alert_id: str) -> AlertAcknowledgmentDTO | None:
+        sql = f"""
+            SELECT id, alert_id, dataset, metric, severity,
+                   acknowledged_by, acknowledged_at, reason,
+                   source, issue_scope
+            FROM {self._TABLE}
+            WHERE alert_id = %s
+        """
+        with self._db_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (alert_id,))
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return self._row_to_dto(row)
+
+    def acknowledge(
+        self,
+        *,
+        alert_id: str,
+        dataset: str,
+        metric: str,
+        severity: str,
+        acknowledged_by: str,
+        reason: str,
+        source: str,
+        issue_scope: dict[str, Any],
+        original_alert: dict[str, Any] | None = None,
+    ) -> AlertAcknowledgmentDTO:
+        scope_payload = json.dumps(dict(issue_scope))
+        alert_payload = json.dumps(original_alert or {})
+        insert_sql = f"""
+            INSERT INTO {self._TABLE} (
+                alert_id, dataset, metric, severity,
+                acknowledged_by, reason, source, issue_scope, original_alert
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb)
+            ON CONFLICT (alert_id) DO NOTHING
+            RETURNING id, alert_id, dataset, metric, severity,
+                      acknowledged_by, acknowledged_at, reason,
+                      source, issue_scope
+        """
+        select_sql = f"""
+            SELECT id, alert_id, dataset, metric, severity,
+                   acknowledged_by, acknowledged_at, reason,
+                   source, issue_scope
+            FROM {self._TABLE}
+            WHERE alert_id = %s
+        """
+        with self._db_pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    insert_sql,
+                    (
+                        alert_id,
+                        dataset,
+                        metric,
+                        severity,
+                        acknowledged_by,
+                        reason,
+                        source,
+                        scope_payload,
+                        alert_payload,
+                    ),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    # ON CONFLICT path: another writer already recorded it.
+                    cur.execute(select_sql, (alert_id,))
+                    row = cur.fetchone()
+            conn.commit()
+        if row is None:
+            raise RuntimeError(
+                f"Failed to read acknowledgment for alert_id={alert_id} after insert"
+            )
+        return self._row_to_dto(row)
+
+    @staticmethod
+    def _row_to_dto(row: Any) -> AlertAcknowledgmentDTO:
+        (
+            ack_id,
+            alert_id,
+            dataset,
+            metric,
+            severity,
+            acknowledged_by,
+            acknowledged_at,
+            reason,
+            source,
+            issue_scope,
+        ) = row
+        if isinstance(issue_scope, str):
+            try:
+                parsed = json.loads(issue_scope)
+            except json.JSONDecodeError:
+                parsed = None
+            issue_scope_dict = parsed if isinstance(parsed, dict) else {}
+        elif isinstance(issue_scope, dict):
+            issue_scope_dict = issue_scope
+        else:
+            # JSONB columns may also arrive as a list/None depending on
+            # adapter — Pydantic requires a dict, so coerce defensively.
+            issue_scope_dict = {}
+        return AlertAcknowledgmentDTO(
+            id=str(ack_id),
+            alert_id=str(alert_id),
+            dataset=str(dataset),
+            metric=str(metric),
+            severity=str(severity),
+            acknowledged_by=str(acknowledged_by),
+            acknowledged_at=acknowledged_at,
+            reason=reason if reason is not None else None,
+            source=str(source) if source is not None else "unknown",
+            issue_scope=issue_scope_dict,
+        )
+
+
+__all__ = [
+    "AlertAcknowledgmentStore",
+    "InMemoryAlertAcknowledgmentStore",
+    "PostgresAlertAcknowledgmentStore",
+]

--- a/libs/web_console_services/alert_acknowledgment_store.py
+++ b/libs/web_console_services/alert_acknowledgment_store.py
@@ -12,8 +12,10 @@ This module defines the storage contract and ships two implementations:
   unavailable.
 * :class:`PostgresAlertAcknowledgmentStore` — backed by the
   ``data_quality_alert_acknowledgments`` table (see migrations 0017 + 0034).
-  Uses ``INSERT ... ON CONFLICT (alert_id) DO NOTHING RETURNING`` to keep
-  acknowledgments idempotent on first-write-wins semantics.
+  Uses ``INSERT ... ON CONFLICT (alert_id) DO UPDATE SET alert_id =
+  EXCLUDED.alert_id RETURNING`` so a single round-trip returns the row
+  whether it was just inserted or already present, preserving first-write-
+  wins idempotency without a follow-up SELECT.
 """
 
 from __future__ import annotations
@@ -24,6 +26,8 @@ import threading
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol
 from uuid import uuid4
+
+from psycopg import sql as psycopg_sql
 
 from .schemas.data_management import AlertAcknowledgmentDTO
 
@@ -66,7 +70,7 @@ class InMemoryAlertAcknowledgmentStore:
     so two concurrent callers can race on the same ``alert_id``. The
     read-check-write block is guarded by a ``threading.Lock`` to preserve
     first-write-wins idempotency. ``Postgres`` does not need this guard
-    because ``INSERT ... ON CONFLICT DO NOTHING RETURNING`` is the atomic
+    because ``INSERT ... ON CONFLICT (alert_id) DO UPDATE`` is the atomic
     idempotency primitive.
     """
 
@@ -118,23 +122,30 @@ class PostgresAlertAcknowledgmentStore:
     The store keeps the synchronous shape of the rest of ``web_console_services``
     (services run blocking work in ``asyncio.to_thread``), so all DB access
     here is sync and uses ``psycopg_pool.ConnectionPool``.
+
+    Identifiers (table names) are composed via :mod:`psycopg.sql` so the
+    repository's "parameterized queries only" rule is satisfied even though
+    the table name is currently a constant.
+
+    Transactions are scoped with ``with conn:`` rather than an explicit
+    ``conn.commit()`` so the store also works against pools that are
+    configured in autocommit mode (where ``commit()`` would raise
+    ``ProgrammingError``).
     """
 
     is_persistent = True
 
-    _TABLE = "data_quality_alert_acknowledgments"
+    _TABLE = psycopg_sql.Identifier("data_quality_alert_acknowledgments")
 
     def __init__(self, db_pool: ConnectionPool) -> None:
         self._db_pool = db_pool
 
     def get(self, alert_id: str) -> AlertAcknowledgmentDTO | None:
-        sql = f"""
-            SELECT id, alert_id, dataset, metric, severity,
-                   acknowledged_by, acknowledged_at, reason,
-                   source, issue_scope
-            FROM {self._TABLE}
-            WHERE alert_id = %s
-        """
+        sql = psycopg_sql.SQL(
+            "SELECT id, alert_id, dataset, metric, severity, "
+            "acknowledged_by, acknowledged_at, reason, source, issue_scope "
+            "FROM {table} WHERE alert_id = %s"
+        ).format(table=self._TABLE)
         with self._db_pool.connection() as conn, conn.cursor() as cur:
             cur.execute(sql, (alert_id,))
             row = cur.fetchone()
@@ -157,28 +168,24 @@ class PostgresAlertAcknowledgmentStore:
     ) -> AlertAcknowledgmentDTO:
         scope_payload = json.dumps(dict(issue_scope))
         alert_payload = json.dumps(original_alert or {})
-        insert_sql = f"""
-            INSERT INTO {self._TABLE} (
-                alert_id, dataset, metric, severity,
-                acknowledged_by, reason, source, issue_scope, original_alert
-            )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb)
-            ON CONFLICT (alert_id) DO NOTHING
-            RETURNING id, alert_id, dataset, metric, severity,
-                      acknowledged_by, acknowledged_at, reason,
-                      source, issue_scope
-        """
-        select_sql = f"""
-            SELECT id, alert_id, dataset, metric, severity,
-                   acknowledged_by, acknowledged_at, reason,
-                   source, issue_scope
-            FROM {self._TABLE}
-            WHERE alert_id = %s
-        """
-        with self._db_pool.connection() as conn:
+        # ``ON CONFLICT ... DO UPDATE SET alert_id = EXCLUDED.alert_id``
+        # performs a no-op update on conflict but keeps RETURNING populated,
+        # so we get a single round-trip whether the row is new or existing.
+        # First-write-wins semantics still hold because the update does not
+        # change any column the caller cares about (no actor/scope rewrite).
+        sql = psycopg_sql.SQL(
+            "INSERT INTO {table} ("
+            "alert_id, dataset, metric, severity, "
+            "acknowledged_by, reason, source, issue_scope, original_alert"
+            ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb) "
+            "ON CONFLICT (alert_id) DO UPDATE SET alert_id = EXCLUDED.alert_id "
+            "RETURNING id, alert_id, dataset, metric, severity, "
+            "acknowledged_by, acknowledged_at, reason, source, issue_scope"
+        ).format(table=self._TABLE)
+        with self._db_pool.connection() as conn, conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    insert_sql,
+                    sql,
                     (
                         alert_id,
                         dataset,
@@ -192,15 +199,10 @@ class PostgresAlertAcknowledgmentStore:
                     ),
                 )
                 row = cur.fetchone()
-                if row is None:
-                    # ON CONFLICT path: another writer already recorded it.
-                    cur.execute(select_sql, (alert_id,))
-                    row = cur.fetchone()
-            conn.commit()
         if row is None:
-            raise RuntimeError(
-                f"Failed to read acknowledgment for alert_id={alert_id} after insert"
-            )
+            # DO UPDATE always returns a row; if we get here, something far
+            # more serious than a conflict happened (e.g. RLS suppression).
+            raise RuntimeError(f"INSERT ... RETURNING produced no row for alert_id={alert_id}")
         return self._row_to_dto(row)
 
     @staticmethod

--- a/libs/web_console_services/alert_acknowledgment_store.py
+++ b/libs/web_console_services/alert_acknowledgment_store.py
@@ -127,10 +127,12 @@ class PostgresAlertAcknowledgmentStore:
     repository's "parameterized queries only" rule is satisfied even though
     the table name is currently a constant.
 
-    Transactions are scoped with ``with conn:`` rather than an explicit
-    ``conn.commit()`` so the store also works against pools that are
-    configured in autocommit mode (where ``commit()`` would raise
-    ``ProgrammingError``).
+    Transactions are scoped by the pool's ``connection()`` context manager,
+    which commits on success and rolls back on exception when the
+    connection is returned to the pool — and, critically, returns the
+    connection to the pool rather than closing it. The store does not call
+    ``conn.commit()`` explicitly because that raises ``ProgrammingError``
+    against pools configured in autocommit mode.
     """
 
     is_persistent = True
@@ -182,7 +184,13 @@ class PostgresAlertAcknowledgmentStore:
             "RETURNING id, alert_id, dataset, metric, severity, "
             "acknowledged_by, acknowledged_at, reason, source, issue_scope"
         ).format(table=self._TABLE)
-        with self._db_pool.connection() as conn, conn:
+        # The pool's connection() context manager already commits on success
+        # and rolls back on exception when the connection is returned to the
+        # pool. Wrapping the raw connection in an extra ``with conn:`` would
+        # invoke ``Connection.__exit__`` which CLOSES the underlying
+        # connection (see psycopg_pool docs), forcing the pool to open a
+        # fresh one for every successful write.
+        with self._db_pool.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     sql,
@@ -219,18 +227,16 @@ class PostgresAlertAcknowledgmentStore:
             source,
             issue_scope,
         ) = row
+        # JSONB columns can arrive as a parsed object (dict/list/scalar) or
+        # as a raw string depending on the adapter. Decode strings, then
+        # coerce anything that is not a dict to ``{}`` so Pydantic accepts
+        # the field.
         if isinstance(issue_scope, str):
             try:
-                parsed = json.loads(issue_scope)
+                issue_scope = json.loads(issue_scope)
             except json.JSONDecodeError:
-                parsed = None
-            issue_scope_dict = parsed if isinstance(parsed, dict) else {}
-        elif isinstance(issue_scope, dict):
-            issue_scope_dict = issue_scope
-        else:
-            # JSONB columns may also arrive as a list/None depending on
-            # adapter — Pydantic requires a dict, so coerce defensively.
-            issue_scope_dict = {}
+                issue_scope = {}
+        issue_scope_dict = issue_scope if isinstance(issue_scope, dict) else {}
         return AlertAcknowledgmentDTO(
             id=str(ack_id),
             alert_id=str(alert_id),
@@ -239,8 +245,10 @@ class PostgresAlertAcknowledgmentStore:
             severity=str(severity),
             acknowledged_by=str(acknowledged_by),
             acknowledged_at=acknowledged_at,
-            reason=reason if reason is not None else None,
-            source=str(source) if source is not None else "unknown",
+            reason=reason,
+            # ``source`` is NOT NULL in the schema (migration 0034 with
+            # default 'unknown'), so no further coercion is needed.
+            source=str(source),
             issue_scope=issue_scope_dict,
         )
 

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -446,6 +446,7 @@ class DataQualityService:
         alert_id: str,
         reason: str,
         *,
+        dataset: str | None = None,
         source: str = "anomaly_alert",
         metric: str = "row_drop",
         severity: str = "warning",
@@ -465,6 +466,15 @@ class DataQualityService:
         durable, callers receive ``RuntimeError`` so the UI never accepts a
         write that would silently disappear on restart.
 
+        ``dataset`` may be passed explicitly by callers that already know
+        which dataset the alert belongs to. The data page UI does this
+        because each rendered :class:`AnomalyAlertDTO` carries its own
+        ``dataset``, and manifest-derived signal ids such as
+        ``alpaca-sip-manifest-pairing`` do not match the
+        ``alert-{idx}`` format that :meth:`_resolve_alert_dataset` knows
+        how to parse. When ``dataset`` is omitted, the legacy mock-id
+        parser is used as a best-effort fallback.
+
         Idempotency: First-write-wins on ``alert_id``.
         """
         self._require_permission(user, Permission.ACKNOWLEDGE_ALERTS)
@@ -476,8 +486,9 @@ class DataQualityService:
                 "accepting acknowledgments."
             )
 
-        dataset = self._resolve_alert_dataset(alert_id)
-        self._require_dataset_access(user, dataset)
+        resolved_dataset = dataset if dataset is not None else self._resolve_alert_dataset(alert_id)
+        self._require_dataset_access(user, resolved_dataset)
+        dataset = resolved_dataset
 
         scope: dict[str, Any] = {
             "dataset": dataset,
@@ -487,11 +498,11 @@ class DataQualityService:
         if issue_scope:
             scope.update(issue_scope)
 
-        # Delegate idempotency to the store. Postgres uses
-        # INSERT ... ON CONFLICT DO NOTHING RETURNING with a SELECT fallback;
-        # the in-memory implementation short-circuits on its own records dict.
-        # Routing through to_thread keeps the blocking DB I/O off the NiceGUI
-        # event loop in production.
+        # Delegate idempotency to the store. Postgres uses a single
+        # INSERT ... ON CONFLICT DO UPDATE SET alert_id = EXCLUDED.alert_id
+        # RETURNING; the in-memory implementation short-circuits on its
+        # own records dict. Routing through to_thread keeps the blocking
+        # DB I/O off the NiceGUI event loop in production.
         return await asyncio.to_thread(
             self._ack_store.acknowledge,
             alert_id=alert_id,

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
-from uuid import uuid4
 
 from libs.platform.web_console_auth.helpers import get_user_id
 from libs.platform.web_console_auth.permissions import (
@@ -23,6 +22,10 @@ from libs.platform.web_console_auth.permissions import (
     has_permission,
 )
 
+from .alert_acknowledgment_store import (
+    AlertAcknowledgmentStore,
+    InMemoryAlertAcknowledgmentStore,
+)
 from .data_manifest_service import (
     ALPACA_SIP_DATASET_KEY,
     AlpacaSipManifestSummaryDTO,
@@ -294,16 +297,15 @@ class DataQualityService:
     """Service layer for data quality reporting.
 
     Enforces dataset-level access on all read paths for licensing compliance.
-    Alert acknowledgments are currently in-memory placeholders.
+
+    Alert acknowledgments are routed through an
+    :class:`AlertAcknowledgmentStore`. When the caller does not provide a
+    durable store, the service falls back to an in-memory implementation and
+    advertises ``acknowledgments_persistent = False`` so the UI can render the
+    controls as unavailable per the Data Page plan AC.
 
     IMPORTANT: ALL read paths filter by user's dataset permissions.
     Users only see quality data for datasets they have access to.
-
-    NOTE: Current implementation uses mock data and in-memory storage.
-    Production implementation requires:
-    - DB queries against data_validation_results table
-    - DB queries against data_anomaly_alerts table
-    - DB persistence for alert acknowledgments
     """
 
     def __init__(
@@ -314,22 +316,20 @@ class DataQualityService:
         data_root: Path | None = None,
         integrity_reports_available: bool | None = None,
         feed_delta_reports_available: bool | None = None,
+        acknowledgment_store: AlertAcknowledgmentStore | None = None,
     ) -> None:
-        # TODO: Replace with PostgreSQL persistence using data_quality_alert_acknowledgments table
-        # Current in-memory implementation is for interface validation only.
-        # Production requires: INSERT ... ON CONFLICT DO NOTHING RETURNING for idempotency
-        self._ack_store: dict[str, AlertAcknowledgmentDTO] = {}
+        self._ack_store: AlertAcknowledgmentStore = (
+            acknowledgment_store or InMemoryAlertAcknowledgmentStore()
+        )
         self._manifest_service = manifest_service or DataManifestService()
         self._report_store = report_store or AlpacaQualityReportStore(data_root=data_root)
         self._integrity_reports_available_override = integrity_reports_available
         self._feed_delta_reports_available_override = feed_delta_reports_available
-        # Hard-pinned false until durable DB-backed acknowledgment storage lands.
-        self._acknowledgments_persistent = False
 
     @property
     def acknowledgments_persistent(self) -> bool:
         """Whether alert acknowledgments are backed by durable server-side storage."""
-        return self._acknowledgments_persistent
+        return self._ack_store.is_persistent
 
     async def get_validation_results(
         self,
@@ -445,41 +445,65 @@ class DataQualityService:
         user: Any,
         alert_id: str,
         reason: str,
+        *,
+        source: str = "anomaly_alert",
+        metric: str = "row_drop",
+        severity: str = "warning",
+        issue_scope: dict[str, Any] | None = None,
+        original_alert: dict[str, Any] | None = None,
     ) -> AlertAcknowledgmentDTO:
         """Acknowledge an anomaly alert (idempotent).
 
-        Permission: ACKNOWLEDGE_ALERTS + dataset-level access for alert's dataset
-        Storage: in-memory placeholder until PostgreSQL persistence is implemented
-        Audit: Logged with user, alert_id, reason
-        Security: Validate user has access to the dataset referenced by alert_id
+        Permission: ACKNOWLEDGE_ALERTS + dataset-level access for alert's dataset.
+        Storage: persistent if an :class:`AlertAcknowledgmentStore` backed by
+        Postgres was injected; otherwise the in-memory fallback is used and
+        :attr:`acknowledgments_persistent` reports False so the UI renders the
+        controls as unavailable.
 
-        Idempotency: First-write-wins (unique constraint on alert_id)
-        - If alert not yet acknowledged: creates acknowledgment, returns AlertAcknowledgmentDTO
-        - If alert already acknowledged: returns existing AlertAcknowledgmentDTO (no error)
-        - Client can safely retry without side effects
+        Per the Phase 5 plan AC, acknowledgments must be persisted server-side
+        before they affect operational state. When the active store is not
+        durable, callers receive ``RuntimeError`` so the UI never accepts a
+        write that would silently disappear on restart.
+
+        Idempotency: First-write-wins on ``alert_id``.
         """
         self._require_permission(user, Permission.ACKNOWLEDGE_ALERTS)
+
+        if not self._ack_store.is_persistent:
+            raise RuntimeError(
+                "quality_acknowledgment_persistence_unavailable: "
+                "configure a Postgres-backed AlertAcknowledgmentStore before "
+                "accepting acknowledgments."
+            )
 
         dataset = self._resolve_alert_dataset(alert_id)
         self._require_dataset_access(user, dataset)
 
-        existing = self._ack_store.get(alert_id)
-        if existing is not None:
-            return existing
+        scope: dict[str, Any] = {
+            "dataset": dataset,
+            "metric": metric,
+            "severity": severity,
+        }
+        if issue_scope:
+            scope.update(issue_scope)
 
-        now = datetime.now(UTC)
-        acknowledgment = AlertAcknowledgmentDTO(
-            id=str(uuid4()),
+        # Delegate idempotency to the store. Postgres uses
+        # INSERT ... ON CONFLICT DO NOTHING RETURNING with a SELECT fallback;
+        # the in-memory implementation short-circuits on its own records dict.
+        # Routing through to_thread keeps the blocking DB I/O off the NiceGUI
+        # event loop in production.
+        return await asyncio.to_thread(
+            self._ack_store.acknowledge,
             alert_id=alert_id,
             dataset=dataset,
-            metric="row_drop",
-            severity="warning",
+            metric=metric,
+            severity=severity,
             acknowledged_by=get_user_id(user),
-            acknowledged_at=now,
             reason=reason,
+            source=source,
+            issue_scope=scope,
+            original_alert=original_alert,
         )
-        self._ack_store[alert_id] = acknowledgment
-        return acknowledgment
 
     async def get_quality_trends(
         self,

--- a/libs/web_console_services/data_quality_service.py
+++ b/libs/web_console_services/data_quality_service.py
@@ -412,7 +412,13 @@ class DataQualityService:
         """Get anomaly alerts with optional filters.
 
         Permission: VIEW_DATA_QUALITY + dataset-level access (filtered)
-        Filtering: Only alerts for datasets user has access to
+        Filtering: Only alerts for datasets user has access to.
+
+        Acknowledgment status is hydrated from the active
+        :class:`AlertAcknowledgmentStore` so the ``acknowledged`` filter
+        reflects what the operator already triaged. Reads from the store
+        are off-loaded to ``asyncio.to_thread`` so blocking DB I/O does not
+        run on the NiceGUI event loop.
         """
         self._require_permission(user, Permission.VIEW_DATA_QUALITY)
 
@@ -433,12 +439,41 @@ class DataQualityService:
             )
             for idx, name in enumerate(_MOCK_QUALITY_DATASETS, start=1)
         ]
-        filtered = [item for item in mock if has_dataset_permission(user, item.dataset)]
+        permitted = [item for item in mock if has_dataset_permission(user, item.dataset)]
         if severity:
-            filtered = [item for item in filtered if item.severity == severity]
+            permitted = [item for item in permitted if item.severity == severity]
+
+        # Hydrate acknowledged state from the durable store. Use a single
+        # thread hop to amortise the GIL release across all per-id lookups.
+        if permitted:
+            permitted = await asyncio.to_thread(self._hydrate_acknowledgments, permitted)
+
         if acknowledged is not None:
-            filtered = [item for item in filtered if item.acknowledged == acknowledged]
-        return filtered
+            permitted = [item for item in permitted if item.acknowledged == acknowledged]
+        return permitted
+
+    def _hydrate_acknowledgments(self, alerts: list[AnomalyAlertDTO]) -> list[AnomalyAlertDTO]:
+        """Return ``alerts`` with ``acknowledged``/``acknowledged_by`` filled in.
+
+        Pydantic models are immutable here, so we rebuild each one. This
+        runs inside ``asyncio.to_thread`` so the synchronous store reads
+        do not block the event loop.
+        """
+        hydrated: list[AnomalyAlertDTO] = []
+        for alert in alerts:
+            ack = self._ack_store.get(alert.id)
+            if ack is None:
+                hydrated.append(alert)
+                continue
+            hydrated.append(
+                alert.model_copy(
+                    update={
+                        "acknowledged": True,
+                        "acknowledged_by": ack.acknowledged_by,
+                    }
+                )
+            )
+        return hydrated
 
     async def acknowledge_alert(
         self,

--- a/libs/web_console_services/schemas/data_management.py
+++ b/libs/web_console_services/schemas/data_management.py
@@ -397,7 +397,13 @@ class AnomalyAlertDTO(BaseModel):
 
 
 class AlertAcknowledgmentDTO(BaseModel):
-    """Acknowledgment record for an anomaly alert."""
+    """Acknowledgment record for an anomaly alert.
+
+    Captures the full AC scope required by Phase 5 of the Data Page plan:
+    actor (``acknowledged_by``), time (``acknowledged_at``), source (where the
+    signal originated), and issue scope (the dataset/metric/severity tuple the
+    operator is acknowledging).
+    """
 
     id: str
     alert_id: str
@@ -407,6 +413,8 @@ class AlertAcknowledgmentDTO(BaseModel):
     acknowledged_by: str
     acknowledged_at: AwareDatetime
     reason: str | None = None
+    source: str = "unknown"
+    issue_scope: dict[str, Any] = Field(default_factory=dict)
 
 
 class QualityTrendPointDTO(BaseModel):

--- a/tests/apps/web_console/services/test_alert_acknowledgment.py
+++ b/tests/apps/web_console/services/test_alert_acknowledgment.py
@@ -9,8 +9,17 @@ from uuid import uuid4
 import pytest
 
 from libs.platform.web_console_auth.permissions import Role
+from libs.web_console_services.alert_acknowledgment_store import (
+    InMemoryAlertAcknowledgmentStore,
+)
 from libs.web_console_services.data_quality_service import DataQualityService
 from libs.web_console_services.schemas.data_management import AlertAcknowledgmentDTO
+
+
+class _FakePersistentStore(InMemoryAlertAcknowledgmentStore):
+    """In-memory store that advertises durable persistence for tests."""
+
+    is_persistent = True
 
 
 @dataclass(frozen=True)
@@ -23,8 +32,13 @@ class DummyUser:
 
 @pytest.fixture()
 async def service() -> DataQualityService:
-    """Create fresh service instance with empty ack store."""
-    return DataQualityService()
+    """Create fresh service with a fake persistent ack store.
+
+    ``DataQualityService.acknowledge_alert`` now refuses to write when the
+    injected store is non-persistent (Phase 5 plan AC). Tests that exercise
+    the acknowledgment flow must inject a store that advertises durability.
+    """
+    return DataQualityService(acknowledgment_store=_FakePersistentStore())
 
 
 @pytest.fixture()
@@ -53,7 +67,9 @@ async def test_acknowledge_alert_returns_existing_on_conflict(
         acknowledged_at=datetime.now(UTC),
         reason="seed",
     )
-    service._ack_store["alert-4"] = existing
+    # Seed the underlying store's records dict so the idempotency check finds
+    # an existing acknowledgment without going through the public write path.
+    service._ack_store._records["alert-4"] = existing  # type: ignore[attr-defined]
 
     result = await service.acknowledge_alert(operator_user, alert_id="alert-4", reason="retry")
 

--- a/tests/apps/web_console/services/test_data_quality_service.py
+++ b/tests/apps/web_console/services/test_data_quality_service.py
@@ -7,7 +7,16 @@ from dataclasses import dataclass
 import pytest
 
 from libs.platform.web_console_auth.permissions import Role
+from libs.web_console_services.alert_acknowledgment_store import (
+    InMemoryAlertAcknowledgmentStore,
+)
 from libs.web_console_services.data_quality_service import DataQualityService
+
+
+class _FakePersistentStore(InMemoryAlertAcknowledgmentStore):
+    """In-memory store that advertises durable persistence for tests."""
+
+    is_persistent = True
 
 
 @dataclass(frozen=True)
@@ -20,8 +29,13 @@ class DummyUser:
 
 @pytest.fixture()
 async def service() -> DataQualityService:
-    """Create fresh service instance with empty ack store."""
-    return DataQualityService()
+    """Create fresh service with a fake persistent ack store.
+
+    ``DataQualityService.acknowledge_alert`` raises when the active store is
+    not durable; tests that exercise that path must inject a persistent
+    store.
+    """
+    return DataQualityService(acknowledgment_store=_FakePersistentStore())
 
 
 @pytest.fixture()

--- a/tests/libs/web_console_services/test_alert_acknowledgment_store.py
+++ b/tests/libs/web_console_services/test_alert_acknowledgment_store.py
@@ -24,9 +24,13 @@ class _FakeCursor:
     def __exit__(self, *_: Any) -> None:
         return None
 
-    def execute(self, sql: str, params: tuple[Any, ...]) -> None:
-        normalized = " ".join(sql.split())
-        if normalized.startswith("INSERT INTO data_quality_alert_acknowledgments"):
+    def execute(self, sql: Any, params: tuple[Any, ...]) -> None:
+        # ``psycopg.sql.Composed`` does not render to a finished SQL string
+        # without a connection context (``Composable.as_string(conn)``). For
+        # the fake we just inspect ``repr(sql)``, which is enough to tell
+        # INSERT vs SELECT apart.
+        rendered = repr(sql)
+        if "INSERT INTO" in rendered:
             (
                 alert_id,
                 dataset,
@@ -38,9 +42,11 @@ class _FakeCursor:
                 scope_json,
                 _original_alert_json,
             ) = params
-            if alert_id in self._db.rows:
-                # ON CONFLICT DO NOTHING — RETURNING yields nothing.
-                self._result = None
+            existing = self._db.rows.get(alert_id)
+            if existing is not None:
+                # ``DO UPDATE SET alert_id = EXCLUDED.alert_id`` returns the
+                # already-stored row unchanged (first-write-wins).
+                self._result = existing
                 return
             row = (
                 str(uuid4()),
@@ -56,17 +62,26 @@ class _FakeCursor:
             )
             self._db.rows[alert_id] = row
             self._result = row
-        elif normalized.startswith("SELECT id, alert_id, dataset"):
+        elif "SELECT id, alert_id, dataset" in rendered:
             (alert_id,) = params
             self._result = self._db.rows.get(alert_id)
         else:
-            raise AssertionError(f"unexpected SQL: {sql}")
+            raise AssertionError(f"unexpected SQL: {rendered}")
 
     def fetchone(self) -> tuple[Any, ...] | None:
         return self._result
 
 
 class _FakeConnection:
+    """Stand-in for psycopg's connection.
+
+    Both the pool's ``connection()`` and the connection's own transaction
+    context manager are exercised in production. The store no longer calls
+    ``conn.commit()`` explicitly — it relies on ``with conn:`` to commit on
+    successful exit. The fake therefore marks ``committed = True`` whenever
+    a context block exits without an exception.
+    """
+
     def __init__(self, fake_db: _FakeDB) -> None:
         self._db = fake_db
         self.committed = False
@@ -74,13 +89,16 @@ class _FakeConnection:
     def __enter__(self) -> _FakeConnection:
         return self
 
-    def __exit__(self, *_: Any) -> None:
-        return None
+    def __exit__(self, exc_type: Any, *_: Any) -> None:
+        if exc_type is None:
+            self.committed = True
 
     def cursor(self) -> _FakeCursor:
         return _FakeCursor(self._db)
 
-    def commit(self) -> None:
+    def commit(self) -> None:  # pragma: no cover - safety net
+        # The store no longer calls commit() directly; keep the method so
+        # any future callers that need an explicit commit do not crash.
         self.committed = True
 
 

--- a/tests/libs/web_console_services/test_alert_acknowledgment_store.py
+++ b/tests/libs/web_console_services/test_alert_acknowledgment_store.py
@@ -1,0 +1,300 @@
+"""Unit tests for libs.web_console_services.alert_acknowledgment_store."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from libs.web_console_services.alert_acknowledgment_store import (
+    InMemoryAlertAcknowledgmentStore,
+    PostgresAlertAcknowledgmentStore,
+)
+
+
+class _FakeCursor:
+    def __init__(self, fake_db: _FakeDB) -> None:
+        self._db = fake_db
+        self._result: tuple[Any, ...] | None = None
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+        normalized = " ".join(sql.split())
+        if normalized.startswith("INSERT INTO data_quality_alert_acknowledgments"):
+            (
+                alert_id,
+                dataset,
+                metric,
+                severity,
+                acknowledged_by,
+                reason,
+                source,
+                scope_json,
+                _original_alert_json,
+            ) = params
+            if alert_id in self._db.rows:
+                # ON CONFLICT DO NOTHING — RETURNING yields nothing.
+                self._result = None
+                return
+            row = (
+                str(uuid4()),
+                alert_id,
+                dataset,
+                metric,
+                severity,
+                acknowledged_by,
+                datetime.now(UTC),
+                reason,
+                source,
+                scope_json,
+            )
+            self._db.rows[alert_id] = row
+            self._result = row
+        elif normalized.startswith("SELECT id, alert_id, dataset"):
+            (alert_id,) = params
+            self._result = self._db.rows.get(alert_id)
+        else:
+            raise AssertionError(f"unexpected SQL: {sql}")
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._result
+
+
+class _FakeConnection:
+    def __init__(self, fake_db: _FakeDB) -> None:
+        self._db = fake_db
+        self.committed = False
+
+    def __enter__(self) -> _FakeConnection:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self._db)
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.rows: dict[str, tuple[Any, ...]] = {}
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.db = _FakeDB()
+        self.last_connection: _FakeConnection | None = None
+
+    def connection(self) -> _FakeConnection:
+        self.last_connection = _FakeConnection(self.db)
+        return self.last_connection
+
+
+def test_in_memory_store_is_not_persistent() -> None:
+    store = InMemoryAlertAcknowledgmentStore()
+    assert store.is_persistent is False
+
+
+def test_in_memory_store_is_idempotent_under_concurrent_writes() -> None:
+    """First-write-wins must hold even when DataQualityService runs
+    ``acknowledge`` from multiple ``asyncio.to_thread`` workers concurrently.
+    Without the lock both threads can pass the ``_records.get is None``
+    check, create distinct DTOs, and the later write would silently win.
+    """
+    import threading as _threading
+
+    store = InMemoryAlertAcknowledgmentStore()
+    start = _threading.Barrier(8)
+    results: list[Any] = []
+    results_lock = _threading.Lock()
+
+    def writer(actor: str) -> None:
+        start.wait()
+        ack = store.acknowledge(
+            alert_id="alert-race",
+            dataset="alpaca_sip",
+            metric="row_drop",
+            severity="warning",
+            acknowledged_by=actor,
+            reason="triage",
+            source="anomaly_alert",
+            issue_scope={"dataset": "alpaca_sip"},
+        )
+        with results_lock:
+            results.append(ack)
+
+    threads = [_threading.Thread(target=writer, args=(f"user-{i}",)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Every thread must observe the same acknowledgment row (first-write-wins).
+    assert len({ack.id for ack in results}) == 1
+    assert all(ack.acknowledged_by == results[0].acknowledged_by for ack in results)
+
+
+def test_in_memory_store_is_idempotent_on_alert_id() -> None:
+    store = InMemoryAlertAcknowledgmentStore()
+    first = store.acknowledge(
+        alert_id="alert-1",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-1",
+        reason="triage",
+        source="anomaly_alert",
+        issue_scope={"dataset": "alpaca_sip"},
+    )
+    second = store.acknowledge(
+        alert_id="alert-1",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-2",
+        reason="ignore",
+        source="anomaly_alert",
+        issue_scope={"dataset": "alpaca_sip"},
+    )
+    assert first.id == second.id
+    assert second.acknowledged_by == "user-1"  # first writer wins
+
+
+def test_postgres_store_persists_scope_and_source() -> None:
+    pool = _FakePool()
+    store = PostgresAlertAcknowledgmentStore(db_pool=pool)  # type: ignore[arg-type]
+
+    ack = store.acknowledge(
+        alert_id="alert-42",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-1",
+        reason="triage",
+        source="manifest_validation",
+        issue_scope={"dataset": "alpaca_sip", "metric": "row_drop"},
+        original_alert={"foo": "bar"},
+    )
+
+    assert store.is_persistent is True
+    assert ack.alert_id == "alert-42"
+    assert ack.source == "manifest_validation"
+    assert ack.issue_scope == {"dataset": "alpaca_sip", "metric": "row_drop"}
+    assert pool.last_connection is not None
+    assert pool.last_connection.committed is True
+
+
+def test_postgres_store_is_idempotent_via_on_conflict() -> None:
+    pool = _FakePool()
+    store = PostgresAlertAcknowledgmentStore(db_pool=pool)  # type: ignore[arg-type]
+
+    first = store.acknowledge(
+        alert_id="alert-99",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-1",
+        reason="triage",
+        source="anomaly_alert",
+        issue_scope={"dataset": "alpaca_sip"},
+    )
+    second = store.acknowledge(
+        alert_id="alert-99",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-2",
+        reason="ignore",
+        source="anomaly_alert",
+        issue_scope={"dataset": "alpaca_sip"},
+    )
+
+    assert first.id == second.id
+    assert second.acknowledged_by == "user-1"
+
+
+def test_postgres_store_get_returns_existing_record() -> None:
+    pool = _FakePool()
+    store = PostgresAlertAcknowledgmentStore(db_pool=pool)  # type: ignore[arg-type]
+
+    store.acknowledge(
+        alert_id="alert-7",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-1",
+        reason="triage",
+        source="anomaly_alert",
+        issue_scope={"dataset": "alpaca_sip"},
+    )
+
+    fetched = store.get("alert-7")
+    assert fetched is not None
+    assert fetched.alert_id == "alert-7"
+    assert fetched.dataset == "alpaca_sip"
+
+
+def test_postgres_store_get_returns_none_when_missing() -> None:
+    pool = _FakePool()
+    store = PostgresAlertAcknowledgmentStore(db_pool=pool)  # type: ignore[arg-type]
+    assert store.get("does-not-exist") is None
+
+
+def test_postgres_store_row_to_dto_coerces_non_dict_scope() -> None:
+    """If issue_scope arrives as a JSON list/null/garbage, coerce to {}.
+
+    Pydantic v2 strictly rejects non-dict values for `issue_scope`; the store
+    must defend against unexpected JSONB shapes so that legacy rows or
+    rows written by a different writer cannot crash readers.
+    """
+    base_row = (
+        "id-1",
+        "alert-x",
+        "alpaca_sip",
+        "row_drop",
+        "warning",
+        "user-1",
+        datetime.now(UTC),
+        "triage",
+        "anomaly_alert",
+    )
+    json_list = base_row + ("[]",)
+    ack_list = PostgresAlertAcknowledgmentStore._row_to_dto(json_list)
+    assert ack_list.issue_scope == {}
+
+    json_garbage = base_row + ("not-json",)
+    ack_garbage = PostgresAlertAcknowledgmentStore._row_to_dto(json_garbage)
+    assert ack_garbage.issue_scope == {}
+
+    none_scope = base_row + (None,)
+    ack_none = PostgresAlertAcknowledgmentStore._row_to_dto(none_scope)
+    assert ack_none.issue_scope == {}
+
+
+def test_postgres_store_serializes_scope_as_json_string() -> None:
+    """The store must JSON-encode dict scopes for the JSONB cast."""
+    pool = _FakePool()
+    store = PostgresAlertAcknowledgmentStore(db_pool=pool)  # type: ignore[arg-type]
+    store.acknowledge(
+        alert_id="alert-json",
+        dataset="alpaca_sip",
+        metric="row_drop",
+        severity="warning",
+        acknowledged_by="user-1",
+        reason="triage",
+        source="anomaly_alert",
+        issue_scope={"nested": {"k": "v"}},
+    )
+    row = pool.db.rows["alert-json"]
+    # scope_json is column 9 in the row tuple
+    assert isinstance(row[9], str)
+    assert json.loads(row[9]) == {"nested": {"k": "v"}}

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -294,6 +294,63 @@ async def test_acknowledge_alert_idempotent_with_persistent_store() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_acknowledge_alert_accepts_explicit_dataset_for_manifest_id() -> None:
+    """Manifest-derived signal ids do not match the legacy mock format.
+
+    The UI knows ``alert.dataset`` and passes it explicitly; the service
+    must NOT try to parse it out of ``alert_id``.
+    """
+    store = FakePersistentAlertAcknowledgmentStore()
+    svc = DataQualityService(acknowledgment_store=store)
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_quality_service.get_user_id", return_value="user-1"),
+    ):
+        ack = await svc.acknowledge_alert(
+            DummyUser(user_id="user-1"),
+            alert_id="alpaca-sip-manifest-pairing",
+            reason="triage",
+            dataset="alpaca_sip",
+            metric="manifest_pairing",
+            severity="warning",
+        )
+
+    assert ack.dataset == "alpaca_sip"
+    assert ack.metric == "manifest_pairing"
+    assert ack.alert_id == "alpaca-sip-manifest-pairing"
+
+
+@pytest.mark.asyncio()
+async def test_acknowledge_alert_falls_back_to_resolver_when_dataset_omitted() -> None:
+    """When the caller does not pass dataset, the legacy alert-{idx}
+    parser still runs as a best-effort fallback for backwards compat."""
+    store = FakePersistentAlertAcknowledgmentStore()
+    svc = DataQualityService(acknowledgment_store=store)
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_quality_service.get_user_id", return_value="user-1"),
+    ):
+        ack = await svc.acknowledge_alert(
+            DummyUser(user_id="user-1"),
+            alert_id="alert-1",
+            reason="triage",
+        )
+
+    # alert-1 maps to _SUPPORTED_DATASETS[0] which is "crsp".
+    assert ack.dataset == "crsp"
+
+
+@pytest.mark.asyncio()
 async def test_acknowledge_alert_unavailable_when_store_not_persistent() -> None:
     svc = DataQualityService()  # defaults to in-memory non-persistent store
 

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -222,6 +222,43 @@ async def test_get_anomaly_alerts_filters_severity_and_acknowledged(
 
 
 @pytest.mark.asyncio()
+async def test_get_anomaly_alerts_hydrates_acknowledged_state_from_store() -> None:
+    """After an operator acknowledges an alert, subsequent reads must
+    surface the acknowledgment so the UI does not re-show the same alert
+    as unacked and the ``acked`` filter is not empty (Codex PR #225 P2)."""
+    store = FakePersistentAlertAcknowledgmentStore()
+    svc = DataQualityService(acknowledgment_store=store)
+
+    # Persist an acknowledgment for the first mocked alert. ``alert-1``
+    # maps to _SUPPORTED_DATASETS[0] which is "crsp" under the legacy
+    # resolver.
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_quality_service.get_user_id", return_value="user-1"),
+    ):
+        await svc.acknowledge_alert(
+            DummyUser(user_id="user-1"), alert_id="alert-1", reason="triage"
+        )
+
+        unacked = await svc.get_anomaly_alerts(
+            DummyUser(user_id="user-1"), severity=None, acknowledged=False
+        )
+        acked = await svc.get_anomaly_alerts(
+            DummyUser(user_id="user-1"), severity=None, acknowledged=True
+        )
+
+    assert "alert-1" not in {a.id for a in unacked}
+    assert {a.id for a in acked} == {"alert-1"}
+    (only,) = acked
+    assert only.acknowledged is True
+    assert only.acknowledged_by == "user-1"
+
+
+@pytest.mark.asyncio()
 async def test_get_anomaly_alerts_excludes_manifest_backed_alpaca_sip_placeholder(
     service: DataQualityService,
 ) -> None:

--- a/tests/libs/web_console_services/test_data_quality_service.py
+++ b/tests/libs/web_console_services/test_data_quality_service.py
@@ -12,6 +12,9 @@ from unittest.mock import patch
 
 import pytest
 
+from libs.web_console_services.alert_acknowledgment_store import (
+    InMemoryAlertAcknowledgmentStore,
+)
 from libs.web_console_services.data_manifest_service import (
     ALPACA_SIP_CORP_ACTIONS_DATASET,
     ALPACA_SIP_DAILY_DATASET,
@@ -27,6 +30,12 @@ from libs.web_console_services.data_quality_service import (
     _build_alpaca_sip_quality_summary,
 )
 from libs.web_console_services.provider_signature import ProviderSignatureDTO
+
+
+class FakePersistentAlertAcknowledgmentStore(InMemoryAlertAcknowledgmentStore):
+    """In-memory store that advertises durable persistence for tests."""
+
+    is_persistent = True
 
 
 @dataclass(frozen=True)
@@ -247,7 +256,10 @@ async def test_get_quarantine_status_excludes_manifest_backed_alpaca_sip_placeho
 
 
 @pytest.mark.asyncio()
-async def test_acknowledge_alert_idempotent(service: DataQualityService) -> None:
+async def test_acknowledge_alert_idempotent_with_persistent_store() -> None:
+    store = FakePersistentAlertAcknowledgmentStore()
+    svc = DataQualityService(acknowledgment_store=store)
+
     with (
         patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
         patch(
@@ -256,16 +268,49 @@ async def test_acknowledge_alert_idempotent(service: DataQualityService) -> None
         ),
         patch("libs.web_console_services.data_quality_service.get_user_id", return_value="user-1"),
     ):
-        first = await service.acknowledge_alert(
-            DummyUser(user_id="user-1"), alert_id="alert-1", reason="triage"
+        first = await svc.acknowledge_alert(
+            DummyUser(user_id="user-1"),
+            alert_id="alert-1",
+            reason="triage",
+            source="anomaly_alert",
+            issue_scope={"page": "data_management"},
         )
-        second = await service.acknowledge_alert(
-            DummyUser(user_id="user-1"), alert_id="alert-1", reason="ignore"
+        second = await svc.acknowledge_alert(
+            DummyUser(user_id="user-1"),
+            alert_id="alert-1",
+            reason="ignore",
         )
 
+    assert svc.acknowledgments_persistent is True
     assert first.id == second.id
     assert second.reason == "triage"
     assert second.acknowledged_by == "user-1"
+    assert first.source == "anomaly_alert"
+    # Issue scope captures dataset/metric/severity plus any caller additions.
+    assert first.issue_scope["dataset"] == first.dataset
+    assert first.issue_scope["metric"] == first.metric
+    assert first.issue_scope["severity"] == first.severity
+    assert first.issue_scope["page"] == "data_management"
+
+
+@pytest.mark.asyncio()
+async def test_acknowledge_alert_unavailable_when_store_not_persistent() -> None:
+    svc = DataQualityService()  # defaults to in-memory non-persistent store
+
+    with (
+        patch("libs.web_console_services.data_quality_service.has_permission", return_value=True),
+        patch(
+            "libs.web_console_services.data_quality_service.has_dataset_permission",
+            return_value=True,
+        ),
+        patch("libs.web_console_services.data_quality_service.get_user_id", return_value="user-1"),
+        pytest.raises(RuntimeError, match="quality_acknowledgment_persistence_unavailable"),
+    ):
+        await svc.acknowledge_alert(
+            DummyUser(user_id="user-1"), alert_id="alert-1", reason="triage"
+        )
+
+    assert svc.acknowledgments_persistent is False
 
 
 def test_resolve_alert_dataset_invalid_id() -> None:
@@ -625,9 +670,9 @@ async def test_alpaca_sip_quality_summary_loads_persisted_report_statuses(
     assert summary.status == "warning"
     assert signals["alpaca_sip_integrity"].status == "passed"
     assert signals["alpaca_feed_delta"].status == "warning"
-    assert "alpaca_sip_integrity_hash:integrity-hash" in signals[
-        "alpaca_sip_integrity"
-    ].reason_codes
+    assert (
+        "alpaca_sip_integrity_hash:integrity-hash" in signals["alpaca_sip_integrity"].reason_codes
+    )
     assert "alpaca_feed_delta_timeframe:1Day" in signals["alpaca_feed_delta"].reason_codes
     assert signals["alpaca_sip_integrity"].observed_at == datetime.fromtimestamp(
         integrity_path.stat().st_mtime,


### PR DESCRIPTION
## Summary

- Closes the Phase 5 acceptance criterion from `docs/TASKS/2026-05-03-data-page-ui-optimization-plan.md`: **"Quality acknowledgments are persisted server-side with actor, time, source, and issue scope before they affect operational state; if persistence is unavailable, acknowledgment controls render unavailable."**
- Replaces the in-process dict in `DataQualityService` with a pluggable `AlertAcknowledgmentStore`, ships a Postgres-backed implementation (`INSERT … ON CONFLICT DO NOTHING RETURNING`) and an in-memory fallback that signals non-persistence.
- Page wiring resolves the store at page-load time: Postgres when `get_sync_db_pool()` succeeds, in-memory otherwise (logged at WARNING). The existing Acknowledge button is already gated on `quality_service.acknowledgments_persistent`, so the UI degrades safely.

## What changed

| Layer | File |
|---|---|
| Migration | `db/migrations/0034_quality_ack_scope_columns.sql` — drops FK, relaxes `alert_id` to TEXT, adds `source` + `issue_scope`. |
| New module | `libs/web_console_services/alert_acknowledgment_store.py` — Protocol + `InMemory` (with `threading.Lock`) + `Postgres` (idempotent via `ON CONFLICT … RETURNING` + SELECT fallback). |
| DTO | `libs/web_console_services/schemas/data_management.py` — `AlertAcknowledgmentDTO` gains `source` + `issue_scope` with safe defaults. |
| Service | `libs/web_console_services/data_quality_service.py` — accepts injected store; `acknowledgments_persistent` delegates; `acknowledge_alert` fails-closed with `RuntimeError` when non-durable; runs the sync store via `asyncio.to_thread`. |
| Page wiring | `apps/web_console_ng/pages/data_management.py` — `_resolve_alert_acknowledgment_store()`. |
| Tests (new) | `tests/libs/web_console_services/test_alert_acknowledgment_store.py` — 9 tests including a concurrent-writers race (8 threads on a barrier) and JSONB non-dict coercion. |
| Tests (updated) | `tests/libs/web_console_services/test_data_quality_service.py`, `tests/apps/web_console/services/{test_alert_acknowledgment,test_data_quality_service}.py` — inject a persistent fake store. |

## Reviewer history

This branch was reviewed iteratively with Gemini + Codex via CLI; both reviewers issued APPROVED in the final iteration after fixes were applied for:

- BLOCKER — two pre-existing test files at `tests/apps/web_console/services/` that wrote to the old dict-shaped `_ack_store`.
- MEDIUM — `_row_to_dto` would crash if `issue_scope` JSONB came back as a list/None.
- MEDIUM — synchronous `_ack_store.get()` on the event loop before `asyncio.to_thread` (removed; idempotency now delegates entirely to the store).
- BLOCKERs — `ruff check` (I001 import order) and `black --check` (class wedged between import blocks).
- LOW — in-memory store TOCTOU race under `asyncio.to_thread` → fixed with `threading.Lock`, regression-tested with 8 threads on a barrier.
- LOW — fallback log level bumped from `info` → `warning`.

## Test plan

- [x] `pytest tests/libs/web_console_services/ tests/apps/web_console/ tests/apps/web_console_ng/components/test_data_manifest_components.py tests/apps/web_console_ng/pages/test_data_management_wiring.py` — 1029 passed.
- [x] `ruff check` clean on all 8 changed files.
- [x] `black --check` clean on all 8 changed files.
- [ ] Run migration 0034 against a staging Postgres with non-empty `data_quality_alert_acknowledgments` (FK drop + UUID→TEXT conversion is safe per Gemini/Codex review but should be smoke-tested before prod).
- [ ] Manual UI verification at `/data` Quality drawer: with `DATABASE_URL` set, Acknowledge button enabled; without, "Acknowledgment controls are unavailable…" label renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)